### PR TITLE
fix(frontend): keep loading bar visible over top bar

### DIFF
--- a/frontend/src/components/SpaceShell.tsx
+++ b/frontend/src/components/SpaceShell.tsx
@@ -20,7 +20,7 @@ export function SpaceShell(props: SpaceShellProps) {
 	return (
 		<main class="ui-shell">
 			<Show when={loadingState.isLoading()}>
-				<div class="fixed top-0 left-0 right-0 z-50">
+				<div class="fixed top-0 left-0 right-0 z-[60] pointer-events-none">
 					<div class="ui-loading-bar" />
 				</div>
 			</Show>


### PR DESCRIPTION
## Summary
- ensure the global loading bar renders above the top navigation so query results loading is visible

## Testing
- mise run test
- mise run e2e