### PR TITLE
backend: narrow mcp signing bypass to SSE

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -956,6 +956,23 @@ def test_middleware_hmac_signature(
     assert response.headers["X-Ugoite-Signature"] == expected_signature
 
 
+def test_middleware_signs_non_streaming_mcp_prefixed_paths(
+    test_client: TestClient,
+) -> None:
+    """REQ-INT-003: non-streaming /mcp* paths MUST still be response-signed."""
+    if not hasattr(app.state, "mcp_test_route_registered"):
+
+        @app.get("/mcp-test-json")
+        async def _mcp_test_json() -> dict[str, str]:
+            return {"status": "ok"}
+
+        app.state.mcp_test_route_registered = True
+
+    response = test_client.get("/mcp-test-json")
+    assert response.status_code == 200
+    assert "X-Ugoite-Signature" in response.headers
+
+
 def test_middleware_ignores_untrusted_forwarded_for(
     test_client: TestClient,
 ) -> None:


### PR DESCRIPTION
close: #307
close : #307

## Summary
- stop using path prefix matching to skip response signing
- skip signing only for SSE responses with content type text/event-stream
- add regression test ensuring non-streaming /mcp* paths still include signature header

## Validation
- uv run pytest tests/test_api.py -k "middleware_hmac_signature or mcp_prefixed_paths"
