### PR TITLE
docs(docsite): improve UI screenshot presentation

### DIFF
--- a/docsite/src/pages/app/frontend/pages/[id].astro
+++ b/docsite/src/pages/app/frontend/pages/[id].astro
@@ -89,7 +89,7 @@ const toc = [
   <section class="doc-card" style="padding: 0; overflow: hidden;">
     <div style="height: 18rem; background: var(--doc-bg-subtle); display: flex; align-items: center; justify-content: center;">
       {hasScreenshot ? (
-        <img src={`${screenshotBase}${screenshotFile}`} alt={`${detail.title} screenshot`} style="width: 100%; height: 100%; object-fit: cover; object-position: top;" loading="lazy" />
+        <img src={`${screenshotBase}${screenshotFile}`} alt={`${detail.title} screenshot`} style="width: 100%; height: 100%; object-fit: contain; object-position: center; background: var(--doc-bg);" loading="lazy" />
       ) : (
         <div style="text-align: center; color: var(--doc-muted);">
           <div style="font-size: 2rem;">🖥️</div>

--- a/docsite/src/pages/app/frontend/pages/index.astro
+++ b/docsite/src/pages/app/frontend/pages/index.astro
@@ -48,7 +48,7 @@ try {
               <img
                 src={`${screenshotBase}${screenshotFile}`}
                 alt={`${page.title} screenshot`}
-                style="width: 100%; height: 100%; object-fit: cover; object-position: top;"
+                style="width: 100%; height: 100%; object-fit: contain; object-position: center; background: var(--doc-bg);"
                 loading="lazy"
               />
             ) : (
@@ -61,7 +61,6 @@ try {
           {/* Info */}
           <div style="padding: 1rem;">
             <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;">
-              <span class="doc-pill" style="font-size: 0.5625rem;">{page.id}</span>
               <span class="doc-pill doc-pill-outline" style="font-size: 0.5625rem;">{page.implementation ?? "—"}</span>
             </div>
             <h2 style="font-size: 1rem; font-weight: 700; margin: 0;">{page.title}</h2>


### PR DESCRIPTION
## Summary
- switch screenshot rendering from cover to contain so captured pages are no longer clipped
- center screenshots on a neutral background for more realistic page framing
- remove noisy page-id pill from cards to keep catalog presentation cleaner

## Related Issue (required)

close: #510

## Testing

- [x] `cd docsite && bun run lint`
- [x] `cd docsite && bun run typecheck`
- [x] `cd docsite && bun run build`