### PR TITLE
fix(backend): make delete asset 404 detail consistent

### DIFF
--- a/backend/src/app/api/endpoints/asset.py
+++ b/backend/src/app/api/endpoints/asset.py
@@ -122,7 +122,7 @@ async def delete_asset_endpoint(
         if "not found" in msg.lower():
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Not found",
+                detail=f"Asset '{asset_id}' not found in space '{space_id}'.",
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -914,6 +914,19 @@ def test_delete_asset_referenced_fails(
     assert "referenced" in delete_res.json()["detail"].lower()
 
 
+def test_delete_asset_not_found_has_consistent_detail(
+    test_client: TestClient,
+    temp_space_root: Path,
+) -> None:
+    """REQ-API-001: Delete asset 404 detail includes resource context."""
+    test_client.post("/spaces", json={"name": "test-ws"})
+    delete_res = test_client.delete("/spaces/test-ws/assets/missing-asset")
+    assert delete_res.status_code == 404
+    detail = delete_res.json()["detail"]
+    assert "missing-asset" in detail
+    assert "test-ws" in detail
+
+
 def test_search_returns_matches(
     test_client: TestClient,
     temp_space_root: Path,


### PR DESCRIPTION
## Summary

- align delete-asset not-found responses with contextual 404 detail format
- include both `asset_id` and `space_id` in the 404 detail for contract consistency
- add API test coverage for the 404 detail shape

## Related Issue (required)

close: #298

## Testing

- [ ] `mise run test`
- [x] `cd backend && uv run pytest tests/test_api.py -k "delete_asset_referenced_fails or delete_asset_not_found_has_consistent_detail" -q`
