### PR TITLE
fix(backend): fail explicitly when per-space metadata read errors

### DIFF
--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -177,8 +177,12 @@ async def list_spaces_endpoint(request: Request) -> list[dict[str, Any]]:
             results.append(_sanitize_space_meta(space_meta))
         except ugoite_core.AuthorizationError:
             continue
-        except Exception:
+        except Exception as exc:
             logger.exception("Failed to read space meta %s", space_id)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to read space metadata",
+            ) from exc
 
     return results
 


### PR DESCRIPTION
## Summary
- return HTTP 500 when per-space metadata read fails in /spaces
- keep authorization failures filtered but stop silently swallowing unexpected metadata errors
- add regression test for explicit failure behavior

close: #327
close : #327