### PR TITLE
perf(backend): avoid quadratic middleware body concatenation

### DIFF
--- a/backend/src/app/core/middleware.py
+++ b/backend/src/app/core/middleware.py
@@ -223,15 +223,12 @@ async def security_middleware(
 
 async def _capture_response_body(response: Response) -> bytes:
     """Consume the response iterator so it can be signed and replayed."""
-    body = b""
     body_iterator = getattr(response, "body_iterator", None)
 
     if body_iterator is None:
         return bytes(response.body or b"")
 
-    async for chunk in body_iterator:
-        body += chunk
-
+    body = b"".join([bytes(chunk) async for chunk in body_iterator])
     response.body_iterator = iterate_in_threadpool(iter([body]))  # type: ignore[attr-defined]
     return body
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -5,11 +5,13 @@ import hashlib
 import hmac
 import io
 import json
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
 import ugoite_core
 from fastapi.testclient import TestClient
+from starlette.responses import StreamingResponse
 
 from app.main import app
 
@@ -1062,6 +1064,26 @@ def test_middleware_signs_non_streaming_mcp_prefixed_paths(
 
     response = test_client.get("/mcp-test-json")
     assert response.status_code == 200
+    assert "X-Ugoite-Signature" in response.headers
+
+
+def test_middleware_replays_chunked_body_without_loss(test_client: TestClient) -> None:
+    """REQ-INT-003: middleware preserves chunked response body while signing."""
+    if not hasattr(app.state, "chunked_route_registered"):
+
+        @app.get("/chunked-test-body")
+        async def _chunked_test_body() -> StreamingResponse:
+            async def _iter() -> AsyncIterator[bytes]:
+                for chunk in (b"a", b"b", b"c"):
+                    yield chunk
+
+            return StreamingResponse(_iter(), media_type="text/plain")
+
+        app.state.chunked_route_registered = True
+
+    response = test_client.get("/chunked-test-body")
+    assert response.status_code == 200
+    assert response.content == b"abc"
     assert "X-Ugoite-Signature" in response.headers
 
 


### PR DESCRIPTION
## Summary

- replace repeated `bytes` concatenation in middleware body capture with chunk collection + `b"".join(...)`
- keep response replay behavior unchanged after signature calculation
- add a regression test for chunked response replay/signing behavior

## Related Issue (required)

close: #305

## Testing

- [ ] `mise run test`
- [x] `cd backend && uv run pytest tests/test_api.py -k middleware -q`
