### PR TITLE
fix(cli): keep logs on stderr and stdout clean

### DIFF
--- a/ugoite-cli/src/ugoite/logging_utils.py
+++ b/ugoite-cli/src/ugoite/logging_utils.py
@@ -33,8 +33,8 @@ class JSONFormatter(logging.Formatter):
 
 
 def setup_logging() -> None:
-    """Configure the root logger with a JSON formatter on stdout."""
-    handler = logging.StreamHandler(sys.stdout)
+    """Configure the root logger with a JSON formatter on stderr."""
+    handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(JSONFormatter())
     root = logging.getLogger()
     # Avoid adding multiple handlers if setup is called multiple times


### PR DESCRIPTION
## Summary

- switch CLI structured logger stream from stdout to stderr
- preserve stdout for command payloads and user-facing command output

## Related Issue (required)

close: #294

## Testing

- [ ] `mise run test`
- [x] `cd ugoite-cli && uv run pytest tests/test_cli_endpoint_routing.py -q`
