### PR TITLE
fix: validate create-space payload name with id rules

### DIFF
--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -185,6 +185,7 @@ async def create_space_endpoint(
 ) -> dict[str, str]:
     """Create a new space."""
     identity = request_identity(request)
+    _validate_path_id(payload.name, "space_id")
     space_id = payload.name  # Using name as ID for now per simple spec
 
     try:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -45,6 +45,13 @@ def test_create_space(test_client: TestClient, temp_space_root: Path) -> None:
     assert (ws_path / "meta.json").exists()
 
 
+def test_create_space_rejects_invalid_name(test_client: TestClient) -> None:
+    """REQ-API-001: create space rejects names violating identifier rules."""
+    response = test_client.post("/spaces", json={"name": "invalid space"})
+    assert response.status_code == 400
+    assert "Invalid space_id" in response.json()["detail"]
+
+
 def test_create_space_conflict(
     test_client: TestClient,
     temp_space_root: Path,


### PR DESCRIPTION
## Summary
- validate  payload  with shared id rules\n- return 400 for invalid identifiers before filesystem operations\n- add regression API test for invalid create-space name
close: #302