### PR TITLE
devex(docsite): standardize localhost binding for dev server

### DIFF
--- a/docsite/package.json
+++ b/docsite/package.json
@@ -4,7 +4,7 @@
 	"version": "0.1.0",
 	"type": "module",
 	"scripts": {
-		"dev": "astro dev --host",
+		"dev": "astro dev --host 127.0.0.1 --strictPort --port 4321",
 		"build": "astro build",
 		"preview": "astro preview --host",
 		"lint": "biome ci astro.config.mjs package.json tsconfig.json biome.json src/env.d.ts",


### PR DESCRIPTION
## Summary

- pin docsite dev server binding to `127.0.0.1` with `--strictPort --port 4321`
- remove ambiguous host resolution from the default dev command used by local scripts

## Related Issue (required)

close: #291

## Testing

- [ ] `mise run test`
