### PR TITLE
ci: add strict frontend typecheck to pre-commit and Frontend CI

### DIFF
--- a/frontend/src/components/SpaceSettings.tsx
+++ b/frontend/src/components/SpaceSettings.tsx
@@ -4,7 +4,7 @@ import type { Space, SpacePatchPayload } from "~/lib/types";
 export interface SpaceSettingsProps {
 	space: Space;
 	onSave: (payload: SpacePatchPayload) => Promise<void>;
-	onTestConnection?: (config: { uri: string }) => Promise<{ status: string }>;
+	onTestConnection?: (config: Record<string, unknown>) => Promise<{ status: string }>;
 }
 
 /**

--- a/frontend/src/components/SqlQueryEditor.tsx
+++ b/frontend/src/components/SqlQueryEditor.tsx
@@ -28,7 +28,7 @@ export function SqlQueryEditor(props: SqlQueryEditorProps) {
 
 	onMount(() => {
 		if (!host) return;
-		const lintSource = (view: EditorView) => {
+		const lintSource: Parameters<typeof linter>[0] = (view) => {
 			const diagnostics = sqlLintDiagnostics(view.state.doc.toString());
 			props.onDiagnostics?.(diagnostics);
 			return diagnostics;
@@ -51,7 +51,8 @@ export function SqlQueryEditor(props: SqlQueryEditorProps) {
 		});
 
 		view = new EditorView({ state, parent: host });
-		lintSource(view);
+		const diagnostics = sqlLintDiagnostics(view.state.doc.toString());
+		props.onDiagnostics?.(diagnostics);
 	});
 
 	createEffect(() => {

--- a/frontend/src/routes/spaces/[space_id]/settings.tsx
+++ b/frontend/src/routes/spaces/[space_id]/settings.tsx
@@ -18,9 +18,10 @@ export default function SpaceSettingsRoute() {
 		await refetch();
 	};
 
-	const handleTestConnection = async (config: { uri: string }) => {
+	const handleTestConnection = async (config: Record<string, unknown>) => {
+		const uri = typeof config.uri === "string" ? config.uri : "";
 		return await spaceApi.testConnection(spaceId(), {
-			storage_config: { uri: config.uri },
+			storage_config: { uri },
 		});
 	};
 


### PR DESCRIPTION
## Summary\n- add frontend typecheck pipeline using  (TypeScript native preview) plus  fallback\n- add  scripts in  and dedicated \n- run  in  and \n- fix existing frontend type issues in source files so typecheck is green\n\n## Tooling decision\n-  provides  binary (Go-native TypeScript compiler preview)\n- CI runs both  and  for strictness plus compatibility\n\n## Validation\n- bun run typecheck (frontend)\n- mise run test\n- mise run e2e\n