### PR TITLE
fix(backend): keep runtime secrets out of repo by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ugoite runtime data (created by ugoite during dev)
+hmac.json
 global.json
 spaces/
 !frontend/src/routes/spaces/

--- a/backend/src/app/core/config.py
+++ b/backend/src/app/core/config.py
@@ -9,4 +9,4 @@ def get_root_path() -> str | Path:
     root = os.environ.get("UGOITE_ROOT")
     if root:
         return root
-    return Path.cwd()
+    return Path.home() / ".ugoite"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,25 @@
+"""Tests for backend root path resolution.
+
+REQ-STO-001: Storage abstraction defaults to user-owned runtime path.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_root_path
+
+
+def test_get_root_path_defaults_to_home_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-STO-001: backend default root path MUST be ~/.ugoite when env is unset."""
+    monkeypatch.delenv("UGOITE_ROOT", raising=False)
+    assert get_root_path() == Path.home() / ".ugoite"
+
+
+def test_get_root_path_prefers_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQ-STO-001: backend MUST honor explicit UGOITE_ROOT override."""
+    custom_root = "/workspace/custom-root"
+    monkeypatch.setenv("UGOITE_ROOT", custom_root)
+    assert get_root_path() == custom_root


### PR DESCRIPTION
## Summary

- change backend default storage root from current working directory to  so HMAC runtime files are not created in repository paths
- add defensive  rule for  to prevent accidental secret commits
- add backend config tests linked to REQ-STO-001 for default root and env override behavior

## Related Issue (required)

close: #543

## Testing

- [x] [0m[32m[//:test:docs][0m ============================= test session starts ==============================
[0m[32m[//:test:docs][0m platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0 -- /home/vscode/.cache/uv/builds-v0/.tmp8IEBkL/bin/python
[0m[32m[//:test:docs][0m cachedir: .pytest_cache
[0m[32m[//:test:docs][0m rootdir: /workspace
[0m[32m[//:test:docs][0m collecting ... collected 22 items
[0m[32m[//:test:docs][0m 
[0m[32m[//:test:docs][0m docs/tests/test_features.py::test_feature_paths_exist PASSED             [  4%]
[0m[32m[//:test:docs][0m docs/tests/test_features.py::test_no_undeclared_feature_modules PASSED   [  9%]
[0m[32m[//:test:docs][0m docs/tests/test_features.py::test_frontend_paths_match_routes PASSED     [ 13%]
[0m[32m[//:test:docs][0m docs/tests/test_guides.py::test_docs_req_ops_001_guides_exist PASSED     [ 18%]
[0m[34m[//frontend:test][0m 
[0m[34m[//frontend:test][0m [1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/workspace/frontend[39m
[0m[34m[//frontend:test][0m 
[0m[32m[//:test:docs][0m docs/tests/test_guides.py::test_docs_req_ops_001_shell_blocks_parse PASSED [ 22%]
[0m[32m[//:test:docs][0m docs/tests/test_guides.py::test_docs_req_ops_001_readme_core_commands_match_mise PASSED [ 27%]
[0m[32m[//:test:docs][0m docs/tests/test_guides.py::test_docs_req_ops_001_env_matrix_matches_runtime_usage PASSED [ 31%]
[0m[32m[//:test:docs][0m docs/tests/test_guides.py::test_docs_req_ops_001_mise_versions_match_ci_pins PASSED [ 36%]
[0m[32m[//:test:docs][0m docs/tests/test_guides.py::test_docs_req_ops_002_docker_build_ci_declared PASSED [ 40%]
[0m[32m[//:test:docs][0m docs/tests/test_requirements.py::test_requirement_ids_are_unique PASSED  [ 45%]
[0m[32m[//:test:docs][0m docs/tests/test_requirements.py::test_required_fields_present PASSED     [ 50%]
[0m[32m[//:test:docs][0m docs/tests/test_requirements.py::test_all_requirements_have_tests PASSED [ 54%]
[0m[32m[//:test:docs][0m docs/tests/test_requirements.py::test_all_tests_reference_valid_requirements PASSED [ 59%]
[0m[34m[//frontend:test][0m  [32m✓[39m src/spec/ui-pages.test.ts [2m([22m[2m7 tests[22m[2m)[22m[33m 562[2mms[22m[39m
[0m[32m[//:test:docs][0m docs/tests/test_requirements.py::test_no_orphan_tests PASSED             [ 63%]
[0m[32m[//:test:docs][0m docs/tests/test_spec_governance.py::test_req_ops_003_governance_files_exist PASSED [ 68%]
[0m[32m[//:test:docs][0m docs/tests/test_spec_governance.py::test_req_ops_003_ids_and_links_are_structurally_valid PASSED [ 72%]
[0m[32m[//:test:docs][0m docs/tests/test_spec_governance.py::test_req_ops_003_bidirectional_links_hold PASSED [ 77%]
[0m[32m[//:test:docs][0m docs/tests/test_versions.py::test_docs_req_ops_004_version_files_exist PASSED [ 81%]
[0m[32m[//:test:docs][0m docs/tests/test_versions.py::test_docs_req_ops_004_milestones_are_unnumbered_and_phased PASSED [ 86%]
[0m[32m[//:test:docs][0m docs/tests/test_versions.py::test_docs_req_ops_004_release_preparation_is_explicit PASSED [ 90%]
[0m[32m[//:test:docs][0m docs/tests/test_versions.py::test_docs_req_ops_004_v02_contains_target_milestones PASSED [ 95%]
[0m[32m[//:test:docs][0m docs/tests/test_versions.py::test_docs_req_ops_004_issue_templates_support_phase PASSED [100%]
[0m[32m[//:test:docs][0m 
[0m[32m[//:test:docs][0m ============================== 22 passed in 1.76s ==============================
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/EntryDetailPane.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[33m 335[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/SpaceSettings.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[33m 382[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/MarkdownEditor.test.tsx [2m([22m[2m12 tests[22m[2m)[22m[33m 491[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/entry-store.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 398[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/SearchBar.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[33m 534[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/ListPanel.test.tsx [2m([22m[2m16 tests[22m[2m)[22m[33m 360[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/FormTable.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 604[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/ThemeMenu.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[33m 557[2mms[22m[39m
[0m[34m[//frontend:test][0m      [33m[2m✓[22m[39m shows language options in settings menu [33m 361[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/create-dialogs.test.tsx [2m([22m[2m8 tests[22m[2m)[22m[33m 1046[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/sql.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 75[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/SpaceSelector.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 249[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/markdown.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 97[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/CanvasPlaceholder.test.tsx [2m([22m[2m8 tests[22m[2m)[22m[32m 165[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/themes/usage.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 194[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/EntryList.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[32m 267[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/routes/spaces/[space_id]/entries/index.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[33m 379[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/SqlQueryEditor.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 297[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/components/AssetUploader.test.tsx [2m([22m[2m7 tests[22m[2m)[22m[32m 166[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/i18n.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 99[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/entry-input.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 73[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/themes/registry.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 127[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/store.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 65[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/routes/spaces/[space_id]/forms/form-detail.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 81[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/space-store.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 44[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/lib/client.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 91[2mms[22m[39m
[0m[34m[//frontend:test][0m  [32m✓[39m src/routes/entries/index.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 52[2mms[22m[39m
[0m[34m[//frontend:test][0m 
[0m[34m[//frontend:test][0m [2m Test Files [22m [1m[32m27 passed[39m[22m[90m (27)[39m
[0m[34m[//frontend:test][0m [2m      Tests [22m [1m[32m166 passed[39m[22m[90m (166)[39m
[0m[34m[//frontend:test][0m [2m   Start at [22m 13:48:24
[0m[34m[//frontend:test][0m [2m   Duration [22m 3.77s[2m (transform 3.82s, setup 2.43s, import 6.11s, tests 7.79s, environment 11.53s)[22m
[0m[34m[//frontend:test][0m 
[0m[32m[//ugoite-core:build][0m ✏️ Setting installed package as editable
[0m[36m[//ugoite-cli:test][0m ============================= test session starts ==============================
[0m[36m[//ugoite-cli:test][0m platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
[0m[36m[//ugoite-cli:test][0m rootdir: /workspace/ugoite-cli
[0m[36m[//ugoite-cli:test][0m configfile: pyproject.toml
[0m[36m[//ugoite-cli:test][0m collected 62 items
[0m[36m[//ugoite-cli:test][0m 
[0m[36m[//ugoite-cli:test][0m tests/test_assets.py .                                                   [  1%]
[0m[36m[//ugoite-cli:test][0m tests/test_cli_endpoint_routing.py .......                               [ 12%]
[0m[36m[//ugoite-cli:test][0m tests/test_cli_form.py ..                                                [ 16%]
[0m[36m[//ugoite-cli:test][0m tests/test_endpoint_config.py ..........                                 [ 32%]
[0m[36m[//ugoite-cli:test][0m tests/test_entries.py .......                                            [ 43%]
[0m[36m[//ugoite-cli:test][0m tests/test_forms.py ...                                                  [ 48%]
[0m[36m[//ugoite-cli:test][0m tests/test_hmac_manager.py ........                                      [ 61%]
[0m[36m[//ugoite-cli:test][0m tests/test_indexer.py ...........                                        [ 79%]
[0m[36m[//ugoite-cli:test][0m tests/test_integrity.py .....                                            [ 87%]
[0m[36m[//ugoite-cli:test][0m tests/test_saved_sql.py ..                                               [ 90%]
[0m[33m[//backend:test][0m ============================= test session starts ==============================
[0m[33m[//backend:test][0m platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
[0m[33m[//backend:test][0m rootdir: /workspace/backend
[0m[33m[//backend:test][0m configfile: pyproject.toml
[0m[33m[//backend:test][0m plugins: anyio-4.12.0
[0m[33m[//backend:test][0m collected 88 items
[0m[33m[//backend:test][0m 
[0m[33m[//backend:test][0m tests/test_api.py ................................................       [ 54%]
[0m[33m[//backend:test][0m tests/test_api_memory.py ....                                            [ 59%]
[0m[33m[//backend:test][0m tests/test_api_reindexing.py .                                           [ 60%]
[0m[33m[//backend:test][0m tests/test_audit.py ..                                                   [ 62%]
[0m[33m[//backend:test][0m tests/test_auth.py ......                                                [ 69%]
[0m[33m[//backend:test][0m tests/test_auth_admin_recovery.py ...                                    [ 72%]
[0m[33m[//backend:test][0m tests/test_auth_passkeys_oauth2_linking.py ..                            [ 75%]
[0m[33m[//backend:test][0m tests/test_config.py ..                                                  [ 77%]
[0m[33m[//backend:test][0m tests/test_entry_attribution.py ..                                       [ 79%]
[0m[33m[//backend:test][0m tests/test_error_sanitization.py .                                       [ 80%]
[0m[33m[//backend:test][0m tests/test_forms.py .....                                                [ 86%]
[0m[33m[//backend:test][0m tests/test_forms_acl.py ....                                             [ 90%]
[0m[33m[//backend:test][0m tests/test_forms_reserved_identity.py ..                                 [ 93%]
[0m[33m[//backend:test][0m tests/test_service_accounts.py .                                         [ 94%]
[0m[33m[//backend:test][0m tests/test_space_members.py ...                                          [ 97%]
[0m[33m[//backend:test][0m tests/test_sql.py ..                                                     [100%]
[0m[33m[//backend:test][0m 
[0m[33m[//backend:test][0m ============================= 88 passed in 25.02s ==============================
[0m[36m[//ugoite-cli:test][0m tests/test_space.py ....                                                 [ 96%]
[0m[36m[//ugoite-cli:test][0m tests/test_sql_rules.py ..                                               [100%]
[0m[36m[//ugoite-cli:test][0m 
[0m[36m[//ugoite-cli:test][0m ============================= 62 passed in 53.31s ==============================
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 0 tests
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 2 tests
[0m[35m[//ugoite-core:test][0m test test_asset_req_asset_001_create_asset ... ok
[0m[35m[//ugoite-core:test][0m test test_asset_req_asset_001_delete_asset ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 10 tests
[0m[35m[//ugoite-core:test][0m test test_entry_req_form_004_deny_extra_attributes ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_entry_006_extract_h2_headers ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_lnk_004_normalize_ugoite_link_uris ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_entry_001_create_entry_basic ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_entry_004_delete_entry ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_form_004_allow_extra_attributes ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_entry_008_assets_linking ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_entry_005_entry_history_append ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_entry_002_update_entry_conflict ... ok
[0m[35m[//ugoite-core:test][0m test test_entry_req_entry_003_update_entry_success ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.14s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 2 tests
[0m[35m[//ugoite-core:test][0m test test_form_req_form_009_system_managed_author_and_updated_by ... ok
[0m[35m[//ugoite-core:test][0m test test_form_req_form_009_reject_client_supplied_author_and_updated_by ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 5 tests
[0m[35m[//ugoite-core:test][0m test test_form_req_form_001_list_column_types ... ok
[0m[35m[//ugoite-core:test][0m test test_form_req_form_005_reject_reserved_metadata_columns ... ok
[0m[35m[//ugoite-core:test][0m test test_form_req_form_006_reject_reserved_metadata_form ... ok
[0m[35m[//ugoite-core:test][0m test test_form_req_form_007_row_reference_requires_target ... ok
[0m[35m[//ugoite-core:test][0m test test_form_req_form_002_upsert_and_list_forms ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 2 tests
[0m[35m[//ugoite-core:test][0m test test_form_req_form_008_reject_user_form_name ... ok
[0m[35m[//ugoite-core:test][0m test test_form_req_form_008_reject_usergroup_form_name ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 9 tests
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_005_word_count ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_001_extract_properties_returns_object ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_010_rich_content_parsing ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_004_inverted_index_generation ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_001_reindex_writes_index_files ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_003_query_index ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_002_validate_properties ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_008_query_sql ... ok
[0m[35m[//ugoite-core:test][0m test test_index_req_idx_009_query_sql_joins ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.40s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 2 tests
[0m[35m[//ugoite-core:test][0m test test_integrity_req_int_001_fake_integrity_provider ... ok
[0m[35m[//ugoite-core:test][0m test test_integrity_req_int_001_real_integrity_provider ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 1 test
[0m[35m[//ugoite-core:test][0m test test_materialized_view_req_api_008_metadata_lifecycle ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 3 tests
[0m[35m[//ugoite-core:test][0m test test_sample_data_req_api_010_list_scenarios ... ok
[0m[35m[//ugoite-core:test][0m test test_sample_data_req_api_010_job_lifecycle ... ok
[0m[35m[//ugoite-core:test][0m test test_sample_data_req_api_009_create_sample_space ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 41.70s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 2 tests
[0m[35m[//ugoite-core:test][0m test test_saved_sql_req_api_007_validation_errors ... ok
[0m[35m[//ugoite-core:test][0m test test_saved_sql_req_api_006_crud ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 2 tests
[0m[35m[//ugoite-core:test][0m test test_search_req_srch_001_keyword_search ... ok
[0m[35m[//ugoite-core:test][0m test test_search_req_srch_002_fallback_scan ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 4 tests
[0m[35m[//ugoite-core:test][0m test test_space_req_sto_008_list_spaces_ignores_missing_meta ... ok
[0m[35m[//ugoite-core:test][0m test test_space_req_sto_002_create_space_scaffolding ... ok
[0m[35m[//ugoite-core:test][0m test test_space_req_sto_005_create_space_idempotency ... ok
[0m[35m[//ugoite-core:test][0m test test_space_req_sto_004_list_spaces_from_directory ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 1 test
[0m[35m[//ugoite-core:test][0m test test_sql_sessions_req_api_008_end_to_end ... ok
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m running 0 tests
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m ============================= test session starts ==============================
[0m[35m[//ugoite-core:test][0m platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
[0m[35m[//ugoite-core:test][0m rootdir: /workspace/ugoite-core
[0m[35m[//ugoite-core:test][0m configfile: pyproject.toml
[0m[35m[//ugoite-core:test][0m plugins: asyncio-1.3.0
[0m[35m[//ugoite-core:test][0m asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
[0m[35m[//ugoite-core:test][0m collected 15 items
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m tests/test_async_bindings.py ..                                          [ 13%]
[0m[35m[//ugoite-core:test][0m tests/test_audit.py ....                                                 [ 40%]
[0m[35m[//ugoite-core:test][0m tests/test_auth.py .                                                     [ 46%]
[0m[35m[//ugoite-core:test][0m tests/test_auth_overview_consistency.py .                                [ 53%]
[0m[35m[//ugoite-core:test][0m tests/test_bindings.py ..                                                [ 66%]
[0m[35m[//ugoite-core:test][0m tests/test_entry_input_modes.py ..                                       [ 80%]
[0m[35m[//ugoite-core:test][0m tests/test_service_accounts.py ...                                       [100%]
[0m[35m[//ugoite-core:test][0m 
[0m[35m[//ugoite-core:test][0m ============================= 15 passed in 18.52s ==============================