### PR TITLE
docs: align README dev scope with mise task

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install dependencies:
 mise run setup
 ```
 
-Start development (frontend + backend):
+Start development (backend + frontend + docsite):
 
 ```bash
 mise run dev


### PR DESCRIPTION
## Summary

- update README dev task description to match `mise run dev` behavior (`backend + frontend + docsite`)

## Related Issue (required)

close: #288

## Testing

- [ ] `mise run test`
