### PR TITLE
feat(docs): separate philosophy design principles from coding guidance

### DIFF
--- a/docs/spec/philosophy/foundation.yaml
+++ b/docs/spec/philosophy/foundation.yaml
@@ -6,32 +6,48 @@ last_updated: 2026-02-15
 philosophies:
   - id: PHIL-001
     title: Freedom Through Modern Abstraction Layers
-    statement: |
-      Ugoite maximizes user freedom by adopting modern abstraction layers that
-      reduce lock-in and preserve optionality. Storage abstraction, a reusable
-      Rust core, open table formats, and portable protocols are treated as
-      first-class architectural assets.
+    product_design_principle: |
+      Product and architecture decisions must preserve user optionality by
+      default. Storage abstraction, reusable core components, open table
+      formats, and portable interfaces are first-class features because they
+      reduce lock-in and preserve long-term user freedom.
+    coding_guideline: |
+      Prefer abstractions and open interfaces over tightly coupled one-off
+      integrations. Reuse shared core modules, avoid storage/provider-specific
+      assumptions in API/UI layers, and keep code paths portable across
+      backends and runtimes.
 
   - id: PHIL-002
     title: Serverless-Oriented Minimal Node Topology
-    statement: |
-      Ugoite minimizes persistent nodes and infrastructure coupling. The target
-      operating model is a small number of composable runtime nodes where
-      clients can directly integrate with storage and AI services when safe,
-      while keeping transitional adapters only where they are currently needed.
+    product_design_principle: |
+      Product capabilities should favor fewer persistent nodes and minimal
+      infrastructure coupling. Clients should integrate directly with storage
+      and AI services where safe, while transitional adapters remain explicit
+      and temporary.
+    coding_guideline: |
+      Keep runtime topology small and explicit in implementation. Avoid adding
+      new always-on services unless required by a documented constraint, and
+      isolate transitional adapters so they can be removed without broad
+      refactoring.
 
   - id: PHIL-003
     title: Build Rules, Not Disposable Artifacts
-    statement: |
-      Ugoite prioritizes durable rules over one-off artifacts. Specifications,
-      code, and tests are coupled so behavior can be re-validated continuously,
-      and user workflows are designed to encode reusable intent rather than
-      repetitive manual steps.
+    product_design_principle: |
+      Product behavior should be encoded as durable, reusable rules rather than
+      manual one-off artifacts. Specifications, implementation, and validation
+      are coupled so behavior can be continuously re-verified.
+    coding_guideline: |
+      Tie behavior changes to specs and tests in the same change set. Prefer
+      reusable helpers, schemas, and automation over manual procedural steps,
+      and avoid introducing logic that cannot be continuously validated in CI.
 
   - id: PHIL-004
     title: Give AI Freedom Inside Trusted Constraints
-    statement: |
-      Ugoite treats AI as a force multiplier that should move quickly inside
-      explicit boundaries. Strict CI, typed interfaces, trusted tools, and
-      policy-linked specifications allow high AI autonomy while keeping risk
-      observable and governable.
+    product_design_principle: |
+      AI should accelerate user workflows, but only within explicit trust
+      boundaries. Product design must make risk observable and governable while
+      retaining high autonomy inside approved constraints.
+    coding_guideline: |
+      Enforce strict typed contracts, CI gates, policy-linked specifications,
+      and trusted toolchains for AI-assisted changes. Do not bypass validation
+      paths or introduce silent fallbacks that hide risk.

--- a/docs/tests/test_spec_governance.py
+++ b/docs/tests/test_spec_governance.py
@@ -223,7 +223,12 @@ def test_req_ops_003_ids_and_links_are_structurally_valid() -> None:
     philosophies = philosophy_loaded.get("philosophies")
     if not isinstance(philosophies, list) or not philosophies:
         _fail("philosophies list is required")
-    _to_id_map(philosophies, "philosophy")
+    philosophy_map = _to_id_map(philosophies, "philosophy")
+    for philosophy_id, philosophy in philosophy_map.items():
+        for key in ("title", "product_design_principle", "coding_guideline"):
+            value = str(philosophy.get(key) or "").strip()
+            if not value:
+                _fail(f"{philosophy_id} must define non-empty {key}")
 
     policy_map = _load_policies()
     requirement_map = _load_requirement_sets()

--- a/docsite/src/lib/spec-data.ts
+++ b/docsite/src/lib/spec-data.ts
@@ -12,6 +12,11 @@ export type LinkItem = {
 	summary?: string;
 };
 
