### PR TITLE
feat(docsite): expose subgroup links from header navigation

### DIFF
--- a/docsite/src/layouts/BaseLayout.astro
+++ b/docsite/src/layouts/BaseLayout.astro
@@ -17,6 +17,14 @@ const { title, description, toc = [], related = [], fullWidth = false } = Astro.
 const hasRight = toc.length > 0 || related.length > 0;
 const navSections = await getNavSectionsWithChildren();
 const searchIndexUrl = withBasePath("/search-index.json");
+const designSection = navSections.find((section) => section.title === "Design Principles");
+const appSection = navSections.find((section) => section.title === "Application");
+const sourceSection = navSections.find((section) => section.title === "Source Docs");
+const subNavByHref = new Map<string, Array<{ title: string; href: string }>>([
+  ["/design", (designSection?.items ?? []).filter((item) => item.href !== "/design").slice(0, 5)],
+  ["/app", (appSection?.items ?? []).filter((item) => item.href !== "/app").slice(0, 5)],
+  ["/docs/spec/index", (sourceSection?.items ?? []).filter((item) => item.href !== "/docs/spec/index").slice(0, 5)],
+]);
 ---
 
 <html lang="en">
@@ -45,9 +53,21 @@ const searchIndexUrl = withBasePath("/search-index.json");
       <div class="site-header-inner">
         <a href={withBasePath("/")} class="site-brand">Ugoite</a>
         <nav class="site-nav">
-          {topLinks.map((link) => (
-            <a href={withBasePath(link.href)}>{link.title}</a>
-          ))}
+          {topLinks.map((link) => {
+            const children = subNavByHref.get(link.href) ?? [];
+            return (
+              <div class="site-nav-menu">
+                <a href={withBasePath(link.href)}>{link.title}</a>
+                {children.length > 0 && (
+                  <div class="site-nav-submenu">
+                    {children.map((item) => (
+                      <a href={withBasePath(item.href)}>{item.title}</a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </nav>
         <div class="site-search">
           <input

--- a/docsite/src/styles.css
+++ b/docsite/src/styles.css
@@ -70,18 +70,56 @@ a:hover {
 		gap: 0.25rem;
 	}
 
-	.site-nav a {
+	.site-nav-menu {
+		position: relative;
+	}
+
+	.site-nav-menu > a {
 		padding: 0.375rem 0.875rem;
 		border-radius: var(--doc-radius-md);
 		font-size: 0.875rem;
 		font-weight: 500;
 		color: var(--doc-muted);
 		transition: all 0.15s ease;
+		display: inline-flex;
 	}
 
-	.site-nav a:hover {
+	.site-nav-menu > a:hover {
 		color: var(--doc-fg);
 		background: var(--doc-accent-soft);
+	}
+
+	.site-nav-submenu {
+		position: absolute;
+		top: calc(100% + 0.25rem);
+		left: 0;
+		min-width: 13rem;
+		display: none;
+		flex-direction: column;
+		gap: 0.125rem;
+		padding: 0.375rem;
+		border: var(--doc-border-width) solid var(--doc-border);
+		border-radius: var(--doc-radius-md);
+		background: var(--doc-bg);
+		box-shadow: var(--doc-shadow-lg);
+	}
+
+	.site-nav-submenu a {
+		padding: 0.375rem 0.625rem;
+		border-radius: var(--doc-radius-sm);
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--doc-muted);
+	}
+
+	.site-nav-submenu a:hover {
+		color: var(--doc-fg);
+		background: var(--doc-accent-soft);
+	}
+
+	.site-nav-menu:hover .site-nav-submenu,
+	.site-nav-menu:focus-within .site-nav-submenu {
+		display: flex;
 	}
 
 	.site-search {


### PR DESCRIPTION
## Summary
- add hover/focus subgroup menus for Design, Application, and Source Docs in the top header navigation
- reuse existing section navigation data so subgroup links stay aligned with spec-driven navigation

## Related Issue (required)

close: #508

## Testing

- [x] `cd docsite && bun run lint`
- [x] `cd docsite && bun run typecheck`
- [x] `cd docsite && bun run build`