### PR TITLE
fix: hide reserved metadata forms from entry creation

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1065,11 +1065,18 @@ requirements:
 
     MUST show the selected Form fields and generate the entry from the
 
-    Form template with the correct frontmatter.
+    Form template with the correct frontmatter. Reserved metadata forms MUST NOT
+
+    be presented as ordinary user-selectable forms in entry creation flows.
+
+    Dashboard-style onboarding MUST count only user-creatable forms when guiding
+
+    the user to create a first entry.
 
     '
   related_spec:
   - data-model/overview.md#forms
+  - data-model/directory-structure.md#space-level
   - stories/core.yaml#STORY-002
   priority: high
   status: implemented
@@ -1080,9 +1087,14 @@ requirements:
       - 'REQ-FE-037: requires form selection before creating an entry'
       - 'REQ-FE-037: blocks submission when required fields are empty'
       - 'REQ-FE-037: pre-fills defaults for required fields'
+      - 'REQ-FE-037: excludes reserved metadata forms from entry creation'
     - file: frontend/src/components/ListPanel.test.tsx
       tests:
       - 'REQ-FE-037: disables new entry when no forms exist'
+    - file: frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
+      tests:
+      - 'REQ-FE-037: dashboard ignores reserved metadata forms in the entry count'
+      - 'REQ-FE-037: dashboard disables entry creation when only reserved metadata forms exist'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.

--- a/frontend/src/components/create-dialogs.test.tsx
+++ b/frontend/src/components/create-dialogs.test.tsx
@@ -350,6 +350,36 @@ describe("CreateEntryDialog", () => {
 		expect(onSubmit).not.toHaveBeenCalled();
 		expect(screen.getByText("Please provide markdown content.")).toBeInTheDocument();
 	});
