### PR TITLE
fix(ci): stabilize devcontainer CI registry pulls

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   version-consistency:
@@ -43,6 +44,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Authenticate GHCR pulls
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and smoke test devcontainer
         uses: devcontainers/ci@v0.3

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -8,6 +8,7 @@
 | Frontend CI | `.github/workflows/frontend-ci.yml` | Push, PR | Lint (biome) |
 | E2E Tests | `.github/workflows/e2e-ci.yml` | Push, PR | Full E2E with live servers |
 | Docker Build CI | `.github/workflows/docker-build-ci.yml` | Push, PR | Build backend/frontend images and validate compose |
+| Devcontainer CI | `.github/workflows/devcontainer-ci.yml` | Push, PR | Build/smoke devcontainer with authenticated pulls and cache |
 | SBOM CI | `.github/workflows/sbom-ci.yml` | Push, PR, merge queue | Generate CycloneDX SBOMs, sign/attest, and run vulnerability gate |
 
 ## Python CI
@@ -45,6 +46,17 @@ jobs:
     - Wait for servers
     - cd e2e && npm run test
     timeout: 30 minutes
+```
+
+## Devcontainer CI
+
+```yaml
+jobs:
+  devcontainer-build-smoke:
+    - docker/setup-buildx-action (enables type=gha cache driver)
+    - docker/login-action (ghcr.io, GITHUB_TOKEN)
+    - devcontainers/ci build + smoke command
+    - Run smoke command: gh/mise/bash versions
 ```
 
 ## SBOM and Supply Chain CI


### PR DESCRIPTION
## Summary
- authenticate devcontainer image pulls against GHCR using GitHub token
- keep a lightweight devcontainer smoke build step in CI
- document the devcontainer CI behavior in docs/spec/testing/ci-cd.md

## Testing
- [x] mise run test
- [x] mise run e2e

close: #586