### PR TITLE
feat(devcontainer): reuse gh auth and setup git credentials

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
 	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
 	"mounts": [
 		"source=frontend_node_modules,target=/workspace/frontend/node_modules,type=volume",
-		"source=backend_venv,target=/workspace/backend/.venv,type=volume"
+		"source=backend_venv,target=/workspace/backend/.venv,type=volume",
+		"source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
 	],
 	"remoteUser": "vscode",
 	"containerEnv": {
@@ -41,5 +42,5 @@
 		"GH_TOKEN": "${localEnv:GH_TOKEN}",
 		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
 	},
-	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && uvx pre-commit install && cd /workspace/e2e && npx playwright --version && npx playwright install --with-deps chromium",
+	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && uvx pre-commit install && gh auth status >/dev/null 2>&1 && gh auth setup-git && cd /workspace/e2e && npx playwright --version && npx playwright install --with-deps chromium",
 }


### PR DESCRIPTION
## Summary

- mount host `~/.config/gh` into the devcontainer so GitHub CLI auth context is reused
- run `gh auth setup-git` during on-create when auth is available

## Related Issue (required)

close: #420

## Testing

- [ ] `mise run test`
