### PR TITLE
feat(dev-auth): automate local login flow for mise run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,21 +72,19 @@ Install dependencies:
 mise run setup
 ```
 
-Start development (backend + frontend + docsite):
+Start development (backend + frontend + docsite — auth is bootstrapped automatically):
 
 ```bash
 mise run dev
 ```
 
-If authentication is enabled and `localhost:3000` returns `Unauthorized`, configure local auth tokens first:
+If you need to rotate/refresh token manually, run:
 
 ```bash
-export UGOITE_BOOTSTRAP_BEARER_TOKEN="dev-local-token"
-export UGOITE_AUTH_BEARER_TOKEN="dev-local-token"
-mise run dev
+UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev
 ```
 
-See [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) for full setup options.
+See [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) for the 2FA + oathtool flow and local-dev secret setup.
 
 Important: During development we expect `BACKEND_URL` to be set to the backend host reachable from the dev server (e.g. `http://localhost:8000`). The frontend dev server proxies `/api` requests to this URL. Client code uses `/api` to access the backend.
 When running with `docker-compose`, we set: `BACKEND_URL=http://backend:8000`.

--- a/backend/mise.toml
+++ b/backend/mise.toml
@@ -6,10 +6,9 @@ run = "uv sync"
 
 [tasks.dev]
 # UGOITE_ALLOW_REMOTE=true allows remote connections in dev containers / Codespaces
-run = "UGOITE_ALLOW_REMOTE=true uv run uvicorn src.app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir . --reload-dir ../ugoite-core/ugoite_core"
+run = "eval \"$(bash ../scripts/dev-auth-env.sh)\" && UGOITE_ALLOW_REMOTE=true uv run uvicorn src.app.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir . --reload-dir ../ugoite-core/ugoite_core"
 
 [tasks.test]
 run = "uv run pytest"
 description = "Run backend pytest suite"
 depends = ["//ugoite-core:build"]
-

--- a/docs/guide/env-matrix.md
+++ b/docs/guide/env-matrix.md
@@ -5,14 +5,18 @@ This matrix summarizes primary runtime variables by mode.
 | Variable | Local dev | E2E runner | Docker Compose | CI |
 |---|---|---|---|---|
 | BACKEND_URL | required for frontend proxy | set by runner | set to backend service URL | required in frontend jobs |
-| UGOITE_AUTH_BEARER_TOKEN | optional | required | optional | optional |
+| UGOITE_AUTH_BEARER_TOKEN | auto-managed by `dev-auth-env.sh` | required | optional | optional |
 | UGOITE_ROOT | optional | required | volume-backed path | test workspace path |
 | UGOITE_ALLOW_REMOTE | optional | required | required | required for API tests |
 | UGOITE_AUTH_BEARER_TOKENS_JSON | optional | required | optional | optional |
 | UGOITE_AUTH_API_KEY | optional | optional | optional | optional |
-| UGOITE_BOOTSTRAP_BEARER_TOKEN | optional | optional | optional | optional |
-| UGOITE_BOOTSTRAP_USER_ID | optional | optional | optional | optional |
+| UGOITE_BOOTSTRAP_BEARER_TOKEN | auto-managed by `dev-auth-env.sh` | optional | optional | optional |
+| UGOITE_BOOTSTRAP_USER_ID | auto-managed by `dev-auth-env.sh` | optional | optional | optional |
 | UGOITE_PROXY_TIMEOUT_MS | optional | optional | optional | optional |
+| UGOITE_DEV_AUTH_FILE | optional | n/a | n/a | n/a |
+| UGOITE_DEV_AUTH_TTL_SECONDS | optional | n/a | n/a | n/a |
+| UGOITE_DEV_AUTH_FORCE_LOGIN | optional | n/a | n/a | n/a |
+| UGOITE_DEV_2FA_SECRET | optional | n/a | n/a | n/a |
 | E2E_AUTH_BEARER_TOKEN | n/a | required | n/a | required for e2e jobs |
 | E2E_STORAGE_ROOT | n/a | required | n/a | optional |
 | E2E_BACKEND_PORT | n/a | optional | n/a | optional |

