### PR TITLE
ugoite-cli: preserve structured HTTP error fields

### DIFF
--- a/ugoite-cli/src/ugoite/endpoint_config.py
+++ b/ugoite-cli/src/ugoite/endpoint_config.py
@@ -110,9 +110,34 @@ def _extract_http_error_detail(raw_body: str) -> str:
         payload_obj = json.loads(raw_body)
     except json.JSONDecodeError:
         return detail
-    if isinstance(payload_obj, dict):
-        return str(payload_obj.get("detail", raw_body))
-    return detail
+
+    if not isinstance(payload_obj, dict):
+        return detail
+
+    parsed_detail = payload_obj.get("detail", raw_body)
+    if not isinstance(parsed_detail, dict):
+        return str(parsed_detail)
+
+    detail_value = parsed_detail.get("detail")
+    if not isinstance(detail_value, str) or not detail_value.strip():
+        detail_value = parsed_detail.get("message")
+    message = (
+        detail_value.strip()
+        if isinstance(detail_value, str) and detail_value.strip()
+        else "request failed"
+    )
+
+    code = parsed_detail.get("code")
+    action = parsed_detail.get("action")
+    extras: list[str] = []
+    if isinstance(code, str) and code.strip():
+        extras.append(f"code={code.strip()}")
+    if isinstance(action, str) and action.strip():
+        extras.append(f"action={action.strip()}")
+
+    if extras:
+        return f"{message} ({', '.join(extras)})"
+    return message
 
 
 def request_json(

--- a/ugoite-cli/tests/test_endpoint_config.py
+++ b/ugoite-cli/tests/test_endpoint_config.py
@@ -103,3 +103,49 @@ def test_request_json_closes_connection_on_error(
         request_json("GET", "http://localhost:8000/spaces")
 
     assert closed["value"] is True
+
+
+def test_request_json_preserves_structured_http_error_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-STO-004: request_json surfaces code/action from structured error payloads."""
+
+    class FakeResponse:
+        status = 403
+
+        def read(self) -> bytes:
+            return (
+                b'{"detail":{"detail":"Forbidden by policy","code":"forbidden",'
+                b'"action":"entry_write"}}'
+            )
+
+    class FakeConnection:
+        def __init__(self, _netloc: str, timeout: int) -> None:
+            _ = timeout
+
+        def request(
+            self,
+            _method: str,
+            _path: str,
+            *,
+            body: str | None,
+            headers: dict[str, str],
+        ) -> None:
+            assert body is None
+            assert headers["Accept"] == "application/json"
+
+        def getresponse(self) -> FakeResponse:
+            return FakeResponse()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "ugoite.endpoint_config.http.client.HTTPConnection",
+        FakeConnection,
+    )
+
+    with pytest.raises(RuntimeError, match="code=forbidden") as exc_info:
+        request_json("GET", "http://localhost:8000/spaces")
+
+    assert "action=entry_write" in str(exc_info.value)


### PR DESCRIPTION
close: #325
close : #325

## Summary
- keep structured HTTP error metadata (code/action) in request_json error details
- format nested detail payloads into readable message while preserving machine-friendly fields
- add REQ-linked regression test for structured error propagation

## Validation
- cd ugoite-cli && uv run pytest tests/test_endpoint_config.py -k "structured_http_error_fields or closes_connection_on_error"
