### PR TITLE
backend: redact hmac key from spaces responses

### DIFF
--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -131,11 +131,13 @@ def _space_uri(space_id: str) -> str:
 def _sanitize_space_meta(space_meta: dict[str, Any]) -> dict[str, Any]:
     """Redact sensitive membership secrets before API response serialization."""
     sanitized = dict(space_meta)
+    sanitized.pop("hmac_key", None)
     settings_obj = sanitized.get("settings")
     if not isinstance(settings_obj, dict):
         return sanitized
 
     settings = dict(settings_obj)
+    settings.pop("hmac_key", None)
     if "invitations" in settings:
         settings["invitations"] = {}
     sanitized["settings"] = settings


### PR DESCRIPTION
close: #282
close : #282

## Summary
- remove hmac_key from sanitized space metadata returned by /spaces and /spaces/{space_id}
- keep existing invitation redaction behavior
- add regression test for list and detail endpoints

## Validation
- uv run pytest tests/test_api.py -k "list_spaces_redacts_hmac_key or test_list_spaces"
