### PR TITLE
docsite: redesign IA and improve docs/spec readability

### DIFF
--- a/docsite/bun.lock
+++ b/docsite/bun.lock
@@ -9,8 +9,9 @@
         "@astrojs/tailwind": "^6.0.0",
         "astro": "^5.13.5",
         "marked": "^16.4.1",
-        "prismjs": "1.29.0",
+        "prismjs": "1.30.0",
         "tailwindcss": "^3.4.17",
+        "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.5",
@@ -736,7 +737,7 @@
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
-    "prismjs": ["prismjs@1.29.0", "", {}, "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="],
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -969,8 +970,6 @@
     "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@astrojs/prism/prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 

--- a/docsite/package.json
+++ b/docsite/package.json
@@ -19,7 +19,8 @@
 		"astro": "^5.13.5",
 		"marked": "^16.4.1",
 		"prismjs": "1.30.0",
-		"tailwindcss": "^3.4.17"
+		"tailwindcss": "^3.4.17",
+		"yaml": "^2.8.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.5",

--- a/docsite/src/layouts/BaseLayout.astro
+++ b/docsite/src/layouts/BaseLayout.astro
@@ -1,14 +1,24 @@
 ---
 import ThemeSwitcher from "../components/ThemeSwitcher.astro";
-import { navSections } from "../lib/navigation";
+import { navSections, topLinks } from "../lib/navigation";
 import "../styles.css";
 
 export interface Props {
   title: string;
   description?: string;
+  showSidebar?: boolean;
 }
 
-const { title, description } = Astro.props;
+const { title, description, showSidebar = true } = Astro.props;
+const currentPath = Astro.url.pathname.replace(/\/+$/, "") || "/";
+
+const isActivePath = (href: string): boolean => {
+  const normalizedHref = href.replace(/\/+$/, "") || "/";
+  if (normalizedHref === "/") {
+    return currentPath === "/";
+  }
+  return currentPath === normalizedHref || currentPath.startsWith(`${normalizedHref}/`);
+};
 ---
 
 <html lang="en">
@@ -19,44 +29,63 @@ const { title, description } = Astro.props;
     <meta name="description" content={description ?? "Ugoite repository-backed documentation."} />
   </head>
   <body>
-    <header class="mx-auto max-w-6xl px-4 py-4">
+    <header class="mx-auto max-w-[88rem] px-4 py-4 md:px-6">
       <div class="doc-card flex flex-wrap items-center justify-between gap-4 py-3">
         <a href="/" class="text-xl font-semibold tracking-tight" data-l10n-key="brand">Ugoite Docsite</a>
-        <nav class="flex flex-wrap items-center gap-3 text-sm">
-          <a href="/docs/guide/cli" class="rounded-full px-3 py-1.5 hover:opacity-80" data-l10n-key="nav_cli">CLI Guide</a>
-          <a href="/docs/spec/api/rest" class="rounded-full px-3 py-1.5 hover:opacity-80" data-l10n-key="nav_rest">REST API</a>
-          <a href="/docs/spec/api/mcp" class="rounded-full px-3 py-1.5 hover:opacity-80" data-l10n-key="nav_mcp">MCP API</a>
+        <nav class="flex flex-wrap items-center gap-2 text-sm">
+          {topLinks.map((link) => (
+            <a
+              href={link.href}
+              class:list={{
+                "doc-pill": true,
+                "doc-pill-active": isActivePath(link.href),
+              }}
+            >
+              {link.title}
+            </a>
+          ))}
         </nav>
         <ThemeSwitcher />
       </div>
     </header>
