### PR TITLE
fix(ci): skip close-link validation for dependabot PRs

### DIFF
--- a/.github/workflows/pr-require-close-issue.yml
+++ b/.github/workflows/pr-require-close-issue.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   require-close-issue-link:
     runs-on: ubuntu-24.04
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Validate PR body contains close issue link
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary

- skip close-issue-link validation when the PR author is `dependabot[bot]`
- keep the validation unchanged for non-draft, human-authored PRs

## Related Issue (required)

close: #503

## Testing

- [ ] `mise run test`
- [x] `mise run test:docs`
