### PR TITLE
feat: add backend health endpoint and quick verification guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ e2e/                # End-to-end tests (Bun)
 - [Specification Index](docs/spec/index.md) - Technical specifications
 - [Architecture Overview](docs/spec/architecture/overview.md) - System design
 - [API Reference](docs/spec/api/rest.md) - REST API documentation
+- [Backend Healthcheck](docs/guide/backend-healthcheck.md) - Quick backend readiness check
 - [Roadmap](docs/tasks/roadmap.md) - Future milestones
 - [Current Tasks](docs/tasks/tasks.md) - Active development
 

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -71,4 +71,10 @@ async def root() -> dict[str, str]:
     return {"message": "Hello World!"}
 
 
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Healthcheck endpoint."""
+    return {"status": "ok"}
+
+
 app.include_router(api_router)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -45,6 +45,13 @@ def test_create_space(test_client: TestClient, temp_space_root: Path) -> None:
     assert (ws_path / "meta.json").exists()
 
 
+def test_health_endpoint(test_client: TestClient) -> None:
+    """REQ-OPS-001: health endpoint returns service readiness."""
+    response = test_client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
 def test_create_space_rejects_invalid_name(test_client: TestClient) -> None:
     """REQ-API-001: create space rejects names violating identifier rules."""
     response = test_client.post("/spaces", json={"name": "invalid space"})

--- a/docs/guide/backend-healthcheck.md
+++ b/docs/guide/backend-healthcheck.md
@@ -1,0 +1,20 @@
+# Backend Healthcheck
+
+Use the backend health endpoint for quick readiness checks.
+
+## Endpoint
+
+- `GET /health`
+- Success response: `200` with JSON body `{ "status": "ok" }`
+
+## Local verification
+
+```bash
+curl -sS http://localhost:8000/health
+```
+
+Expected output:
+
+```json
+{"status":"ok"}
+```


### PR DESCRIPTION
## Summary
- add backend health endpoint at /health
- add backend API test for health endpoint
- add quick verification guide for local curl check

## Related Issue
close: #330

## Testing
- /workspace/backend/.venv/bin/python -m pytest backend/tests/test_api.py -k health_endpoint -q