### PR TITLE
Align API paths with feature registry

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -62,7 +62,7 @@ All note updates require `parent_revision_id` for conflict detection:
 
 ```python
 # Update endpoint returns 409 if revision mismatch
-@router.put("/workspaces/{workspace_id}/notes/{note_id}")
+@router.put("/api/workspaces/{workspace_id}/notes/{note_id}")
 async def update_note_endpoint(payload: NoteUpdate):
     try:
         update_note(ws_path, note_id, payload.markdown, payload.parent_revision_id)
@@ -133,15 +133,15 @@ See [docs/spec/api/rest.md](../docs/spec/api/rest.md) and [docs/spec/api/mcp.md]
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/workspaces` | List all workspaces |
-| POST | `/workspaces` | Create workspace |
-| GET | `/workspaces/{id}` | Get workspace metadata |
-| GET | `/workspaces/{id}/notes` | List notes (index data) |
-| POST | `/workspaces/{id}/notes` | Create note |
-| GET | `/workspaces/{id}/notes/{noteId}` | Get full note |
-| PUT | `/workspaces/{id}/notes/{noteId}` | Update note |
-| DELETE | `/workspaces/{id}/notes/{noteId}` | Delete (tombstone) note |
-| POST | `/workspaces/{id}/query` | Query notes by filter |
+| GET | `/api/workspaces` | List all workspaces |
+| POST | `/api/workspaces` | Create workspace |
+| GET | `/api/workspaces/{id}` | Get workspace metadata |
+| GET | `/api/workspaces/{id}/notes` | List notes (index data) |
+| POST | `/api/workspaces/{id}/notes` | Create note |
+| GET | `/api/workspaces/{id}/notes/{noteId}` | Get full note |
+| PUT | `/api/workspaces/{id}/notes/{noteId}` | Update note |
+| DELETE | `/api/workspaces/{id}/notes/{noteId}` | Delete (tombstone) note |
+| POST | `/api/workspaces/{id}/query` | Query notes by filter |
 
 ## Testing Strategy
 

--- a/backend/src/app/api/endpoints/attachment.py
+++ b/backend/src/app/api/endpoints/attachment.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.post(
-    "/workspaces/{workspace_id}/attachments",
+    "/api/workspaces/{workspace_id}/attachments",
     status_code=status.HTTP_201_CREATED,
 )
 async def upload_attachment_endpoint(
@@ -46,7 +46,7 @@ async def upload_attachment_endpoint(
         ) from e
 
 
-@router.get("/workspaces/{workspace_id}/attachments")
+@router.get("/api/workspaces/{workspace_id}/attachments")
 async def list_attachments_endpoint(
     workspace_id: str,
 ) -> list[dict[str, Any]]:
@@ -65,7 +65,7 @@ async def list_attachments_endpoint(
         ) from e
 
 
-@router.delete("/workspaces/{workspace_id}/attachments/{attachment_id}")
+@router.delete("/api/workspaces/{workspace_id}/attachments/{attachment_id}")
 async def delete_attachment_endpoint(
     workspace_id: str,
     attachment_id: str,

--- a/backend/src/app/api/endpoints/classes.py
+++ b/backend/src/app/api/endpoints/classes.py
@@ -18,7 +18,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.get("/workspaces/{workspace_id}/classes")
+@router.get("/api/workspaces/{workspace_id}/classes")
 async def list_classes_endpoint(workspace_id: str) -> list[dict[str, Any]]:
     """List all classes in the workspace."""
     _validate_path_id(workspace_id, "workspace_id")
@@ -35,7 +35,7 @@ async def list_classes_endpoint(workspace_id: str) -> list[dict[str, Any]]:
         ) from e
 
 
-@router.get("/workspaces/{workspace_id}/classes/types")
+@router.get("/api/workspaces/{workspace_id}/classes/types")
 async def list_class_types_endpoint(workspace_id: str) -> list[str]:
     """Get list of available column types."""
     _validate_path_id(workspace_id, "workspace_id")
@@ -54,7 +54,7 @@ async def list_class_types_endpoint(workspace_id: str) -> list[str]:
         ) from e
 
 
-@router.get("/workspaces/{workspace_id}/classes/{class_name}")
+@router.get("/api/workspaces/{workspace_id}/classes/{class_name}")
 async def get_class_endpoint(workspace_id: str, class_name: str) -> dict[str, Any]:
     """Get a specific class definition."""
     _validate_path_id(workspace_id, "workspace_id")
@@ -76,7 +76,10 @@ async def get_class_endpoint(workspace_id: str, class_name: str) -> dict[str, An
         ) from e
 
 
