### PR TITLE
chore(tools): update tool versions to latest

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -13,11 +13,11 @@ BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA = "true"
 BROWSERSLIST_IGNORE_OLD_DATA = "true"
 
 [tools]
-biome = "2.3.11"
-bun = "1.3.2"
-python = "3.13"
-rust = "1.92.0"
-uv = "0.9.8"
+biome = "latest"
+bun = "latest"
+python = "latest"
+rust = "latest"
+uv = "latest"
 
 [tasks.setup]
 depends = ["//backend:install", "//frontend:install", "//ieapp-cli:install", "//ieapp-core:install", "//e2e:install"]


### PR DESCRIPTION
This pull request updates the tool versions specified in the `mise.toml` configuration file to always use the latest available versions instead of fixed version numbers. This change helps ensure that the project consistently uses the most up-to-date tools.

Tool version management:

* Updated the `biome`, `bun`, `python`, `rust`, and `uv` tool entries in `mise.toml` to use `"latest"` instead of specific version numbers.