+export type PhilosophyItem = LinkItem & {
+	productDesignPrinciple?: string;
+	codingGuideline?: string;
+};
+
 export type RequirementGroup = {
 	setId: string;
 	sourceFile: string;
@@ -84,21 +89,29 @@ function sortByTitle<T extends { title: string }>(items: T[]): T[] {
 	return [...items].sort((a, b) => a.title.localeCompare(b.title));
 }
 
-export async function getPhilosophies(): Promise<LinkItem[]> {
+export async function getPhilosophies(): Promise<PhilosophyItem[]> {
 	const filePath = path.join(specRoot, "philosophy/foundation.yaml");
 	const data = await readYaml<{
-		philosophies?: Array<{ id: string; title: string; statement?: string }>;
+		philosophies?: Array<{
+			id: string;
+			title: string;
+			statement?: string;
+			product_design_principle?: string;
+			coding_guideline?: string;
+		}>;
 	}>(filePath);
 	return sortByTitle(
 		(data.philosophies ?? []).map((item) => ({
 			id: item.id,
 			title: item.title,
-			summary: item.statement?.trim(),
+			summary: (item.product_design_principle ?? item.statement)?.trim(),
+			productDesignPrinciple: item.product_design_principle?.trim(),
+			codingGuideline: item.coding_guideline?.trim(),
 		})),
 	);
 }
 
-export async function getPhilosophyById(id: string): Promise<LinkItem | null> {
+export async function getPhilosophyById(id: string): Promise<PhilosophyItem | null> {
 	const items = await getPhilosophies();
 	return items.find((item) => item.id === id) ?? null;
 }

--- a/docsite/src/pages/design/philosophy.astro
+++ b/docsite/src/pages/design/philosophy.astro
@@ -25,7 +25,12 @@ const toc = philosophies.map((p) => ({ id: p.id.toLowerCase(), title: p.id }));
       <a href={withBasePath(`/design/philosophy/${p.id.toLowerCase()}`)} id={p.id.toLowerCase()} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
         <span class="doc-pill" style="margin-bottom: 0.75rem;">{p.id}</span>
         <h2 style="font-size: 1.125rem; font-weight: 700;">{p.title}</h2>
-        <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.7;">{p.summary}</p>
+        <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.7;">
+          <strong>Product Design Principle:</strong> {p.productDesignPrinciple ?? p.summary}
+        </p>
+        <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.7;">
+          <strong>Coding Guideline:</strong> {p.codingGuideline}
+        </p>
       </a>
     ))}
   </div>

--- a/docsite/src/pages/design/philosophy/[id].astro
+++ b/docsite/src/pages/design/philosophy/[id].astro
@@ -28,7 +28,11 @@ const tokenize = (text: string): string[] =>
     .split(/\s+/)
     .filter((token) => token.length > 3);
 
-const philosophyTokens = new Set(tokenize(`${item.title} ${item.summary ?? ""}`));
+const philosophyTokens = new Set(
+  tokenize(
+    `${item.title} ${item.productDesignPrinciple ?? item.summary ?? ""} ${item.codingGuideline ?? ""}`,
+  ),
+);
 const relatedPolicies = [...policies]
   .map((policy) => {
     const sourceTokens = tokenize(`${policy.title} ${policy.summary ?? ""}`);
@@ -45,7 +49,8 @@ const requirementIds = [...new Set(relatedPolicies.flatMap((policy) => policy.li
 const featureKinds = await getFeatureKindsLinkedToRequirements(requirementIds);
 
 const toc = [
-  { id: "statement", title: "Statement" },
+  { id: "product-design", title: "Product Design Principle" },
+  { id: "coding-guideline", title: "Coding Guideline" },
   { id: "policies", title: "Related Policies" },
   { id: "requirements", title: "Related Requirements" },
   { id: "features", title: "Related Features" },
@@ -54,7 +59,7 @@ const toc = [
 
 <BaseLayout
   title={`${item.id} | Philosophy | Ugoite`}
-  description={item.summary}
+  description={item.productDesignPrinciple ?? item.summary}
   toc={toc}
   related={[
     { href: "/design/philosophy", label: "Philosophy Index" },
@@ -67,9 +72,14 @@ const toc = [
     <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem;">Derived from docs/spec/philosophy/foundation.yaml</p>
   </section>
 
-  <section id="statement" class="doc-card">
-    <h2 style="font-size: 1.125rem; font-weight: 700; margin-bottom: 0.75rem;">Statement</h2>
-    <p style="color: var(--doc-muted); line-height: 1.7;">{item.summary}</p>
+  <section id="product-design" class="doc-card">
+    <h2 style="font-size: 1.125rem; font-weight: 700; margin-bottom: 0.75rem;">Product Design Principle</h2>
+    <p style="color: var(--doc-muted); line-height: 1.7;">{item.productDesignPrinciple ?? item.summary}</p>
+  </section>
+
+  <section id="coding-guideline" class="doc-card">
+    <h2 style="font-size: 1.125rem; font-weight: 700; margin-bottom: 0.75rem;">Coding Guideline</h2>
+    <p style="color: var(--doc-muted); line-height: 1.7;">{item.codingGuideline}</p>
   </section>
 
   <section id="policies" class="doc-card">


### PR DESCRIPTION
## Summary
- split all four philosophy entries into product design principle and coding guideline fields
- enforce the new philosophy schema in governance tests
- update docsite data parsing and philosophy pages to render both sections clearly

## Testing
- [x] cd docsite && bun run lint && bun run typecheck
- [x] mise run test
- [x] UGOITE_PROXY_TIMEOUT_MS=45000 mise run e2e

close: #589