--- a/docs/guide/local-dev-auth-login.md
+++ b/docs/guide/local-dev-auth-login.md
@@ -1,38 +1,70 @@
 # Local Development Authentication and Login
 
-When auth is enabled, opening `http://localhost:3000` without a valid bearer token can return `Unauthorized`.
-Use one of the following local setups before running `mise run dev`.
+`mise run dev` now runs an automatic local login flow and token persistence step
+via `scripts/dev-auth-env.sh`. You do not need to export bearer env vars
+manually for the common dev path.
 
-## Option 1: Single bootstrap token
-
-Set one token that the backend accepts and the frontend sends.
+## 1) Install oathtool (required for local 2FA code generation)
 
 ```bash
-export UGOITE_BOOTSTRAP_BEARER_TOKEN="dev-local-token"
-export UGOITE_AUTH_BEARER_TOKEN="dev-local-token"
+sudo apt-get update && sudo apt-get install -y oathtool
+```
+
+## 2) Development 2FA secret (dev-only plain secret)
+
+For local development, the script uses this default Base32 secret:
+
+```text
+JBSWY3DPEHPK3PXP
+```
+
+This is intentionally documented in plain text for development convenience only.
+Do not reuse this secret in production.
+
+You can override it with:
+
+```bash
+export UGOITE_DEV_2FA_SECRET="YOUR_BASE32_SECRET"
+```
+
+## 3) Run development
+
+```bash
 mise run dev
 ```
 
-## Option 2: Explicit token list
+On first run (or after expiry), the script:
+- generates a TOTP code using `oathtool`
+- creates a local bearer token
+- stores it in `~/.ugoite/dev-auth.json`
+- exports backend/frontend auth env vars automatically
 
-Use JSON to define accepted tokens and keep the frontend token in sync.
+## 4) Token reuse and re-login
+
+- Cached token is reused while valid (default TTL: 12 hours).
+- Expired token triggers automatic re-login flow.
+- Force re-login manually:
 
 ```bash
-export UGOITE_AUTH_BEARER_TOKENS_JSON='["dev-local-token","another-token"]'
-export UGOITE_AUTH_BEARER_TOKEN="dev-local-token"
-mise run dev
+UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev
 ```
 
-## Verify login/auth locally
+Optional overrides:
+
+```bash
+export UGOITE_DEV_AUTH_FILE="$HOME/.ugoite/dev-auth.json"
+export UGOITE_DEV_AUTH_TTL_SECONDS=43200
+export UGOITE_DEV_USER_ID="dev-local-user"
+```
+
+## 5) Verify auth locally
 
 1. Open `http://localhost:3000`.
-2. Open browser devtools and confirm API calls include `Authorization: Bearer <token>`.
-3. Check backend health (the `/health` endpoint is intentionally unauthenticated and should return `200 OK`):
+2. Confirm API calls include `Authorization: Bearer <token>`.
+3. Check backend health (`/health` is intentionally unauthenticated):
 
 ```bash
 curl -i http://localhost:8000/health
 ```
 
 Expected response: `HTTP/1.1 200 OK` with body `{"status":"ok"}`.
-
-If the page still shows `Unauthorized`, follow [Troubleshooting Unauthorized Spaces](./troubleshooting-unauthorized-spaces.md).

--- a/docs/guide/troubleshooting-unauthorized-spaces.md
+++ b/docs/guide/troubleshooting-unauthorized-spaces.md
@@ -6,10 +6,11 @@ When the spaces page returns `Unauthorized`, validate these items in order:
    - `curl -sS http://localhost:8000/health`
 2. Confirm frontend proxy target.
    - `BACKEND_URL` must point to the backend reachable by the frontend process.
