### PR TITLE
test(cli): isolate tests from ~/.ugoite endpoint config

### DIFF
--- a/ugoite-cli/tests/conftest.py
+++ b/ugoite-cli/tests/conftest.py
@@ -7,6 +7,18 @@ import fsspec
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def isolate_cli_user_config(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-STO-001: isolate CLI endpoint config per test run."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("UGOITE_CLI_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("UGOITE_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+
 @pytest.fixture(params=["file"])
 def fs_impl(
     request: pytest.FixtureRequest,


### PR DESCRIPTION
## Summary

- add an autouse pytest fixture in `ugoite-cli/tests/conftest.py` to isolate HOME/config env vars per test
- prevent test behavior from depending on persisted `~/.ugoite/cli-endpoints.json` state
- keep explicit per-test env overrides functional for endpoint path tests

## Related Issue (required)

close: #285

## Testing

- [ ] `mise run test`
- [x] `cd ugoite-cli && uv run ugoite config set --mode backend >/dev/null && uv run pytest tests/test_cli_form.py::test_cli_form_update tests/test_endpoint_config.py -q`
