### PR TITLE
ops: add script to clean stale dev servers and occupied ports

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -71,3 +71,7 @@ run = "bash e2e/scripts/run-e2e.sh entries"
 [tasks."smoke:local"]
 description = "Run quick local backend/frontend smoke checks"
 run = "bash scripts/local-smoke-check.sh"
+
+[tasks."cleanup:ports"]
+description = "Kill stale local dev servers on standard ports"
+run = "bash scripts/cleanup-dev-ports.sh"

--- a/scripts/cleanup-dev-ports.sh
+++ b/scripts/cleanup-dev-ports.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+backend_port="${E2E_BACKEND_PORT:-8000}"
+frontend_port="${E2E_FRONTEND_PORT:-3000}"
+
+describe_port() {
+  local port="$1"
+  echo "Port ${port}:"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  else
+    ss -ltnp "( sport = :${port} )" || true
+  fi
+}
+
+kill_port() {
+  local port="$1"
+  fuser -k "${port}/tcp" 2>/dev/null || true
+}
+
+describe_port "$backend_port"
+describe_port "$frontend_port"
+
+kill_port "$backend_port"
+kill_port "$frontend_port"
+
+echo "Cleaned stale servers on ports ${backend_port} and ${frontend_port}"


### PR DESCRIPTION
## Summary
- add cleanup script to inspect and kill stale local dev server ports
- add root cleanup:ports task

## Related Issue
close: #332

## Testing
- script and task definition update only