### PR TITLE
docs(docsite): remove Space Links pages from UI catalog

### DIFF
--- a/docsite/src/lib/spec-data.ts
+++ b/docsite/src/lib/spec-data.ts
@@ -4,6 +4,7 @@ import YAML from "yaml";
 
 const docsRoot = path.resolve(process.cwd(), "../docs");
 const specRoot = path.join(docsRoot, "spec");
+const hiddenUiPageIds = new Set(["space-links", "space-link-detail"]);
 
 export type LinkItem = {
 	id: string;
@@ -203,6 +204,7 @@ export async function getUiPages(): Promise<UiPageSpec[]> {
 			};
 		}>(fullPath);
 		if (!data.page?.id || !data.page.title || !data.page.route) continue;
+		if (hiddenUiPageIds.has(data.page.id)) continue;
 
 		pages.push({
 			fileName,
@@ -233,6 +235,9 @@ export async function getUiPageById(id: string): Promise<UiPageDetail | null> {
 		};
 
 		if (page.id !== id || !page.title || !page.route) {
+			continue;
+		}
+		if (hiddenUiPageIds.has(page.id)) {
 			continue;
 		}
 


### PR DESCRIPTION
## Summary
- filter deprecated `space-links` and `space-link-detail` pages from docsite UI page data
- remove the deleted Space Links pages from generated routes and navigation derived from UI specs

## Related Issue (required)

close: #509

## Testing

- [x] `cd docsite && bun run lint`
- [x] `cd docsite && bun run typecheck`
- [x] `cd docsite && bun run build`