### PR TITLE
fix: add server-side logging for frontend proxy 502 errors

### DIFF
--- a/frontend/src/routes/api/[...path].ts
+++ b/frontend/src/routes/api/[...path].ts
@@ -66,7 +66,11 @@ const proxyRequest = async (event: APIEvent): Promise<Response> => {
 			statusText: response.statusText,
 			headers: responseHeaders,
 		});
-	} catch {
+	} catch (error) {
+		const message =
+			`API proxy upstream request failed method=${request.method} target=${targetUrl.toString()} ` +
+			`error=${error instanceof Error ? error.message : String(error)}\n`;
+		process.stderr.write(message);
 		return new Response("Backend service unavailable", { status: 502 });
 	}
 };


### PR DESCRIPTION
## Summary\n- log upstream proxy failures with method and target context\n- keep existing 502 response behavior for clients\n- avoid console usage to satisfy frontend lint rules\n\n

close: #321