### PR TITLE
Docs/markdown as table plan

### DIFF
--- a/docs/tasks/archive/milestone-2-full-configuration.md
+++ b/docs/tasks/archive/milestone-2-full-configuration.md
@@ -496,6 +496,6 @@ For this milestone to be considered complete:
 
 ## References
 
-- [Roadmap](roadmap.md) - Future milestones
-- [MVP Archive](archive/mvp-milestone.md) - Previous milestone
-- [Architecture Overview](../spec/architecture/overview.md) - System design (TO-BE)
+- [Roadmap](../roadmap.md) - Future milestones
+- [MVP Archive](mvp-milestone.md) - Previous milestone
+- [Architecture Overview](../../spec/architecture/overview.md) - System design (TO-BE)

--- a/docs/tasks/roadmap.md
+++ b/docs/tasks/roadmap.md
@@ -150,7 +150,6 @@ Focus on desktop application using Tauri:
 ## Timeline (Tentative)
 
 ```
-2026 Q1  |████████████████| Milestone 2: Full Configuration
 2026 Q2  |████████████████| Milestone 3: Markdown as Table
 2026 Q3  |████████████████| Milestone 4: User Controlled View
 2026 Q4  |████████████████| Milestone 5: AI-Enabled & AI-Used

--- a/docs/tasks/tasks.md
+++ b/docs/tasks/tasks.md
@@ -1,6 +1,6 @@
 # Milestone 3: Markdown as Table
 
-**Status**: 🔄 In Progress  
+**Status**: 📋 Planned  
 **Goal**: Store notes as Parquet-backed tables while preserving the current UI behavior
 
 This milestone replaces the current Markdown-based storage with a Parquet table model, while keeping user experience unchanged. Notes become row-based records defined by Classes, and queryable via a domain-specific SQL.

--- a/e2e/notes.test.ts
+++ b/e2e/notes.test.ts
@@ -24,13 +24,9 @@ describe("Notes CRUD", () => {
 	afterAll(async () => {
 		// Cleanup: delete all notes created during tests
 		await Promise.allSettled(
-			createdNoteIds.map(async (id) => {
-				try {
-					await client.deleteApi(`/workspaces/default/notes/${id}`);
-				} catch {
-					// Ignore cleanup errors
-				}
-			}),
+			createdNoteIds.map((id) =>
+				client.deleteApi(`/workspaces/default/notes/${id}`),
+			),
 		);
 	});
 


### PR DESCRIPTION
This pull request updates the project roadmap documentation to reflect new milestones and clarify the development sequence, and also improves the cleanup logic in the end-to-end notes test. The roadmap now includes more granular milestones for data storage and user interface customization, and reorders the timeline to better match planned priorities.

**Roadmap and Documentation Updates:**

* Added two new milestones to the roadmap: "Markdown as Table" (storing notes as class-backed Parquet tables with SQL querying) and "User Controlled View" (user-defined UI views driven by queries), shifting the numbering and sequence of all subsequent milestones. [[1]](diffhunk://#diff-fca539bf67553ca5b9a8e249823552e721ff766ff3d46f7530dd77fa09cf2e45L15-R20) [[2]](diffhunk://#diff-fca539bf67553ca5b9a8e249823552e721ff766ff3d46f7530dd77fa09cf2e45L56-R93)
* Marked "Full Configuration" milestone as completed, updated its documentation reference to an archive, and clarified its focus on codebase unification and architecture refinement. [[1]](diffhunk://#diff-fca539bf67553ca5b9a8e249823552e721ff766ff3d46f7530dd77fa09cf2e45L15-R20) [[2]](diffhunk://#diff-fca539bf67553ca5b9a8e249823552e721ff766ff3d46f7530dd77fa09cf2e45L35-R39)
* Updated milestone sections to provide detailed objectives and deliverables for each new and existing milestone, especially for "Markdown as Table" and "User Controlled View".
* Adjusted the timeline chart to reflect the new milestone order and projected quarters for each phase, extending into 2027.

**Test Cleanup Improvement:**

* Improved the cleanup logic in `e2e/notes.test.ts` by using `Promise.allSettled` to delete all created notes in parallel and ensure all deletions are attempted, regardless of individual failures.