### PR TITLE
fix(docsite): show search input on mobile

### DIFF
--- a/docsite/src/styles.css
+++ b/docsite/src/styles.css
@@ -1036,7 +1036,7 @@ a:hover {
 
 		.site-search {
 			order: 4;
-			width: 100%;
+			flex: 0 0 100%;
 		}
 
 		.doc-card-hero {


### PR DESCRIPTION
## Summary

- make docsite search input visible on mobile/tablet breakpoints
- allow the header search container to flex on smaller widths
- keep search usable on narrow screens by wrapping header layout

## Related Issue (required)

close: #554

## Testing

- [x] `mise run test`
- [x] `mise run e2e`
