### PR TITLE
feat(frontend): propagate request id through api proxy

### DIFF
--- a/frontend/src/routes/api/[...path].ts
+++ b/frontend/src/routes/api/[...path].ts
@@ -51,6 +51,24 @@ const filterRequestHeaders = (headers: Headers): Headers => {
 	return filtered;
 };
 
+const resolveRequestId = (headers: Headers): string => {
+	const existingRequestId =
+		headers.get("x-request-id") ?? headers.get("x-correlation-id") ?? headers.get("x-trace-id");
+	if (existingRequestId && existingRequestId.trim().length > 0) {
+		return existingRequestId;
+	}
+	return crypto.randomUUID();
+};
+
+const ensureRequestId = (headers: Headers): string => {
+	const requestId = resolveRequestId(headers);
+	headers.set("x-request-id", requestId);
+	if (!headers.has("x-correlation-id")) {
+		headers.set("x-correlation-id", requestId);
+	}
+	return requestId;
+};
+
 const buildTargetUrl = (requestUrl: string, baseUrl: string): URL => {
 	const url = new URL(requestUrl);
 	const path = url.pathname.replace(/^\/api/, "");
@@ -67,6 +85,7 @@ const proxyRequest = async (event: APIEvent): Promise<Response> => {
 	const request = event.request;
 	const targetUrl = buildTargetUrl(request.url, backendUrl);
 	const headers = filterRequestHeaders(request.headers);
+	const requestId = ensureRequestId(headers);
 	if (!headers.has("authorization")) {
 		const proxyBearerToken = process.env.UGOITE_AUTH_BEARER_TOKEN;
 		if (proxyBearerToken) {
@@ -95,6 +114,9 @@ const proxyRequest = async (event: APIEvent): Promise<Response> => {
 	try {
 		const response = await fetch(targetUrl, init);
 		const responseHeaders = filterResponseHeaders(response.headers);
+		if (!responseHeaders.has("x-request-id")) {
+			responseHeaders.set("x-request-id", requestId);
+		}
 		return new Response(response.body, {
 			status: response.status,
 			statusText: response.statusText,


### PR DESCRIPTION
## Summary
- propagate incoming request correlation headers to backend through the frontend API proxy
- generate a request id when none is provided and forward it as x-request-id
- echo x-request-id in proxy responses when upstream does not provide one

close: #322
close : #322