### PR TITLE
feat(docsite): add GitHub repository link in navigation

### DIFF
--- a/docsite/src/layouts/BaseLayout.astro
+++ b/docsite/src/layouts/BaseLayout.astro
@@ -69,6 +69,7 @@ const subNavByHref = new Map<string, Array<{ title: string; href: string }>>([
             );
           })}
         </nav>
+        <a href="https://github.com/ugoite/ugoite" class="site-github-link" target="_blank" rel="noreferrer">GitHub</a>
         <div class="site-search">
           <input
             type="search"
@@ -106,6 +107,7 @@ const subNavByHref = new Map<string, Array<{ title: string; href: string }>>([
           {topLinks.map((link) => (
             <a href={withBasePath(link.href)} class="doc-sidebar-link">{link.title}</a>
           ))}
+          <a href="https://github.com/ugoite/ugoite" class="doc-sidebar-link" target="_blank" rel="noreferrer">GitHub</a>
         </div>
         <DocNavTree navSections={navSections} />
       </nav>

--- a/docsite/src/styles.css
+++ b/docsite/src/styles.css
@@ -70,6 +70,20 @@ a:hover {
 		gap: 0.25rem;
 	}
 
+	.site-github-link {
+		padding: 0.375rem 0.875rem;
+		border-radius: var(--doc-radius-md);
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--doc-muted);
+		transition: all 0.15s ease;
+	}
+
+	.site-github-link:hover {
+		color: var(--doc-fg);
+		background: var(--doc-accent-soft);
+	}
+
 	.site-nav-menu {
 		position: relative;
 	}
@@ -1014,6 +1028,10 @@ a:hover {
 		}
 
 		.site-nav {
+			display: none;
+		}
+
+		.site-github-link {
 			display: none;
 		}
 


### PR DESCRIPTION
## Summary

- add a GitHub repository link in the docsite header navigation
- include the same GitHub link in mobile navigation for discoverability
- style the new header link consistently with existing top navigation

## Related Issue (required)

close: #555

## Testing

- [x] `mise run test`
- [x] `mise run e2e`
