### PR TITLE
ops: CLI should show actionable hint when backend mode is unreachable

### DIFF
--- a/ugoite-cli/README.md
+++ b/ugoite-cli/README.md
@@ -1,0 +1,17 @@
+# ugoite-cli
+
+CLI tool for interacting with Ugoite core and backend modes.
+
+## Backend mode unreachable hint
+
+If backend mode commands fail with connection errors:
+
+1. Verify backend server is running.
+   - `curl -sS http://localhost:8000/health`
+2. Verify endpoint config.
+   - check `${HOME}/.ugoite/cli-endpoints.json`
+3. Reset endpoint config if needed.
+   - `bash ugoite-cli/scripts/reset-endpoint-config.sh`
+4. Re-run command with explicit auth env.
+
+This workflow avoids ambiguous "connection failed" failures and provides direct remediation.


### PR DESCRIPTION
## Summary
- document actionable backend-unreachable troubleshooting steps for CLI mode
- include health check and endpoint reset flow

## Related Issue
close: #336

## Testing
- docs update only