### PR TITLE
fix: do not mask list-spaces runtime failures

### DIFF
--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -150,8 +150,11 @@ async def list_spaces_endpoint(request: Request) -> list[dict[str, Any]]:
     try:
         space_ids = await ugoite_core.list_spaces(storage_config)
     except RuntimeError as exc:
-        logger.warning("Failed to list spaces, returning empty list: %s", exc)
-        return []
+        logger.warning("Failed to list spaces: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list spaces",
+        ) from exc
     except Exception as exc:
         logger.exception("Failed to list spaces")
         raise HTTPException(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -99,7 +99,7 @@ def test_list_spaces_handles_core_failure(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REQ-STO-009: /spaces returns empty list on core failure."""
+    """REQ-STO-009: /spaces returns explicit error on core failure."""
 
     async def _raise(_config: dict[str, str]) -> list[str]:
         msg = "boom"
@@ -108,8 +108,8 @@ def test_list_spaces_handles_core_failure(
     monkeypatch.setattr(ugoite_core, "list_spaces", _raise)
 
     response = test_client.get("/spaces")
-    assert response.status_code == 200
-    assert response.json() == []
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to list spaces"
 
 
 def test_get_space(


### PR DESCRIPTION
## Summary
- stop returning empty list when core list-spaces fails\n- return HTTP 500 with stable diagnostic detail\n- update regression test to assert explicit error response

close: #296