### PR TITLE
docs(version): split v0.1 release-preparation milestone

### DIFF
--- a/docs/version/v0.1.yaml
+++ b/docs/version/v0.1.yaml
@@ -50,16 +50,12 @@ milestones:
         status: in_progress
   - id: release-preparation
     status: planned
+    source:
+      - docs/version/v0.1/release-preparation.yaml
     phases:
       - id: container-image-deployment
         status: planned
-        deliverables:
-          - Validate backend/frontend images in staging and production workflows.
       - id: quickstart-documentation-finalization
         status: planned
-        deliverables:
-          - Finalize quick-start and tutorial docs for first-time operators.
       - id: release-notes-drafting
         status: planned
-        deliverables:
-          - Prepare changelog, known issues, and next-step guidance.

--- a/docs/version/v0.1/release-preparation.yaml
+++ b/docs/version/v0.1/release-preparation.yaml
@@ -1,0 +1,23 @@
+id: release-preparation
+version: "0.1"
+status: planned
+title: "Release Preparation"
+goal: >
+  Finalize release readiness for v0.1 with deployable images, operator-ready
+  documentation, and clear release communication.
+phases:
+  - id: container-image-deployment
+    status: planned
+    tasks:
+      - description: "Validate backend/frontend images in staging and production workflows"
+        done: false
+  - id: quickstart-documentation-finalization
+    status: planned
+    tasks:
+      - description: "Finalize quick-start and tutorial docs for first-time operators"
+        done: false
+  - id: release-notes-drafting
+    status: planned
+    tasks:
+      - description: "Prepare changelog, known issues, and next-step guidance"
+        done: false


### PR DESCRIPTION
## Summary
- move v0.1 release-preparation details into a dedicated milestone YAML at docs/version/v0.1/release-preparation.yaml
- reference the new source file from docs/version/v0.1.yaml
- keep release-preparation phase IDs in v0.1.yaml for milestone-level validation consistency

## Validation
- mise run test
- mise run e2e

Closes #616

close: #616
