### PR TITLE
chore: add renovate for mise tool updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["config:base"],
+  "enabledManagers": ["mise"],
+  "labels": ["dependencies", "mise"],
+  "schedule": ["every weekday"]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,20 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 3 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          configurationFile: .github/renovate.json


### PR DESCRIPTION
This pull request sets up automated dependency management for the project using Renovate. It adds configuration files and a GitHub Actions workflow to regularly check for and update dependencies managed by `mise`.

Dependency automation setup:

* Added `.github/renovate.json` to configure Renovate, specifying the use of the `mise` manager, labels for PRs, and a schedule to run every weekday.
* Added `.github/workflows/renovate.yml` to create a GitHub Actions workflow that runs Renovate on a scheduled basis and via manual dispatch.