### PR TITLE
feat(docsite): add in-site search capability

### DIFF
--- a/docsite/src/layouts/BaseLayout.astro
+++ b/docsite/src/layouts/BaseLayout.astro
@@ -16,6 +16,7 @@ export interface Props {
 const { title, description, toc = [], related = [], fullWidth = false } = Astro.props;
 const hasRight = toc.length > 0 || related.length > 0;
 const navSections = await getNavSectionsWithChildren();
+const searchIndexUrl = withBasePath("/search-index.json");
 ---
 
 <html lang="en">
@@ -39,7 +40,7 @@ const navSections = await getNavSectionsWithChildren();
       />
     </noscript>
   </head>
-  <body>
+  <body data-search-index-url={searchIndexUrl}>
     <header class="site-header">
       <div class="site-header-inner">
         <a href={withBasePath("/")} class="site-brand">Ugoite</a>
@@ -48,6 +49,17 @@ const navSections = await getNavSectionsWithChildren();
             <a href={withBasePath(link.href)}>{link.title}</a>
           ))}
         </nav>
+        <div class="site-search">
+          <input
+            type="search"
+            class="site-search-input"
+            placeholder="Search docs"
+            aria-label="Search docs"
+            data-doc-search-input
+            autocomplete="off"
+          />
+          <div class="site-search-results" data-doc-search-results hidden></div>
+        </div>
         <button
           type="button"
           class="mobile-nav-toggle"
@@ -133,6 +145,9 @@ const navSections = await getNavSectionsWithChildren();
         const overlay = document.querySelector("[data-mobile-nav-overlay]");
         const openButton = document.querySelector("[data-mobile-nav-open]");
         const closeButton = document.querySelector("[data-mobile-nav-close]");
+        const searchInput = document.querySelector("[data-doc-search-input]");
+        const searchResults = document.querySelector("[data-doc-search-results]");
+        const searchIndexUrl = document.body.dataset.searchIndexUrl ?? "/search-index.json";
 
         if (!nav || !overlay || !openButton || !closeButton) {
           return;
@@ -160,6 +175,62 @@ const navSections = await getNavSectionsWithChildren();
             setOpen(false);
           }
         });
+
+        if (searchInput instanceof HTMLInputElement && searchResults instanceof HTMLDivElement) {
+          let searchIndex = [];
+          let searchLoaded = false;
+
+          const renderResults = (query, results) => {
+            if (query.length < 2 || results.length === 0) {
+              searchResults.hidden = true;
+              searchResults.innerHTML = "";
+              return;
+            }
+
+            searchResults.hidden = false;
+            searchResults.innerHTML = results
+              .slice(0, 8)
+              .map((item) => {
+                const snippet = item.content ? item.content.slice(0, 140) : "";
+                return `<a class="site-search-result" href="${item.href}"><span class="site-search-result-title">${item.title}</span>${snippet ? `<span class=\"site-search-result-snippet\">${snippet}</span>` : ""}</a>`;
+              })
+              .join("");
+          };
+
+          const loadSearchIndex = async () => {
+            if (searchLoaded) return;
+            const response = await fetch(searchIndexUrl);
+            if (!response.ok) return;
+            searchIndex = await response.json();
+            searchLoaded = true;
+          };
+
+          searchInput.addEventListener("input", async () => {
+            const query = searchInput.value.trim().toLowerCase();
+            if (query.length < 2) {
+              renderResults(query, []);
+              return;
+            }
+            await loadSearchIndex();
+            const queryTerms = query.split(/\s+/).filter(Boolean);
+            const matches = searchIndex.filter((item) => {
+              const haystack = `${item.title} ${item.content}`.toLowerCase();
+              return queryTerms.every((term) => haystack.includes(term));
+            });
+            renderResults(query, matches);
+          });
+
+          document.addEventListener("click", (event) => {
+            const target = event.target;
+            if (
+              target instanceof Node &&
+              !searchResults.contains(target) &&
+              target !== searchInput
+            ) {
+              searchResults.hidden = true;
+            }
+          });
+        }
       })();
     </script>
   </body>

