### PR TITLE
fix: simplify CLI space args in remote modes

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -31,19 +31,20 @@ Create a local data directory and list spaces:
 
 ```bash
 mkdir -p ./spaces
-cargo run -q -p ugoite-cli -- space list ./spaces
+cargo run -q -p ugoite-cli -- space list --root ./spaces
 ```
 
 Create a new space:
 
 ```bash
-cargo run -q -p ugoite-cli -- create-space ./spaces demo
+cargo run -q -p ugoite-cli -- create-space --root ./spaces demo
 ```
 
 ## Notes
 
-- The CLI expects a root path argument for most commands. Use the same `./spaces`
-  directory as the Docker Compose setup for consistency.
+- In `core` mode, commands that touch local storage require an explicit
+  `--root <LOCAL_ROOT>` flag. Use the same `./spaces` directory as the Docker
+  Compose setup for consistency.
 - If you use another directory, ensure it is writable and backed by local
   storage.
 
@@ -55,9 +56,9 @@ CLI can run in three modes, and stores the selection in `~/.ugoite/cli-endpoints
 - `backend`: call backend REST endpoints directly (e.g. `http://localhost:8000`)
 - `api`: call the frontend-proxied API base (e.g. `http://localhost:3000/api`)
 
-When mode is `backend` or `api`, path arguments such as `root_path`/`space_path`
-are used only to derive a space ID (`.../spaces/<space_id>`), and filesystem I/O
-is performed on the remote server (not the local path).
+When mode is `backend` or `api`, remote commands accept a `SPACE_ID` (or the
+shared `SPACE_ID_OR_PATH` argument for commands that also work in `core` mode)
+and perform filesystem I/O on the remote server instead of the local machine.
 
 ```bash
 # Show current setting

--- a/docs/spec/requirements/storage.yaml
+++ b/docs/spec/requirements/storage.yaml
@@ -364,3 +364,42 @@ requirements:
       tests:
       - test_list_spaces_missing_root_creates_default
       - test_list_spaces_handles_core_failure
+- set_id: REQCAT-STORAGE
+  source_file: requirements/storage.yaml
+  scope: Storage architecture, data persistence, and portability requirements.
+  linked_policies:
+  - POL-001
+  - POL-002
+  - POL-003
+  - POL-011
+  - POL-014
+  linked_specifications:
+  - SPEC-ARCH-OVERVIEW
+  - SPEC-DM-DIRECTORY
+  - SPEC-DM-OVERVIEW
+  - SPEC-ARCH-DECISIONS
+  id: REQ-STO-010
+  title: Mode-appropriate CLI space identifiers
+  description: 'When endpoint routing is `backend` or `api`, CLI commands MUST
+
+    accept remote space identifiers without requiring misleading local-root
+
+    positional arguments.
+
+    When endpoint routing is `core`, commands that need local storage access
+
+    MUST require an explicit local root input before touching the filesystem.
+
+    '
+  related_spec:
+  - features/spaces.yaml#space.list
+  - features/spaces.yaml#space.create
+  priority: medium
+  status: implemented
+  tests:
+    pytest:
+    - file: ugoite-cli/tests/test_cli_endpoint_routing.rs
+      tests:
+      - test_create_space_req_sto_010_requires_root_only_in_core_mode
+      - test_space_list_req_sto_010_accepts_backend_mode_without_local_root
+      - test_entry_and_form_list_req_sto_010_use_space_id_or_path_help

--- a/ugoite-cli/src/commands/entry.rs
+++ b/ugoite-cli/src/commands/entry.rs
@@ -14,14 +14,28 @@ pub struct EntryCmd {
 #[derive(Subcommand)]
 pub enum EntrySubCmd {
     /// List entries in a space
-    List { space_path: String },
+    List {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
+        space_path: String,
+    },
     /// Get an entry
     Get {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         entry_id: String,
     },
     /// Create an entry
     Create {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         entry_id: String,
         #[arg(long, default_value = "# New Entry\n", allow_hyphen_values = true)]
@@ -31,6 +45,10 @@ pub enum EntrySubCmd {
     },
     /// Update an entry
     Update {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         entry_id: String,
         #[arg(long)]
@@ -44,6 +62,10 @@ pub enum EntrySubCmd {
     },
     /// Delete an entry
     Delete {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         entry_id: String,
         #[arg(long)]
@@ -51,17 +73,29 @@ pub enum EntrySubCmd {
     },
     /// Get entry history
     History {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         entry_id: String,
     },
     /// Get a specific revision
     Revision {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         entry_id: String,
         revision_id: String,
     },
     /// Restore an entry to a revision
     Restore {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         entry_id: String,
         revision_id: String,

--- a/ugoite-cli/src/commands/form.rs
+++ b/ugoite-cli/src/commands/form.rs
@@ -15,14 +15,28 @@ pub struct FormCmd {
 #[derive(Subcommand)]
 pub enum FormSubCmd {
     /// List forms
-    List { space_path: String },
+    List {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
+        space_path: String,
+    },
     /// Get a form
     Get {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         form_name: String,
     },
     /// Upsert a form from a JSON file
     Update {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         form_file: String,
         #[arg(long)]

--- a/ugoite-cli/src/commands/space.rs
+++ b/ugoite-cli/src/commands/space.rs
@@ -13,12 +13,22 @@ pub struct SpaceCmd {
 #[derive(Subcommand)]
 pub enum SpaceSubCmd {
     /// List spaces
-    List { root_path: String },
+    List {
+        #[arg(long = "root", value_name = "LOCAL_ROOT")]
+        root_path: Option<String>,
+    },
     /// Get space metadata
-    Get { root_path: String, space_id: String },
+    Get {
+        #[arg(long = "root", value_name = "LOCAL_ROOT")]
+        root_path: Option<String>,
+        #[arg(value_name = "SPACE_ID")]
+        space_id: String,
+    },
     /// Patch space metadata
     Patch {
-        root_path: String,
+        #[arg(long = "root", value_name = "LOCAL_ROOT")]
+        root_path: Option<String>,
+        #[arg(value_name = "SPACE_ID")]
         space_id: String,
         #[arg(long)]
         name: Option<String>,
@@ -29,7 +39,9 @@ pub enum SpaceSubCmd {
     },
     /// Create sample data
     SampleData {
+        #[arg(value_name = "LOCAL_ROOT")]
         root_path: String,
+        #[arg(value_name = "SPACE_ID")]
         space_id: String,
         #[arg(long)]
         scenario: Option<String>,
@@ -42,7 +54,9 @@ pub enum SpaceSubCmd {
     SampleScenarios,
     /// Create a sample data job
     SampleJob {
+        #[arg(value_name = "LOCAL_ROOT")]
         root_path: String,
+        #[arg(value_name = "SPACE_ID")]
         space_id: String,
         #[arg(long)]
         scenario: Option<String>,
@@ -52,14 +66,21 @@ pub enum SpaceSubCmd {
         seed: Option<u64>,
     },
     /// Get sample data job status
-    SampleJobStatus { root_path: String, job_id: String },
+    SampleJobStatus {
+        #[arg(value_name = "LOCAL_ROOT")]
+        root_path: String,
+        job_id: String,
+    },
     /// Test storage connection
     TestConnection { storage_config_json: String },
     /// List service accounts (backend/api mode only)
-    ServiceAccountList { root_path: String, space_id: String },
+    ServiceAccountList {
+        #[arg(value_name = "SPACE_ID")]
+        space_id: String,
+    },
     /// Create a service account (backend/api mode only)
     ServiceAccountCreate {
-        root_path: String,
+        #[arg(value_name = "SPACE_ID")]
         space_id: String,
         #[arg(long)]
         display_name: String,
@@ -67,9 +88,19 @@ pub enum SpaceSubCmd {
         scopes: Vec<String>,
     },
     /// List space members (backend/api mode only)
-    Members { space_path: String },
+    Members {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
+        space_path: String,
+    },
     /// Audit events (backend/api mode only)
     AuditEvents {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         #[arg(long, default_value_t = 0)]
         offset: u64,
@@ -78,7 +109,12 @@ pub enum SpaceSubCmd {
     },
 }
 
-pub async fn create_space_cmd(root_path: &str, space_id: &str) -> Result<()> {
+fn require_local_root<'a>(root_path: Option<&'a str>, command_name: &str) -> Result<&'a str> {
+    root_path
+        .ok_or_else(|| anyhow::anyhow!("{command_name} requires --root <LOCAL_ROOT> in core mode"))
+}
+
+pub async fn create_space_cmd(root_path: Option<&str>, space_id: &str) -> Result<()> {
     let config = load_config();
     if let Some(base) = base_url(&config) {
         let result = http::http_post(
@@ -89,6 +125,7 @@ pub async fn create_space_cmd(root_path: &str, space_id: &str) -> Result<()> {
         print_json(&result);
         return Ok(());
     }
+    let root_path = require_local_root(root_path, "create-space")?;
     let op = operator_for_path(root_path)?;
     ugoite_core::space::create_space(&op, space_id, root_path).await?;
     print_json(&serde_json::json!({"created": true, "id": space_id}));
@@ -104,7 +141,8 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root_path)?;
+            let root_path = require_local_root(root_path.as_deref(), "space list")?;
+            let op = operator_for_path(root_path)?;
             let spaces = ugoite_core::space::list_spaces(&op).await?;
             print_json(&spaces);
         }
@@ -117,7 +155,8 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root_path)?;
+            let root_path = require_local_root(root_path.as_deref(), "space get")?;
+            let op = operator_for_path(root_path)?;
             let space = ugoite_core::space::get_space_raw(&op, &space_id).await?;
             print_json(&space);
         }
@@ -149,7 +188,8 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root_path)?;
+            let root_path = require_local_root(root_path.as_deref(), "space patch")?;
+            let op = operator_for_path(root_path)?;
             let result =
                 ugoite_core::space::patch_space(&op, &space_id, &serde_json::Value::Object(patch))
                     .await?;
@@ -218,10 +258,7 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
             };
             print_json(&serde_json::json!({"status": "ok", "mode": mode}));
         }
-        SpaceSubCmd::ServiceAccountList {
-            root_path: _,
-            space_id,
-        } => {
+        SpaceSubCmd::ServiceAccountList { space_id } => {
             if let Some(base) = base_url(&config) {
                 let result =
                     http::http_get(&format!("{base}/spaces/{space_id}/service-accounts")).await?;
@@ -231,7 +268,6 @@ pub async fn run(cmd: SpaceCmd) -> Result<()> {
             bail!("service-account-list requires backend or api mode");
         }
         SpaceSubCmd::ServiceAccountCreate {
-            root_path: _,
             space_id,
             display_name,
             scopes,

--- a/ugoite-cli/src/main.rs
+++ b/ugoite-cli/src/main.rs
@@ -35,9 +35,18 @@ enum Commands {
     /// Link management commands (deprecated: use row_reference fields)
     Link(commands::link::LinkCmd),
     /// Create a new space
-    CreateSpace { root_path: String, space_id: String },
+    CreateSpace {
+        #[arg(long = "root", value_name = "LOCAL_ROOT")]
+        root_path: Option<String>,
+        #[arg(value_name = "SPACE_ID")]
+        space_id: String,
+    },
     /// Query the index
     Query {
+        #[arg(
+            value_name = "SPACE_ID_OR_PATH",
+            help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
+        )]
         space_path: String,
         #[arg(long)]
         sql: String,
@@ -77,7 +86,7 @@ async fn run(cli: Cli) -> Result<()> {
         Commands::CreateSpace {
             root_path,
             space_id,
-        } => commands::space::create_space_cmd(&root_path, &space_id).await,
+        } => commands::space::create_space_cmd(root_path.as_deref(), &space_id).await,
         Commands::Query {
             space_path,
             sql,

--- a/ugoite-cli/tests/integration_test.rs
+++ b/ugoite-cli/tests/integration_test.rs
@@ -77,7 +77,7 @@ fn test_space_create_and_list() {
     let config_path = dir.path().join("cli-config.json");
 
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "test-space"])
+        .args(["create-space", "--root", &root, "test-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -88,7 +88,7 @@ fn test_space_create_and_list() {
     );
 
     let output = Command::new(ugoite_bin())
-        .args(["space", "list", &root])
+        .args(["space", "list", "--root", &root])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");

--- a/ugoite-cli/tests/test_assets.rs
+++ b/ugoite-cli/tests/test_assets.rs
@@ -22,7 +22,7 @@ fn test_asset_lifecycle() {
 
     // Create space first
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "asset-space"])
+        .args(["create-space", "--root", &root, "asset-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");

--- a/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -180,7 +180,6 @@ fn test_cli_config_set_and_show() {
 fn test_space_list_uses_remote_endpoint_when_backend_mode() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.json");
-    let root = dir.path().to_string_lossy().to_string();
 
     // Set to backend mode with an unreachable URL
     Command::new(ugoite_bin())
@@ -198,7 +197,7 @@ fn test_space_list_uses_remote_endpoint_when_backend_mode() {
 
     // Space list should attempt to contact backend (and fail since it's unreachable)
     let output = Command::new(ugoite_bin())
-        .args(["space", "list", &root])
+        .args(["space", "list"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -220,7 +219,6 @@ fn test_space_list_uses_remote_endpoint_when_backend_mode() {
 fn test_create_space_req_api_001_routes_to_backend_post_spaces() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.json");
-    let root = dir.path().to_string_lossy().to_string();
     let (base_url, request_rx, server_handle) = spawn_recording_server(
         "HTTP/1.1 201 Created",
         r#"{"id":"my-space","name":"my-space"}"#,
@@ -241,7 +239,7 @@ fn test_create_space_req_api_001_routes_to_backend_post_spaces() {
     assert!(set_output.status.success());
 
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "my-space"])
+        .args(["create-space", "my-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -270,7 +268,6 @@ fn test_create_space_req_api_001_routes_to_backend_post_spaces() {
 fn test_create_space_req_api_001_routes_to_api_post_spaces() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.json");
-    let root = dir.path().to_string_lossy().to_string();
     let (base_url, request_rx, server_handle) = spawn_recording_server(
         "HTTP/1.1 201 Created",
         r#"{"id":"api-space","name":"api-space"}"#,
@@ -284,7 +281,7 @@ fn test_create_space_req_api_001_routes_to_api_post_spaces() {
     assert!(set_output.status.success());
 
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "api-space"])
+        .args(["create-space", "api-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -313,7 +310,6 @@ fn test_create_space_req_api_001_routes_to_api_post_spaces() {
 fn test_space_list_req_sto_004_returns_remote_json_without_panicking() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.json");
-    let root = dir.path().to_string_lossy().to_string();
     let (base_url, server_handle) =
         spawn_json_server(r#"[{"id":"remote-space","name":"Remote Space"}]"#);
 
@@ -332,7 +328,7 @@ fn test_space_list_req_sto_004_returns_remote_json_without_panicking() {
     assert!(set_output.status.success());
 
     let output = Command::new(ugoite_bin())
-        .args(["space", "list", &root])
+        .args(["space", "list"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -354,12 +350,96 @@ fn test_space_list_req_sto_004_returns_remote_json_without_panicking() {
     assert_eq!(value[0]["id"].as_str(), Some("remote-space"));
 }
 
+/// REQ-STO-010: Core-mode commands require an explicit local root, while backend mode does not.
+#[test]
+fn test_create_space_req_sto_010_requires_root_only_in_core_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+
+    let core_output = Command::new(ugoite_bin())
+        .args(["create-space", "local-space"])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        !core_output.status.success(),
+        "create-space should fail in core mode without --root"
+    );
+    let stderr = String::from_utf8_lossy(&core_output.stderr);
+    assert!(
+        stderr.contains("create-space requires --root <LOCAL_ROOT> in core mode"),
+        "{stderr}"
+    );
+}
+
+/// REQ-STO-010: Space list accepts backend mode without a local root argument.
+#[test]
+fn test_space_list_req_sto_010_accepts_backend_mode_without_local_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.json");
+    let (base_url, server_handle) =
+        spawn_json_server(r#"[{"id":"remote-space","name":"Remote Space"}]"#);
+
+    let set_output = Command::new(ugoite_bin())
+        .args([
+            "config",
+            "set",
+            "--mode",
+            "backend",
+            "--backend-url",
+            &base_url,
+        ])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+    assert!(set_output.status.success());
+
+    let output = Command::new(ugoite_bin())
+        .args(["space", "list"])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+
+    server_handle.join().unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("JSON");
+    assert_eq!(value[0]["id"].as_str(), Some("remote-space"));
+}
+
+/// REQ-STO-010: Entry and form help describe the shared space identifier argument.
+#[test]
+fn test_entry_and_form_list_req_sto_010_use_space_id_or_path_help() {
+    let entry_help = Command::new(ugoite_bin())
+        .args(["entry", "list", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(entry_help.status.success());
+    let entry_stdout = String::from_utf8_lossy(&entry_help.stdout);
+    assert!(entry_stdout.contains("SPACE_ID_OR_PATH"), "{entry_stdout}");
+    assert!(!entry_stdout.contains("SPACE_PATH"), "{entry_stdout}");
+
+    let form_help = Command::new(ugoite_bin())
+        .args(["form", "list", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(form_help.status.success());
+    let form_stdout = String::from_utf8_lossy(&form_help.stdout);
+    assert!(form_stdout.contains("SPACE_ID_OR_PATH"), "{form_stdout}");
+    assert!(!form_stdout.contains("SPACE_PATH"), "{form_stdout}");
+}
+
 /// REQ-SEC-003: Service account create routes to backend when in backend mode.
 #[test]
 fn test_space_service_account_create_routes_to_backend() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.json");
-    let root = dir.path().to_string_lossy().to_string();
 
     // Set to backend mode with an unreachable URL
     Command::new(ugoite_bin())
@@ -380,9 +460,11 @@ fn test_space_service_account_create_routes_to_backend() {
         .args([
             "space",
             "service-account-create",
-            &root,
             "my-space",
+            "--display-name",
             "sa-name",
+            "--scopes",
+            "spaces:read",
         ])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()

--- a/ugoite-cli/tests/test_cli_form.rs
+++ b/ugoite-cli/tests/test_cli_form.rs
@@ -41,7 +41,7 @@ fn test_cli_form_update() {
     let space_path = format!("{root}/spaces/form-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "form-space"])
+        .args(["create-space", "--root", &root, "form-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");

--- a/ugoite-cli/tests/test_endpoint_config.rs
+++ b/ugoite-cli/tests/test_endpoint_config.rs
@@ -74,7 +74,7 @@ fn test_parse_space_id_from_path_and_id() {
 
     // Create a space - this tests that space_id can be derived from path components
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "path-id-space"])
+        .args(["create-space", "--root", &root, "path-id-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -87,7 +87,7 @@ fn test_parse_space_id_from_path_and_id() {
 
     // List spaces - verify the space shows up with the expected ID
     let list_output = Command::new(ugoite_bin())
-        .args(["space", "list", &root])
+        .args(["space", "list", "--root", &root])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");

--- a/ugoite-cli/tests/test_entries.rs
+++ b/ugoite-cli/tests/test_entries.rs
@@ -20,7 +20,7 @@ fn setup_space_with_form(dir: &tempfile::TempDir, space_id: &str) -> (String, st
     let space_path = format!("{root}/spaces/{space_id}");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, space_id])
+        .args(["create-space", "--root", &root, space_id])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");

--- a/ugoite-cli/tests/test_forms.rs
+++ b/ugoite-cli/tests/test_forms.rs
@@ -23,7 +23,7 @@ fn setup_space_with_form(
     let space_path = format!("{root}/spaces/{space_id}");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, space_id])
+        .args(["create-space", "--root", &root, space_id])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");

--- a/ugoite-cli/tests/test_indexer.rs
+++ b/ugoite-cli/tests/test_indexer.rs
@@ -19,7 +19,7 @@ fn setup_space_with_entries(dir: &tempfile::TempDir) -> (String, String, std::pa
     let space_path = format!("{root}/spaces/idx-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "idx-space"])
+        .args(["create-space", "--root", &root, "idx-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");
@@ -118,7 +118,7 @@ fn test_extract_properties_h2_sections() {
     let space_path = format!("{root}/spaces/prop-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "prop-space"])
+        .args(["create-space", "--root", &root, "prop-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");
@@ -172,7 +172,7 @@ fn test_extract_properties_precedence() {
     let space_path = format!("{root}/spaces/prec-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "prec-space"])
+        .args(["create-space", "--root", &root, "prec-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");
@@ -270,7 +270,7 @@ fn test_validate_properties_missing_required() {
     let space_path = format!("{root}/spaces/val-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "val-space"])
+        .args(["create-space", "--root", &root, "val-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");
@@ -321,7 +321,7 @@ fn test_validate_properties_valid() {
     let space_path = format!("{root}/spaces/valid-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "valid-space"])
+        .args(["create-space", "--root", &root, "valid-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");

--- a/ugoite-cli/tests/test_integrity.rs
+++ b/ugoite-cli/tests/test_integrity.rs
@@ -21,7 +21,7 @@ fn test_integrity_provider_for_space_success() {
     let config_path = dir.path().join("cli-config.json");
 
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "int-space"])
+        .args(["create-space", "--root", &root, "int-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -42,14 +42,14 @@ fn test_integrity_provider_missing_hmac_key() {
 
     // Create space without HMAC key configuration
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "no-hmac-space"])
+        .args(["create-space", "--root", &root, "no-hmac-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");
 
     // Attempting to access a space requiring HMAC without key should fail
     let output = Command::new(ugoite_bin())
-        .args(["space", "list", &root])
+        .args(["space", "list", "--root", &root])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -68,7 +68,7 @@ fn test_integrity_provider_invalid_hmac_key() {
 
     // Create space
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "hmac-space"])
+        .args(["create-space", "--root", &root, "hmac-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");

--- a/ugoite-cli/tests/test_saved_sql.rs
+++ b/ugoite-cli/tests/test_saved_sql.rs
@@ -22,7 +22,7 @@ fn test_saved_sql_req_api_006_crud() {
     let space_path = format!("{root}/spaces/sql-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "sql-space"])
+        .args(["create-space", "--root", &root, "sql-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");
@@ -72,7 +72,7 @@ fn test_saved_sql_req_api_007_validation() {
     let space_path = format!("{root}/spaces/sql-space");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "sql-space"])
+        .args(["create-space", "--root", &root, "sql-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");

--- a/ugoite-cli/tests/test_space.rs
+++ b/ugoite-cli/tests/test_space.rs
@@ -28,7 +28,7 @@ fn test_create_space_scaffolding() {
     let config_path = dir.path().join("cli-config.json");
 
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "my-space"])
+        .args(["create-space", "--root", &root, "my-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -53,7 +53,7 @@ fn test_create_space_req_sto_003_permissions() {
     let config_path = dir.path().join("cli-config.json");
 
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "private-space"])
+        .args(["create-space", "--root", &root, "private-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -84,7 +84,7 @@ fn test_create_space_s3_unimplemented() {
 
     // Attempting to use s3:// path should fail gracefully
     let output = Command::new(ugoite_bin())
-        .args(["create-space", "s3://my-bucket", "my-space"])
+        .args(["create-space", "--root", "s3://my-bucket", "my-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -107,14 +107,14 @@ fn test_create_space_idempotency() {
 
     // Create space first time
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "idempotent-space"])
+        .args(["create-space", "--root", &root, "idempotent-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
 
     // Second creation should fail with "already exists" error
     let output2 = Command::new(ugoite_bin())
-        .args(["create-space", &root, "idempotent-space"])
+        .args(["create-space", "--root", &root, "idempotent-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");
@@ -138,7 +138,7 @@ fn test_create_sample_space_req_api_009() {
     let config_path = dir.path().join("cli-config.json");
 
     let output = Command::new(ugoite_bin())
-        .args(["create-space", &root, "sample-space"])
+        .args(["create-space", "--root", &root, "sample-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("failed to execute");

--- a/ugoite-cli/tests/test_sql_rules.rs
+++ b/ugoite-cli/tests/test_sql_rules.rs
@@ -21,7 +21,7 @@ fn test_cli_sql_lint_reports_errors() {
     let config_path = dir.path().join("cli-config.json");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "lint-space"])
+        .args(["create-space", "--root", &root, "lint-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");
@@ -56,7 +56,7 @@ fn test_cli_sql_complete_suggests_tables() {
     let config_path = dir.path().join("cli-config.json");
 
     Command::new(ugoite_bin())
-        .args(["create-space", &root, "complete-space"])
+        .args(["create-space", "--root", &root, "complete-space"])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create space");


### PR DESCRIPTION
## Summary
- remove misleading local-root positional arguments from remote CLI space commands and require `--root` only in core mode
- update entry/form help text to explain the shared `SPACE_ID_OR_PATH` contract for local and remote routing
- add REQ-STO-010 coverage and refresh the CLI guide examples for the new argument shape

## Related Issue (required)
closes #697

## Testing
- [x] cd /workspace/ugoite-cli && cargo test --test test_cli_endpoint_routing
- [x] cd /workspace && mise run test
- [x] cd /workspace && mise run e2e
