### PR TITLE
fix(backend): read form ACL settings via get_space

### DIFF
--- a/backend/src/app/api/endpoints/forms.py
+++ b/backend/src/app/api/endpoints/forms.py
@@ -34,10 +34,9 @@ async def _persist_form_acl_settings(
 
     existing_form_acls: dict[str, Any] = {}
     try:
-        space_meta = await ugoite_core.patch_space(
+        space_meta = await ugoite_core.get_space(
             storage_config,
             space_id,
-            json.dumps({}),
         )
         settings = space_meta.get("settings")
         if isinstance(settings, dict):


### PR DESCRIPTION
## Summary

- stop using `patch_space` with an empty patch when reading current form ACL settings
- use explicit `get_space` for metadata read before composing ACL updates
- keep ACL write path unchanged (`patch_space` only for actual settings update)

## Related Issue (required)

close: #308

## Testing

- [ ] `mise run test`
- [x] `cd backend && uv run pytest tests/test_forms_acl.py -q`
