### PR TITLE
fix(ci): stabilize Rust dependency automation for Arrow stack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,11 +42,13 @@ updates:
           - "iceberg"
     ignore:
       - dependency-name: "arrow-array"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "arrow-schema"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "parquet"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "iceberg"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directory: "/backend"


### PR DESCRIPTION
## Summary

- prevent isolated minor/major bumps for arrow-array, arrow-schema, parquet, and iceberg in cargo dependabot updates
- keep lockstep ecosystem updates intentional so CI remains actionable and merge throughput is not blocked by deterministic incompatibility PRs

## Related Issue (required)

close: #539

## Testing

- [x] ============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/vscode/.cache/uv/builds-v0/.tmphQ4trm/bin/python
cachedir: .pytest_cache
rootdir: /workspace
collecting ... collected 22 items

docs/tests/test_features.py::test_feature_paths_exist PASSED             [  4%]
docs/tests/test_features.py::test_no_undeclared_feature_modules PASSED   [  9%]
docs/tests/test_features.py::test_frontend_paths_match_routes PASSED     [ 13%]
docs/tests/test_guides.py::test_docs_req_ops_001_guides_exist PASSED     [ 18%]
docs/tests/test_guides.py::test_docs_req_ops_001_shell_blocks_parse PASSED [ 22%]
docs/tests/test_guides.py::test_docs_req_ops_001_readme_core_commands_match_mise PASSED [ 27%]
docs/tests/test_guides.py::test_docs_req_ops_001_env_matrix_matches_runtime_usage PASSED [ 31%]
docs/tests/test_guides.py::test_docs_req_ops_001_mise_versions_match_ci_pins PASSED [ 36%]
docs/tests/test_guides.py::test_docs_req_ops_002_docker_build_ci_declared PASSED [ 40%]
docs/tests/test_requirements.py::test_requirement_ids_are_unique PASSED  [ 45%]
docs/tests/test_requirements.py::test_required_fields_present PASSED     [ 50%]
docs/tests/test_requirements.py::test_all_requirements_have_tests PASSED [ 54%]
docs/tests/test_requirements.py::test_all_tests_reference_valid_requirements PASSED [ 59%]
docs/tests/test_requirements.py::test_no_orphan_tests PASSED             [ 63%]
docs/tests/test_spec_governance.py::test_req_ops_003_governance_files_exist PASSED [ 68%]
docs/tests/test_spec_governance.py::test_req_ops_003_ids_and_links_are_structurally_valid PASSED [ 72%]
docs/tests/test_spec_governance.py::test_req_ops_003_bidirectional_links_hold PASSED [ 77%]
docs/tests/test_versions.py::test_docs_req_ops_004_version_files_exist PASSED [ 81%]
docs/tests/test_versions.py::test_docs_req_ops_004_milestones_are_unnumbered_and_phased PASSED [ 86%]
docs/tests/test_versions.py::test_docs_req_ops_004_release_preparation_is_explicit PASSED [ 90%]
docs/tests/test_versions.py::test_docs_req_ops_004_v02_contains_target_milestones PASSED [ 95%]
docs/tests/test_versions.py::test_docs_req_ops_004_issue_templates_support_phase PASSED [100%]

============================== 22 passed in 0.94s ==============================
