### PR TITLE
ops: provide one command local smoke check task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -56,3 +56,6 @@ run = "bash e2e/scripts/run-e2e.sh smoke"
 [tasks."e2e:entries"]
 description = "Run entries E2E tests"
 run = "bash e2e/scripts/run-e2e.sh entries"
+[tasks."smoke:local"]
+description = "Run quick local backend/frontend smoke checks"
+run = "bash scripts/local-smoke-check.sh"

--- a/scripts/local-smoke-check.sh
+++ b/scripts/local-smoke-check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+backend_url="${BACKEND_URL:-http://localhost:8000}"
+frontend_url="${FRONTEND_URL:-http://localhost:3000}"
+
+echo "Checking backend health: ${backend_url}/health"
+curl -fsS "${backend_url}/health" > /dev/null
+
+echo "Checking backend spaces endpoint: ${backend_url}/spaces"
+curl -fsS "${backend_url}/spaces" > /dev/null
+
+echo "Checking frontend root: ${frontend_url}"
+curl -fsS "${frontend_url}" > /dev/null
+
+echo "Local smoke check passed"


### PR DESCRIPTION
## Summary
- add local smoke check script for backend and frontend readiness
- add root smoke:local task to run checks in one command

## Related Issue
close: #331

## Testing
- script validation by inspection