-    <main class="mx-auto max-w-6xl px-4 pb-16">
-      <div class="doc-shell">
-        <aside class="doc-sidebar">
-          <p class="text-xs font-semibold uppercase tracking-wide" style="color: var(--doc-muted);">Navigation</p>
-          <div class="mt-3 space-y-4">
-            {navSections.map((section) => (
-              <section>
-                <h2 class="text-sm font-semibold">{section.title}</h2>
-                <ul class="mt-2 space-y-1 text-sm" style="color: var(--doc-muted);">
-                  {section.items.map((item) => (
-                    <li>
-                      <a href={item.href} class="block rounded px-2 py-1 hover:opacity-80">{item.title}</a>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            ))}
-          </div>
-        </aside>
-        <section>
+    <main class="mx-auto max-w-[88rem] px-4 pb-16 md:px-6">
+      <div class:list={{ "doc-shell": showSidebar, "doc-shell-standalone": !showSidebar }}>
+        {showSidebar && (
+          <aside class="doc-sidebar">
+            <p class="doc-sidebar-label">Knowledge Map</p>
+            <div class="mt-4 space-y-5">
+              {navSections.map((section) => (
+                <section>
+                  <h2 class="text-sm font-semibold">{section.title}</h2>
+                  {section.description && <p class="mt-1 text-xs doc-muted">{section.description}</p>}
+                  <ul class="mt-2 space-y-1.5 text-sm">
+                    {section.items.map((item) => (
+                      <li>
+                        <a
+                          href={item.href}
+                          class:list={{
+                            "doc-nav-link": true,
+                            "doc-nav-link-active": isActivePath(item.href),
+                          }}
+                        >
+                          {item.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </aside>
+        )}
+        <section class="min-w-0">
           <slot />
         </section>
       </div>
     </main>
-    <footer class="mx-auto max-w-6xl px-4 pb-10 text-xs" style="color: var(--doc-muted);">
+    <footer class="mx-auto max-w-[88rem] px-4 pb-10 text-xs md:px-6">
       <div class="doc-card flex flex-wrap items-center justify-between gap-2 py-2">
-        <span>Repository-backed documentation from docs/ and docs/spec.</span>
+        <span class="doc-muted">Repository-backed documentation from docs/ and docs/spec.</span>
         <a href="/docs/spec/index">Open specification index</a>
       </div>
     </footer>

--- a/docsite/src/lib/i18n.ts
+++ b/docsite/src/lib/i18n.ts
@@ -11,9 +11,9 @@ export const DOCSITE_I18N: Record<DocsiteLocale, Record<string, string>> = {
 		language_label: "Language",
 		mode_light: "Light",
 		mode_dark: "Dark",
-		home_title: "Ugoite Documentation",
+		home_title: "Ship with confidence from one source of truth",
 		home_desc:
-			"This site renders the main project docs from the repository docs/ directory.",
+			"Ugoite Docsite renders docs/ directly and organizes architecture, API, requirements, and governance into one readable map.",
 		home_link_cli: "CLI Guide",
 		home_link_rest: "REST API Spec",
 		home_link_mcp: "MCP API Spec",
@@ -29,9 +29,9 @@ export const DOCSITE_I18N: Record<DocsiteLocale, Record<string, string>> = {
 		language_label: "言語",
 		mode_light: "ライト",
 		mode_dark: "ダーク",
-		home_title: "Ugoite ドキュメント",
+		home_title: "単一の信頼できる情報源で、確信を持って開発する",
 		home_desc:
-			"このサイトは、リポジトリ内の docs/ ディレクトリにある主要ドキュメントをそのまま表示します。",
+			"Ugoite Docsite は docs/ を直接レンダリングし、アーキテクチャ・API・要件・ガバナンスを読みやすい情報マップとして整理します。",
 		home_link_cli: "CLI ガイド",
 		home_link_rest: "REST API 仕様",
 		home_link_mcp: "MCP API 仕様",

--- a/docsite/src/lib/navigation.ts
+++ b/docsite/src/lib/navigation.ts
@@ -5,48 +5,133 @@ export type NavItem = {
 };
 
 export type NavSection = {
+	id: string;
 	title: string;
+	description?: string;
 	items: NavItem[];
 };
 
 export const topLinks: NavItem[] = [
-	{ title: "Overview", href: "/" },
+	{ title: "Home", href: "/" },
 	{ title: "Specification Index", href: "/docs/spec/index" },
+	{ title: "Requirements", href: "/docs/spec/requirements/README" },
+	{ title: "REST API", href: "/docs/spec/api/rest" },
 	{ title: "Tasks", href: "/docs/tasks/tasks" },
-	{ title: "CLI Guide", href: "/docs/guide/cli" },
 ];
 
 export const navSections: NavSection[] = [
 	{
+		id: "getting-started",
 		title: "Getting Started",
+		description: "Entry points for setup, operation, and contribution.",
 		items: [
 			{ title: "README", href: "/docs/README" },
 			{ title: "CLI Guide", href: "/docs/guide/cli" },
+			{ title: "Tasks", href: "/docs/tasks/tasks" },
+			{ title: "Roadmap", href: "/docs/tasks/roadmap" },
 		],
 	},
 	{
-		title: "Specifications",
+		id: "architecture",
+		title: "Architecture & Design",
+		description: "Core boundaries, rationale, and long-term direction.",
 		items: [
-			{ title: "Spec Index", href: "/docs/spec/index" },
-			{ title: "Architecture", href: "/docs/spec/architecture/overview" },
-			{ title: "Data Model", href: "/docs/spec/data-model/overview" },
-			{ title: "UI Specs", href: "/docs/spec/ui/README" },
+			{ title: "Architecture Overview", href: "/docs/spec/architecture/overview" },
+			{ title: "Technology Stack", href: "/docs/spec/architecture/stack" },
+			{ title: "Architecture Decisions", href: "/docs/spec/architecture/decisions" },
+			{
+				title: "Frontend-Backend Interface",
+				href: "/docs/spec/architecture/frontend-backend-interface",
+			},
+			{ title: "Future-Proofing", href: "/docs/spec/architecture/future-proofing" },
 		],
 	},
 	{
-		title: "APIs",
+		id: "features",
+		title: "Features & Stories",
+		description: "Feature registry and user-scenario coverage.",
 		items: [
+			{ title: "Features Registry", href: "/docs/spec/features/README" },
+			{ title: "Ugoite SQL", href: "/docs/spec/features/sql" },
+			{ title: "Core Stories", href: "/docs/spec/stories/core" },
+			{ title: "Advanced Stories", href: "/docs/spec/stories/advanced" },
+		],
+	},
+	{
+		id: "data-api",
+		title: "Data & API",
+		description: "Storage model and external interaction contracts.",
+		items: [
+			{ title: "Data Model Overview", href: "/docs/spec/data-model/overview" },
+			{ title: "Directory Structure", href: "/docs/spec/data-model/directory-structure" },
+			{ title: "SQL Sessions", href: "/docs/spec/data-model/sql-sessions" },
 			{ title: "REST API", href: "/docs/spec/api/rest" },
 			{ title: "MCP API", href: "/docs/spec/api/mcp" },
 			{ title: "OpenAPI", href: "/docs/spec/api/openapi" },
 		],
 	},
 	{
-		title: "Requirements",
+		id: "requirements",
+		title: "Requirements & Governance",
+		description: "Traceability, taxonomy, and machine-readable contracts.",
 		items: [
 			{ title: "Requirements Overview", href: "/docs/spec/requirements/README" },
-			{ title: "Frontend Requirements", href: "/docs/spec/requirements/frontend" },
 			{ title: "API Requirements", href: "/docs/spec/requirements/api" },
+			{ title: "Frontend Requirements", href: "/docs/spec/requirements/frontend" },
+			{ title: "Specifications Catalog", href: "/docs/spec/specifications" },
+			{ title: "Policies", href: "/docs/spec/policies/policies" },
+			{ title: "Philosophy", href: "/docs/spec/philosophy/foundation" },
 		],
+		},
+	{
+		id: "quality",
+		title: "Security & Quality",
+		description: "Security posture, verification, and resilience practices.",
+		items: [
+			{ title: "Security Overview", href: "/docs/spec/security/overview" },
+			{ title: "Testing Strategy", href: "/docs/spec/testing/strategy" },
+			{ title: "CI/CD", href: "/docs/spec/testing/ci-cd" },
+			{ title: "Error Handling", href: "/docs/spec/quality/error-handling" },
+			{ title: "Success Metrics", href: "/docs/spec/product/success-metrics" },
+			{ title: "CLI Guide", href: "/docs/guide/cli" },
+		],
+	},
+];
+
+export const homeHeroLinks: NavItem[] = [
+	{ title: "Read Spec Index", href: "/docs/spec/index" },
+	{ title: "Review REST API", href: "/docs/spec/api/rest" },
+	{ title: "Track Requirements", href: "/docs/spec/requirements/README" },
+];
+
+export const homeCapabilityCards: Array<{
+	title: string;
+	summary: string;
+	href: string;
+	tag: string;
+}> = [
+	{
+		title: "Architecture First",
+		summary: "Understand module boundaries and responsibility contracts before coding.",
+		href: "/docs/spec/architecture/overview",
+		tag: "Core",
+	},
+	{
+		title: "API Contract Clarity",
+		summary: "Jump from user stories to REST and MCP contracts in one flow.",
+		href: "/docs/spec/api/rest",
+		tag: "Interface",
+	},
+	{
+		title: "Requirement Traceability",
+		summary: "Track REQ-* items with test mappings and governance metadata.",
+		href: "/docs/spec/requirements/README",
+		tag: "Quality",
+	},
+	{
+		title: "Data Model Grounding",
+		summary: "Model markdown fields, forms, and SQL sessions with concrete specs.",
+		href: "/docs/spec/data-model/overview",
+		tag: "Storage",
 	},
 ];

--- a/docsite/src/pages/docs/[...slug].astro
+++ b/docsite/src/pages/docs/[...slug].astro
@@ -2,7 +2,9 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { Marked } from "marked";
+import { parse as parseYaml } from "yaml";
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { navSections } from "../../lib/navigation";
 
 function escapeHtml(raw: string): string {
   return raw
@@ -43,9 +45,96 @@ function sanitizeUrl(raw: string | null | undefined): string | null {
   return null;
 }
 
+function slugifyHeading(raw: string): string {
+  return raw
+    .toLowerCase()
+    .trim()
+    .replace(/[`*_~]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+}
+
+type Heading = {
+  level: number;
+  text: string;
+  id: string;
+};
+
+function createYamlSummary(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `Array (${value.length})`;
+  }
+  if (value && typeof value === "object") {
+    return `Object (${Object.keys(value).length})`;
+  }
+  if (typeof value === "string") {
+    return value.length > 96 ? `${value.slice(0, 96)}…` : value;
+  }
+  return String(value);
+}
+
+function renderYamlNode(value: unknown, depth = 0): string {
+  if (value === null || value === undefined) {
+    return "<span class=\"doc-yaml-empty\">null</span>";
+  }
+
+  if (typeof value === "string") {
+    const escaped = escapeHtml(value);
+    if (value.includes("\n")) {
+      return `<pre><code>${escaped}</code></pre>`;
+    }
+    return `<code>${escaped}</code>`;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return `<code>${escapeHtml(String(value))}</code>`;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "<span class=\"doc-yaml-empty\">[]</span>";
+    const allScalars = value.every(
+      (entry) => entry === null || ["string", "number", "boolean"].includes(typeof entry),
+    );
+
+    if (allScalars) {
+      return `<ul class=\"doc-yaml-list\">${value
+        .map((entry) => `<li>${renderYamlNode(entry, depth + 1)}</li>`)
+        .join("")}</ul>`;
+    }
+
+    return `<div class=\"doc-yaml-stack\">${value
+      .map((entry, index) => {
+        const itemLabel = `item_${index + 1}`;
+        return `<details class=\"doc-yaml-details\" ${depth < 2 ? "open" : ""}><summary>${itemLabel} · ${escapeHtml(createYamlSummary(entry))}</summary>${renderYamlNode(entry, depth + 1)}</details>`;
+      })
+      .join("")}</div>`;
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+      return "<span class=\"doc-yaml-empty\">{}</span>";
+    }
+
+    return `<div class=\"doc-yaml-stack\">${entries
+      .map(([key, entryValue]) => {
+        const summary = createYamlSummary(entryValue);
+        const content = renderYamlNode(entryValue, depth + 1);
+        return `<details class=\"doc-yaml-details\" ${depth < 2 ? "open" : ""}><summary><code>${escapeHtml(key)}</code><span class=\"doc-yaml-summary\">${escapeHtml(summary)}</span></summary>${content}</details>`;
+      })
+      .join("")}</div>`;
+  }
+
+  return `<code>${escapeHtml(String(value))}</code>`;
+}
+
 const safeMarked = new Marked({
   gfm: true,
 });
+
+const headings: Heading[] = [];
+const headingCounter = new Map<string, number>();
 
 safeMarked.use({
   renderer: {
@@ -72,48 +161,112 @@ safeMarked.use({
       const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
       return `<img src="${escapeAttribute(safeSrc)}" alt="${safeAlt}"${titleAttr} loading="lazy" decoding="async" />`;
     },
+    heading({ tokens, depth }) {
+      const rawText = this.parser.parseInline(tokens);
+      const baseId = slugifyHeading(rawText);
+      const count = headingCounter.get(baseId) ?? 0;
+      headingCounter.set(baseId, count + 1);
+      const resolvedId = count === 0 ? baseId : `${baseId}-${count + 1}`;
+
+      headings.push({
+        level: depth,
+        text: rawText,
+        id: resolvedId,
+      });
+
+      return `<h${depth} id="${escapeAttribute(resolvedId)}">${rawText}</h${depth}>`;
+    },
   },
 });
 
 export async function getStaticPaths() {
   const docsRoot = path.resolve(process.cwd(), "../docs");
-  const walkMarkdownFiles = async (dir: string): Promise<string[]> => {
+  const walkDocFiles = async (dir: string): Promise<string[]> => {
     const entries = await fs.readdir(dir, { withFileTypes: true });
     const files = await Promise.all(
       entries.map(async (entry) => {
         const fullPath = path.join(dir, entry.name);
-        if (entry.isDirectory()) return await walkMarkdownFiles(fullPath);
-        if (entry.isFile() && entry.name.endsWith(".md")) return [fullPath];
+        if (entry.isDirectory()) return await walkDocFiles(fullPath);
+        if (
+          entry.isFile() &&
+          (entry.name.endsWith(".md") || entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))
+        ) {
+          return [fullPath];
+        }
         return [];
       })
     );
     return files.flat();
   };
 
-  const markdownFiles = await walkMarkdownFiles(docsRoot);
-  return markdownFiles.map((file) => {
+  const docFiles = await walkDocFiles(docsRoot);
+  const bySlug = new Map<string, string>();
+
+  for (const file of docFiles) {
     const relative = path.relative(docsRoot, file).replace(/\\/g, "/");
-    const slug = relative.replace(/\.md$/, "");
-    return { params: { slug } };
-  });
+    const slug = relative.replace(/\.(md|yaml|yml)$/i, "");
+    const extensionPriority = relative.endsWith(".md") ? 3 : relative.endsWith(".yaml") ? 2 : 1;
+    const existing = bySlug.get(slug);
+
+    if (!existing) {
+      bySlug.set(slug, relative);
+      continue;
+    }
+
+    const existingPriority = existing.endsWith(".md") ? 3 : existing.endsWith(".yaml") ? 2 : 1;
+    if (extensionPriority > existingPriority) {
+      bySlug.set(slug, relative);
+    }
+  }
+
+  return Array.from(bySlug.keys()).map((slug) => ({ params: { slug } }));
 }
 
 const docsRoot = path.resolve(process.cwd(), "../docs");
 const slugPath = String(Astro.params.slug || "").replace(/^\/+/, "");
-const relativePath = `${slugPath}.md`;
+
+const candidatePaths = [`${slugPath}.md`, `${slugPath}.yaml`, `${slugPath}.yml`];
+let relativePath: string | null = null;
+
+for (const candidate of candidatePaths) {
+  try {
+    await fs.access(path.join(docsRoot, candidate));
+    relativePath = candidate;
+    break;
+  } catch {
+    continue;
+  }
+}
+
+if (!relativePath) {
+  throw new Error(`Document not found for slug: ${slugPath}`);
+}
+
 const fullPath = path.join(docsRoot, relativePath);
-const markdown = await fs.readFile(fullPath, "utf-8");
-const html = safeMarked.parse(markdown);
+const source = await fs.readFile(fullPath, "utf-8");
+const isYaml = relativePath.endsWith(".yaml") || relativePath.endsWith(".yml");
+const html = isYaml ? renderYamlNode(parseYaml(source)) : safeMarked.parse(source);
+
 const parts = slugPath.split("/").filter(Boolean);
 const breadcrumbs = parts.map((part, index) => ({
-  label: part,
+  label: part.replaceAll("-", " "),
   href: `/docs/${parts.slice(0, index + 1).join("/")}`,
 }));
+
+const currentDocPath = `/docs/${slugPath}`;
+const relatedLinks = navSections
+  .flatMap((section) => section.items)
+  .filter((item) => item.href !== currentDocPath)
+  .filter((item) => {
+    const scope = slugPath.split("/").slice(0, 2).join("/");
+    return scope.length > 0 ? item.href.includes(scope) : true;
+  })
+  .slice(0, 6);
 ---
 
 <BaseLayout title={`Docs: ${relativePath}`} description={`Repository source: /docs/${relativePath}`}>
   <section class="doc-card mb-4">
-    <nav class="text-xs" style="color: var(--doc-muted);">
+    <nav class="text-xs doc-muted">
       <a href="/">home</a>
       <span> / </span>
       <a href="/docs/spec/index">docs</a>
@@ -124,9 +277,43 @@ const breadcrumbs = parts.map((part, index) => ({
         </>
       ))}
     </nav>
-    <p class="mt-2 text-xs" style="color: var(--doc-muted);"><span data-l10n-key="source_prefix">Source:</span> /docs/{relativePath}</p>
+    <div class="mt-3 flex flex-wrap items-center gap-2 text-xs">
+      <span class="doc-badge">{isYaml ? "YAML" : "Markdown"}</span>
+      <span class="doc-muted"><span data-l10n-key="source_prefix">Source:</span> /docs/{relativePath}</span>
+    </div>
   </section>
-  <article class="prose doc-prose max-w-none">
-    <Fragment set:html={html} />
-  </article>
+
+  <div class="doc-content-grid">
+    <article class="prose doc-prose max-w-none">
+      <Fragment set:html={html} />
+    </article>
+
+    <aside class="doc-aside">
+      {headings.length > 0 && (
+        <section>
+          <h2 class="text-sm font-semibold">On this page</h2>
+          <ul class="mt-2 space-y-1 text-sm">
+            {headings
+              .filter((heading) => heading.level <= 3)
+              .map((heading) => (
+                <li class:list={{ "pl-3": heading.level === 3 }}>
+                  <a href={`#${heading.id}`} class="doc-inline-link">{heading.text}</a>
+                </li>
+              ))}
+          </ul>
+        </section>
+      )}
+
+      <section class="mt-5">
+        <h2 class="text-sm font-semibold">Related docs</h2>
+        <ul class="mt-2 space-y-1.5 text-sm">
+          {relatedLinks.map((link) => (
+            <li>
+              <a href={link.href} class="doc-inline-link">{link.title}</a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </aside>
+  </div>
 </BaseLayout>

--- a/docsite/src/pages/index.astro
+++ b/docsite/src/pages/index.astro
@@ -1,30 +1,141 @@
 ---
+import { promises as fs } from "node:fs";
+import path from "node:path";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { navSections } from "../lib/navigation";
+import { homeCapabilityCards, homeHeroLinks, navSections } from "../lib/navigation";
+
+const docsRoot = path.resolve(process.cwd(), "../docs");
+
+const walkByExtensions = async (dir: string): Promise<{ markdown: number; yaml: number }> => {
+  const items = await fs.readdir(dir, { withFileTypes: true });
+  let markdown = 0;
+  let yaml = 0;
+
+  for (const item of items) {
+    const fullPath = path.join(dir, item.name);
+    if (item.isDirectory()) {
+      const child = await walkByExtensions(fullPath);
+      markdown += child.markdown;
+      yaml += child.yaml;
+      continue;
+    }
+
+    if (!item.isFile()) continue;
+    if (item.name.endsWith(".md")) markdown += 1;
+    if (item.name.endsWith(".yaml") || item.name.endsWith(".yml")) yaml += 1;
+  }
+
+  return { markdown, yaml };
+};
+
+const counts = await walkByExtensions(docsRoot);
 ---
 
-<BaseLayout title="Ugoite Docsite" description="Ugoite documentation portal for specs, APIs, guides, and tasks.">
-  <section class="doc-card">
-    <span class="doc-badge">Local-First / AI-Native</span>
-    <h1 class="mt-3 text-4xl font-bold tracking-tight" data-l10n-key="home_title">Ugoite Documentation</h1>
-    <p class="mt-3 text-sm" style="color: var(--doc-muted);" data-l10n-key="home_desc">
-      This site renders the main project docs from the repository <code>docs/</code> directory.
-    </p>
-    <div class="mt-5 flex flex-wrap gap-2 text-sm">
-      <a href="/docs/guide/cli" class="rounded-full px-4 py-2" style="background: var(--doc-accent-soft); color: var(--doc-accent);" data-l10n-key="home_link_cli">CLI Guide</a>
-      <a href="/docs/spec/api/rest" class="rounded-full border px-4 py-2" style="border-color: var(--doc-border);" data-l10n-key="home_link_rest">REST API Spec</a>
-      <a href="/docs/spec/api/mcp" class="rounded-full border px-4 py-2" style="border-color: var(--doc-border);" data-l10n-key="home_link_mcp">MCP API Spec</a>
+<BaseLayout
+  title="Ugoite Docsite"
+  description="Repository-backed, human-readable docs portal for specs, APIs, requirements, and governance."
+  showSidebar={false}
+>
+  <section class="doc-hero">
+    <div class="doc-hero-grid">
+      <div>
+        <span class="doc-badge">Local-First / AI-Native</span>
+        <h1 class="mt-4 text-4xl font-bold tracking-tight sm:text-5xl" data-l10n-key="home_title">
+          Ship with confidence from one source of truth
+        </h1>
+        <p class="mt-4 max-w-2xl text-sm sm:text-base doc-muted" data-l10n-key="home_desc">
+          Ugoite Docsite renders docs/ directly and organizes architecture, API, requirements, and governance into
+          one readable map.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-2 text-sm">
+          {homeHeroLinks.map((link) => (
+            <a href={link.href} class="doc-cta">{link.title}</a>
+          ))}
+        </div>
+      </div>
+      <div class="doc-visual">
+        <div class="doc-visual-head">
+          <span class="doc-badge">Doc Graph</span>
+          <span class="text-xs doc-muted">Live from repository files</span>
+        </div>
+        <div class="doc-visual-grid">
+          <article class="doc-visual-card">
+            <p class="doc-visual-label">Specs</p>
+            <p class="doc-visual-value">{counts.markdown}</p>
+            <p class="text-xs doc-muted">Markdown pages</p>
+          </article>
+          <article class="doc-visual-card">
+            <p class="doc-visual-label">Contracts</p>
+            <p class="doc-visual-value">{counts.yaml}</p>
+            <p class="text-xs doc-muted">YAML artifacts</p>
+          </article>
+          <article class="doc-visual-card">
+            <p class="doc-visual-label">Domains</p>
+            <p class="doc-visual-value">{navSections.length}</p>
+            <p class="text-xs doc-muted">Knowledge lanes</p>
+          </article>
+          <article class="doc-visual-card">
+            <p class="doc-visual-label">Priority</p>
+            <p class="doc-visual-value">REQ-*</p>
+            <p class="text-xs doc-muted">Traceability-first</p>
+          </article>
+        </div>
+      </div>
     </div>
   </section>
 
-  <section class="mt-4 grid gap-4 md:grid-cols-2">
+  <section class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+    {homeCapabilityCards.map((card) => (
+      <article class="doc-card doc-capability-card">
+        <p class="doc-card-tag">{card.tag}</p>
+        <h2 class="mt-2 text-lg font-semibold">{card.title}</h2>
+        <p class="mt-2 text-sm doc-muted">{card.summary}</p>
+        <a href={card.href} class="mt-4 inline-flex items-center gap-1 text-sm font-semibold">
+          Open
+          <span aria-hidden="true">→</span>
+        </a>
+      </article>
+    ))}
+  </section>
+
+  <section class="mt-6 grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+    <article class="doc-card">
+      <h2 class="text-xl font-semibold">Knowledge Architecture</h2>
+      <p class="mt-2 text-sm doc-muted">
+        Navigate the same hierarchy as docs/spec/index.md with focused lanes by responsibility.
+      </p>
+      <div class="mt-4 grid gap-3 sm:grid-cols-2">
+        {navSections.map((section) => (
+          <a href={section.items[0]?.href ?? "/docs/spec/index"} class="doc-lane" aria-label={`Open ${section.title}`}>
+            <p class="text-sm font-semibold">{section.title}</p>
+            <p class="mt-1 text-xs doc-muted">{section.description}</p>
+            <p class="mt-2 text-xs">{section.items.length} linked docs</p>
+          </a>
+        ))}
+      </div>
+    </article>
+
+    <article class="doc-card">
+      <h2 class="text-xl font-semibold">Quick Start</h2>
+      <ul class="mt-3 space-y-2 text-sm">
+        <li><a class="doc-inline-link" href="/docs/README">1. Read project overview</a></li>
+        <li><a class="doc-inline-link" href="/docs/spec/architecture/overview">2. Check module boundaries</a></li>
+        <li><a class="doc-inline-link" href="/docs/spec/api/rest">3. Review API contracts</a></li>
+        <li><a class="doc-inline-link" href="/docs/spec/requirements/README">4. Verify requirement mappings</a></li>
+        <li><a class="doc-inline-link" href="/docs/tasks/tasks">5. Pick active milestones</a></li>
+      </ul>
+    </article>
+  </section>
+
+  <section class="mt-6 grid gap-4 md:grid-cols-2">
     {navSections.map((section) => (
       <article class="doc-card">
         <h2 class="text-lg font-semibold">{section.title}</h2>
-        <ul class="mt-3 space-y-2 text-sm" style="color: var(--doc-muted);">
+        <p class="mt-1 text-xs doc-muted">{section.description}</p>
+        <ul class="mt-3 space-y-2 text-sm">
           {section.items.map((item) => (
             <li>
-              <a href={item.href} class="flex items-center justify-between rounded px-2 py-1 hover:opacity-80">
+              <a href={item.href} class="doc-row-link">
                 <span>{item.title}</span>
                 <span aria-hidden="true">→</span>
               </a>

--- a/docsite/src/styles.css
+++ b/docsite/src/styles.css
@@ -4,6 +4,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+	color-scheme: light dark;
+}
+
 body {
 	background: var(--doc-bg);
 	color: var(--doc-fg);
@@ -26,13 +30,17 @@ a {
 @layer components {
 	.doc-shell {
 		display: grid;
-		grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr);
+		grid-template-columns: minmax(16rem, 20rem) minmax(0, 1fr);
 		gap: 1rem;
+	}
+
+	.doc-shell-standalone {
+		display: block;
 	}
 
 	.doc-sidebar {
 		position: sticky;
-		top: 1rem;
+		top: 1.25rem;
 		height: fit-content;
 		border: var(--doc-border-width) solid var(--doc-border);
 		background: var(--doc-card);
@@ -41,12 +49,28 @@ a {
 		padding: 1rem;
 	}
 
+	.doc-sidebar-label {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--doc-muted);
+	}
+
 	.doc-card {
 		border: var(--doc-border-width) solid var(--doc-border);
 		background: var(--doc-card);
 		border-radius: var(--doc-radius-lg);
 		box-shadow: var(--doc-shadow-sm);
 		padding: 1.25rem;
+	}
+
+	.doc-card-tag {
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--doc-muted);
 	}
 
 	.doc-badge {
@@ -60,6 +84,171 @@ a {
 		color: var(--doc-accent);
 	}
 
+	.doc-pill {
+		display: inline-flex;
+		align-items: center;
+		border-radius: 999px;
+		padding: 0.4rem 0.8rem;
+		border: var(--doc-border-width) solid var(--doc-border);
+		background: var(--doc-card);
+		color: var(--doc-muted);
+		font-weight: 600;
+	}
+
+	.doc-pill-active {
+		color: var(--doc-accent);
+		background: var(--doc-accent-soft);
+		border-color: var(--doc-accent);
+	}
+
+	.doc-nav-link {
+		display: block;
+		padding: 0.4rem 0.55rem;
+		border-radius: calc(var(--doc-radius-lg) - 6px);
+		color: var(--doc-muted);
+	}
+
+	.doc-nav-link:hover {
+		background: var(--doc-accent-soft);
+		color: var(--doc-accent);
+	}
+
+	.doc-nav-link-active {
+		background: var(--doc-accent-soft);
+		color: var(--doc-accent);
+		font-weight: 600;
+	}
+
+	.doc-hero {
+		border: var(--doc-border-width) solid var(--doc-border);
+		background: var(--doc-card);
+		border-radius: var(--doc-radius-lg);
+		box-shadow: var(--doc-shadow-sm);
+		padding: 1.5rem;
+	}
+
+	.doc-hero-grid {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+	}
+
+	.doc-visual {
+		border: var(--doc-border-width) solid var(--doc-border);
+		border-radius: calc(var(--doc-radius-lg) - 2px);
+		padding: 1rem;
+		background: color-mix(in srgb, var(--doc-accent-soft) 35%, var(--doc-card));
+	}
+
+	.doc-visual-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.doc-visual-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.75rem;
+		margin-top: 0.85rem;
+	}
+
+	.doc-visual-card {
+		border: var(--doc-border-width) solid var(--doc-border);
+		background: var(--doc-card);
+		border-radius: calc(var(--doc-radius-lg) - 4px);
+		padding: 0.85rem;
+	}
+
+	.doc-visual-label {
+		font-size: 0.74rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--doc-muted);
+	}
+
+	.doc-visual-value {
+		font-size: 1.35rem;
+		font-weight: 700;
+		line-height: 1.1;
+		margin-top: 0.3rem;
+	}
+
+	.doc-cta {
+		display: inline-flex;
+		align-items: center;
+		border-radius: 999px;
+		padding: 0.46rem 0.9rem;
+		border: var(--doc-border-width) solid var(--doc-border);
+		background: var(--doc-card);
+		font-weight: 600;
+	}
+
+	.doc-cta:hover {
+		background: var(--doc-accent-soft);
+		color: var(--doc-accent);
+	}
+
+	.doc-capability-card {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.doc-lane {
+		display: block;
+		border: var(--doc-border-width) solid var(--doc-border);
+		border-radius: calc(var(--doc-radius-lg) - 4px);
+		padding: 0.85rem;
+		background: var(--doc-card);
+		color: inherit;
+	}
+
+	.doc-lane:hover {
+		border-color: var(--doc-accent);
+		background: var(--doc-accent-soft);
+	}
+
+	.doc-row-link {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		border-radius: calc(var(--doc-radius-lg) - 6px);
+		padding: 0.45rem 0.55rem;
+		color: var(--doc-muted);
+	}
+
+	.doc-row-link:hover {
+		background: var(--doc-accent-soft);
+		color: var(--doc-accent);
+	}
+
+	.doc-inline-link {
+		color: var(--doc-accent);
+	}
+
+	.doc-inline-link:hover {
+		opacity: 0.85;
+	}
+
+	.doc-content-grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+		gap: 1rem;
+	}
+
+	.doc-aside {
+		position: sticky;
+		top: 1.25rem;
+		height: fit-content;
+		border: var(--doc-border-width) solid var(--doc-border);
+		background: var(--doc-card);
+		border-radius: var(--doc-radius-lg);
+		box-shadow: var(--doc-shadow-sm);
+		padding: 1rem;
+	}
+
 	.doc-prose {
 		border: var(--doc-border-width) solid var(--doc-border);
 		background: var(--doc-card);
@@ -68,13 +257,71 @@ a {
 		padding: 1.25rem;
 	}
 
+	.doc-yaml-empty {
+		color: var(--doc-muted);
+		font-style: italic;
+	}
+
+	.doc-yaml-stack {
+		display: grid;
+		gap: 0.55rem;
+	}
+
+	.doc-yaml-details {
+		border: var(--doc-border-width) solid var(--doc-border);
+		border-radius: calc(var(--doc-radius-lg) - 6px);
+		padding: 0.55rem 0.7rem;
+		background: color-mix(in srgb, var(--doc-card) 84%, var(--doc-accent-soft));
+	}
+
+	.doc-yaml-details > summary {
+		cursor: pointer;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.8rem;
+		font-weight: 600;
+	}
+
+	.doc-yaml-summary {
+		color: var(--doc-muted);
+		font-weight: 500;
+		font-size: 0.75rem;
+	}
+
+	.doc-yaml-list {
+		padding-left: 1rem;
+		margin: 0.4rem 0;
+	}
+
+	.doc-muted {
+		color: var(--doc-muted);
+	}
+
 	@media (max-width: 960px) {
 		.doc-shell {
 			grid-template-columns: 1fr;
 		}
 
+		.doc-hero-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.doc-content-grid {
+			grid-template-columns: 1fr;
+		}
+
 		.doc-sidebar {
 			position: static;
+		}
+
+		.doc-aside {
+			position: static;
+		}
+
+		.doc-visual-grid {
+			grid-template-columns: 1fr 1fr;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- redesign docsite IA to mirror docs/spec taxonomy with richer knowledge lanes
- rebuild homepage with concise hero, visual doc graph, quick-start path, and capability cards
- upgrade docs renderer to support both Markdown and YAML with human-readable structured rendering
- add per-page TOC and related-doc links for faster navigation

## Validation
- mise run //:test
- mise run //:e2e
- Playwright MCP visual checks on http://localhost:4321/, /docs/spec/api/rest, /docs/spec/specifications