-3. Confirm auth token wiring.
-   - Frontend server should receive `UGOITE_AUTH_BEARER_TOKEN`.
-4. Confirm token exists in backend auth source.
-   - Include the token in `UGOITE_AUTH_BEARER_TOKENS_JSON` or bootstrap settings.
+3. Refresh local dev login/session.
+   - Re-run `mise run dev`.
+   - If needed, force refresh: `UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev`.
+4. Confirm frontend/backend started with the same generated token.
+   - `scripts/dev-auth-env.sh` should export both `UGOITE_AUTH_BEARER_TOKEN` and `UGOITE_BOOTSTRAP_BEARER_TOKEN`.
 5. Retry with clean browser session.
    - Clear stale cookies and local storage.
 

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -4,7 +4,7 @@ run = "bun install"
 [tasks.dev]
 # Ensure development has the frontend configured to use the same domain sub-path for
 # backend calls and that the dev-server proxy forwards the path to the local backend.
-run = "BACKEND_URL=http://localhost:8000 bun run dev"
+run = "eval \"$(bash ../scripts/dev-auth-env.sh)\" && BACKEND_URL=http://localhost:8000 bun run dev"
 
 [tasks.test]
 run = "bun run test:run"

--- a/frontend/src/routes/spaces/[space_id]/settings.tsx
+++ b/frontend/src/routes/spaces/[space_id]/settings.tsx
@@ -21,7 +21,7 @@ const authHintFromError = (value: unknown): string => {
 		message.includes("authentication") ||
 		message.includes("unauthorized")
 	) {
-		return "Authentication required. Configure UGOITE_AUTH_BEARER_TOKEN or UGOITE_AUTH_API_KEY for frontend server process.";
+		return "Authentication required. Re-run `mise run dev` (or `UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev`) to refresh local login.";
 	}
 	if (
 		message.includes("403") ||
@@ -129,8 +129,9 @@ export default function SpaceSettingsRoute() {
 
 				<div class="ui-card">
 					<p class="text-sm ui-muted">
-						Localhost and remote mode both require authenticated sessions. For frontend proxy usage,
-						configure <code>UGOITE_AUTH_BEARER_TOKEN</code> or <code>UGOITE_AUTH_API_KEY</code>.
+						Localhost and remote mode both require authenticated sessions. Use local login flow via
+						<code>mise run dev</code> and force refresh with
+						<code>UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev</code> when needed.
 					</p>
 				</div>
 

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -1,5 +1,5 @@
 import { A, useNavigate } from "@solidjs/router";
-import { createEffect, createMemo, createResource, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createResource, createSignal, For, JSX, Show } from "solid-js";
 import { spaceApi } from "~/lib/space-api";
 
 const toMessage = (value: unknown): string => {
@@ -16,23 +16,33 @@ export default function SpacesIndexRoute() {
 	});
 	const [redirected, setRedirected] = createSignal(false);
 
-	const authHint = createMemo(() => {
+	const authHint = createMemo((): JSX.Element | null => {
 		const message = toMessage(spaces.error).toLowerCase();
 		if (
 			message.includes("401") ||
 			message.includes("authentication") ||
 			message.includes("unauthorized")
 		) {
-			return "Sign in by setting UGOITE_AUTH_BEARER_TOKEN or UGOITE_AUTH_API_KEY on the frontend server process.";
+			return (
+				<span>
+					Authentication required. Re-run <code>mise run dev</code> (or{" "}
+					<code>UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev</code>) to refresh local login.
+				</span>
+			);
 		}
 		if (
 			message.includes("403") ||
 			message.includes("forbidden") ||
 			message.includes("not authorized")
 		) {
-			return "Your identity is authenticated, but this space is not shared with your user yet. Ask a space admin for an invitation.";
+			return (
+				<span>
+					Your identity is authenticated, but this space is not shared with your user yet. Ask a
+					space admin for an invitation.
+				</span>
+			);
 		}
-		return "";
+		return null;
 	});
 
 	createEffect(() => {
@@ -62,8 +72,9 @@ export default function SpacesIndexRoute() {
 			<section class="ui-card ui-stack-sm">
 				<h2 class="text-lg font-semibold">Authentication</h2>
 				<p class="text-sm ui-muted">
-					Localhost and remote mode both require authentication. Configure frontend/backend using
-					<code>UGOITE_AUTH_BEARER_TOKEN</code> or <code>UGOITE_AUTH_API_KEY</code>.
+					Localhost and remote mode both require authentication. Use the local login flow via
+					<code>mise run dev</code> (or force refresh with
+					<code>UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev</code>).
 				</p>
 			</section>
 

--- a/scripts/dev-auth-env.sh
+++ b/scripts/dev-auth-env.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${HOME:-}" ]; then
+  echo "HOME is not set; cannot determine auth file path." >&2
+  exit 1
+fi
+AUTH_FILE="${UGOITE_DEV_AUTH_FILE:-${HOME}/.ugoite/dev-auth.json}"
+AUTH_TTL_SECONDS="${UGOITE_DEV_AUTH_TTL_SECONDS:-43200}"
+DEV_2FA_SECRET="${UGOITE_DEV_2FA_SECRET:-JBSWY3DPEHPK3PXP}"
+DEV_USER_ID="${UGOITE_DEV_USER_ID:-dev-local-user}"
+
+auth_dir="$(dirname "$AUTH_FILE")"
+mkdir -p "$auth_dir"
+lock_file="${AUTH_FILE}.lock"
+exec 9>"$lock_file"
+if command -v flock >/dev/null 2>&1; then
+  flock 9
+fi
+
+now_epoch="$(date +%s)"
+token=""
+expires_at="0"
+
+if [ -f "$AUTH_FILE" ]; then
+  read -r token expires_at < <(
+    python - "$AUTH_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+except Exception:
+    print("", "0")
+    raise SystemExit(0)
+
+token = payload.get("bearer_token")
+expires = payload.get("expires_at", 0)
+if not isinstance(token, str):
+    token = ""
+if not isinstance(expires, int):
+    expires = 0
+print(token, expires)
+PY
+  )
+fi
+
+if [ -z "$token" ] || [ "$expires_at" -le "$now_epoch" ] || [ "${UGOITE_DEV_AUTH_FORCE_LOGIN:-false}" = "true" ]; then
+  if ! command -v oathtool >/dev/null 2>&1; then
+    echo "oathtool is required for local dev 2FA flow. Install it first." >&2
+    exit 1
+  fi
+
+  otp_code="$(oathtool --totp -b "$DEV_2FA_SECRET" | tr -d '\n')"
+  if [ -z "$otp_code" ]; then
+    echo "failed to generate 2FA code via oathtool" >&2
+    exit 1
+  fi
+
+  token="$(python - <<'PY'
+import secrets
+print(f"dev-{secrets.token_urlsafe(24)}")
+PY
+)"
+  expires_at="$((now_epoch + AUTH_TTL_SECONDS))"
+
+  python - "$AUTH_FILE" "$token" "$expires_at" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+token = sys.argv[2]
+expires_at = int(sys.argv[3])
+path.parent.mkdir(parents=True, exist_ok=True)
+payload = {
+    "bearer_token": token,
+    "expires_at": expires_at,
+}
+path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+  echo "Generated new local dev token; expires_at=${expires_at}" >&2
+fi
+
+python - "$token" "$DEV_USER_ID" <<'PY'
+import shlex
+import sys
+
+token = sys.argv[1]
+user_id = sys.argv[2]
+print(f"export UGOITE_BOOTSTRAP_BEARER_TOKEN={shlex.quote(token)}")
+print(f"export UGOITE_AUTH_BEARER_TOKEN={shlex.quote(token)}")
+print(f"export UGOITE_BOOTSTRAP_USER_ID={shlex.quote(user_id)}")
+PY


### PR DESCRIPTION
## Summary
- add a persisted dev token bootstrap script with 2FA/oathtool support and token expiry handling
- wire backend/frontend `mise run dev` to auto-load local auth env from the new login flow
- update local development auth docs, troubleshooting, and env matrix for the new flow

## Testing
- [x] mise run test
- [x] UGOITE_PROXY_TIMEOUT_MS=45000 mise run e2e

close: #590