### PR TITLE
ops: add artifact cleanup task for temporary local review files

### DIFF
--- a/e2e/mise.toml
+++ b/e2e/mise.toml
@@ -20,3 +20,7 @@ description = "Run form E2E tests only"
 [tasks."test:screenshot"]
 run = "npm run test:screenshot"
 description = "Export docsite screenshots from UI page specs"
+
+[tasks."cleanup:artifacts"]
+run = "bash scripts/cleanup-artifacts.sh"
+description = "Remove temporary local review and test artifacts"

--- a/e2e/scripts/cleanup-artifacts.sh
+++ b/e2e/scripts/cleanup-artifacts.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -rf e2e/test-results e2e/playwright-report e2e/.playwright
+rm -f backend-pytest.xml cli-pytest.xml core-pytest.xml docs-pytest.xml
+
+echo "Cleaned common local review artifacts"


### PR DESCRIPTION
## Summary
- add cleanup script for common local test and review artifacts
- add e2e cleanup:artifacts task for one-command cleanup

## Related Issue
close: #349

## Testing
- script and task definition update only