### PR TITLE
docs: add explicit log redaction guidance for auth material

### DIFF
--- a/docs/guide/log-redaction.md
+++ b/docs/guide/log-redaction.md
@@ -1,0 +1,19 @@
+# Log Redaction Guidance
+
+Never expose authentication material in logs, screenshots, or bug reports.
+
+## Always redact
+
+- Bearer tokens
+- API keys
+- HMAC secrets
+- Authorization headers
+- Cookie or session secrets
+
+## Safe reporting checklist
+
+- Replace secrets with `[REDACTED]`.
+- Keep only token prefix when needed for correlation.
+- Remove credential-bearing query strings.
+- Review shell history before sharing command output.
+- Sanitize CI logs before publishing artifacts.


### PR DESCRIPTION
## Summary
- add explicit redaction guidance for auth-related logs and reports
- include checklist for safe issue and CI artifact sharing

## Related Issue
close: #345

## Testing
- docs update only