### PR TITLE
feat: add create-space empty state action

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -53,6 +53,10 @@ requirements:
   title: No Client-side Default Space Creation
   description: 'Frontend MUST NOT auto-create spaces when none exist.
 
+    When `/spaces` has no spaces yet, the UI MUST offer an explicit user-triggered
+
+    create-space action instead of silently creating a default space.
+
     '
   related_spec:
   - architecture/overview.md
@@ -63,6 +67,10 @@ requirements:
     - file: frontend/src/lib/space-store.test.ts
       tests:
       - should keep selection empty when no spaces exist
+    - file: frontend/src/routes/spaces/index.test.tsx
+      tests:
+      - 'REQ-FE-002: shows a create-space action when no spaces exist'
+      - 'REQ-FE-002: creates a space only after explicit user submission'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -1,0 +1,66 @@
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import SpacesIndexRoute from "./index";
+import { spaceApi } from "~/lib/space-api";
+
+const navigateMock = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+	useNavigate: () => navigateMock,
+	A: (props: { href: string; class?: string; children: unknown }) => (
+		<a href={props.href} class={props.class}>
+			{props.children}
+		</a>
+	),
+}));
+
+vi.mock("~/lib/space-api", () => ({
+	spaceApi: {
+		list: vi.fn(),
+		create: vi.fn(),
+	},
+}));
+
+describe("/spaces", () => {
+	beforeEach(() => {
+		navigateMock.mockReset();
+		(spaceApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+		(spaceApi.create as ReturnType<typeof vi.fn>).mockReset();
+	});
+
+	it("REQ-FE-002: shows a create-space action when no spaces exist", async () => {
+		render(() => <SpacesIndexRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByText("No spaces available.")).toBeInTheDocument();
+		});
+
+		expect(screen.getByRole("button", { name: "Create space" })).toBeInTheDocument();
+		expect(spaceApi.create).not.toHaveBeenCalled();
+	});
+
+	it("REQ-FE-002: creates a space only after explicit user submission", async () => {
+		(spaceApi.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+			id: "my-space",
+			name: "my-space",
+		});
+
+		render(() => <SpacesIndexRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByText("No spaces available.")).toBeInTheDocument();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Create space" }));
+		fireEvent.input(screen.getByLabelText("Space name"), {
+			target: { value: "my-space" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Create space" }));
+
+		await waitFor(() => {
+			expect(spaceApi.create).toHaveBeenCalledWith("my-space");
+			expect(navigateMock).toHaveBeenCalledWith("/spaces/my-space/dashboard");
+		});
+	});
+});

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -1,5 +1,13 @@
 import { A, useNavigate } from "@solidjs/router";
-import { createEffect, createMemo, createResource, createSignal, For, JSX, Show } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createResource,
+	createSignal,
+	For,
+	Show,
+	type JSX,
+} from "solid-js";
 import { spaceApi } from "~/lib/space-api";
 
 const toMessage = (value: unknown): string => {
@@ -11,10 +19,14 @@ const toMessage = (value: unknown): string => {
 
 export default function SpacesIndexRoute() {
 	const navigate = useNavigate();
-	const [spaces] = createResource(async () => {
+	const [spaces, { refetch: refetchSpaces }] = createResource(async () => {
 		return await spaceApi.list();
 	});
 	const [redirected, setRedirected] = createSignal(false);
+	const [showCreateForm, setShowCreateForm] = createSignal(false);
+	const [newSpaceName, setNewSpaceName] = createSignal("");
+	const [createError, setCreateError] = createSignal<string | null>(null);
+	const [isCreating, setIsCreating] = createSignal(false);
 
 	const authHint = createMemo((): JSX.Element | null => {
 		const message = toMessage(spaces.error).toLowerCase();
@@ -45,6 +57,42 @@ export default function SpacesIndexRoute() {
 		return null;
 	});
 
+	const hasNoSpaces = createMemo(
+		() => !spaces.loading && !spaces.error && (spaces()?.length ?? 0) === 0,
+	);
+
+	const openCreateForm = () => {
+		setCreateError(null);
+		setShowCreateForm(true);
+	};
+
+	const closeCreateForm = () => {
+		setShowCreateForm(false);
+		setNewSpaceName("");
+		setCreateError(null);
+	};
+
+	const handleCreateSpace = async (event: Event) => {
+		event.preventDefault();
+		const spaceName = newSpaceName().trim();
+		if (!spaceName) {
+			setCreateError("Please provide a space name.");
+			return;
+		}
+		setIsCreating(true);
+		setCreateError(null);
+		try {
+			const created = await spaceApi.create(spaceName);
+			await refetchSpaces();
+			closeCreateForm();
+			navigate(`/spaces/${created.id}/dashboard`);
+		} catch (error) {
+			setCreateError(toMessage(error) || "Failed to create space.");
+		} finally {
+			setIsCreating(false);
+		}
+	};
+
 	createEffect(() => {
 		if (!spaces.error || redirected()) {
 			return;
@@ -64,9 +112,20 @@ export default function SpacesIndexRoute() {
 		<main class="mx-auto max-w-4xl ui-page ui-stack">
 			<div class="flex flex-wrap items-center justify-between gap-3">
 				<h1 class="ui-page-title">Spaces</h1>
-				<A href="/" class="ui-muted text-sm">
-					Back to Home
-				</A>
+				<div class="flex flex-wrap items-center gap-2">
+					<Show when={!spaces.error && !showCreateForm() && !hasNoSpaces()}>
+						<button
+							type="button"
+							class="ui-button ui-button-primary text-sm"
+							onClick={openCreateForm}
+						>
+							Create space
+						</button>
+					</Show>
+					<A href="/" class="ui-muted text-sm">
+						Back to Home
+					</A>
+				</div>
 			</div>
 
 			<section class="ui-card ui-stack-sm">
@@ -80,6 +139,49 @@ export default function SpacesIndexRoute() {
 
 			<section class="ui-card">
 				<h2 class="text-lg font-semibold mb-3">Available Spaces</h2>
+				<Show when={showCreateForm()}>
+					<form class="ui-card ui-stack-sm mb-4" onSubmit={handleCreateSpace}>
+						<div>
+							<h3 class="text-base font-semibold">Create space</h3>
+							<p class="text-sm ui-muted">
+								Spaces are never created automatically. Choose a name to create one explicitly.
+							</p>
+						</div>
+						<div class="ui-field">
+							<label class="ui-label" for="space-name">
+								Space name
+							</label>
+							<input
+								id="space-name"
+								type="text"
+								class="ui-input"
+								value={newSpaceName()}
+								onInput={(event) => setNewSpaceName(event.currentTarget.value)}
+								placeholder="Enter space name..."
+							/>
+						</div>
+						<Show when={createError()}>
+							<p class="ui-alert ui-alert-error text-sm">{createError()}</p>
+						</Show>
+						<div class="flex flex-wrap justify-end gap-2">
+							<button
+								type="button"
+								class="ui-button ui-button-secondary text-sm"
+								onClick={closeCreateForm}
+								disabled={isCreating()}
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								class="ui-button ui-button-primary text-sm"
+								disabled={!newSpaceName().trim() || isCreating()}
+							>
+								{isCreating() ? "Creating..." : "Create space"}
+							</button>
+						</div>
+					</form>
+				</Show>
 				<Show when={spaces.loading}>
 					<p class="text-sm ui-muted">Loading spaces...</p>
 				</Show>
@@ -89,8 +191,19 @@ export default function SpacesIndexRoute() {
 						<p class="text-sm ui-muted mt-2">{authHint()}</p>
 					</Show>
 				</Show>
-				<Show when={spaces() && spaces()?.length === 0}>
-					<p class="text-sm ui-muted">No spaces available.</p>
+				<Show when={hasNoSpaces() && !showCreateForm()}>
+					<div class="ui-card ui-card-dashed ui-stack-sm">
+						<p class="text-sm ui-muted">No spaces available.</p>
+						<div>
+							<button
+								type="button"
+								class="ui-button ui-button-primary text-sm"
+								onClick={openCreateForm}
+							>
+								Create space
+							</button>
+						</div>
+					</div>
 				</Show>
 				<ul class="ui-stack-sm">
 					<For each={spaces() || []}>


### PR DESCRIPTION
## Summary

- add an explicit create-space form to the `/spaces` empty state instead of leaving first-run users at a dead end
- keep REQ-FE-002 intact by only creating spaces after an explicit user action and redirecting into the new dashboard on success
- cover the new flow with requirement-traced route tests and update the frontend requirements spec

## Related Issue (required)

closes #667

## Testing

- [x] `cd frontend && bun run test:run src/routes/spaces/index.test.tsx`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_requirements.py -q`
- [x] `cd frontend && bun run lint`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
