### PR TITLE
fix: hide assets form in form grid

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1113,6 +1113,10 @@ requirements:
       tests:
       - 'REQ-FE-037: dashboard ignores reserved metadata forms in the entry count'
       - 'REQ-FE-037: dashboard disables entry creation when only reserved metadata forms exist'
+    - file: frontend/src/routes/spaces/[space_id]/forms/index.test.tsx
+      tests:
+      - 'REQ-FE-037: form grid defaults to the first creatable form'
+      - 'REQ-FE-037: form grid shows empty state when only reserved metadata forms exist'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.

--- a/frontend/src/routes/spaces/[space_id]/forms/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms/index.test.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom/vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { createMemo, createSignal } from "solid-js";
+import SpaceFormsIndexPane from "./index";
+import { EntriesRouteContext } from "~/lib/entries-route-context";
+import { createEntryStore } from "~/lib/entry-store";
+import { createSpaceStore } from "~/lib/space-store";
+import type { Form } from "~/lib/types";
+
+const navigateMock = vi.fn();
+const searchParamsMock: Record<string, string> = {};
+const setSearchParamsMock = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+	useNavigate: () => navigateMock,
+	useSearchParams: () => [searchParamsMock, setSearchParamsMock],
+}));
+
+vi.mock("~/components/SpaceShell", () => ({
+	SpaceShell: (props: { children: unknown }) => <div>{props.children}</div>,
+}));
+
+vi.mock("~/components/FormTable", () => ({
+	FormTable: (props: { entryForm: { name: string } }) => (
+		<div>Form table: {props.entryForm.name}</div>
+	),
+}));
+
+vi.mock("~/components/create-dialogs", () => ({
+	CreateFormDialog: () => <div>Create form dialog</div>,
+}));
+
+vi.mock("~/lib/sql-session-api", () => ({
+	sqlSessionApi: {
+		get: vi.fn(),
+		rows: vi.fn(),
+	},
+}));
+
+describe("/spaces/:space_id/forms", () => {
+	const assetsForm: Form = {
+		name: "Assets",
+		version: 1,
+		template: "",
+		fields: {
+			link: { type: "string", required: true },
+			name: { type: "string", required: true },
+			uploaded_at: { type: "timestamp", required: true },
+		},
+	};
+	const meetingForm: Form = {
+		name: "Meeting",
+		version: 1,
+		template: "",
+		fields: { Date: { type: "date", required: true } },
+	};
+
+	beforeEach(() => {
+		navigateMock.mockReset();
+		setSearchParamsMock.mockReset();
+		for (const key of Object.keys(searchParamsMock)) {
+			delete searchParamsMock[key];
+		}
+	});
+
+	function renderPane(forms: Form[]) {
+		render(() => {
+			const entryStore = createEntryStore(() => "default");
+			const spaceStore = createSpaceStore();
+			const [formList] = createSignal(forms);
+			const [loadingForms] = createSignal(false);
+			const [columnTypes] = createSignal<string[]>([]);
+			return (
+				<EntriesRouteContext.Provider
+					value={{
+						spaceStore,
+						spaceId: () => "default",
+						entryStore,
+						forms: createMemo(() => formList()),
+						loadingForms,
+						columnTypes,
+						refetchForms: () => undefined,
+					}}
+				>
+					<SpaceFormsIndexPane />
+				</EntriesRouteContext.Provider>
+			);
+		});
+	}
+
+	it("REQ-FE-037: form grid defaults to the first creatable form", async () => {
+		renderPane([assetsForm, meetingForm]);
+
+		await waitFor(() => {
+			expect(setSearchParamsMock).toHaveBeenCalledWith({ form: "Meeting" }, { replace: true });
+		});
+		expect(screen.queryByRole("option", { name: "Assets" })).not.toBeInTheDocument();
+		expect(screen.getByRole("option", { name: "Meeting" })).toBeInTheDocument();
+	});
+
+	it("REQ-FE-037: form grid shows empty state when only reserved metadata forms exist", async () => {
+		renderPane([assetsForm]);
+
+		await waitFor(() => {
+			expect(screen.getByText("Create a form to get started.")).toBeInTheDocument();
+		});
+		expect(setSearchParamsMock).not.toHaveBeenCalled();
+		expect(screen.queryByRole("option", { name: "Assets" })).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/routes/spaces/[space_id]/forms/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms/index.tsx
@@ -13,6 +13,7 @@ import { CreateFormDialog } from "~/components/create-dialogs";
 import { SpaceShell } from "~/components/SpaceShell";
 import { useEntriesRouteContext } from "~/lib/entries-route-context";
 import { formApi } from "~/lib/form-api";
+import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { sqlSessionApi } from "~/lib/sql-session-api";
 import type { FormCreatePayload } from "~/lib/types";
 
@@ -51,6 +52,7 @@ export default function SpaceFormsIndexPane() {
 	);
 
 	const selectedFormValue = createMemo(() => selectedFormName().trim());
+	const selectableForms = createMemo(() => filterCreatableEntryForms(ctx.forms()));
 
 	const handleFormSelection = (value: string) => {
 		if (!value) return;
@@ -75,8 +77,9 @@ export default function SpaceFormsIndexPane() {
 			setPage(1);
 			return;
 		}
-		if (selectedFormValue().trim()) return;
-		const first = ctx.forms()[0];
+		const selected = selectedFormValue().trim();
+		if (selectableForms().some((form) => form.name === selected)) return;
+		const first = selectableForms()[0];
 		if (first?.name) {
 			setSearchParams({ form: first.name }, { replace: true });
 		}
@@ -94,7 +97,7 @@ export default function SpaceFormsIndexPane() {
 	});
 
 	const selectedForm = createMemo(() =>
-		ctx.forms().find((entry) => entry.name === selectedFormValue()),
+		selectableForms().find((entry) => entry.name === selectedFormValue()),
 	);
 
 	const sessionEntries = createMemo(() => sessionRows()?.rows || []);
@@ -141,7 +144,7 @@ export default function SpaceFormsIndexPane() {
 								<option value="" disabled>
 									Select form
 								</option>
-								{ctx.forms().map((entry) => (
+								{selectableForms().map((entry) => (
 									<option value={entry.name}>{entry.name}</option>
 								))}
 							</select>


### PR DESCRIPTION
## Summary
- filter reserved metadata forms out of the user-facing form grid selector and default selection
- keep the empty state when only reserved forms exist instead of defaulting to Assets
- add REQ-FE-037 coverage for form-grid behavior

## Related Issue (required)
closes #680

## Testing
- [x] mise run test
- [x] mise run e2e
