### PR TITLE
chore: add PR template and enforce close issue link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+-
+
+## Related Issue (required)
+
+close: #
+
+## Testing
+
+- [ ] `mise run test`

--- a/.github/workflows/pr-require-close-issue.yml
+++ b/.github/workflows/pr-require-close-issue.yml
@@ -1,0 +1,32 @@
+name: PR Require Close Issue Link
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  require-close-issue-link:
+    runs-on: ubuntu-24.04
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: Validate PR body contains close issue link
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const pattern = /(?:^|\n)\s*close:\s*#\d+\s*(?:\n|$)/i;
+
+            if (!pattern.test(body)) {
+              core.setFailed(
+                "PR body must include an issue link line in this exact format: close: #123"
+              );
+            }


### PR DESCRIPTION
## Summary
- add a repository PR template
- add a workflow that requires close: #<issue-number> in PR body

## Related Issue
close: #362

## Testing
- not run (workflow and template only)