+
+	it("REQ-FE-037: excludes reserved metadata forms from entry creation", async () => {
+		const onSubmit = vi.fn();
+		const onClose = vi.fn();
+		const forms = [
+			{
+				name: "Assets",
+				version: 1,
+				fields: {
+					link: { type: "string", required: true },
+				},
+				template: "",
+			},
+			{
+				name: "Meeting",
+				version: 1,
+				fields: { Date: { type: "date", required: true } },
+				template: "",
+			},
+		];
+
+		render(() => (
+			<CreateEntryDialog open={true} forms={forms} onClose={onClose} onSubmit={onSubmit} />
+		));
+
+		const select = screen.getByRole("combobox");
+		expect(screen.queryByRole("option", { name: "Assets" })).not.toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "Meeting" })).toBeInTheDocument();
+		expect((select as HTMLSelectElement).value).toBe("Meeting");
+	});
 });
 
 describe("EditFormDialog", () => {

--- a/frontend/src/components/create-dialogs.tsx
+++ b/frontend/src/components/create-dialogs.tsx
@@ -11,7 +11,11 @@ import {
 import { buildEntryMarkdownFromFields, type EntryInputMode } from "~/lib/entry-input";
 import type { Form, FormCreatePayload } from "~/lib/types";
 import { RESERVED_METADATA_COLUMNS, isReservedMetadataColumn } from "~/lib/metadata-columns";
-import { RESERVED_METADATA_CLASSES, isReservedMetadataForm } from "~/lib/metadata-forms";
+import {
+	RESERVED_METADATA_CLASSES,
+	filterCreatableEntryForms,
+	isReservedMetadataForm,
+} from "~/lib/metadata-forms";
 
 const numericFieldTypes = new Set(["integer", "long", "number", "double", "float"]);
 
@@ -132,8 +136,10 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
 	let inputRef: HTMLInputElement | undefined;
 	let dialogRef: HTMLDialogElement | undefined;
 
+	const selectableForms = createMemo(() => filterCreatableEntryForms(props.forms));
+
 	const selectedFormDef = createMemo(() =>
-		props.forms.find((entryForm) => entryForm.name === selectedForm()),
+		selectableForms().find((entryForm) => entryForm.name === selectedForm()),
 	);
 
 	const requiredFields = createMemo(() => {
@@ -235,12 +241,13 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
 		setLastGeneratedMarkdown("");
 		setInitializedFormName("");
 		setChatStep(0);
+		const availableForms = selectableForms();
 		/* v8 ignore start */
 		const defaultForm = props.defaultForm?.trim();
-		if (defaultForm && props.forms.some((entryForm) => entryForm.name === defaultForm)) {
+		if (defaultForm && availableForms.some((entryForm) => entryForm.name === defaultForm)) {
 			setSelectedForm(defaultForm);
-		} else if (props.forms.length === 1) {
-			setSelectedForm(props.forms[0].name);
+		} else if (availableForms.length === 1) {
+			setSelectedForm(availableForms[0].name);
 		} else {
 			setSelectedForm("");
 		}
@@ -370,7 +377,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
 						</div>
 
 						<Show
-							when={props.forms.length > 0}
+							when={selectableForms().length > 0}
 							fallback={
 								<div class="ui-card ui-card-dashed text-sm ui-muted">
 									Create a form first to start writing entries.
@@ -393,7 +400,9 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
 									<option value="" disabled>
 										Select a form
 									</option>
-									<For each={props.forms}>{(s) => <option value={s.name}>{s.name}</option>}</For>
+									<For each={selectableForms()}>
+										{(entryForm) => <option value={entryForm.name}>{entryForm.name}</option>}
+									</For>
 								</select>
 								<Show when={selectedFormDef()}>
 									{(entryForm) => (
@@ -605,7 +614,9 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
 							</button>
 							<button
 								type="submit"
-								disabled={!title().trim() || !selectedForm().trim() || props.forms.length === 0}
+								disabled={
+									!title().trim() || !selectedForm().trim() || selectableForms().length === 0
+								}
 								class="ui-button ui-button-primary text-sm"
 							>
 								Create

--- a/frontend/src/lib/metadata-forms.ts
+++ b/frontend/src/lib/metadata-forms.ts
@@ -1,9 +1,15 @@
 export const RESERVED_METADATA_CLASSES = ["SQL", "Assets"] as const;
 
+type NamedForm = { name: string };
+
 const RESERVED_METADATA_CLASS_SET = new Set(
 	RESERVED_METADATA_CLASSES.map((name) => name.trim().toLowerCase()),
 );
 
 export function isReservedMetadataForm(name: string): boolean {
 	return RESERVED_METADATA_CLASS_SET.has(name.trim().toLowerCase());
+}
+
+export function filterCreatableEntryForms<T extends NamedForm>(forms: readonly T[]): T[] {
+	return forms.filter((form) => !isReservedMetadataForm(form.name));
 }

--- a/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
@@ -1,0 +1,108 @@
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import SpaceDashboardRoute from "./dashboard";
+import { spaceApi } from "~/lib/space-api";
+import { formApi } from "~/lib/form-api";
+import { assetApi } from "~/lib/asset-api";
+import type { Form } from "~/lib/types";
+
+const navigateMock = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+	useNavigate: () => navigateMock,
+	useParams: () => ({ space_id: "default" }),
+	A: (props: { href: string; class?: string; children: unknown }) => (
+		<a href={props.href} class={props.class}>
+			{props.children}
+		</a>
+	),
+}));
+
+vi.mock("~/components/SpaceShell", () => ({
+	SpaceShell: (props: { children: unknown }) => <div>{props.children}</div>,
+}));
+
+vi.mock("~/components/AssetUploader", () => ({
+	AssetUploader: () => <div>Asset uploader</div>,
+}));
+
+vi.mock("~/lib/entry-store", () => ({
+	createEntryStore: () => ({
+		createEntry: vi.fn(),
+	}),
+}));
+
+vi.mock("~/lib/space-api", () => ({
+	spaceApi: {
+		get: vi.fn(),
+	},
+}));
+
+vi.mock("~/lib/form-api", () => ({
+	formApi: {
+		list: vi.fn(),
+		listTypes: vi.fn(),
+		create: vi.fn(),
+	},
+}));
+
+vi.mock("~/lib/asset-api", () => ({
+	assetApi: {
+		list: vi.fn(),
+		upload: vi.fn(),
+		delete: vi.fn(),
+	},
+}));
+
+describe("/spaces/:space_id/dashboard", () => {
+	const meetingForm: Form = {
+		name: "Meeting",
+		version: 1,
+		template: "",
+		fields: { Date: { type: "date", required: true } },
+	};
+	const assetsForm: Form = {
+		name: "Assets",
+		version: 1,
+		template: "",
+		fields: {
+			link: { type: "string", required: true },
+			name: { type: "string", required: true },
+			uploaded_at: { type: "timestamp", required: true },
+		},
+	};
+
+	beforeEach(() => {
+		navigateMock.mockReset();
+		(spaceApi.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "default",
+			name: "Default Space",
+			created_at: "2025-01-01T00:00:00Z",
+		});
+		(formApi.listTypes as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+		(assetApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+	});
+
+	it("REQ-FE-037: dashboard ignores reserved metadata forms in the entry count", async () => {
+		(formApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([assetsForm, meetingForm]);
+
+		render(() => <SpaceDashboardRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByText("1 forms available")).toBeInTheDocument();
+		});
+		expect(screen.queryByText("2 forms available")).not.toBeInTheDocument();
+	});
+
+	it("REQ-FE-037: dashboard disables entry creation when only reserved metadata forms exist", async () => {
+		(formApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([assetsForm]);
+
+		render(() => <SpaceDashboardRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Create a form first to start writing entries.")).toBeInTheDocument();
+		});
+		expect(screen.getByRole("button", { name: "New entry" })).toBeDisabled();
+	});
+});

--- a/frontend/src/routes/spaces/[space_id]/dashboard.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.tsx
@@ -6,6 +6,7 @@ import { assetApi } from "~/lib/asset-api";
 import { SpaceShell } from "~/components/SpaceShell";
 import { createEntryStore } from "~/lib/entry-store";
 import { buildEntryMarkdownByMode, type EntryInputMode } from "~/lib/entry-input";
+import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { formApi } from "~/lib/form-api";
 import { spaceApi } from "~/lib/space-api";
 import type { FormCreatePayload } from "~/lib/types";
@@ -49,6 +50,7 @@ export default function SpaceDashboardRoute() {
 	);
 
 	const safeForms = createMemo(() => forms() || []);
+	const entryForms = createMemo(() => filterCreatableEntryForms(safeForms()));
 
 	const handleCreateForm = async (payload: FormCreatePayload) => {
 		try {
@@ -70,7 +72,7 @@ export default function SpaceDashboardRoute() {
 			alert("Please select a form to create an entry.");
 			return;
 		}
-		const formDef = safeForms().find((entryForm) => entryForm.name === formName);
+		const formDef = entryForms().find((entryForm) => entryForm.name === formName);
 		if (!formDef) {
 			alert("Selected form was not found. Please refresh and try again.");
 			return;
@@ -127,8 +129,8 @@ export default function SpaceDashboardRoute() {
 								fallback={<p class="text-sm ui-muted">Loading forms...</p>}
 							>
 								<p class="text-sm ui-muted">
-									{safeForms().length > 0
-										? `${safeForms().length} forms available`
+									{entryForms().length > 0
+										? `${entryForms().length} forms available`
 										: "Create a form first to start writing entries."}
 								</p>
 							</Show>
@@ -137,6 +139,7 @@ export default function SpaceDashboardRoute() {
 							<button
 								type="button"
 								class="ui-button ui-button-primary text-sm"
+								disabled={entryForms().length === 0}
 								onClick={() => setShowCreateEntryDialog(true)}
 							>
 								New entry
@@ -189,7 +192,7 @@ export default function SpaceDashboardRoute() {
 
 			<CreateEntryDialog
 				open={showCreateEntryDialog()}
-				forms={safeForms()}
+				forms={entryForms()}
 				onClose={() => setShowCreateEntryDialog(false)}
 				onSubmit={handleCreateEntry}
 			/>

--- a/frontend/src/routes/spaces/[space_id]/entries/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.tsx
@@ -12,6 +12,7 @@ import { CreateEntryDialog } from "~/components/create-dialogs";
 import { SpaceShell } from "~/components/SpaceShell";
 import { buildEntryMarkdownByMode, type EntryInputMode } from "~/lib/entry-input";
 import { useEntriesRouteContext } from "~/lib/entries-route-context";
+import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { sqlSessionApi } from "~/lib/sql-session-api";
 import type { EntryRecord } from "~/lib/types";
 
@@ -21,6 +22,7 @@ export default function SpaceEntriesIndexPane() {
 	const ctx = useEntriesRouteContext();
 	const spaceId = () => ctx.spaceId();
 	const [showCreateEntryDialog, setShowCreateEntryDialog] = createSignal(false);
+	const creatableForms = createMemo(() => filterCreatableEntryForms(ctx.forms()));
 
 	const sessionId = createMemo(() => (searchParams.session ? String(searchParams.session) : ""));
 	const [page, setPage] = createSignal(1);
@@ -108,7 +110,7 @@ export default function SpaceEntriesIndexPane() {
 			alert("Please select a form to create an entry.");
 			return;
 		}
-		const formDef = ctx.forms().find((s) => s.name === formName);
+		const formDef = creatableForms().find((s) => s.name === formName);
 		if (!formDef) {
 			alert("Selected form was not found. Please refresh and try again.");
 			return;
@@ -229,8 +231,8 @@ export default function SpaceEntriesIndexPane() {
 
 			<CreateEntryDialog
 				open={showCreateEntryDialog()}
-				forms={ctx.forms()}
-				defaultForm={ctx.forms()[0]?.name}
+				forms={creatableForms()}
+				defaultForm={creatableForms()[0]?.name}
 				onClose={() => setShowCreateEntryDialog(false)}
 				onSubmit={handleCreateEntry}
 			/>


### PR DESCRIPTION
## Summary

- filter reserved metadata forms out of entry-creation flows so fresh spaces no longer treat `Assets`/`SQL` as normal content forms
- update dashboard and entries views to count only user-creatable forms and disable entry creation when none exist
- extend REQ-FE-037 coverage with dialog and dashboard tests for the reserved-form onboarding case

## Related Issue (required)

closes #666

## Testing

- [x] `cd frontend && bun run test:run src/components/create-dialogs.test.tsx src/routes/spaces/[space_id]/dashboard.test.tsx src/routes/spaces/[space_id]/entries/index.test.tsx`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_requirements.py -q`
- [x] `cd frontend && bun run lint`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
