### PR TITLE
fix: exclude release automation from all-tests status

### DIFF
--- a/.github/workflows/all-tests-ci.yml
+++ b/.github/workflows/all-tests-ci.yml
@@ -24,3 +24,6 @@ jobs:
         uses: int128/wait-for-workflows-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          exclude-workflow-names: |
+            Release CI
+            Release Publish

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -382,3 +382,38 @@ requirements:
     - file: docs/tests/test_guides.py
       tests:
       - test_docs_req_ops_012_devcontainer_trigger_paths_cover_inputs
+- set_id: REQCAT-OPS
+  source_file: requirements/ops.yaml
+  scope: Operational quality, workflow, and automation requirements.
+  linked_policies:
+  - POL-003
+  - POL-005
+  - POL-008
+  - POL-009
+  - POL-010
+  - POL-013
+  linked_specifications:
+  - SPEC-TESTING-CICD
+  - SPEC-TESTING-STRATEGY
+  - SPEC-ARCH-STACK
+  - SPEC-PRODUCT-METRICS
+  id: REQ-OPS-013
+  title: All Tests Status Workflow Curation
+  description: 'All Tests Status MUST aggregate code-quality workflow health and
+
+    exclude release/publish automation workflows (at minimum `Release CI` and
+
+    `Release Publish`) so auxiliary release failures do not mark branch health
+
+    red.
+
+    '
+  related_spec:
+  - testing/ci-cd.md
+  priority: medium
+  status: implemented
+  tests:
+    pytest:
+    - file: docs/tests/test_guides.py
+      tests:
+      - test_docs_req_ops_013_all_tests_status_excludes_release_automation

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -14,6 +14,7 @@
 | SBOM CI | `.github/workflows/sbom-ci.yml` | Push, PR, merge queue | Generate CycloneDX SBOMs, sign/attest, and run vulnerability gate |
 | Commitlint CI | `.github/workflows/commitlint-ci.yml` | PR, merge queue | Enforce Conventional Commits |
 | PR Template Validation | `.github/workflows/pr-require-close-issue.yml` | PR body events via `pull_request_target` | Enforce required PR sections and accepted close/closes issue links |
+| All Tests Status | `.github/workflows/all-tests-ci.yml` | Push on `main`, PR, merge queue | Aggregate code-quality workflow health while excluding release/publish automation |
 | Release CI | `.github/workflows/release-ci.yml` | Push on `main` | Create/update release PR with release-please (no auto publish) |
 | Release Publish | `.github/workflows/release-publish.yml` | Manual (`workflow_dispatch`) | Human-approved stable/alpha/beta GitHub release publish |
 
@@ -159,13 +160,14 @@ This enables Husky `commit-msg` hook and runs `commitlint` before commit is acce
 
 1. **Conventional Commits** are required locally (Husky + Commitlint) and in CI (`commitlint-ci`).
 2. **Static checks and tests** must pass through existing CI workflows and `All Tests Status`.
-3. **Release CI** runs on pushes to `main` and uses release-please to create/update a release PR with SemVer planning.
-4. **Release automation bootstrap** is seeded from `.github/.release-please-manifest.json` and `package.json`, and both must start at `0.0.1`.
-5. **Release CI authentication** must prefer `RELEASE_PLEASE_TOKEN` when that secret is configured, and only fall back to `GITHUB_TOKEN` when no dedicated release token is available.
-6. **Repository or organization Actions workflow permissions** must keep "Allow GitHub Actions to create and approve pull requests" enabled whenever the fallback `GITHUB_TOKEN` path is used, or release-please cannot open/update the release PR even when the workflow requests `pull-requests: write`.
-7. **Human review** must confirm the planned release scope before publishing.
-8. **Release Publish** is manual (`workflow_dispatch`) and requires explicit `APPROVED` confirmation.
-9. **Stable/alpha/beta channels** are validated by channel-specific SemVer patterns at publish time.
+3. **All Tests Status** must stay focused on code-quality workflows and exclude release/publish automation (`Release CI`, `Release Publish`) so auxiliary release failures do not turn branch health red.
+4. **Release CI** runs on pushes to `main` and uses release-please to create/update a release PR with SemVer planning.
+5. **Release automation bootstrap** is seeded from `.github/.release-please-manifest.json` and `package.json`, and both must start at `0.0.1`.
+6. **Release CI authentication** must prefer `RELEASE_PLEASE_TOKEN` when that secret is configured, and only fall back to `GITHUB_TOKEN` when no dedicated release token is available.
+7. **Repository or organization Actions workflow permissions** must keep "Allow GitHub Actions to create and approve pull requests" enabled whenever the fallback `GITHUB_TOKEN` path is used, or release-please cannot open/update the release PR even when the workflow requests `pull-requests: write`.
+8. **Human review** must confirm the planned release scope before publishing.
+9. **Release Publish** is manual (`workflow_dispatch`) and requires explicit `APPROVED` confirmation.
+10. **Stable/alpha/beta channels** are validated by channel-specific SemVer patterns at publish time.
 
 ## Environment Variables
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -9,6 +9,7 @@ REQ-OPS-008: PR template validation rules must be enforced in CI.
 REQ-OPS-009: Release automation bootstrap and PR permissions must be documented.
 REQ-OPS-010: Frontend local-dev proxy readiness must be declared.
 REQ-OPS-012: Devcontainer trigger paths must cover setup inputs.