-@router.post("/workspaces/{workspace_id}/classes", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/api/workspaces/{workspace_id}/classes",
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_class_endpoint(
     workspace_id: str,
     payload: ClassCreate,

--- a/backend/src/app/api/endpoints/link.py
+++ b/backend/src/app/api/endpoints/link.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.post(
-    "/workspaces/{workspace_id}/links",
+    "/api/workspaces/{workspace_id}/links",
     status_code=status.HTTP_201_CREATED,
 )
 async def create_link_endpoint(
@@ -62,7 +62,7 @@ async def create_link_endpoint(
         ) from e
 
 
-@router.get("/workspaces/{workspace_id}/links")
+@router.get("/api/workspaces/{workspace_id}/links")
 async def list_links_endpoint(workspace_id: str) -> list[dict[str, Any]]:
     """List all unique links in the workspace."""
     _validate_path_id(workspace_id, "workspace_id")
@@ -79,7 +79,7 @@ async def list_links_endpoint(workspace_id: str) -> list[dict[str, Any]]:
         ) from e
 
 
-@router.delete("/workspaces/{workspace_id}/links/{link_id}")
+@router.delete("/api/workspaces/{workspace_id}/links/{link_id}")
 async def delete_link_endpoint(
     workspace_id: str,
     link_id: str,

--- a/backend/src/app/api/endpoints/note.py
+++ b/backend/src/app/api/endpoints/note.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.post(
-    "/workspaces/{workspace_id}/notes",
+    "/api/workspaces/{workspace_id}/notes",
     status_code=status.HTTP_201_CREATED,
 )
 async def create_note_endpoint(
@@ -63,7 +63,7 @@ async def create_note_endpoint(
     return {"id": note_id, "revision_id": note_data.get("revision_id", "")}
 
 
-@router.get("/workspaces/{workspace_id}/notes")
+@router.get("/api/workspaces/{workspace_id}/notes")
 async def list_notes_endpoint(workspace_id: str) -> list[dict[str, Any]]:
     """List all notes in a workspace."""
     _validate_path_id(workspace_id, "workspace_id")
@@ -80,7 +80,7 @@ async def list_notes_endpoint(workspace_id: str) -> list[dict[str, Any]]:
         ) from e
 
 
-@router.get("/workspaces/{workspace_id}/notes/{note_id}")
+@router.get("/api/workspaces/{workspace_id}/notes/{note_id}")
 async def get_note_endpoint(workspace_id: str, note_id: str) -> dict[str, Any]:
     """Get a note by ID."""
     _validate_path_id(workspace_id, "workspace_id")
@@ -108,7 +108,7 @@ async def get_note_endpoint(workspace_id: str, note_id: str) -> dict[str, Any]:
         ) from e
 
 
-@router.put("/workspaces/{workspace_id}/notes/{note_id}")
+@router.put("/api/workspaces/{workspace_id}/notes/{note_id}")
 async def update_note_endpoint(
     workspace_id: str,
     note_id: str,
@@ -185,7 +185,7 @@ async def update_note_endpoint(
         ) from e
 
 
-@router.delete("/workspaces/{workspace_id}/notes/{note_id}")
+@router.delete("/api/workspaces/{workspace_id}/notes/{note_id}")
 async def delete_note_endpoint(
     workspace_id: str,
     note_id: str,
@@ -218,7 +218,7 @@ async def delete_note_endpoint(
         return {"id": note_id, "status": "deleted"}
 
 
-@router.get("/workspaces/{workspace_id}/notes/{note_id}/history")
+@router.get("/api/workspaces/{workspace_id}/notes/{note_id}/history")
 async def get_note_history_endpoint(
     workspace_id: str,
     note_id: str,
@@ -249,7 +249,7 @@ async def get_note_history_endpoint(
         ) from e
 
 
-@router.get("/workspaces/{workspace_id}/notes/{note_id}/history/{revision_id}")
+@router.get("/api/workspaces/{workspace_id}/notes/{note_id}/history/{revision_id}")
 async def get_note_revision_endpoint(
     workspace_id: str,
     note_id: str,
@@ -287,7 +287,7 @@ async def get_note_revision_endpoint(
         ) from e
 
 
-@router.post("/workspaces/{workspace_id}/notes/{note_id}/restore")
+@router.post("/api/workspaces/{workspace_id}/notes/{note_id}/restore")
 async def restore_note_endpoint(
     workspace_id: str,
     note_id: str,

--- a/backend/src/app/api/endpoints/search.py
+++ b/backend/src/app/api/endpoints/search.py
@@ -18,7 +18,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.post("/workspaces/{workspace_id}/query")
+@router.post("/api/workspaces/{workspace_id}/query")
 async def query_endpoint(
     workspace_id: str,
     payload: QueryRequest,
@@ -42,7 +42,7 @@ async def query_endpoint(
         ) from e
 
 
-@router.get("/workspaces/{workspace_id}/search")
+@router.get("/api/workspaces/{workspace_id}/search")
 async def search_endpoint(
     workspace_id: str,
     q: Annotated[str, Query(..., min_length=1)],

--- a/backend/src/app/api/endpoints/workspace.py
+++ b/backend/src/app/api/endpoints/workspace.py
@@ -120,7 +120,7 @@ def _workspace_uri(workspace_id: str) -> str:
     return workspace_uri(get_root_path(), workspace_id)
 
 
-@router.get("/workspaces")
+@router.get("/api/workspaces")
 async def list_workspaces_endpoint() -> list[dict[str, Any]]:
     """List all workspaces."""
     try:
@@ -142,7 +142,7 @@ async def list_workspaces_endpoint() -> list[dict[str, Any]]:
         return results
 
 
-@router.post("/workspaces", status_code=status.HTTP_201_CREATED)
+@router.post("/api/workspaces", status_code=status.HTTP_201_CREATED)
 async def create_workspace_endpoint(
     payload: WorkspaceCreate,
 ) -> dict[str, str]:
@@ -176,7 +176,7 @@ async def create_workspace_endpoint(
     }
 
 
-@router.get("/workspaces/{workspace_id}")
+@router.get("/api/workspaces/{workspace_id}")
 async def get_workspace_endpoint(workspace_id: str) -> dict[str, Any]:
     """Get workspace metadata."""
     _validate_path_id(workspace_id, "workspace_id")
@@ -201,7 +201,7 @@ async def get_workspace_endpoint(workspace_id: str) -> dict[str, Any]:
         ) from e
 
 
-@router.patch("/workspaces/{workspace_id}")
+@router.patch("/api/workspaces/{workspace_id}")
 async def patch_workspace_endpoint(
     workspace_id: str,
     payload: WorkspacePatch,
@@ -243,7 +243,7 @@ async def patch_workspace_endpoint(
         ) from e
 
 
-@router.post("/workspaces/{workspace_id}/test-connection")
+@router.post("/api/workspaces/{workspace_id}/test-connection")
 async def test_connection_endpoint(
     workspace_id: str,
     payload: TestConnectionRequest,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 def test_create_workspace(test_client: TestClient, temp_workspace_root: Path) -> None:
     """Test creating a new workspace."""
-    response = test_client.post("/workspaces", json={"name": "test-ws"})
+    response = test_client.post("/api/workspaces", json={"name": "test-ws"})
     assert response.status_code == 201
     data = response.json()
     assert data["id"] == "test-ws"
@@ -30,10 +30,10 @@ def test_create_workspace_conflict(
 ) -> None:
     """Test creating a workspace that already exists."""
     # Create first time
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
     # Create second time
-    response = test_client.post("/workspaces", json={"name": "test-ws"})
+    response = test_client.post("/api/workspaces", json={"name": "test-ws"})
     assert response.status_code == 409
     assert "already exists" in response.json()["detail"]
 
@@ -44,10 +44,10 @@ def test_list_workspaces(
 ) -> None:
     """Test listing workspaces."""
     # Create some workspaces
-    test_client.post("/workspaces", json={"name": "ws1"})
-    test_client.post("/workspaces", json={"name": "ws2"})
+    test_client.post("/api/workspaces", json={"name": "ws1"})
+    test_client.post("/api/workspaces", json={"name": "ws2"})
 
-    response = test_client.get("/workspaces")
+    response = test_client.get("/api/workspaces")
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
@@ -59,9 +59,9 @@ def test_get_workspace(
     temp_workspace_root: Path,
 ) -> None:
     """Test getting a specific workspace."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
-    response = test_client.get("/workspaces/test-ws")
+    response = test_client.get("/api/workspaces/test-ws")
     assert response.status_code == 200
     data = response.json()
     assert data["id"] == "test-ws"
@@ -72,20 +72,20 @@ def test_get_workspace_not_found(
     temp_workspace_root: Path,
 ) -> None:
     """Test getting a non-existent workspace."""
-    response = test_client.get("/workspaces/nonexistent")
+    response = test_client.get("/api/workspaces/nonexistent")
     assert response.status_code == 404
 
 
 def test_create_note(test_client: TestClient, temp_workspace_root: Path) -> None:
     """Test creating a note in a workspace."""
     # Create workspace first
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
     note_payload = {
         "content": "# My Note\n\nSome content",
     }
 
-    response = test_client.post("/workspaces/test-ws/notes", json=note_payload)
+    response = test_client.post("/api/workspaces/test-ws/notes", json=note_payload)
     assert response.status_code == 201
     data = response.json()
     assert "id" in data
@@ -103,7 +103,7 @@ def test_create_note_conflict(
     temp_workspace_root: Path,
 ) -> None:
     """Test creating a note with an existing ID (if ID is provided)."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
     # Create note with specific ID
     note_id = "my-note"
@@ -112,10 +112,10 @@ def test_create_note_conflict(
         "content": "# My Note",
     }
 
-    test_client.post("/workspaces/test-ws/notes", json=note_payload)
+    test_client.post("/api/workspaces/test-ws/notes", json=note_payload)
 
     # Try again
-    response = test_client.post("/workspaces/test-ws/notes", json=note_payload)
+    response = test_client.post("/api/workspaces/test-ws/notes", json=note_payload)
     assert response.status_code == 409
 
 
@@ -124,17 +124,17 @@ def test_list_notes(
     temp_workspace_root: Path,
 ) -> None:
     """Test listing notes in a workspace."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note1", "content": "# Note 1"},
     )
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note2", "content": "# Note 2"},
     )
 
-    response = test_client.get("/workspaces/test-ws/notes")
+    response = test_client.get("/api/workspaces/test-ws/notes")
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
@@ -156,12 +156,12 @@ def test_list_notes_workspace_not_found_returns_404(
     test_client: TestClient,
     temp_workspace_root: Path,
 ) -> None:
-    """GET /workspaces/{id}/notes should return 404 when workspace root.
+    """GET /api/workspaces/{id}/notes should return 404 when workspace root.
 
     lacks workspaces dir.
     """
     # temp_workspace_root fixture sets IEAPP_ROOT to an empty temporary directory
-    response = test_client.get("/workspaces/Stay/notes")
+    response = test_client.get("/api/workspaces/Stay/notes")
     assert response.status_code == 404
 
 
@@ -170,13 +170,13 @@ def test_get_note(
     temp_workspace_root: Path,
 ) -> None:
     """Test getting a specific note."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "test-note", "content": "# Test Note\n\nContent here"},
     )
 
-    response = test_client.get("/workspaces/test-ws/notes/test-note")
+    response = test_client.get("/api/workspaces/test-ws/notes/test-note")
     assert response.status_code == 200
     data = response.json()
     assert data["id"] == "test-note"
@@ -190,9 +190,9 @@ def test_get_note_not_found(
     temp_workspace_root: Path,
 ) -> None:
     """Test getting a non-existent note."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
-    response = test_client.get("/workspaces/test-ws/notes/nonexistent")
+    response = test_client.get("/api/workspaces/test-ws/notes/nonexistent")
     assert response.status_code == 404
 
 
@@ -201,14 +201,14 @@ def test_update_note(
     temp_workspace_root: Path,
 ) -> None:
     """Test updating a note."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "test-note", "content": "# Original Title"},
     )
 
     # Get the note to get the revision_id
-    get_response = test_client.get("/workspaces/test-ws/notes/test-note")
+    get_response = test_client.get("/api/workspaces/test-ws/notes/test-note")
     revision_id = get_response.json()["revision_id"]
 
     # Update the note
@@ -218,7 +218,7 @@ def test_update_note(
     }
 
     response = test_client.put(
-        "/workspaces/test-ws/notes/test-note",
+        "/api/workspaces/test-ws/notes/test-note",
         json=update_payload,
     )
     assert response.status_code == 200
@@ -228,7 +228,7 @@ def test_update_note(
     assert data["revision_id"] != revision_id  # New revision
 
     # Verify the note was updated by fetching it
-    get_response = test_client.get("/workspaces/test-ws/notes/test-note")
+    get_response = test_client.get("/api/workspaces/test-ws/notes/test-note")
     updated_note = get_response.json()
     assert updated_note["title"] == "Updated Title"
     # Note: get_note returns "content" field (not "markdown")
@@ -240,7 +240,7 @@ def test_update_note_class_validation_error_returns_422_and_does_not_update(
     temp_workspace_root: Path,
 ) -> None:
     """Updating a classed note should fail with 422 when it violates the class."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
     class_def = {
         "name": "Meeting",
@@ -249,7 +249,7 @@ def test_update_note_class_validation_error_returns_422_and_does_not_update(
         "fields": {"Date": {"type": "date", "required": True}},
         "defaults": None,
     }
-    res = test_client.post("/workspaces/test-ws/classes", json=class_def)
+    res = test_client.post("/api/workspaces/test-ws/classes", json=class_def)
     assert res.status_code == 201
 
     # Create a note with class Meeting but missing required Date property
@@ -262,18 +262,18 @@ class: Meeting
 Discuss stuff
 """
     res = test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "meeting-1", "content": note_content},
     )
     assert res.status_code == 201
 
-    get_res = test_client.get("/workspaces/test-ws/notes/meeting-1")
+    get_res = test_client.get("/api/workspaces/test-ws/notes/meeting-1")
     assert get_res.status_code == 200
     original = get_res.json()
     original_revision_id = original["revision_id"]
 
     update_res = test_client.put(
-        "/workspaces/test-ws/notes/meeting-1",
+        "/api/workspaces/test-ws/notes/meeting-1",
         json={
             "markdown": note_content,
             "parent_revision_id": original_revision_id,
@@ -283,7 +283,7 @@ Discuss stuff
     assert "Missing required field" in update_res.json()["detail"]
 
     # Ensure it did not update the revision
-    get_res = test_client.get("/workspaces/test-ws/notes/meeting-1")
+    get_res = test_client.get("/api/workspaces/test-ws/notes/meeting-1")
     assert get_res.status_code == 200
     after = get_res.json()
     assert after["revision_id"] == original_revision_id
@@ -294,19 +294,19 @@ def test_update_note_conflict(
     temp_workspace_root: Path,
 ) -> None:
     """Test updating a note with a stale parent_revision_id returns 409."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "test-note", "content": "# Original"},
     )
 
     # Get the original revision_id
-    get_response = test_client.get("/workspaces/test-ws/notes/test-note")
+    get_response = test_client.get("/api/workspaces/test-ws/notes/test-note")
     original_revision_id = get_response.json()["revision_id"]
 
     # First update succeeds
     test_client.put(
-        "/workspaces/test-ws/notes/test-note",
+        "/api/workspaces/test-ws/notes/test-note",
         json={
             "markdown": "# Update 1",
             "parent_revision_id": original_revision_id,
@@ -315,7 +315,7 @@ def test_update_note_conflict(
 
     # Second update with stale revision_id should fail with 409
     response = test_client.put(
-        "/workspaces/test-ws/notes/test-note",
+        "/api/workspaces/test-ws/notes/test-note",
         json={
             "markdown": "# Update 2",
             "parent_revision_id": original_revision_id,  # Stale!
@@ -335,19 +335,19 @@ def test_delete_note(
     temp_workspace_root: Path,
 ) -> None:
     """Test deleting (tombstoning) a note."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "test-note", "content": "# To Delete"},
     )
 
-    response = test_client.delete("/workspaces/test-ws/notes/test-note")
+    response = test_client.delete("/api/workspaces/test-ws/notes/test-note")
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "deleted"
 
     # Deleted notes should not appear in list
-    list_response = test_client.get("/workspaces/test-ws/notes")
+    list_response = test_client.get("/api/workspaces/test-ws/notes")
     notes = list_response.json()
     note_ids = [n["id"] for n in notes]
     assert "test-note" not in note_ids
@@ -358,19 +358,19 @@ def test_get_note_history(
     temp_workspace_root: Path,
 ) -> None:
     """Test getting note history."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "test-note", "content": "# Original"},
     )
 
     # Get initial revision
-    get_response = test_client.get("/workspaces/test-ws/notes/test-note")
+    get_response = test_client.get("/api/workspaces/test-ws/notes/test-note")
     revision_id = get_response.json()["revision_id"]
 
     # Update to create another revision
     test_client.put(
-        "/workspaces/test-ws/notes/test-note",
+        "/api/workspaces/test-ws/notes/test-note",
         json={
             "markdown": "# Updated",
             "parent_revision_id": revision_id,
@@ -378,7 +378,7 @@ def test_get_note_history(
     )
 
     # Get history
-    response = test_client.get("/workspaces/test-ws/notes/test-note/history")
+    response = test_client.get("/api/workspaces/test-ws/notes/test-note/history")
     assert response.status_code == 200
     data = response.json()
     assert "revisions" in data
@@ -390,19 +390,19 @@ def test_get_note_revision(
     temp_workspace_root: Path,
 ) -> None:
     """Test getting a specific revision."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "test-note", "content": "# Original"},
     )
 
     # Get the revision_id
-    get_response = test_client.get("/workspaces/test-ws/notes/test-note")
+    get_response = test_client.get("/api/workspaces/test-ws/notes/test-note")
     revision_id = get_response.json()["revision_id"]
 
     # Get the specific revision
     response = test_client.get(
-        f"/workspaces/test-ws/notes/test-note/history/{revision_id}",
+        f"/api/workspaces/test-ws/notes/test-note/history/{revision_id}",
     )
     assert response.status_code == 200
     data = response.json()
@@ -414,19 +414,19 @@ def test_restore_note(
     temp_workspace_root: Path,
 ) -> None:
     """Test restoring a note to a previous revision."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "test-note", "content": "# Original"},
     )
 
     # Get original revision
-    get_response = test_client.get("/workspaces/test-ws/notes/test-note")
+    get_response = test_client.get("/api/workspaces/test-ws/notes/test-note")
     original_revision_id = get_response.json()["revision_id"]
 
     # Update the note
     test_client.put(
-        "/workspaces/test-ws/notes/test-note",
+        "/api/workspaces/test-ws/notes/test-note",
         json={
             "markdown": "# Updated",
             "parent_revision_id": original_revision_id,
@@ -435,7 +435,7 @@ def test_restore_note(
 
     # Restore to original
     response = test_client.post(
-        "/workspaces/test-ws/notes/test-note/restore",
+        "/api/workspaces/test-ws/notes/test-note/restore",
         json={"revision_id": original_revision_id},
     )
     assert response.status_code == 200
@@ -449,7 +449,7 @@ def test_query_notes(
     temp_workspace_root: Path,
 ) -> None:
     """Test structured query endpoint."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
     # Create a note that should be indexed
     # Note: In a real scenario, the indexer runs in background.
@@ -462,7 +462,7 @@ def test_query_notes(
     # trigger indexing (unlikely per spec).
     # Or, we just test that the endpoint exists and returns empty list for now.
 
-    response = test_client.post("/workspaces/test-ws/query", json={"filter": {}})
+    response = test_client.post("/api/workspaces/test-ws/query", json={"filter": {}})
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
@@ -472,16 +472,16 @@ def test_upload_attachment_and_link_to_note(
     temp_workspace_root: Path,
 ) -> None:
     """Attachments can be uploaded, returned with id, and linked to a note."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     note_res = test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note-1", "content": "# Attach Note"},
     )
     assert note_res.status_code == 201
 
     file_bytes = b"hello attachment"
     response = test_client.post(
-        "/workspaces/test-ws/attachments",
+        "/api/workspaces/test-ws/attachments",
         files={"file": ("voice.m4a", io.BytesIO(file_bytes), "audio/m4a")},
     )
     assert response.status_code == 201
@@ -490,7 +490,7 @@ def test_upload_attachment_and_link_to_note(
     assert attachment["path"].startswith("attachments/")
 
     update_res = test_client.put(
-        "/workspaces/test-ws/notes/note-1",
+        "/api/workspaces/test-ws/notes/note-1",
         json={
             "markdown": "# Attach Note\ncontent",
             "parent_revision_id": note_res.json()["revision_id"],
@@ -500,7 +500,7 @@ def test_upload_attachment_and_link_to_note(
     assert update_res.status_code == 200
 
     # Ensure GET reflects the attachment reference
-    get_res = test_client.get("/workspaces/test-ws/notes/note-1")
+    get_res = test_client.get("/api/workspaces/test-ws/notes/note-1")
     assert get_res.status_code == 200
     content = get_res.json()
     assert any(a["id"] == attachment["id"] for a in content.get("attachments", []))
@@ -511,20 +511,20 @@ def test_delete_attachment_referenced_fails(
     temp_workspace_root: Path,
 ) -> None:
     """Deleting an attachment referenced by a note should fail."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     note_res = test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note-1", "content": "# Attach Note"},
     )
 
     response = test_client.post(
-        "/workspaces/test-ws/attachments",
+        "/api/workspaces/test-ws/attachments",
         files={"file": ("voice.m4a", io.BytesIO(b"data"), "audio/m4a")},
     )
     attachment = response.json()
 
     test_client.put(
-        "/workspaces/test-ws/notes/note-1",
+        "/api/workspaces/test-ws/notes/note-1",
         json={
             "markdown": "# Attach Note\nupdated",
             "parent_revision_id": note_res.json()["revision_id"],
@@ -533,7 +533,7 @@ def test_delete_attachment_referenced_fails(
     )
 
     delete_res = test_client.delete(
-        f"/workspaces/test-ws/attachments/{attachment['id']}",
+        f"/api/workspaces/test-ws/attachments/{attachment['id']}",
     )
     assert delete_res.status_code == 409
     assert "referenced" in delete_res.json()["detail"].lower()
@@ -544,32 +544,32 @@ def test_create_and_list_links(
     temp_workspace_root: Path,
 ) -> None:
     """Links are created bi-directionally and listed at workspace level."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note-a", "content": "# A"},
     )
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note-b", "content": "# B"},
     )
 
     create_res = test_client.post(
-        "/workspaces/test-ws/links",
+        "/api/workspaces/test-ws/links",
         json={"source": "note-a", "target": "note-b", "kind": "related"},
     )
     assert create_res.status_code == 201
     link = create_res.json()
     assert link["id"]
 
-    list_res = test_client.get("/workspaces/test-ws/links")
+    list_res = test_client.get("/api/workspaces/test-ws/links")
     assert list_res.status_code == 200
     links = list_res.json()
     assert any(link_item["id"] == link["id"] for link_item in links)
 
     # Note meta files should contain the link
-    note_a = test_client.get("/workspaces/test-ws/notes/note-a").json()
-    note_b = test_client.get("/workspaces/test-ws/notes/note-b").json()
+    note_a = test_client.get("/api/workspaces/test-ws/notes/note-a").json()
+    note_b = test_client.get("/api/workspaces/test-ws/notes/note-b").json()
     assert any(item["target"] == "note-b" for item in note_a.get("links", []))
     assert any(item["target"] == "note-a" for item in note_b.get("links", []))
 
@@ -579,27 +579,27 @@ def test_delete_link_updates_notes(
     temp_workspace_root: Path,
 ) -> None:
     """Deleting a link should remove it from both notes."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note-a", "content": "# A"},
     )
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "note-b", "content": "# B"},
     )
 
     create_res = test_client.post(
-        "/workspaces/test-ws/links",
+        "/api/workspaces/test-ws/links",
         json={"source": "note-a", "target": "note-b", "kind": "related"},
     )
     link_id = create_res.json()["id"]
 
-    delete_res = test_client.delete(f"/workspaces/test-ws/links/{link_id}")
+    delete_res = test_client.delete(f"/api/workspaces/test-ws/links/{link_id}")
     assert delete_res.status_code == 200
 
-    note_a = test_client.get("/workspaces/test-ws/notes/note-a").json()
-    note_b = test_client.get("/workspaces/test-ws/notes/note-b").json()
+    note_a = test_client.get("/api/workspaces/test-ws/notes/note-a").json()
+    note_b = test_client.get("/api/workspaces/test-ws/notes/note-b").json()
     assert all(item["id"] != link_id for item in note_a.get("links", []))
     assert all(item["id"] != link_id for item in note_b.get("links", []))
 
@@ -609,13 +609,16 @@ def test_search_returns_matches(
     temp_workspace_root: Path,
 ) -> None:
     """Hybrid search returns notes containing the keyword via inverted index."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     test_client.post(
-        "/workspaces/test-ws/notes",
+        "/api/workspaces/test-ws/notes",
         json={"id": "alpha", "content": "# Alpha\nProject rocket"},
     )
 
-    search_res = test_client.get("/workspaces/test-ws/search", params={"q": "rocket"})
+    search_res = test_client.get(
+        "/api/workspaces/test-ws/search",
+        params={"q": "rocket"},
+    )
     assert search_res.status_code == 200
     ids = [n["id"] for n in search_res.json()]
     assert "alpha" in ids
@@ -626,10 +629,10 @@ def test_update_workspace_storage_connector(
     temp_workspace_root: Path,
 ) -> None:
     """PATCH workspace should persist storage connector details."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
 
     patch_res = test_client.patch(
-        "/workspaces/test-ws",
+        "/api/workspaces/test-ws",
         json={
             "storage_config": {
                 "uri": "s3://bucket/path",
@@ -649,9 +652,9 @@ def test_test_connection_endpoint(
     temp_workspace_root: Path,
 ) -> None:
     """POST /test-connection returns success for local connector stub."""
-    test_client.post("/workspaces", json={"name": "test-ws"})
+    test_client.post("/api/workspaces", json={"name": "test-ws"})
     res = test_client.post(
-        "/workspaces/test-ws/test-connection",
+        "/api/workspaces/test-ws/test-connection",
         json={"storage_config": {"uri": "file:///tmp"}},
     )
     assert res.status_code == 200
@@ -699,9 +702,9 @@ def test_middleware_blocks_remote_clients(test_client: TestClient) -> None:
 def test_get_class_types(test_client: TestClient, temp_workspace_root: Path) -> None:
     """Test getting available class column types (REQ-CLS-001)."""
     # Create workspace to ensure path is valid
-    test_client.post("/workspaces", json={"name": "test-ws-types"})
+    test_client.post("/api/workspaces", json={"name": "test-ws-types"})
 
-    response = test_client.get("/workspaces/test-ws-types/classes/types")
+    response = test_client.get("/api/workspaces/test-ws-types/classes/types")
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
@@ -715,7 +718,7 @@ def test_update_class_with_migration(
 ) -> None:
     """Test updating class with migration strategies (REQ-CLS-002)."""
     # 1. Create Workspace
-    test_client.post("/workspaces", json={"name": "test-ws-mig"})
+    test_client.post("/api/workspaces", json={"name": "test-ws-mig"})
 
     # 2. Create Initial Class
     note_class = {
@@ -725,15 +728,15 @@ def test_update_class_with_migration(
             "status": {"type": "string"},
         },
     }
-    test_client.post("/workspaces/test-ws-mig/classes", json=note_class)
+    test_client.post("/api/workspaces/test-ws-mig/classes", json=note_class)
 
     # 3. Create Note
     note_payload = {
         "content": "---\nclass: project\n---\n# Project A\n\n## status\nActive\n",
     }
-    # Using endpoints: POST /workspaces/{id}/notes
+    # Using endpoints: POST /api/workspaces/{id}/notes
     # It autogenerates ID.
-    res = test_client.post("/workspaces/test-ws-mig/notes", json=note_payload)
+    res = test_client.post("/api/workspaces/test-ws-mig/notes", json=note_payload)
     assert res.status_code == 201
     note_id = res.json()["id"]
 
@@ -749,11 +752,11 @@ def test_update_class_with_migration(
             "priority": "High",
         },
     }
-    res = test_client.post("/workspaces/test-ws-mig/classes", json=updated_class)
+    res = test_client.post("/api/workspaces/test-ws-mig/classes", json=updated_class)
     assert res.status_code == 201
 
     # 5. Verify Note
-    res = test_client.get(f"/workspaces/test-ws-mig/notes/{note_id}")
+    res = test_client.get(f"/api/workspaces/test-ws-mig/notes/{note_id}")
     assert res.status_code == 200
     note_data = res.json()
     content = note_data["content"]

--- a/backend/tests/test_api_memory.py
+++ b/backend/tests/test_api_memory.py
@@ -34,13 +34,13 @@ def memory_client(
 
 def test_create_workspace_memory(memory_client: TestClient) -> None:
     """Test creating a workspace in memory fs."""
-    response = memory_client.post("/workspaces", json={"name": "mem-ws"})
+    response = memory_client.post("/api/workspaces", json={"name": "mem-ws"})
     assert response.status_code == 201
     data = response.json()
     assert data["id"] == "mem-ws"
 
     # Verify it exists in list
-    response = memory_client.get("/workspaces")
+    response = memory_client.get("/api/workspaces")
     assert response.status_code == 200
     workspaces = response.json()
     assert any(ws["id"] == "mem-ws" for ws in workspaces)
@@ -50,17 +50,17 @@ def test_create_note_memory(memory_client: TestClient) -> None:
     """Test creating a note in memory fs."""
     # Create workspace first
     ws_id = "note-ws"
-    memory_client.post("/workspaces", json={"name": ws_id})
+    memory_client.post("/api/workspaces", json={"name": ws_id})
 
     # Create note
     note_payload = {"content": "# Memory Note\n\nStored in RAM."}
-    response = memory_client.post(f"/workspaces/{ws_id}/notes", json=note_payload)
+    response = memory_client.post(f"/api/workspaces/{ws_id}/notes", json=note_payload)
     assert response.status_code == 201
     note_data = response.json()
     note_id = note_data["id"]
 
     # Get note
-    response = memory_client.get(f"/workspaces/{ws_id}/notes/{note_id}")
+    response = memory_client.get(f"/api/workspaces/{ws_id}/notes/{note_id}")
     assert response.status_code == 200
     assert response.json()["content"] == note_payload["content"]
 
@@ -68,17 +68,17 @@ def test_create_note_memory(memory_client: TestClient) -> None:
 def test_update_note_and_search_memory(memory_client: TestClient) -> None:
     """End-to-end note update and search on memory filesystem."""
     ws_id = "mem-search"
-    memory_client.post("/workspaces", json={"name": ws_id})
+    memory_client.post("/api/workspaces", json={"name": ws_id})
 
     create_res = memory_client.post(
-        f"/workspaces/{ws_id}/notes",
+        f"/api/workspaces/{ws_id}/notes",
         json={"id": "m1", "content": "# Title\n\nrocket launch"},
     )
     assert create_res.status_code == 201
     revision_id = create_res.json()["revision_id"]
 
     update_res = memory_client.put(
-        f"/workspaces/{ws_id}/notes/m1",
+        f"/api/workspaces/{ws_id}/notes/m1",
         json={
             "markdown": "# Updated Title\n\nrocket launch scheduled",
             "parent_revision_id": revision_id,
@@ -89,7 +89,7 @@ def test_update_note_and_search_memory(memory_client: TestClient) -> None:
     assert new_revision != revision_id
 
     search_res = memory_client.get(
-        f"/workspaces/{ws_id}/search",
+        f"/api/workspaces/{ws_id}/search",
         params={"q": "rocket"},
     )
     assert search_res.status_code == 200
@@ -100,26 +100,26 @@ def test_update_note_and_search_memory(memory_client: TestClient) -> None:
 def test_attachments_and_links_memory(memory_client: TestClient) -> None:
     """Ensure attachments and links work over memory-backed fsspec."""
     ws_id = "mem-graph"
-    memory_client.post("/workspaces", json={"name": ws_id})
+    memory_client.post("/api/workspaces", json={"name": ws_id})
 
     note_a = memory_client.post(
-        f"/workspaces/{ws_id}/notes",
+        f"/api/workspaces/{ws_id}/notes",
         json={"id": "a", "content": "# A"},
     ).json()
     memory_client.post(
-        f"/workspaces/{ws_id}/notes",
+        f"/api/workspaces/{ws_id}/notes",
         json={"id": "b", "content": "# B"},
     )
 
     upload_res = memory_client.post(
-        f"/workspaces/{ws_id}/attachments",
+        f"/api/workspaces/{ws_id}/attachments",
         files={"file": ("voice.m4a", io.BytesIO(b"data"), "audio/m4a")},
     )
     assert upload_res.status_code == 201
     attachment = upload_res.json()
 
     update_res = memory_client.put(
-        f"/workspaces/{ws_id}/notes/a",
+        f"/api/workspaces/{ws_id}/notes/a",
         json={
             "markdown": "# A\nwith attachment",
             "parent_revision_id": note_a["revision_id"],
@@ -129,13 +129,13 @@ def test_attachments_and_links_memory(memory_client: TestClient) -> None:
     assert update_res.status_code == 200
 
     link_res = memory_client.post(
-        f"/workspaces/{ws_id}/links",
+        f"/api/workspaces/{ws_id}/links",
         json={"source": "a", "target": "b", "kind": "related"},
     )
     assert link_res.status_code == 201
     link_id = link_res.json()["id"]
 
-    get_a = memory_client.get(f"/workspaces/{ws_id}/notes/a")
+    get_a = memory_client.get(f"/api/workspaces/{ws_id}/notes/a")
     assert get_a.status_code == 200
     note_payload = get_a.json()
     assert any(

--- a/backend/tests/test_api_reindexing.py
+++ b/backend/tests/test_api_reindexing.py
@@ -12,7 +12,7 @@ def test_update_note_reflects_in_query(
     """Test that updating a note reflects in the query index (REQ-IDX-001)."""
     # 1. Create Workspace
     ws_id = "reindex-test-ws"
-    test_client.post("/workspaces", json={"name": ws_id})
+    test_client.post("/api/workspaces", json={"name": ws_id})
 
     # 2. Create Class
     note_class = {
@@ -23,14 +23,14 @@ def test_update_note_reflects_in_query(
             "priority": {"type": "string"},
         },
     }
-    test_client.post(f"/workspaces/{ws_id}/classes", json=note_class)
+    test_client.post(f"/api/workspaces/{ws_id}/classes", json=note_class)
 
     # 3. Create Note with Class
     note_payload = {
         "title": "My Task",
         "content": "---\nclass: Task\n---\n# My Task\n\n## priority\nhigh\n",
     }
-    res = test_client.post(f"/workspaces/{ws_id}/notes", json=note_payload)
+    res = test_client.post(f"/api/workspaces/{ws_id}/notes", json=note_payload)
     assert res.status_code == 201
     note_id = res.json()["id"]
     rev_id = res.json()["revision_id"]
@@ -40,7 +40,7 @@ def test_update_note_reflects_in_query(
     # The current create_note might trigger sync indexing or not.
     # Let's see if query returns expected result.
     res = test_client.post(
-        f"/workspaces/{ws_id}/query",
+        f"/api/workspaces/{ws_id}/query",
         json={"filter": {"class": "Task"}},
     )
     assert res.status_code == 200
@@ -53,12 +53,15 @@ def test_update_note_reflects_in_query(
         "markdown": "---\nclass: Task\n---\n# My Task\n\n## priority\nlow\n",
         "parent_revision_id": rev_id,
     }
-    res = test_client.put(f"/workspaces/{ws_id}/notes/{note_id}", json=update_payload)
+    res = test_client.put(
+        f"/api/workspaces/{ws_id}/notes/{note_id}",
+        json=update_payload,
+    )
     assert res.status_code == 200
 
     # 6. Query again - should be low
     res = test_client.post(
-        f"/workspaces/{ws_id}/query",
+        f"/api/workspaces/{ws_id}/query",
         json={"filter": {"class": "Task"}},
     )
     assert res.status_code == 200

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -18,8 +18,9 @@ Start here:
 ## Conventions
 
 - **"Class" is the user-facing term** (legacy term: schema).
-- **API paths**: Backend paths are canonical; frontend calls the same
-  path prefixed with `/api`.
+- **API paths**: Backend paths are canonical and include the `/api`
+  prefix; frontend calls the same path *without* `/api` (the client
+  adds the prefix).
 - **Machine-readable docs**: Stories, Requirements, and Features are expressed
   in YAML so we can validate doc↔code consistency in tests.
 

--- a/docs/spec/api/openapi.yaml
+++ b/docs/spec/api/openapi.yaml
@@ -9,7 +9,7 @@ servers:
   - url: http://localhost:8000
 
 paths:
-  /workspaces:
+  /api/workspaces:
     get:
       summary: List workspaces
       responses:
@@ -21,7 +21,7 @@ paths:
         "201":
           description: Created
 
-  /workspaces/{workspace_id}:
+  /api/workspaces/{workspace_id}:
     get:
       summary: Get workspace
       parameters:
@@ -45,7 +45,7 @@ paths:
         "200":
           description: OK
 
-  /workspaces/{workspace_id}/test-connection:
+  /api/workspaces/{workspace_id}/test-connection:
     post:
       summary: Test storage connection
       parameters:
@@ -58,7 +58,7 @@ paths:
         "200":
           description: OK
 
-  /workspaces/{workspace_id}/notes:
+  /api/workspaces/{workspace_id}/notes:
     get:
       summary: List notes
       parameters:
@@ -82,7 +82,7 @@ paths:
         "201":
           description: Created
 
-  /workspaces/{workspace_id}/notes/{note_id}:
+  /api/workspaces/{workspace_id}/notes/{note_id}:
     get:
       summary: Get note
       parameters:
@@ -134,7 +134,7 @@ paths:
         "200":
           description: OK
 
-  /workspaces/{workspace_id}/query:
+  /api/workspaces/{workspace_id}/query:
     post:
       summary: Query notes
       parameters:
@@ -147,7 +147,7 @@ paths:
         "200":
           description: OK
 
-  /workspaces/{workspace_id}/search:
+  /api/workspaces/{workspace_id}/search:
     get:
       summary: Keyword search
       parameters:
@@ -165,7 +165,7 @@ paths:
         "200":
           description: OK
 
-  /workspaces/{workspace_id}/classes:
+  /api/workspaces/{workspace_id}/classes:
     get:
       summary: List classes
       parameters:
@@ -189,7 +189,7 @@ paths:
         "201":
           description: Created
 
-  /workspaces/{workspace_id}/classes/types:
+  /api/workspaces/{workspace_id}/classes/types:
     get:
       summary: List class column types
       parameters:
@@ -202,7 +202,7 @@ paths:
         "200":
           description: OK
 
-  /workspaces/{workspace_id}/attachments:
+  /api/workspaces/{workspace_id}/attachments:
     get:
       summary: List attachments
       parameters:
@@ -226,7 +226,7 @@ paths:
         "201":
           description: Created
 
-  /workspaces/{workspace_id}/attachments/{attachment_id}:
+  /api/workspaces/{workspace_id}/attachments/{attachment_id}:
     delete:
       summary: Delete attachment
       parameters:
@@ -244,7 +244,7 @@ paths:
         "200":
           description: OK
 
-  /workspaces/{workspace_id}/links:
+  /api/workspaces/{workspace_id}/links:
     get:
       summary: List links
       parameters:
@@ -268,7 +268,7 @@ paths:
         "201":
           description: Created
 
-  /workspaces/{workspace_id}/links/{link_id}:
+  /api/workspaces/{workspace_id}/links/{link_id}:
     delete:
       summary: Delete link
       parameters:

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -4,7 +4,7 @@
 
 The REST API is the primary interface for the frontend and external integrations.
 
-**Base URL**: `http://localhost:8000` (development)
+**Base URL**: `http://localhost:8000/api` (development)
 
 ## Authentication
 
@@ -17,7 +17,7 @@ When `IEAPP_ALLOW_REMOTE=true`, authentication is required (future milestone).
 
 #### List Workspaces
 ```http
-GET /workspaces
+GET /api/workspaces
 ```
 
 **Response**: `200 OK`
@@ -33,7 +33,7 @@ GET /workspaces
 
 #### Create Workspace
 ```http
-POST /workspaces
+POST /api/workspaces
 Content-Type: application/json
 
 {
@@ -46,14 +46,14 @@ Content-Type: application/json
 
 #### Get Workspace
 ```http
-GET /workspaces/{id}
+GET /api/workspaces/{id}
 ```
 
 **Response**: `200 OK`
 
 #### Update Workspace
 ```http
-PATCH /workspaces/{id}
+PATCH /api/workspaces/{id}
 Content-Type: application/json
 
 {
@@ -67,7 +67,7 @@ Content-Type: application/json
 
 #### Test Connection
 ```http
-POST /workspaces/{id}/test-connection
+POST /api/workspaces/{id}/test-connection
 Content-Type: application/json
 
 {
@@ -84,7 +84,7 @@ Content-Type: application/json
 
 #### List Notes
 ```http
-GET /workspaces/{ws_id}/notes
+GET /api/workspaces/{ws_id}/notes
 ```
 
 **Response**: `200 OK`
@@ -104,7 +104,7 @@ GET /workspaces/{ws_id}/notes
 
 #### Create Note
 ```http
-POST /workspaces/{ws_id}/notes
+POST /api/workspaces/{ws_id}/notes
 Content-Type: application/json
 
 {
@@ -124,7 +124,7 @@ Content-Type: application/json
 
 #### Get Note
 ```http
-GET /workspaces/{ws_id}/notes/{note_id}
+GET /api/workspaces/{ws_id}/notes/{note_id}
 ```
 
 **Response**: `200 OK`
@@ -139,7 +139,7 @@ GET /workspaces/{ws_id}/notes/{note_id}
 
 #### Update Note
 ```http
-PUT /workspaces/{ws_id}/notes/{note_id}
+PUT /api/workspaces/{ws_id}/notes/{note_id}
 Content-Type: application/json
 
 {
@@ -160,14 +160,14 @@ Content-Type: application/json
 
 #### Delete Note
 ```http
-DELETE /workspaces/{ws_id}/notes/{note_id}
+DELETE /api/workspaces/{ws_id}/notes/{note_id}
 ```
 
 **Response**: `204 No Content`
 
 #### Get Note History
 ```http
-GET /workspaces/{ws_id}/notes/{note_id}/history
+GET /api/workspaces/{ws_id}/notes/{note_id}/history
 ```
 
 **Response**: `200 OK`
@@ -183,14 +183,14 @@ GET /workspaces/{ws_id}/notes/{note_id}/history
 
 #### Get Revision
 ```http
-GET /workspaces/{ws_id}/notes/{note_id}/history/{revision_id}
+GET /api/workspaces/{ws_id}/notes/{note_id}/history/{revision_id}
 ```
 
 **Response**: `200 OK`
 
 #### Restore Revision
 ```http
-POST /workspaces/{ws_id}/notes/{note_id}/restore
+POST /api/workspaces/{ws_id}/notes/{note_id}/restore
 Content-Type: application/json
 
 {
@@ -206,7 +206,7 @@ Content-Type: application/json
 
 #### List Classes
 ```http
-GET /workspaces/{ws_id}/classes
+GET /api/workspaces/{ws_id}/classes
 ```
 
 **Response**: `200 OK`
@@ -222,14 +222,14 @@ GET /workspaces/{ws_id}/classes
 
 #### Get Class
 ```http
-GET /workspaces/{ws_id}/classes/{name}
+GET /api/workspaces/{ws_id}/classes/{name}
 ```
 
 **Response**: `200 OK`
 
 #### Create/Update Class
 ```http
-PUT /workspaces/{ws_id}/classes/{name}
+PUT /api/workspaces/{ws_id}/classes/{name}
 Content-Type: application/json
 
 {
@@ -247,14 +247,14 @@ Content-Type: application/json
 
 #### Delete Class
 ```http
-DELETE /workspaces/{ws_id}/classes/{name}
+DELETE /api/workspaces/{ws_id}/classes/{name}
 ```
 
 **Response**: `204 No Content` or `409 Conflict` if notes still reference it
 
 #### List Column Types
 ```http
-GET /workspaces/{ws_id}/classes/types
+GET /api/workspaces/{ws_id}/classes/types
 ```
 
 **Response**: `200 OK`
@@ -268,7 +268,7 @@ GET /workspaces/{ws_id}/classes/types
 
 #### Upload Attachment
 ```http
-POST /workspaces/{ws_id}/attachments
+POST /api/workspaces/{ws_id}/attachments
 Content-Type: multipart/form-data
 
 file=@audio.m4a
@@ -285,7 +285,7 @@ file=@audio.m4a
 
 #### Delete Attachment
 ```http
-DELETE /workspaces/{ws_id}/attachments/{id}
+DELETE /api/workspaces/{ws_id}/attachments/{id}
 ```
 
 **Response**: `204 No Content` or `409 Conflict` if still referenced
@@ -296,14 +296,14 @@ DELETE /workspaces/{ws_id}/attachments/{id}
 
 #### List Links
 ```http
-GET /workspaces/{ws_id}/links
+GET /api/workspaces/{ws_id}/links
 ```
 
 **Response**: `200 OK`
 
 #### Create Link
 ```http
-POST /workspaces/{ws_id}/links
+POST /api/workspaces/{ws_id}/links
 Content-Type: application/json
 
 {
@@ -317,7 +317,7 @@ Content-Type: application/json
 
 #### Delete Link
 ```http
-DELETE /workspaces/{ws_id}/links/{id}
+DELETE /api/workspaces/{ws_id}/links/{id}
 ```
 
 **Response**: `204 No Content`
@@ -328,7 +328,7 @@ DELETE /workspaces/{ws_id}/links/{id}
 
 #### Structured Query
 ```http
-POST /workspaces/{ws_id}/query
+POST /api/workspaces/{ws_id}/query
 Content-Type: application/json
 
 {
@@ -343,7 +343,7 @@ Content-Type: application/json
 
 #### Keyword Search
 ```http
-GET /workspaces/{ws_id}/search?q=project
+GET /api/workspaces/{ws_id}/search?q=project
 ```
 
 **Response**: `200 OK`

--- a/docs/spec/features/README.md
+++ b/docs/spec/features/README.md
@@ -38,11 +38,11 @@ apis:
   - id: note.create
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/notes
+      path: /api/workspaces/{workspace_id}/notes
       file: backend/src/app/api/endpoints/note.py
       function: create_note_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes
+      path: /workspaces/{workspace_id}/notes
       file: frontend/src/lib/note-api.ts
       function: noteApi.create
     ieapp_core:

--- a/docs/spec/features/attachments.yaml
+++ b/docs/spec/features/attachments.yaml
@@ -8,11 +8,11 @@ apis:
   - id: attachment.upload
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/attachments
+      path: /api/workspaces/{workspace_id}/attachments
       file: backend/src/app/api/endpoints/attachment.py
       function: upload_attachment_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/attachments
+      path: /workspaces/{workspace_id}/attachments
       file: frontend/src/lib/attachment-api.ts
       function: attachmentApi.upload
     ieapp_core:
@@ -26,11 +26,11 @@ apis:
   - id: attachment.list
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/attachments
+      path: /api/workspaces/{workspace_id}/attachments
       file: backend/src/app/api/endpoints/attachment.py
       function: list_attachments_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/attachments
+      path: /workspaces/{workspace_id}/attachments
       file: frontend/src/lib/attachment-api.ts
       function: attachmentApi.list
     ieapp_core:
@@ -44,11 +44,11 @@ apis:
   - id: attachment.delete
     method: DELETE
     backend:
-      path: /workspaces/{workspace_id}/attachments/{attachment_id}
+      path: /api/workspaces/{workspace_id}/attachments/{attachment_id}
       file: backend/src/app/api/endpoints/attachment.py
       function: delete_attachment_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/attachments/{attachment_id}
+      path: /workspaces/{workspace_id}/attachments/{attachment_id}
       file: frontend/src/lib/attachment-api.ts
       function: attachmentApi.delete
     ieapp_core:

--- a/docs/spec/features/classes.yaml
+++ b/docs/spec/features/classes.yaml
@@ -8,11 +8,11 @@ apis:
   - id: class.list
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/classes
+      path: /api/workspaces/{workspace_id}/classes
       file: backend/src/app/api/endpoints/classes.py
       function: list_classes_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/classes
+      path: /workspaces/{workspace_id}/classes
       file: frontend/src/lib/class-api.ts
       function: classApi.list
     ieapp_core:
@@ -26,11 +26,11 @@ apis:
   - id: class.types
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/classes/types
+      path: /api/workspaces/{workspace_id}/classes/types
       file: backend/src/app/api/endpoints/classes.py
       function: list_class_types_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/classes/types
+      path: /workspaces/{workspace_id}/classes/types
       file: frontend/src/lib/class-api.ts
       function: classApi.listTypes
     ieapp_core:
@@ -44,11 +44,11 @@ apis:
   - id: class.get
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/classes/{class_name}
+      path: /api/workspaces/{workspace_id}/classes/{class_name}
       file: backend/src/app/api/endpoints/classes.py
       function: get_class_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/classes/{class_name}
+      path: /workspaces/{workspace_id}/classes/{class_name}
       file: frontend/src/lib/class-api.ts
       function: classApi.get
     ieapp_core:
@@ -62,11 +62,11 @@ apis:
   - id: class.upsert
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/classes
+      path: /api/workspaces/{workspace_id}/classes
       file: backend/src/app/api/endpoints/classes.py
       function: create_class_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/classes
+      path: /workspaces/{workspace_id}/classes
       file: frontend/src/lib/class-api.ts
       function: classApi.create
     ieapp_core:

--- a/docs/spec/features/features.yaml
+++ b/docs/spec/features/features.yaml
@@ -11,8 +11,9 @@ version: "0.2"
 updated: "2026-01"
 
 conventions:
-  canonical_path: Backend HTTP path.
-  frontend_path_prefix: /api
+  canonical_path: Backend HTTP path (includes /api prefix).
+  backend_path_prefix: /api
+  frontend_path_prefix: ""
   columns:
     - method
     - backend.path

--- a/docs/spec/features/links.yaml
+++ b/docs/spec/features/links.yaml
@@ -8,11 +8,11 @@ apis:
   - id: link.create
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/links
+      path: /api/workspaces/{workspace_id}/links
       file: backend/src/app/api/endpoints/link.py
       function: create_link_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/links
+      path: /workspaces/{workspace_id}/links
       file: frontend/src/lib/link-api.ts
       function: linkApi.create
     ieapp_core:
@@ -26,11 +26,11 @@ apis:
   - id: link.list
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/links
+      path: /api/workspaces/{workspace_id}/links
       file: backend/src/app/api/endpoints/link.py
       function: list_links_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/links
+      path: /workspaces/{workspace_id}/links
       file: frontend/src/lib/link-api.ts
       function: linkApi.list
     ieapp_core:
@@ -44,11 +44,11 @@ apis:
   - id: link.delete
     method: DELETE
     backend:
-      path: /workspaces/{workspace_id}/links/{link_id}
+      path: /api/workspaces/{workspace_id}/links/{link_id}
       file: backend/src/app/api/endpoints/link.py
       function: delete_link_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/links/{link_id}
+      path: /workspaces/{workspace_id}/links/{link_id}
       file: frontend/src/lib/link-api.ts
       function: linkApi.delete
     ieapp_core:

--- a/docs/spec/features/notes.yaml
+++ b/docs/spec/features/notes.yaml
@@ -8,11 +8,11 @@ apis:
   - id: note.create
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/notes
+      path: /api/workspaces/{workspace_id}/notes
       file: backend/src/app/api/endpoints/note.py
       function: create_note_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes
+      path: /workspaces/{workspace_id}/notes
       file: frontend/src/lib/note-api.ts
       function: noteApi.create
     ieapp_core:
@@ -26,11 +26,11 @@ apis:
   - id: note.list
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/notes
+      path: /api/workspaces/{workspace_id}/notes
       file: backend/src/app/api/endpoints/note.py
       function: list_notes_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes
+      path: /workspaces/{workspace_id}/notes
       file: frontend/src/lib/note-api.ts
       function: noteApi.list
     ieapp_core:
@@ -44,11 +44,11 @@ apis:
   - id: note.get
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/notes/{note_id}
+      path: /api/workspaces/{workspace_id}/notes/{note_id}
       file: backend/src/app/api/endpoints/note.py
       function: get_note_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes/{note_id}
+      path: /workspaces/{workspace_id}/notes/{note_id}
       file: frontend/src/lib/note-api.ts
       function: noteApi.get
     ieapp_core:
@@ -62,11 +62,11 @@ apis:
   - id: note.update
     method: PUT
     backend:
-      path: /workspaces/{workspace_id}/notes/{note_id}
+      path: /api/workspaces/{workspace_id}/notes/{note_id}
       file: backend/src/app/api/endpoints/note.py
       function: update_note_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes/{note_id}
+      path: /workspaces/{workspace_id}/notes/{note_id}
       file: frontend/src/lib/note-api.ts
       function: noteApi.update
     ieapp_core:
@@ -80,11 +80,11 @@ apis:
   - id: note.delete
     method: DELETE
     backend:
-      path: /workspaces/{workspace_id}/notes/{note_id}
+      path: /api/workspaces/{workspace_id}/notes/{note_id}
       file: backend/src/app/api/endpoints/note.py
       function: delete_note_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes/{note_id}
+      path: /workspaces/{workspace_id}/notes/{note_id}
       file: frontend/src/lib/note-api.ts
       function: noteApi.delete
     ieapp_core:
@@ -98,11 +98,11 @@ apis:
   - id: note.history
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/notes/{note_id}/history
+      path: /api/workspaces/{workspace_id}/notes/{note_id}/history
       file: backend/src/app/api/endpoints/note.py
       function: get_note_history_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes/{note_id}/history
+      path: /workspaces/{workspace_id}/notes/{note_id}/history
       file: frontend/src/lib/note-api.ts
       function: noteApi.history
     ieapp_core:
@@ -116,11 +116,11 @@ apis:
   - id: note.revision
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/notes/{note_id}/history/{revision_id}
+      path: /api/workspaces/{workspace_id}/notes/{note_id}/history/{revision_id}
       file: backend/src/app/api/endpoints/note.py
       function: get_note_revision_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes/{note_id}/history/{revision_id}
+      path: /workspaces/{workspace_id}/notes/{note_id}/history/{revision_id}
       file: frontend/src/lib/note-api.ts
       function: noteApi.getRevision
     ieapp_core:
@@ -134,11 +134,11 @@ apis:
   - id: note.restore
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/notes/{note_id}/restore
+      path: /api/workspaces/{workspace_id}/notes/{note_id}/restore
       file: backend/src/app/api/endpoints/note.py
       function: restore_note_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/notes/{note_id}/restore
+      path: /workspaces/{workspace_id}/notes/{note_id}/restore
       file: frontend/src/lib/note-api.ts
       function: noteApi.restore
     ieapp_core:

--- a/docs/spec/features/search.yaml
+++ b/docs/spec/features/search.yaml
@@ -8,11 +8,11 @@ apis:
   - id: query.execute
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/query
+      path: /api/workspaces/{workspace_id}/query
       file: backend/src/app/api/endpoints/search.py
       function: query_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/query
+      path: /workspaces/{workspace_id}/query
       file: frontend/src/lib/search-api.ts
       function: searchApi.query
     ieapp_core:
@@ -26,11 +26,11 @@ apis:
   - id: search.keyword
     method: GET
     backend:
-      path: /workspaces/{workspace_id}/search
+      path: /api/workspaces/{workspace_id}/search
       file: backend/src/app/api/endpoints/search.py
       function: search_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/search
+      path: /workspaces/{workspace_id}/search
       file: frontend/src/lib/search-api.ts
       function: searchApi.keyword
     ieapp_core:

--- a/docs/spec/features/workspaces.yaml
+++ b/docs/spec/features/workspaces.yaml
@@ -8,11 +8,11 @@ apis:
   - id: workspace.list
     method: GET
     backend:
-      path: /workspaces
+      path: /api/workspaces
       file: backend/src/app/api/endpoints/workspace.py
       function: list_workspaces_endpoint
     frontend:
-      path: /api/workspaces
+      path: /workspaces
       file: frontend/src/lib/workspace-api.ts
       function: workspaceApi.list
     ieapp_core:
@@ -26,11 +26,11 @@ apis:
   - id: workspace.create
     method: POST
     backend:
-      path: /workspaces
+      path: /api/workspaces
       file: backend/src/app/api/endpoints/workspace.py
       function: create_workspace_endpoint
     frontend:
-      path: /api/workspaces
+      path: /workspaces
       file: frontend/src/lib/workspace-api.ts
       function: workspaceApi.create
     ieapp_core:
@@ -44,11 +44,11 @@ apis:
   - id: workspace.get
     method: GET
     backend:
-      path: /workspaces/{workspace_id}
+      path: /api/workspaces/{workspace_id}
       file: backend/src/app/api/endpoints/workspace.py
       function: get_workspace_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}
+      path: /workspaces/{workspace_id}
       file: frontend/src/lib/workspace-api.ts
       function: workspaceApi.get
     ieapp_core:
@@ -62,11 +62,11 @@ apis:
   - id: workspace.patch
     method: PATCH
     backend:
-      path: /workspaces/{workspace_id}
+      path: /api/workspaces/{workspace_id}
       file: backend/src/app/api/endpoints/workspace.py
       function: patch_workspace_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}
+      path: /workspaces/{workspace_id}
       file: frontend/src/lib/workspace-api.ts
       function: workspaceApi.patch
     ieapp_core:
@@ -80,11 +80,11 @@ apis:
   - id: workspace.test_connection
     method: POST
     backend:
-      path: /workspaces/{workspace_id}/test-connection
+      path: /api/workspaces/{workspace_id}/test-connection
       file: backend/src/app/api/endpoints/workspace.py
       function: test_connection_endpoint
     frontend:
-      path: /api/workspaces/{workspace_id}/test-connection
+      path: /workspaces/{workspace_id}/test-connection
       file: frontend/src/lib/workspace-api.ts
       function: workspaceApi.testConnection
     ieapp_core:

--- a/docs/spec/product/success-metrics.md
+++ b/docs/spec/product/success-metrics.md
@@ -16,7 +16,7 @@ These metrics help evaluate whether IEapp is delivering on its principles
 
 ## Performance Metrics
 
-- **List/query latency**: `GET /workspaces/{id}/notes` and `POST /workspaces/{id}/query` remain fast as notes scale.
+- **List/query latency**: `GET /api/workspaces/{id}/notes` and `POST /api/workspaces/{id}/query` remain fast as notes scale.
 - **Indexer cost**: incremental updates complete quickly and do not block the UI.
 
 ## Developer Experience Metrics

--- a/docs/spec/requirements/api.yaml
+++ b/docs/spec/requirements/api.yaml
@@ -28,8 +28,8 @@ requirements:
       e2e:
         - file: e2e/smoke.test.ts
           tests:
-            - GET /workspaces returns list
-            - GET /workspaces includes default workspace
+            - GET /api/workspaces returns list
+            - GET /api/workspaces includes default workspace
 
   - id: REQ-API-002
     title: Note CRUD
@@ -76,4 +76,5 @@ requirements:
         - file: docs/tests/test_features.py
           tests:
             - test_feature_paths_exist
+            - test_feature_paths_match_implementation
             - test_no_undeclared_feature_modules

--- a/docs/spec/requirements/index.yaml
+++ b/docs/spec/requirements/index.yaml
@@ -128,7 +128,7 @@ requirements:
   - id: REQ-IDX-007
     title: Hybrid Search Endpoint
     description: |
-      Expose GET /workspaces/{ws_id}/search using the inverted index (keyword)
+      Expose GET /api/workspaces/{ws_id}/search using the inverted index (keyword)
       and falling back to a simple scan when the index is absent.
     related_spec:
       - stories/core.yaml#STORY-005

--- a/docs/spec/requirements/note.yaml
+++ b/docs/spec/requirements/note.yaml
@@ -36,7 +36,7 @@ requirements:
       e2e:
         - file: e2e/notes.test.ts
           tests:
-            - POST /workspaces/default/notes creates a new note
+            - POST /api/workspaces/default/notes creates a new note
 
   - id: REQ-NOTE-002
     title: Optimistic Concurrency via Revisions
@@ -92,7 +92,7 @@ requirements:
       e2e:
         - file: e2e/notes.test.ts
           tests:
-            - PUT /workspaces/default/notes/:id updates note
+            - PUT /api/workspaces/default/notes/:id updates note
 
   - id: REQ-NOTE-004
     title: Note Deletion (Tombstone)
@@ -117,7 +117,7 @@ requirements:
       e2e:
         - file: e2e/notes.test.ts
           tests:
-            - DELETE /workspaces/default/notes/:id removes note
+            - DELETE /api/workspaces/default/notes/:id removes note
       rust:
         - file: ieapp-core/tests/test_note.rs
           tests:

--- a/docs/spec/stories/advanced.yaml
+++ b/docs/spec/stories/advanced.yaml
@@ -21,8 +21,8 @@ stories:
       - User invokes their connected MCP Agent (e.g., "Format this voice note")
       - Agent reads the transcript (via MCP), extracts fields, and updates the note with H2 headers
     related_apis:
-      - rest: POST /workspaces/{ws_id}/attachments
-      - rest: PUT /workspaces/{ws_id}/notes/{note_id}
+      - rest: POST /api/workspaces/{ws_id}/attachments
+      - rest: PUT /api/workspaces/{ws_id}/notes/{note_id}
       - mcp: ieapp://{workspace_id}/notes/{note_id}
     requirements:
       - REQ-NOTE-008
@@ -38,7 +38,7 @@ stories:
       - Code execution is handled by explicit tooling (future)
       - Output (text, tables, charts) is rendered interactively below the code block
     related_apis:
-      - rest: POST /workspaces/{ws_id}/notes/{note_id}/blocks/{block_id}/execute
+      - rest: POST /api/workspaces/{ws_id}/notes/{note_id}/blocks/{block_id}/execute
     requirements: []
 
   - id: STORY-008
@@ -53,7 +53,7 @@ stories:
       - Agent executes the logic and presents the result for confirmation
     related_apis:
       - mcp: ieapp://{workspace_id}/notes/list
-      - rest: GET/PUT /workspaces/{ws_id}/notes/{note_id}
+      - rest: GET/PUT /api/workspaces/{ws_id}/notes/{note_id}
     requirements: []
 
   - id: STORY-009
@@ -69,8 +69,8 @@ stories:
       - Quick Add: Users can add a new row (Note) directly from the grid view
       - Changes are saved immediately or on blur
     related_apis:
-      - rest: PUT /workspaces/{ws_id}/notes/{note_id}
-      - rest: POST /workspaces/{ws_id}/notes
+      - rest: PUT /api/workspaces/{ws_id}/notes/{note_id}
+      - rest: POST /api/workspaces/{ws_id}/notes
     requirements:
       - REQ-FE-030
       - REQ-FE-031

--- a/docs/spec/stories/core.yaml
+++ b/docs/spec/stories/core.yaml
@@ -24,9 +24,9 @@ stories:
       - Frontend provides validation warnings if a note violates its Class definition
       - Creating a note from a Class pre-fills the template
     related_apis:
-      - rest: POST /workspaces/{ws_id}/notes
-      - rest: PUT /workspaces/{ws_id}/notes/{note_id}
-      - rest: GET /workspaces/{ws_id}/classes
+      - rest: POST /api/workspaces/{ws_id}/notes
+      - rest: PUT /api/workspaces/{ws_id}/notes/{note_id}
+      - rest: GET /api/workspaces/{ws_id}/classes
       - mcp: ieapp://{workspace_id}/classes
     requirements:
       - REQ-NOTE-006
@@ -42,8 +42,8 @@ stories:
       - Configurable storage backend via connection string (e.g., `s3://my-bucket/notes`)
       - Seamless switching between local and remote storage
     related_apis:
-      - rest: PATCH /workspaces/{id}
-      - rest: POST /workspaces/{id}/test-connection
+      - rest: PATCH /api/workspaces/{id}
+      - rest: POST /api/workspaces/{id}/test-connection
     requirements:
       - REQ-STO-001
       - REQ-STO-006
@@ -58,9 +58,9 @@ stories:
       - Every save creates a new immutable revision
       - UI allows browsing history and reverting
     related_apis:
-      - rest: GET /workspaces/{ws_id}/notes/{note_id}/history
-      - rest: GET /workspaces/{ws_id}/notes/{note_id}/history/{revision_id}
-      - rest: POST /workspaces/{ws_id}/notes/{note_id}/restore
+      - rest: GET /api/workspaces/{ws_id}/notes/{note_id}/history
+      - rest: GET /api/workspaces/{ws_id}/notes/{note_id}/history/{revision_id}
+      - rest: POST /api/workspaces/{ws_id}/notes/{note_id}/restore
     requirements:
       - REQ-NOTE-005
 
@@ -75,8 +75,8 @@ stories:
       - Structured queries filter by Class and properties
       - Results are ranked by relevance
     related_apis:
-      - rest: GET /workspaces/{ws_id}/search?q=query
-      - rest: POST /workspaces/{ws_id}/query
+      - rest: GET /api/workspaces/{ws_id}/search?q=query
+      - rest: POST /api/workspaces/{ws_id}/query
     requirements:
       - REQ-IDX-003
       - REQ-IDX-004

--- a/docs/spec/stories/experimental.yaml
+++ b/docs/spec/stories/experimental.yaml
@@ -19,9 +19,9 @@ stories:
       - Invited users can view and edit notes based on permissions
       - Concurrent edits are handled with conflict resolution
     related_apis:
-      - rest: POST /workspaces/{ws_id}/members
-      - rest: GET /workspaces/{ws_id}/members
-      - rest: DELETE /workspaces/{ws_id}/members/{user_id}
+      - rest: POST /api/workspaces/{ws_id}/members
+      - rest: GET /api/workspaces/{ws_id}/members
+      - rest: DELETE /api/workspaces/{ws_id}/members/{user_id}
     requirements: []
     milestone: User Management
 
@@ -67,7 +67,7 @@ stories:
       - Semantic search returns notes by conceptual similarity
       - Combined with keyword search for best results
     related_apis:
-      - rest: GET /workspaces/{ws_id}/search?type=semantic&q=query
+      - rest: GET /api/workspaces/{ws_id}/search?type=semantic&q=query
     requirements: []
     milestone: AI-Enabled & AI-Used
 
@@ -82,7 +82,7 @@ stories:
       - Tasks invoke MCP resources/tools via schedules
       - Results logged and notifications sent
     related_apis:
-      - rest: POST /workspaces/{ws_id}/schedules
-      - rest: GET /workspaces/{ws_id}/schedules
+      - rest: POST /api/workspaces/{ws_id}/schedules
+      - rest: GET /api/workspaces/{ws_id}/schedules
     requirements: []
     milestone: AI-Enabled & AI-Used

--- a/docs/tasks/tasks.md
+++ b/docs/tasks/tasks.md
@@ -446,7 +446,7 @@ stories:
       - Output (text/charts) is returned to AI context
     related_apis:
       - MCP resource: ieapp://{workspace_id}/notes/list
-      - REST: POST /workspaces/{ws_id}/query
+      - REST: POST /api/workspaces/{ws_id}/query
     requirements:
 ```
 

--- a/e2e/classes.test.ts
+++ b/e2e/classes.test.ts
@@ -22,13 +22,13 @@ describe("Class", () => {
 
 		// Create Class
 		const createRes = await client.postApi(
-			`/workspaces/${workspaceId}/classes`,
+			`/api/workspaces/${workspaceId}/classes`,
 			classDef,
 		);
 		expect(createRes.status).toBe(201);
 
 		// List Classes
-		const listRes = await client.getApi(`/workspaces/${workspaceId}/classes`);
+		const listRes = await client.getApi(`/api/workspaces/${workspaceId}/classes`);
 		expect(listRes.status).toBe(200);
 		const noteClasses = (await listRes.json()) as any[];
 		expect(Array.isArray(noteClasses)).toBe(true);
@@ -48,7 +48,7 @@ describe("Class", () => {
 		};
 
 		// Create Class
-		await client.postApi(`/workspaces/${workspaceId}/classes`, classDef);
+		await client.postApi(`/api/workspaces/${workspaceId}/classes`, classDef);
 
 		// Create Note with this class
 		const noteContent = `---
@@ -57,17 +57,17 @@ class: ${className}
 ## Status
 Active
 `;
-		const noteRes = await client.postApi(`/workspaces/${workspaceId}/notes`, {
+		const noteRes = await client.postApi(`/api/workspaces/${workspaceId}/notes`, {
 			content: noteContent,
 		});
 		expect(noteRes.status).toBe(201);
 		const note = (await noteRes.json()) as { id: string };
 
 		// Wait for indexing (search endpoint triggers run_once)
-		await client.getApi(`/workspaces/${workspaceId}/search?q=Active`);
+		await client.getApi(`/api/workspaces/${workspaceId}/search?q=Active`);
 
 		// Query
-		const queryRes = await client.postApi(`/workspaces/${workspaceId}/query`, {
+		const queryRes = await client.postApi(`/api/workspaces/${workspaceId}/query`, {
 			filter: { class: className },
 		});
 		expect(queryRes.status).toBe(200);
@@ -79,6 +79,6 @@ Active
 		expect(foundNote.properties.Status).toBe("Active");
 
 		// Cleanup
-		await client.deleteApi(`/workspaces/${workspaceId}/notes/${note.id}`);
+		await client.deleteApi(`/api/workspaces/${workspaceId}/notes/${note.id}`);
 	});
 });

--- a/e2e/lib/client.ts
+++ b/e2e/lib/client.ts
@@ -209,7 +209,7 @@ export async function waitForServers(
 	await waitFor(
 		async () => {
 			try {
-				const res = await client.getApi("/workspaces");
+				const res = await client.getApi("/api/workspaces");
 				return res.ok;
 			} catch {
 				return false;

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -42,9 +42,9 @@ describe("Smoke Tests", () => {
 			expect(body.toLowerCase()).toContain("<!doctype html>");
 		});
 
-		test("GET /notes/:id returns HTML", async () => {
+			test("GET /notes/:id returns HTML", async () => {
 			// Create a note first so we can navigate to a real detail route
-			const createRes = await client.postApi("/workspaces/default/notes", {
+				const createRes = await client.postApi("/api/workspaces/default/notes", {
 				content: `# E2E Detail Route Note\n\nCreated at ${new Date().toISOString()}`,
 			});
 			expect(createRes.status).toBe(201);
@@ -59,7 +59,7 @@ describe("Smoke Tests", () => {
 			expect(body.toLowerCase()).toContain("<!doctype html>");
 
 			// Cleanup
-			await client.deleteApi(`/workspaces/default/notes/${created.id}`);
+				await client.deleteApi(`/api/workspaces/default/notes/${created.id}`);
 		});
 
 		test("GET /about returns HTML", async () => {
@@ -72,16 +72,16 @@ describe("Smoke Tests", () => {
 	});
 
 	describe("API Workspaces", () => {
-		test("GET /workspaces returns list", async () => {
-			const res = await client.getApi("/workspaces");
+		test("GET /api/workspaces returns list", async () => {
+			const res = await client.getApi("/api/workspaces");
 			expect(res.ok).toBe(true);
 
 			const json = await res.json();
 			expect(Array.isArray(json)).toBe(true);
 		});
 
-		test("GET /workspaces includes default workspace", async () => {
-			const res = await client.getApi("/workspaces");
+		test("GET /api/workspaces includes default workspace", async () => {
+			const res = await client.getApi("/api/workspaces");
 			const workspaces = await res.json();
 
 			const defaultWs = workspaces.find(
@@ -92,8 +92,8 @@ describe("Smoke Tests", () => {
 	});
 
 	describe("API Notes", () => {
-		test("GET /workspaces/default/notes returns list", async () => {
-			const res = await client.getApi("/workspaces/default/notes");
+		test("GET /api/workspaces/default/notes returns list", async () => {
+			const res = await client.getApi("/api/workspaces/default/notes");
 			expect(res.ok).toBe(true);
 
 			const json = await res.json();

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -147,12 +147,12 @@ E2E tests are located in the root `/e2e` directory using Bun's native test runne
 
 The frontend connects to the backend REST API:
 
-- `GET /workspaces` - List workspaces
-- `POST /workspaces` - Create workspace
-- `GET /workspaces/{id}/notes` - List notes
-- `POST /workspaces/{id}/notes` - Create note
-- `PUT /workspaces/{id}/notes/{noteId}` - Update note (requires `parent_revision_id`)
-- `DELETE /workspaces/{id}/notes/{noteId}` - Delete note
+- `GET /api/workspaces` - List workspaces
+- `POST /api/workspaces` - Create workspace
+- `GET /api/workspaces/{id}/notes` - List notes
+- `POST /api/workspaces/{id}/notes` - Create note
+- `PUT /api/workspaces/{id}/notes/{noteId}` - Update note (requires `parent_revision_id`)
+- `DELETE /api/workspaces/{id}/notes/{noteId}` - Delete note
 
 See [docs/spec/api/rest.md](../docs/spec/api/rest.md) and [docs/spec/api/mcp.md](../docs/spec/api/mcp.md) for the API specification.
 

--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -14,7 +14,6 @@ if (backendUrl) {
 		target: backendUrl,
 		changeOrigin: true,
 		secure: false,
-		rewrite: (path: string) => path.replace(/^\/api/, ""),
 	};
 } else if (env.NODE_ENV === "development") {
 	throw new Error(


### PR DESCRIPTION
This pull request updates the API to consistently use the `/api/` prefix for all REST endpoints, improving clarity and aligning with best practices for API versioning and namespacing. The change affects all backend endpoint definitions, the documentation, and corresponding tests.

Key changes include:

**API Endpoint Updates:**

- All REST API routes in the backend (including notes, workspaces, attachments, classes, links, and search) have been updated to use the `/api/` prefix, e.g., `/api/workspaces/{workspace_id}/notes` instead of `/workspaces/{workspace_id}/notes`. [[1]](diffhunk://#diff-11fb671003c95874d1344e5fbd0f6f78244abc39a33531d102bc758f90d69c1aL24-R24) [[2]](diffhunk://#diff-af52137d357d131653c2428ef1dec2d71621a4aa3a5f92e718649019a85df648L20-R20) [[3]](diffhunk://#diff-cd056b480a9b5d68001acf854ceba4b6f50ac2a3281120badd22672c3b67db20L21-R21) [[4]](diffhunk://#diff-8810d924e0d619c5cacaa265111e9444d231bfe4cdd36bee8fe6f4964756a8f8L22-R22) [[5]](diffhunk://#diff-41b4dc2560543a7e6feeff3a8a0e07dc7520afd90ff0bd6753b5cc4f12b14d2eL21-R21) [[6]](diffhunk://#diff-61dff06fb9155c77011bfd26a5d5152c093ee1f6fcaee509dc4322385724181dL123-R123)

**Documentation Updates:**

- The API documentation in `backend/README.md` has been updated to reflect the new `/api/`-prefixed routes in all endpoint listings and code samples. [[1]](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dL65-R65) [[2]](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dL136-R144)

**Test Updates:**

- All API calls in the test suite (`backend/tests/test_api.py`) have been updated to use the new `/api/`-prefixed endpoints to ensure tests align with the updated API routes. [[1]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L15-R15) [[2]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L33-R36) [[3]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L47-R50) [[4]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L62-R64) [[5]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L75-R88) [[6]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L106-R106) [[7]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L115-R118)