### PR TITLE
fix(docsite): avoid duplicate routes for overlapping sources

### DIFF
--- a/docsite/src/pages/docs/[...slug].astro
+++ b/docsite/src/pages/docs/[...slug].astro
@@ -114,10 +114,19 @@ export async function getStaticPaths() {
   };
 
   const docFiles = await walkDocFiles(docsRoot);
-  return docFiles.map((file) => {
+  const extensionPriority = (filePath: string): number => {
+    if (filePath.endsWith(".md")) return 0;
+    if (filePath.endsWith(".yaml")) return 1;
+    return 2;
+  };
+  const orderedFiles = [...docFiles].sort((a, b) => extensionPriority(a) - extensionPriority(b));
+  const seenSlugs = new Set<string>();
+  return orderedFiles.flatMap((file) => {
     const relative = path.relative(docsRoot, file).replace(/\\/g, "/");
     const slug = relative.replace(/\.(md|ya?ml)$/, "");
-    return { params: { slug } };
+    if (seenSlugs.has(slug)) return [];
+    seenSlugs.add(slug);
+    return [{ params: { slug } }];
   });
 }
 


### PR DESCRIPTION
## Summary

- deduplicate static docs route generation when both Markdown and YAML share the same slug
- enforce deterministic source precedence (`.md` > `.yaml` > `.yml`) for overlapping sources

## Related Issue (required)

close: #290

## Testing

- [ ] `mise run test`
- [x] `cd docsite && bun run typecheck`
