### PR TITLE
fix(backend): sanitize 5xx HTTP error details

### DIFF
--- a/backend/tests/test_error_sanitization.py
+++ b/backend/tests/test_error_sanitization.py
@@ -1,0 +1,26 @@
+"""Regression tests for API error sanitization."""
+
+import pytest
+import ugoite_core
+from fastapi.testclient import TestClient
+
+
+def test_server_error_detail_is_sanitized(
+    test_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-API-001: 5xx HTTP details must be sanitized into stable public schema."""
+    test_client.post("/spaces", json={"name": "test-ws"})
+
+    async def _raise(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        msg = "leak /workspace/backend/private-path"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(ugoite_core, "search_entries", _raise)
+
+    response = test_client.get("/spaces/test-ws/search", params={"q": "hello"})
+    assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }


### PR DESCRIPTION
## Summary
- add centralized FastAPI HTTPException sanitizer for 5xx string details
- return stable public error detail schema with code/message for internal server errors
- add regression test to prevent leaking raw exception strings

close: #299
close : #299