### PR TITLE
feat(docsite): capture and embed CLI command outputs

### DIFF
--- a/.github/workflows/docsite-pages.yml
+++ b/.github/workflows/docsite-pages.yml
@@ -34,6 +34,32 @@ jobs:
       - name: Install project dependencies
         run: mise run setup
 
+      - name: Capture CLI command outputs
+        run: |
+          mkdir -p docsite/src/generated
+          python3 - <<'PY'
+          import json
+          import subprocess
+
+          commands = [
+              "cd ugoite-cli && uv run ugoite --help",
+              "cd ugoite-cli && uv run ugoite space list",
+          ]
+          results = []
+          for command in commands:
+              proc = subprocess.run(
+                  command,
+                  shell=True,
+                  check=False,
+                  text=True,
+                  capture_output=True,
+              )
+              output = (proc.stdout or "") + (proc.stderr or "")
+              results.append({"command": command, "output": output.strip()})
+          with open("docsite/src/generated/cli-command-outputs.json", "w", encoding="utf-8") as f:
+              json.dump(results, f, ensure_ascii=False, indent=2)
+          PY
+
       - name: Capture UI screenshots
         run: mise run screenshot
 

--- a/docsite/src/pages/app/cli/index.astro
+++ b/docsite/src/pages/app/cli/index.astro
@@ -2,12 +2,21 @@
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import TerminalCommand from "../../../components/TerminalCommand.astro";
 import { withBasePath } from "../../../lib/base-path";
+import fs from "node:fs/promises";
+import path from "node:path";
 
 const toc = [
   { id: "overview", title: "Overview" },
   { id: "setup", title: "Setup" },
+  { id: "examples", title: "Command Outputs" },
   { id: "commands", title: "Commands" },
 ];
+
+const generatedPath = path.resolve(process.cwd(), "src/generated/cli-command-outputs.json");
+const commandOutputs = await fs
+  .readFile(generatedPath, "utf-8")
+  .then((raw) => JSON.parse(raw) as { command: string; output: string }[])
+  .catch(() => []);
 ---
 
 <BaseLayout title="CLI | Ugoite" description="Command-line interface for scriptable knowledge management." toc={toc}
@@ -42,6 +51,20 @@ const toc = [
       </div>
     </div>
   </section>
+
+  {commandOutputs.length > 0 && (
+    <section id="examples" class="doc-card">
+      <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Captured Command Outputs</h2>
+      <div style="display: grid; gap: 1rem;">
+        {commandOutputs.map((entry) => (
+          <div>
+            <TerminalCommand command={entry.command} />
+            <pre style="margin-top: 0.5rem; font-size: 0.75rem; padding: 0.75rem; border-radius: var(--doc-radius-md); background: var(--doc-bg-subtle); overflow-x: auto;"><code>{entry.output || "(no output)"}</code></pre>
+          </div>
+        ))}
+      </div>
+    </section>
+  )}
 
   <section id="commands">
     <a href={withBasePath("/app/cli/commands")} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit; display: block;">


### PR DESCRIPTION
## Summary

- add a docsite-pages CI step that executes representative `ugoite-cli` commands and writes captured outputs to `docsite/src/generated/cli-command-outputs.json`
- render captured command outputs on `/app/cli` when the generated file is present, while keeping local builds resilient when the file is absent

## Related Issue (required)

close: #530

## Testing

- [x] `mise run test`
