### PR TITLE
chore(license): adopt MIT across repository metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ugoite contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ See [Roadmap](docs/tasks/roadmap.md) for planned milestones:
 
 ---
 
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE).
+
+---
+
 ## Contributing
 
 Contributions welcome! See [AGENTS.md](AGENTS.md) for development guidelines.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,6 +3,7 @@ name = "app"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
+license = { text = "MIT" }
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.121.1",

--- a/docsite/package.json
+++ b/docsite/package.json
@@ -2,6 +2,7 @@
 	"name": "ugoite-docsite",
 	"private": true,
 	"version": "0.1.0",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"dev": "astro dev --host 127.0.0.1 --strictPort --port 4321",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,6 +2,7 @@
 	"name": "ugoite-e2e",
 	"type": "module",
 	"private": true,
+	"license": "MIT",
 	"scripts": {
 		"test": "playwright test --grep-invert @screenshot",
 		"test:smoke": "playwright test smoke.test.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "ugoite-frontend",
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"dev": "vinxi dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ugoite-release-tooling",
       "version": "0.0.0",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "description": "Repository-level commit and release automation tooling",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "prepare": "husky",
     "commitlint:range": "commitlint --from \"${COMMITLINT_FROM:-HEAD~1}\" --to \"${COMMITLINT_TO:-HEAD}\" --verbose",

--- a/ugoite-cli/Cargo.toml
+++ b/ugoite-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ugoite-cli"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [[bin]]
 name = "ugoite"

--- a/ugoite-core/Cargo.toml
+++ b/ugoite-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ugoite-core"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [lib]
 name = "_ugoite_core"

--- a/ugoite-core/pyproject.toml
+++ b/ugoite-core/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ugoite-core"
+license = { text = "MIT" }
 requires-python = ">=3.12"
 dependencies = []
 dynamic = ["version"]


### PR DESCRIPTION
## Summary
- add a root MIT LICENSE file
- update README with explicit MIT license section
- align package and module metadata to MIT across root/frontend/docsite/e2e, Python projects, and Rust crates

## Validation
- mise run test
- mise run e2e

Closes #618

close: #618
