### PR TITLE
ops: provide reset command for CLI endpoint routing config

### DIFF
--- a/ugoite-cli/scripts/reset-endpoint-config.sh
+++ b/ugoite-cli/scripts/reset-endpoint-config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config_path="${HOME}/.ugoite/cli-endpoints.json"
+
+if [ -f "${config_path}" ]; then
+  rm -f "${config_path}"
+  echo "Removed ${config_path}"
+else
+  echo "No endpoint config found at ${config_path}"
+fi
+
+echo "CLI endpoint routing config reset complete"


### PR DESCRIPTION
## Summary
- add reset script for ~/.ugoite/cli-endpoints.json
- provide one command path for endpoint routing reset

## Related Issue
close: #335

## Testing
- script update only