### PR TITLE
fix: validate entry create payload id

### DIFF
--- a/backend/src/app/api/endpoints/entry.py
+++ b/backend/src/app/api/endpoints/entry.py
@@ -38,10 +38,11 @@ async def create_entry_endpoint(
     _validate_path_id(space_id, "space_id")
     storage_config = _storage_config()
     await _ensure_space_exists(storage_config, space_id)
-    if payload.id:
+    if payload.id is not None:
         _validate_path_id(payload.id, "entry_id")
-
-    entry_id = payload.id or str(uuid.uuid4())
+        entry_id = payload.id
+    else:
+        entry_id = str(uuid.uuid4())
 
     try:
         await _validate_entry_markdown_against_form(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -197,6 +197,25 @@ def test_create_entry_rejects_invalid_client_id(
     assert "Invalid entry_id" in response.json()["detail"]
 
 
+def test_create_entry_rejects_empty_client_id(
+    test_client: TestClient,
+    temp_space_root: Path,
+) -> None:
+    """REQ-ENTRY-001: entry create rejects empty-but-present client ids."""
+    test_client.post("/spaces", json={"name": "test-ws"})
+    _create_form(test_client, "test-ws")
+
+    response = test_client.post(
+        "/spaces/test-ws/entries",
+        json={
+            "id": "",
+            "content": "---\nform: Entry\n---\n# Title\n\n## Body\ntext",
+        },
+    )
+    assert response.status_code == 400
+    assert "Invalid entry_id" in response.json()["detail"]
+
+
 def test_list_entries(
     test_client: TestClient,
     temp_space_root: Path,


### PR DESCRIPTION
## Summary
validate optional id field in create entry payload\n- reject invalid ids with 400 before create flow\n- add regression API test for invalid client-provided entry id

close: #301