### PR TITLE
Add GitHub CLI devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
 	"name": "mise",
 	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"features": {
-		"ghcr.io/devcontainers-extra/features/mise:1": {}
+		"ghcr.io/devcontainers-extra/features/mise:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"customizations": {
 		"vscode": {
@@ -36,7 +37,9 @@
 		"E2E_FRONTEND_MODE": "prod"
 	},
 	"remoteEnv": {
-		"MISE_EXPERIMENTAL": "1"
+		"MISE_EXPERIMENTAL": "1",
+		"GH_TOKEN": "${localEnv:GH_TOKEN}",
+		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
 	},
 	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && uvx pre-commit install",
 }


### PR DESCRIPTION
This pull request updates the `.devcontainer/devcontainer.json` configuration to improve the development container environment by adding support for GitHub CLI and enabling seamless use of GitHub authentication tokens.

Development environment enhancements:

* Added the `github-cli` feature to the devcontainer, allowing developers to use GitHub CLI commands within the container.

Authentication and environment variable improvements:

* Configured `GH_TOKEN` and `GITHUB_TOKEN` environment variables to be passed from the local environment into the devcontainer, enabling authenticated GitHub operations inside the container.