### PR TITLE
chore(repo): remove placeholder root artifacts

### DIFF
--- a/.github/workflows/yaml-workflow-ci.yml
+++ b/.github/workflows/yaml-workflow-ci.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check root placeholder artifacts
+        run: bash scripts/check-placeholder-artifacts.sh
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: root-artifact-hygiene
+        name: root artifact hygiene
+        entry: bash scripts/check-placeholder-artifacts.sh
+        language: system
+        always_run: true
+        pass_filenames: false
+
       - id: shell-quality
         name: shell quality gates
         entry: bash scripts/check-shell-quality.sh --fix

--- a/dev.log
+++ b/dev.log
@@ -1,1 +1,0 @@
-This file is intentionally left blank.

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -5,7 +5,7 @@
 | Workflow | File | Triggers | Purpose |
 |----------|------|----------|---------|
 | Python CI | `.github/workflows/python-ci.yml` | Push, PR | Lint (ruff), type check, pytest |
-| YAML Workflow CI | `.github/workflows/yaml-workflow-ci.yml` | Push, PR | Lint (yamllint + actionlint) |
+| YAML Workflow CI | `.github/workflows/yaml-workflow-ci.yml` | Push, PR | Lint (yamllint + actionlint) and root artifact hygiene |
 | Frontend CI | `.github/workflows/frontend-ci.yml` | Push, PR | Lint (biome) |
 | E2E Tests | `.github/workflows/e2e-ci.yml` | Push, PR | Full E2E with live servers |
 | Docker Build CI | `.github/workflows/docker-build-ci.yml` | Push, PR | Build backend/frontend images and validate compose |
@@ -34,6 +34,7 @@ jobs:
 ```yaml
 jobs:
   ci:
+    - root placeholder artifact guard
     - yamllint (repo YAML/config checks)
     - actionlint (GitHub Actions workflow lint)
 ```
@@ -95,6 +96,7 @@ Hooks configured in `.pre-commit-config.yaml`:
 - **Ruff**: Auto-formats and lints Python
 - **Yamllint**: Validates YAML syntax/style on committed YAML files
 - **Actionlint**: Validates `.github/workflows/*` syntax and workflow semantics
+- **Root artifact hygiene**: Blocks root-level files with placeholder-only content
 - **Ty**: Type checks Python projects
 
 Conventional Commit enforcement (local):

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -31,8 +31,12 @@ README_PATH = REPO_ROOT / "README.md"
 MISE_PATH = REPO_ROOT / "mise.toml"
 ENV_MATRIX_PATH = GUIDE_DIR / "env-matrix.md"
 COLUMN_COUNT_THRESHOLD = 2
-REQUIRED_PRE_COMMIT_HOOKS = {"yamllint", "actionlint"}
-REQUIRED_YAML_WORKFLOW_CI_STEPS = {"Run yamllint", "Run actionlint"}
+REQUIRED_PRE_COMMIT_HOOKS = {"root-artifact-hygiene", "yamllint", "actionlint"}
+REQUIRED_YAML_WORKFLOW_CI_STEPS = {
+    "Check root placeholder artifacts",
+    "Run yamllint",
+    "Run actionlint",
+}
 
 CODE_BLOCK_PATTERN = re.compile(
     r"```(?:bash|sh|shell)\s*\n(.*?)\n```",

--- a/scripts/check-placeholder-artifacts.sh
+++ b/scripts/check-placeholder-artifacts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+mapfile -t placeholder_files < <(
+  python3 - <<'PY'
+from pathlib import Path
+
+SENTINEL = "This file is intentionally left blank."
+root = Path(".")
+
+for path in sorted(root.iterdir()):
+    if not path.is_file() or path.name.startswith("."):
+        continue
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        continue
+    if text.strip() == SENTINEL:
+        print(path.as_posix())
+PY
+)
+
+if [ "${#placeholder_files[@]}" -gt 0 ]; then
+  echo "Found placeholder root artifacts that must be removed:" >&2
+  printf "  - %s\n" "${placeholder_files[@]}" >&2
+  exit 1
+fi
+
+echo "Repository root placeholder artifact check passed."


### PR DESCRIPTION
## Summary
- remove placeholder root artifact `dev.log`
- add `scripts/check-placeholder-artifacts.sh` guard for root files with placeholder-only content
- enforce the guard in pre-commit and YAML Workflow CI, and document it in CI/CD spec

## Validation
- mise run test
- mise run e2e

close: #623
