### PR TITLE
quality: require 100 percent Rust coverage

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,6 +24,9 @@ jobs:
           toolchain: 1.93.0
           components: rustfmt, clippy
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -148,3 +151,7 @@ jobs:
       - name: Run cargo test (core)
         working-directory: ./ugoite-core
         run: cargo test
+
+      - name: Run rust coverage 100 percent (core)
+        working-directory: ./ugoite-core
+        run: cargo llvm-cov --summary-only --fail-under-lines 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,13 @@ repos:
         files: \.rs$
         pass_filenames: false
 
+      - id: cargo-coverage-100
+        name: cargo llvm-cov 100 percent
+        entry: bash -c "cd ugoite-core && uv run cargo llvm-cov --summary-only --fail-under-lines 100"
+        language: system
+        files: \.rs$
+        pass_filenames: false
+
       - id: ty-backend
         name: "ty: backend type check"
         entry: bash -c "cd backend && uv run ty check ."


### PR DESCRIPTION
Summary\n- add a pre-commit hook that fails below 100 percent Rust line coverage\n- install and run cargo llvm-cov in python CI with fail under 100\n\nclose : #422