### PR TITLE
docs: align conflict handling contract

### DIFF
--- a/docs/spec/architecture/decisions.md
+++ b/docs/spec/architecture/decisions.md
@@ -108,14 +108,16 @@ Use revision-based optimistic concurrency:
 - Every entry has a `revision_id`
 - Updates include `parent_revision_id`
 - Server rejects if parent doesn't match current
-- Client handles 409 Conflict with merge UI
+- Current frontend editor flow handles 409 Conflict with explicit refresh guidance
+  while keeping the local draft visible
+- Rich in-editor merge UI is deferred to a future milestone
 
 **Consequences**:
 - (+) Responsive UI with optimistic updates
-- (+) No data loss (conflicts are surfaced)
+- (+) No silent data loss (conflicts are surfaced and the local draft remains visible)
 - (+) Simple implementation
-- (-) Users must resolve conflicts manually
-- (-) Last-write-wins would be simpler (but risky)
+- (-) Users must refresh and reconcile conflicts manually
+- (-) There is no built-in merge UI yet
 
 ---
 

--- a/docs/spec/architecture/frontend-backend-interface.md
+++ b/docs/spec/architecture/frontend-backend-interface.md
@@ -21,6 +21,9 @@ and responsibility boundaries.
 - Backend compares `parent_revision_id` with current head.
 - On match: backend persists, appends history, returns new `revision_id`.
 - On mismatch: backend returns **409 Conflict** with the current revision info.
+- Current entry-editor recovery flow keeps the local draft visible, shows refresh
+  guidance, and leaves merge/reconciliation to the user. A dedicated merge UI is
+  not part of the current milestone contract.
 
 ### Entry Creation & Indexing
 
@@ -50,6 +53,6 @@ and responsibility boundaries.
 |---|---|---|
 | 400 | Treat as validation bug; log details | "Invalid input" |
 | 404 | Remove stale selection; redirect to list | "Not found" |
-| 409 | Trigger conflict flow | "Changed on server" |
+| 409 | Keep the current draft visible and prompt an explicit refresh | "Changed on server. Refresh to load the latest version." |
 | 422 | Highlight invalid fields | Field-level error |
 | 5xx | Retry/backoff or show offline mode | "Server error" |

--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -273,19 +273,29 @@ requirements:
   - SPEC-UI-PAGES
   - SPEC-ARCH-INTERFACE
   id: REQ-FE-009
-  title: Conflict Message Display
-  description: 'Frontend MUST notify the user on 409 Conflict errors.
+  title: Conflict Refresh Guidance
+  description: 'Frontend MUST notify the user on 409 Conflict errors, keep the
+
+    current draft visible in the editor, and require an explicit refresh before
+
+    loading the latest server revision. A merge UI is not part of the current
+
+    milestone contract.
 
     '
   related_spec:
   - architecture/frontend-backend-interface.md#error-handling-standards
+  - architecture/decisions.md#adr-005
   priority: high
   status: implemented
   tests:
     vitest:
     - file: frontend/src/components/MarkdownEditor.test.tsx
       tests:
-      - should show conflict message when there is a conflict
+      - 'REQ-FE-009: should show conflict message when there is a conflict'
+    - file: frontend/src/components/EntryDetailPane.test.tsx
+      tests:
+      - 'REQ-FE-009: shows refresh guidance on revision conflict'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.

--- a/frontend/src/components/EntryDetailPane.test.tsx
+++ b/frontend/src/components/EntryDetailPane.test.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom/vitest";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 import { EntryDetailPane } from "./EntryDetailPane";
-import { entryApi } from "~/lib/entry-api";
+import { entryApi, RevisionConflictError } from "~/lib/entry-api";
 import { assetApi } from "~/lib/asset-api";
 
 vi.mock("~/lib/entry-api", () => {
@@ -274,6 +274,39 @@ describe("EntryDetailPane", () => {
 
 		await waitFor(() => {
 			expect(screen.getByText("Server unavailable")).toBeInTheDocument();
+		});
+	});
+
+	it("REQ-FE-009: shows refresh guidance on revision conflict", async () => {
+		(entryApi.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "entry-1",
+			title: "Test Entry",
+			form: null,
+			content: "# Test Entry",
+			revision_id: "rev-1",
+			created_at: "2026-01-01T00:00:00Z",
+			updated_at: "2026-01-01T00:00:00Z",
+		});
+		(entryApi.update as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new RevisionConflictError("Revision conflict", "server-rev"),
+		);
+
+		render(() => (
+			<EntryDetailPane spaceId={() => "default"} entryId={() => "entry-1"} onDeleted={vi.fn()} />
+		));
+
+		await waitFor(() => expect(entryApi.get).toHaveBeenCalled());
+
+		const textarea = await screen.findByPlaceholderText("Start writing in Markdown...");
+		fireEvent.input(textarea, { target: { value: "Updated content" } });
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					"This entry was modified elsewhere. Your draft is still in the editor; refresh to load the latest version.",
+				),
+			).toBeInTheDocument();
 		});
 	});
 

--- a/frontend/src/components/EntryDetailPane.tsx
+++ b/frontend/src/components/EntryDetailPane.tsx
@@ -325,7 +325,7 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
 		/* v8 ignore start */
 		if (error instanceof RevisionConflictError) {
 			setConflictMessage(
-				"This entry was modified elsewhere. Please refresh to see the latest version.",
+				"This entry was modified elsewhere. Your draft is still in the editor; refresh to load the latest version.",
 			);
 			return;
 		}

--- a/frontend/src/components/MarkdownEditor.test.tsx
+++ b/frontend/src/components/MarkdownEditor.test.tsx
@@ -65,7 +65,7 @@ describe("MarkdownEditor", () => {
 		expect(onSave).toHaveBeenCalled();
 	});
 
-	it("should show conflict message when there is a conflict", () => {
+	it("REQ-FE-009: should show conflict message when there is a conflict", () => {
 		render(() => (
 			<MarkdownEditor
 				content="# Test"


### PR DESCRIPTION
## Summary

- align ADR-005 and the frontend/backend interface docs with the current refresh-based 409 conflict flow
- make REQ-FE-009 explicit that the editor keeps the local draft visible and requires refresh rather than an in-editor merge UI
- add frontend requirement-traced tests for the conflict message and refresh guidance copy

## Related Issue (required)

closes #665

## Testing

- [x] `cd frontend && bun run test:run src/components/MarkdownEditor.test.tsx src/components/EntryDetailPane.test.tsx`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_requirements.py -q`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
