### PR TITLE
fix: harden devcontainer config against copilot feature outage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"features": {
 		"ghcr.io/devcontainers-extra/features/mise:1": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers/features/copilot-cli:1": {}
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"customizations": {
 		"vscode": {
@@ -42,5 +41,5 @@
 		"GH_TOKEN": "${localEnv:GH_TOKEN}",
 		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
 	},
-	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && uvx pre-commit install && cd /workspace/e2e && npx playwright --version && npx playwright install --with-deps chromium",
+	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && uvx pre-commit install && cd /workspace/e2e && npx playwright --version && npx playwright install --with-deps chromium"
 }


### PR DESCRIPTION
## Summary

- remove the external `ghcr.io/devcontainers/features/copilot-cli:1` feature from `.devcontainer/devcontainer.json`
- keep required `mise` and `github-cli` features for the current smoke command set
- fix invalid trailing comma in `devcontainer.json` so config parsing is deterministic

## Related Issue (required)

close: #536

## Testing

- [x] `mise run test`