+REQ-OPS-013: All Tests Status must exclude release automation from branch health.
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ SBOM_CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "sbom-ci.yml"
 DEVCONTAINER_CI_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "devcontainer-ci.yml"
 )
+ALL_TESTS_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "all-tests-ci.yml"
 PR_TEMPLATE_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "pr-require-close-issue.yml"
 )
@@ -120,6 +122,13 @@ REQUIRED_WAIT_FOR_HTTP_FRAGMENTS = {
 REQUIRED_LOCAL_DEV_AUTH_GUIDE_FRAGMENTS = {
     "/api/*",
     "waits for `http://localhost:8000/health`",
+}
+REQUIRED_ALL_TESTS_EXCLUDED_WORKFLOWS = {"Release CI", "Release Publish"}
+REQUIRED_ALL_TESTS_DOC_FRAGMENTS = {
+    "| All Tests Status | `.github/workflows/all-tests-ci.yml` |",
+    "exclude release/publish automation",
+    "Release CI",
+    "Release Publish",
 }
 REQUIRED_DEVCONTAINER_TRIGGER_PATTERNS = {
     ".github/workflows/devcontainer-ci.yml",
@@ -569,6 +578,78 @@ def test_docs_req_ops_012_devcontainer_trigger_paths_cover_inputs() -> None:
 
     if details:
         raise AssertionError("; ".join(details))
+
+
+def test_docs_req_ops_013_all_tests_status_excludes_release_automation() -> None:
+    """REQ-OPS-013: All Tests Status must exclude release automation workflows."""
+    details = _collect_all_tests_status_details()
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def _collect_all_tests_status_details() -> list[str]:
+    workflow = _load_yaml_base_mapping(ALL_TESTS_WORKFLOW_PATH)
+    jobs = workflow.get("jobs", {})
+    if not isinstance(jobs, dict):
+        message = "all-tests-ci.yml must define jobs"
+        raise TypeError(message)
+
+    all_tests_job = jobs.get("all-tests-check")
+    if not isinstance(all_tests_job, dict):
+        message = "all-tests-ci.yml must define jobs.all-tests-check"
+        raise TypeError(message)
+
+    steps = all_tests_job.get("steps", [])
+    if not isinstance(steps, list):
+        message = "all-tests-ci.yml jobs.all-tests-check.steps must be a list"
+        raise TypeError(message)
+
+    wait_step = next(
+        (
+            step
+            for step in steps
+            if isinstance(step, dict)
+            and step.get("uses") == "int128/wait-for-workflows-action@v1"
+        ),
+        None,
+    )
+    if wait_step is None:
+        return ["all-tests-ci missing wait-for-workflows-action step"]
+
+    with_block = wait_step.get("with", {})
+    if not isinstance(with_block, dict):
+        message = "all-tests-ci wait-for-workflows step must define a with mapping"
+        raise TypeError(message)
+
+    excluded_workflows = with_block.get("exclude-workflow-names", "")
+    if not isinstance(excluded_workflows, str):
+        message = "all-tests-ci exclude-workflow-names must be a multiline string"
+        raise TypeError(message)
+
+    missing_exclusions = sorted(
+        workflow_name
+        for workflow_name in REQUIRED_ALL_TESTS_EXCLUDED_WORKFLOWS
+        if workflow_name not in excluded_workflows
+    )
+    guide_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
+    missing_doc_fragments = sorted(
+        fragment
+        for fragment in REQUIRED_ALL_TESTS_DOC_FRAGMENTS
+        if fragment not in guide_text
+    )
+
+    details: list[str] = []
+    if missing_exclusions:
+        details.append(
+            "all-tests-ci exclude-workflow-names missing: "
+            + ", ".join(missing_exclusions),
+        )
+    if missing_doc_fragments:
+        details.append(
+            "ci-cd guide missing All Tests Status fragments: "
+            + ", ".join(missing_doc_fragments),
+        )
+    return details
 
 
 def _collect_release_ci_requirement_details() -> list[str]:


### PR DESCRIPTION
## Summary
- exclude Release CI and Release Publish from All Tests Status aggregation
- document the curated All Tests Status contract in the CI/CD spec
- add REQ-OPS-013 coverage so docs/tests enforce the exclusion list

## Related Issue (required)
close: #675

## Testing
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests -q
- [x] RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 mise run test
- [x] RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 mise run e2e