### PR TITLE
fix: avoid CLI backend runtime panic

### DIFF
--- a/docs/spec/requirements/storage.yaml
+++ b/docs/spec/requirements/storage.yaml
@@ -153,6 +153,7 @@ requirements:
     - file: ugoite-cli/tests/test_cli_endpoint_routing.rs
       tests:
       - test_space_list_uses_remote_endpoint_when_backend_mode
+      - test_space_list_req_sto_004_returns_remote_json_without_panicking
     - file: ugoite-cli/tests/test_integrity.rs
       tests:
       - test_integrity_provider_for_space_success

--- a/ugoite-cli/src/commands/asset.rs
+++ b/ugoite-cli/src/commands/asset.rs
@@ -35,7 +35,7 @@ pub async fn run(cmd: AssetCmd) -> Result<()> {
         AssetSubCmd::List { space_path } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/assets"))?;
+                let result = http::http_get(&format!("{base}/spaces/{space_id}/assets")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -73,7 +73,8 @@ pub async fn run(cmd: AssetCmd) -> Result<()> {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
                 let result =
-                    http::http_delete(&format!("{base}/spaces/{space_id}/assets/{asset_id}"))?;
+                    http::http_delete(&format!("{base}/spaces/{space_id}/assets/{asset_id}"))
+                        .await?;
                 print_json(&result);
                 return Ok(());
             }

--- a/ugoite-cli/src/commands/entry.rs
+++ b/ugoite-cli/src/commands/entry.rs
@@ -76,7 +76,7 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
         EntrySubCmd::List { space_path } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/entries"))?;
+                let result = http::http_get(&format!("{base}/spaces/{space_id}/entries")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -92,7 +92,7 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
                 let result =
-                    http::http_get(&format!("{base}/spaces/{space_id}/entries/{entry_id}"))?;
+                    http::http_get(&format!("{base}/spaces/{space_id}/entries/{entry_id}")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -112,7 +112,8 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 let result = http::http_post(
                     &format!("{base}/spaces/{space_id}/entries/{entry_id}"),
                     &serde_json::json!({"content": content, "author": author}),
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -147,7 +148,8 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 let result = http::http_put(
                     &format!("{base}/spaces/{space_id}/entries/{entry_id}"),
                     &body,
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -185,7 +187,7 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 } else {
                     format!("{base}/spaces/{space_id}/entries/{entry_id}")
                 };
-                let result = http::http_delete(&url)?;
+                let result = http::http_delete(&url).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -202,7 +204,8 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
             if let Some(base) = base_url(&config) {
                 let result = http::http_get(&format!(
                     "{base}/spaces/{space_id}/entries/{entry_id}/history"
-                ))?;
+                ))
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -220,7 +223,8 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
             if let Some(base) = base_url(&config) {
                 let result = http::http_get(&format!(
                     "{base}/spaces/{space_id}/entries/{entry_id}/revisions/{revision_id}"
-                ))?;
+                ))
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -241,7 +245,8 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 let result = http::http_post(
                     &format!("{base}/spaces/{space_id}/entries/{entry_id}/restore/{revision_id}"),
                     &serde_json::json!({"author": author}),
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }

--- a/ugoite-cli/src/commands/form.rs
+++ b/ugoite-cli/src/commands/form.rs
@@ -38,7 +38,7 @@ pub async fn run(cmd: FormCmd) -> Result<()> {
         FormSubCmd::List { space_path } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/forms"))?;
+                let result = http::http_get(&format!("{base}/spaces/{space_id}/forms")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -54,7 +54,7 @@ pub async fn run(cmd: FormCmd) -> Result<()> {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
                 let result =
-                    http::http_get(&format!("{base}/spaces/{space_id}/forms/{form_name}"))?;
+                    http::http_get(&format!("{base}/spaces/{space_id}/forms/{form_name}")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -79,7 +79,8 @@ pub async fn run(cmd: FormCmd) -> Result<()> {
                 let result = http::http_put(
                     &format!("{base}/spaces/{space_id}/forms/{form_name}"),
                     &form_def,
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }

--- a/ugoite-cli/src/commands/index.rs
+++ b/ugoite-cli/src/commands/index.rs
@@ -28,7 +28,8 @@ pub async fn run(cmd: IndexCmd) -> Result<()> {
                 let result = http::http_post(
                     &format!("{base}/spaces/{space_id}/index"),
                     &serde_json::json!({}),
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -40,7 +41,7 @@ pub async fn run(cmd: IndexCmd) -> Result<()> {
         IndexSubCmd::Stats { space_path } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/stats"))?;
+                let result = http::http_get(&format!("{base}/spaces/{space_id}/stats")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -57,7 +58,7 @@ pub async fn query_cmd(space_path: &str, sql: &str) -> Result<()> {
     let config = load_config();
     let (root, space_id) = parse_space_path(space_path);
     if let Some(base) = base_url(&config) {
-        let result = http::http_get(&format!("{base}/spaces/{space_id}/query?sql={sql}"))?;
+        let result = http::http_get(&format!("{base}/spaces/{space_id}/query?sql={sql}")).await?;
         print_json(&result);
         return Ok(());
     }

--- a/ugoite-cli/src/commands/search.rs
+++ b/ugoite-cli/src/commands/search.rs
@@ -23,7 +23,8 @@ pub async fn run(cmd: SearchCmd) -> Result<()> {
         SearchSubCmd::Keyword { space_path, query } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/search?q={query}"))?;
+                let result =
+                    http::http_get(&format!("{base}/spaces/{space_id}/search?q={query}")).await?;
                 print_json(&result);
                 return Ok(());
             }

--- a/ugoite-cli/src/commands/space.rs
+++ b/ugoite-cli/src/commands/space.rs
@@ -84,7 +84,8 @@ pub async fn create_space_cmd(root_path: &str, space_id: &str) -> Result<()> {
         let result = http::http_post(
             &format!("{base}/spaces/{space_id}"),
             &serde_json::json!({"id": space_id}),
-        )?;
+        )
+        .await?;
         print_json(&result);
         return Ok(());
     }
@@ -99,7 +100,7 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
     match cmd.sub {
         SpaceSubCmd::List { root_path } => {
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces"))?;
+                let result = http::http_get(&format!("{base}/spaces")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -112,7 +113,7 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
             space_id,
         } => {
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}"))?;
+                let result = http::http_get(&format!("{base}/spaces/{space_id}")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -143,7 +144,8 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
                 let result = http::http_patch(
                     &format!("{base}/spaces/{space_id}"),
                     &serde_json::Value::Object(patch),
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -221,7 +223,8 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
             space_id,
         } => {
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/service-accounts"))?;
+                let result =
+                    http::http_get(&format!("{base}/spaces/{space_id}/service-accounts")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -240,7 +243,8 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
                         "display_name": display_name,
                         "scopes": scopes,
                     }),
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -249,7 +253,7 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
         SpaceSubCmd::Members { space_path } => {
             let (_, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/members"))?;
+                let result = http::http_get(&format!("{base}/spaces/{space_id}/members")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -264,7 +268,8 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
             if let Some(base) = base_url(&config) {
                 let result = http::http_get(&format!(
                     "{base}/spaces/{space_id}/audit-events?offset={offset}&limit={limit}"
-                ))?;
+                ))
+                .await?;
                 print_json(&result);
                 return Ok(());
             }

--- a/ugoite-cli/src/commands/sql.rs
+++ b/ugoite-cli/src/commands/sql.rs
@@ -64,7 +64,7 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
         SqlSubCmd::SavedList { space_path } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/sql"))?;
+                let result = http::http_get(&format!("{base}/spaces/{space_id}/sql")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -76,7 +76,8 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
         SqlSubCmd::SavedGet { space_path, sql_id } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_get(&format!("{base}/spaces/{space_id}/sql/{sql_id}"))?;
+                let result =
+                    http::http_get(&format!("{base}/spaces/{space_id}/sql/{sql_id}")).await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -101,7 +102,8 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
                 let result = http::http_post(
                     &format!("{base}/spaces/{space_id}/sql"),
                     &serde_json::json!({"id": sql_id, "name": name, "sql": sql, "variables": vars, "author": author}),
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -136,7 +138,8 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
                 let result = http::http_put(
                     &format!("{base}/spaces/{space_id}/sql/{sql_id}"),
                     &serde_json::json!({"name": name, "sql": sql, "variables": vars, "parent_revision_id": parent_revision_id, "author": author}),
-                )?;
+                )
+                .await?;
                 print_json(&result);
                 return Ok(());
             }
@@ -163,7 +166,8 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
         SqlSubCmd::SavedDelete { space_path, sql_id } => {
             let (root, space_id) = parse_space_path(&space_path);
             if let Some(base) = base_url(&config) {
-                let result = http::http_delete(&format!("{base}/spaces/{space_id}/sql/{sql_id}"))?;
+                let result =
+                    http::http_delete(&format!("{base}/spaces/{space_id}/sql/{sql_id}")).await?;
                 print_json(&result);
                 return Ok(());
             }

--- a/ugoite-cli/src/http.rs
+++ b/ugoite-cli/src/http.rs
@@ -1,76 +1,61 @@
 use anyhow::{bail, Result};
 
-pub fn http_get(url: &str) -> Result<serde_json::Value> {
-    let client = reqwest::blocking::Client::new();
+pub async fn http_get(url: &str) -> Result<serde_json::Value> {
+    let client = reqwest::Client::new();
     let req = add_auth_headers(client.get(url));
-    let resp = req.send()?;
+    let resp = req.send().await?;
     if !resp.status().is_success() {
-        bail!(
-            "HTTP {}: {}",
-            resp.status(),
-            resp.text().unwrap_or_default()
-        );
+        let status = resp.status();
+        bail!("HTTP {}: {}", status, resp.text().await.unwrap_or_default());
     }
-    Ok(resp.json()?)
+    Ok(resp.json().await?)
 }
 
-pub fn http_post(url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
-    let client = reqwest::blocking::Client::new();
+pub async fn http_post(url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
+    let client = reqwest::Client::new();
     let req = add_auth_headers(client.post(url).json(body));
-    let resp = req.send()?;
+    let resp = req.send().await?;
     if !resp.status().is_success() {
-        bail!(
-            "HTTP {}: {}",
-            resp.status(),
-            resp.text().unwrap_or_default()
-        );
+        let status = resp.status();
+        bail!("HTTP {}: {}", status, resp.text().await.unwrap_or_default());
     }
-    Ok(resp.json().unwrap_or(serde_json::Value::Null))
+    Ok(resp.json().await.unwrap_or(serde_json::Value::Null))
 }
 
-pub fn http_put(url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
-    let client = reqwest::blocking::Client::new();
+pub async fn http_put(url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
+    let client = reqwest::Client::new();
     let req = add_auth_headers(client.put(url).json(body));
-    let resp = req.send()?;
+    let resp = req.send().await?;
     if !resp.status().is_success() {
-        bail!(
-            "HTTP {}: {}",
-            resp.status(),
-            resp.text().unwrap_or_default()
-        );
+        let status = resp.status();
+        bail!("HTTP {}: {}", status, resp.text().await.unwrap_or_default());
     }
-    Ok(resp.json().unwrap_or(serde_json::Value::Null))
+    Ok(resp.json().await.unwrap_or(serde_json::Value::Null))
 }
 
-pub fn http_patch(url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
-    let client = reqwest::blocking::Client::new();
+pub async fn http_patch(url: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
+    let client = reqwest::Client::new();
     let req = add_auth_headers(client.patch(url).json(body));
-    let resp = req.send()?;
+    let resp = req.send().await?;
     if !resp.status().is_success() {
-        bail!(
-            "HTTP {}: {}",
-            resp.status(),
-            resp.text().unwrap_or_default()
-        );
+        let status = resp.status();
+        bail!("HTTP {}: {}", status, resp.text().await.unwrap_or_default());
     }
-    Ok(resp.json().unwrap_or(serde_json::Value::Null))
+    Ok(resp.json().await.unwrap_or(serde_json::Value::Null))
 }
 
-pub fn http_delete(url: &str) -> Result<serde_json::Value> {
-    let client = reqwest::blocking::Client::new();
+pub async fn http_delete(url: &str) -> Result<serde_json::Value> {
+    let client = reqwest::Client::new();
     let req = add_auth_headers(client.delete(url));
-    let resp = req.send()?;
+    let resp = req.send().await?;
     if !resp.status().is_success() {
-        bail!(
-            "HTTP {}: {}",
-            resp.status(),
-            resp.text().unwrap_or_default()
-        );
+        let status = resp.status();
+        bail!("HTTP {}: {}", status, resp.text().await.unwrap_or_default());
     }
-    Ok(resp.json().unwrap_or(serde_json::Value::Null))
+    Ok(resp.json().await.unwrap_or(serde_json::Value::Null))
 }
 
-fn add_auth_headers(req: reqwest::blocking::RequestBuilder) -> reqwest::blocking::RequestBuilder {
+fn add_auth_headers(req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
     let mut r = req;
     if let Ok(token) = std::env::var("UGOITE_AUTH_BEARER_TOKEN") {
         r = r.header("Authorization", format!("Bearer {token}"));

--- a/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -1,7 +1,11 @@
 //! Integration tests for CLI endpoint routing configuration.
 //! REQ-STO-001, REQ-STO-004, REQ-SEC-003
 
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
 
 fn ugoite_bin() -> String {
     let mut path = std::env::current_exe().unwrap();
@@ -11,6 +15,39 @@ fn ugoite_bin() -> String {
     }
     path.push("ugoite");
     path.to_string_lossy().to_string()
+}
+
+fn spawn_json_server(body: &'static str) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut buffer = [0_u8; 1024];
+                    let _ = stream.read(&mut buffer);
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    stream.write_all(response.as_bytes()).unwrap();
+                    return;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for CLI backend request"
+                    );
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("failed to accept test request: {error}"),
+            }
+        }
+    });
+    (format!("http://{}", addr), handle)
 }
 
 /// REQ-STO-001: Config set/show round-trips correctly.
@@ -79,6 +116,57 @@ fn test_space_list_uses_remote_endpoint_when_backend_mode() {
         !output.status.success(),
         "Expected failure connecting to unreachable backend"
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Cannot drop a runtime"),
+        "CLI should return a normal connection error instead of panicking: {stderr}"
+    );
+}
+
+/// REQ-STO-004: Backend mode returns remote space JSON without Tokio runtime panic.
+#[test]
+fn test_space_list_req_sto_004_returns_remote_json_without_panicking() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    let root = dir.path().to_string_lossy().to_string();
+    let (base_url, server_handle) =
+        spawn_json_server(r#"[{"id":"remote-space","name":"Remote Space"}]"#);
+
+    let set_output = Command::new(ugoite_bin())
+        .args([
+            "config",
+            "set",
+            "--mode",
+            "backend",
+            "--backend-url",
+            &base_url,
+        ])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+    assert!(set_output.status.success());
+
+    let output = Command::new(ugoite_bin())
+        .args(["space", "list", &root])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+
+    server_handle.join().unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Cannot drop a runtime"),
+        "CLI should not panic in backend mode: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("JSON");
+    assert_eq!(value[0]["id"].as_str(), Some("remote-space"));
 }
 
 /// REQ-SEC-003: Service account create routes to backend when in backend mode.


### PR DESCRIPTION
## Summary

- switch CLI backend/API mode HTTP calls from blocking reqwest to async reqwest on the shared Tokio runtime
- update backend-routed command handlers to await the shared HTTP helpers instead of dropping a nested blocking runtime
- add a requirement-traced integration test that proves `space list` returns backend JSON without panicking in backend mode

## Related Issue (required)

closes #668

## Testing

- [x] `cargo fmt --all && CARGO_BUILD_JOBS=1 cargo test -q -p ugoite-cli --test test_cli_endpoint_routing`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_requirements.py -q`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
