### PR TITLE
fix: constrain X-Forwarded-For trust to explicit mode

### DIFF
--- a/backend/src/app/core/middleware.py
+++ b/backend/src/app/core/middleware.py
@@ -98,9 +98,13 @@ async def security_middleware(
     root_path = get_root_path()
     # 1. Localhost Binding Check (unless disabled via env var)
     allow_remote = os.environ.get("UGOITE_ALLOW_REMOTE", "false").lower() == "true"
+    trust_proxy_headers = (
+        os.environ.get("UGOITE_TRUST_PROXY_HEADERS", "false").lower() == "true"
+    )
     client_host = resolve_client_host(
         request.headers,
         request.client.host if request.client else None,
+        trust_proxy_headers=trust_proxy_headers,
     )
 
     if not allow_remote and not is_local_host(client_host):

--- a/backend/src/app/core/security.py
+++ b/backend/src/app/core/security.py
@@ -24,22 +24,26 @@ LOCAL_CLIENT_SENTINELS: Final[set[str]] = {
 def resolve_client_host(
     headers: Mapping[str, str],
     client_host: str | None,
+    *,
+    trust_proxy_headers: bool = False,
 ) -> str | None:
     """Resolve the client host honoring proxy headers when present.
 
     Args:
         headers: Request headers (case-insensitive mapping provided by Starlette).
         client_host: Host extracted from the ASGI scope.
+        trust_proxy_headers: Whether to honor `X-Forwarded-For` from trusted proxies.
 
     Returns:
         The best-effort remote address string or ``None`` when unavailable.
 
     """
-    forwarded = headers.get("x-forwarded-for")
-    if forwarded:
-        candidate = forwarded.split(",", 1)[0].strip()
-        if candidate:
-            return candidate
+    if trust_proxy_headers:
+        forwarded = headers.get("x-forwarded-for")
+        if forwarded:
+            candidate = forwarded.split(",", 1)[0].strip()
+            if candidate:
+                return candidate
 
     return client_host
 


### PR DESCRIPTION
## Summary
- ignore  by default when resolving client host\n- add explicit  mode to trust proxy headers
- add middleware tests for spoofed/untrusted and trusted modes
close: #284