### PR TITLE
fix: update postAttachCommand to onCreateCommand in devcontainer conf…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,5 @@
 	"remoteEnv": {
 		"MISE_EXPERIMENTAL": "1"
 	},
-	"postAttachCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && uvx pre-commit install",
+	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && uvx pre-commit install",
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the devcontainer configuration by moving the setup commands from `postAttachCommand` to `onCreateCommand`. This ensures that environment setup and permissions are handled during container creation rather than after attaching, streamlining the development environment setup.