### PR TITLE
fix(backend): add payload size guard for query filter

### DIFF
--- a/backend/src/app/api/endpoints/search.py
+++ b/backend/src/app/api/endpoints/search.py
@@ -19,6 +19,7 @@ from app.core.authorization import (
 from app.models.payloads import QueryRequest
 
 SQL_ERROR_PREFIX = "UGOITE_SQL_ERROR"
+_MAX_QUERY_FILTER_BYTES = 32_768
 
 
 def _is_sql_error(detail: str) -> bool:
@@ -46,6 +47,12 @@ async def query_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="SQL queries must use SQL session endpoints.",
         )
+    query_payload = json.dumps(payload.filter)
+    if len(query_payload.encode("utf-8")) > _MAX_QUERY_FILTER_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Query filter too large: max {_MAX_QUERY_FILTER_BYTES} bytes.",
+        )
 
     try:
         await ugoite_core.require_space_action(
@@ -54,7 +61,6 @@ async def query_endpoint(
             identity,
             "entry_read",
         )
-        query_payload = json.dumps(payload.filter)
         rows = await ugoite_core.query_index(storage_config, space_id, query_payload)
         entry_like_rows = [row for row in rows if isinstance(row, dict)]
         return await ugoite_core.filter_readable_entries(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -703,6 +703,21 @@ def test_query_entries(
     assert isinstance(response.json(), list)
 
 
+def test_query_entries_rejects_oversized_filter(
+    test_client: TestClient,
+    temp_space_root: Path,
+) -> None:
+    """REQ-STO-004: Query endpoint rejects oversized filter payloads."""
+    test_client.post("/spaces", json={"name": "test-ws"})
+    oversized_value = "x" * 40_000
+    response = test_client.post(
+        "/spaces/test-ws/query",
+        json={"filter": {"note": oversized_value}},
+    )
+    assert response.status_code == 400
+    assert "Query filter too large" in response.json()["detail"]
+
+
 def test_query_entries_sql(
     test_client: TestClient,
     temp_space_root: Path,


### PR DESCRIPTION
## Summary

- add max byte-size guard for `/spaces/{space_id}/query` filter payloads
- return explicit `400` when query filter exceeds safe limit
- add API test coverage for oversized filter rejection

## Related Issue (required)

close: #313

## Testing

- [ ] `mise run test`
- [x] `cd backend && uv run pytest tests/test_api.py -k "query_entries and oversized_filter" -q`