--- a/docsite/src/pages/search-index.json.ts
+++ b/docsite/src/pages/search-index.json.ts
@@ -1,0 +1,84 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { APIRoute } from "astro";
+import { getNavSectionsWithChildren, topLinks } from "../lib/navigation";
+
+type SearchItem = {
+	title: string;
+	href: string;
+	content: string;
+};
+
+function titleFromPath(relativePath: string): string {
+	const base = relativePath
+		.replace(/\.(md|ya?ml)$/i, "")
+		.split("/")
+		.at(-1) ?? relativePath;
+	return base.replaceAll(/[-_]/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function toPlainText(raw: string): string {
+	return raw
+		.replaceAll(/```[\s\S]*?```/g, " ")
+		.replaceAll(/`[^`]*`/g, " ")
+		.replaceAll(/!\[[^\]]*]\([^)]*\)/g, " ")
+		.replaceAll(/\[[^\]]*]\([^)]*\)/g, " ")
+		.replaceAll(/[#>*_~\-]+/g, " ")
+		.replaceAll(/\s+/g, " ")
+		.trim();
+}
+
+async function readDocItems(): Promise<SearchItem[]> {
+	const docsRoot = path.resolve(process.cwd(), "../docs");
+	const walk = async (dir: string): Promise<string[]> => {
+		const entries = await fs.readdir(dir, { withFileTypes: true });
+		const files = await Promise.all(
+			entries.map(async (entry) => {
+				const fullPath = path.join(dir, entry.name);
+				if (entry.isDirectory()) return await walk(fullPath);
+				if (entry.isFile() && /\.(md|ya?ml)$/i.test(entry.name)) return [fullPath];
+				return [];
+			}),
+		);
+		return files.flat();
+	};
+
+	const docFiles = await walk(docsRoot);
+	const items = await Promise.all(
+		docFiles.map(async (fullPath) => {
+			const relative = path.relative(docsRoot, fullPath).replaceAll("\\", "/");
+			const source = await fs.readFile(fullPath, "utf-8");
+			return {
+				title: titleFromPath(relative),
+				href: `/docs/${relative.replace(/\.(md|ya?ml)$/i, "")}`,
+				content: toPlainText(source).slice(0, 6000),
+			};
+		}),
+	);
+	return items;
+}
+
+export const GET: APIRoute = async () => {
+	const sections = await getNavSectionsWithChildren();
+	const navItems: SearchItem[] = [
+		...topLinks.map((item) => ({ title: item.title, href: item.href, content: "" })),
+		...sections.flatMap((section) => [
+			...section.items.map((item) => ({ title: item.title, href: item.href, content: "" })),
+			...section.items.flatMap((item) =>
+				(item.items ?? []).map((child) => ({ title: child.title, href: child.href, content: "" })),
+			),
+		]),
+	];
+	const docItems = await readDocItems();
+	const deduped = new Map<string, SearchItem>();
+	for (const item of [...navItems, ...docItems]) {
+		deduped.set(`${item.href}:${item.title}`, item);
+	}
+
+	return new Response(JSON.stringify([...deduped.values()]), {
+		headers: {
+			"content-type": "application/json; charset=utf-8",
+			"cache-control": "public, max-age=300",
+		},
+	});
+};

--- a/docsite/src/styles.css
+++ b/docsite/src/styles.css
@@ -84,6 +84,60 @@ a:hover {
 		background: var(--doc-accent-soft);
 	}
 
+	.site-search {
+		position: relative;
+		min-width: 14rem;
+	}
+
+	.site-search-input {
+		width: 100%;
+		padding: 0.4rem 0.65rem;
+		border-radius: var(--doc-radius-md);
+		border: var(--doc-border-width) solid var(--doc-border);
+		background: var(--doc-card);
+		color: var(--doc-fg);
+		font-size: 0.8125rem;
+	}
+
+	.site-search-results {
+		position: absolute;
+		top: calc(100% + 0.4rem);
+		left: 0;
+		right: 0;
+		max-height: 20rem;
+		overflow-y: auto;
+		background: var(--doc-card);
+		border: var(--doc-border-width) solid var(--doc-border);
+		border-radius: var(--doc-radius-md);
+		box-shadow: var(--doc-shadow-md);
+		padding: 0.25rem;
+		z-index: 70;
+	}
+
+	.site-search-result {
+		display: block;
+		padding: 0.45rem 0.55rem;
+		border-radius: var(--doc-radius-sm);
+	}
+
+	.site-search-result:hover {
+		background: var(--doc-accent-soft);
+	}
+
+	.site-search-result-title {
+		display: block;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--doc-fg);
+	}
+
+	.site-search-result-snippet {
+		display: block;
+		font-size: 0.6875rem;
+		color: var(--doc-muted);
+		margin-top: 0.2rem;
+	}
+
 	.mobile-nav-toggle {
 		display: none;
 		align-items: center;
@@ -922,6 +976,10 @@ a:hover {
 		}
 
 		.site-nav {
+			display: none;
+		}
+
+		.site-search {
 			display: none;
 		}
 


### PR DESCRIPTION
## Summary

- add a generated `search-index.json` endpoint containing navigation targets and docs content snippets
- add a docs header search input with client-side filtering and result navigation
- style search input/dropdown for desktop docs navigation

## Related Issue (required)

close: #423

## Testing

- [ ] `mise run test`
- [x] `cd docsite && bun run typecheck`
