### PR TITLE
fix: update script paths in mise.toml for sandbox tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -16,9 +16,9 @@ depends = ["//backend:install", "//frontend:install", "//ieapp-cli:install"]
 [tasks.dev]
 depends = ["//backend:dev", "//frontend:dev"]
 
-[tasks.sandbox:install-javy]
-run = "bash scripts/setup_javy.sh"
+[tasks."sandbox:install-javy"]
+run = "bash /workspace/scripts/setup_javy.sh"
 
-[tasks.sandbox:build]
+[tasks."sandbox:build"]
 depends = ["sandbox:install-javy"]
-run = "bash backend/src/app/sandbox/build_sandbox_wasm.sh"
+run = "bash /workspace/backend/src/app/sandbox/build_sandbox_wasm.sh"


### PR DESCRIPTION
This pull request updates the sandbox-related task definitions in the `mise.toml` configuration to use fully qualified paths and consistent task naming. These changes improve reliability when running scripts from different working directories.

**Configuration improvements:**

* Updated the `sandbox:install-javy` and `sandbox:build` tasks to use fully qualified paths for script execution, ensuring scripts run correctly regardless of the current working directory.
* Changed task keys to quoted strings (e.g., `tasks."sandbox:install-javy"`) for consistency and to avoid parsing issues.