### PR TITLE
fix: remove persistent spaces auth card

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1339,3 +1339,34 @@ requirements:
       - 'REQ-FE-054: normalizeTimestamp falls back to string output for missing or invalid numeric inputs'
       - 'REQ-FE-054: formatDateLabel renders valid timestamps as locale dates'
       - 'REQ-FE-054: formatDateLabel falls back to trimmed text or em dash'
+- set_id: REQCAT-FRONTEND
+  source_file: requirements/frontend.yaml
+  scope: Frontend route, component, and interaction requirements.
+  linked_policies:
+  - POL-006
+  - POL-009
+  - POL-013
+  - POL-014
+  linked_specifications:
+  - SPEC-UI-OVERVIEW
+  - SPEC-UI-PAGES
+  - SPEC-ARCH-INTERFACE
+  id: REQ-FE-056
+  title: Contextual Spaces Auth Guidance
+  description: 'The `/spaces` route MUST avoid persistent authentication guidance during
+
+    normal rendering. Auth guidance MUST only appear when space loading actually
+
+    fails, and the error copy MUST stay concise and contextual to the failure.
+
+    '
+  related_spec:
+  - architecture/frontend-backend-interface.md#error-handling-standards
+  priority: medium
+  status: implemented
+  tests:
+    vitest:
+    - file: frontend/src/routes/spaces/index.test.tsx
+      tests:
+      - 'REQ-FE-056: does not show persistent auth guidance during normal space listing'
+      - 'REQ-FE-056: shows concise auth errors only when space loading fails'

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -63,4 +63,39 @@ describe("/spaces", () => {
 			expect(navigateMock).toHaveBeenCalledWith("/spaces/my-space/dashboard");
 		});
 	});
+
+	it("REQ-FE-056: does not show persistent auth guidance during normal space listing", async () => {
+		(spaceApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{ id: "default", name: "default" },
+		]);
+
+		render(() => <SpacesIndexRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Available Spaces")).toBeInTheDocument();
+			expect(screen.getByText("Open Space")).toBeInTheDocument();
+		});
+
+		expect(screen.queryByRole("heading", { name: "Authentication" })).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/localhost and remote mode both require authentication/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("REQ-FE-056: shows concise auth errors only when space loading fails", async () => {
+		(spaceApi.list as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("403 Forbidden"));
+
+		render(() => <SpacesIndexRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Failed to load spaces.")).toBeInTheDocument();
+		});
+
+		expect(
+			screen.getByText("You are signed in but do not have permission to view these spaces."),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/localhost and remote mode both require authentication/i),
+		).not.toBeInTheDocument();
+	});
 });

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -1,13 +1,5 @@
 import { A, useNavigate } from "@solidjs/router";
-import {
-	createEffect,
-	createMemo,
-	createResource,
-	createSignal,
-	For,
-	Show,
-	type JSX,
-} from "solid-js";
+import { createEffect, createMemo, createResource, createSignal, For, Show } from "solid-js";
 import { spaceApi } from "~/lib/space-api";
 
 const toMessage = (value: unknown): string => {
@@ -19,8 +11,15 @@ const toMessage = (value: unknown): string => {
 
 export default function SpacesIndexRoute() {
 	const navigate = useNavigate();
+	const [spacesError, setSpacesError] = createSignal("");
 	const [spaces, { refetch: refetchSpaces }] = createResource(async () => {
-		return await spaceApi.list();
+		setSpacesError("");
+		try {
+			return await spaceApi.list();
+		} catch (error) {
+			setSpacesError(toMessage(error) || "Failed to load spaces.");
+			return [];
+		}
 	});
 	const [redirected, setRedirected] = createSignal(false);
 	const [showCreateForm, setShowCreateForm] = createSignal(false);
@@ -28,37 +27,27 @@ export default function SpacesIndexRoute() {
 	const [createError, setCreateError] = createSignal<string | null>(null);
 	const [isCreating, setIsCreating] = createSignal(false);
 
-	const authHint = createMemo((): JSX.Element | null => {
-		const message = toMessage(spaces.error).toLowerCase();
+	const authHint = createMemo((): string => {
+		const message = spacesError().toLowerCase();
 		if (
 			message.includes("401") ||
 			message.includes("authentication") ||
 			message.includes("unauthorized")
 		) {
-			return (
-				<span>
-					Authentication required. Re-run <code>mise run dev</code> (or{" "}
-					<code>UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev</code>) to refresh local login.
-				</span>
-			);
+			return "Authentication required. Re-run `mise run dev` if you need to refresh local login.";
 		}
 		if (
 			message.includes("403") ||
 			message.includes("forbidden") ||
 			message.includes("not authorized")
 		) {
-			return (
-				<span>
-					Your identity is authenticated, but this space is not shared with your user yet. Ask a
-					space admin for an invitation.
-				</span>
-			);
+			return "You are signed in but do not have permission to view these spaces.";
 		}
-		return null;
+		return "";
 	});
 
 	const hasNoSpaces = createMemo(
-		() => !spaces.loading && !spaces.error && (spaces()?.length ?? 0) === 0,
+		() => !spaces.loading && !spacesError() && (spaces()?.length ?? 0) === 0,
 	);
 
 	const openCreateForm = () => {
@@ -94,10 +83,10 @@ export default function SpacesIndexRoute() {
 	};
 
 	createEffect(() => {
-		if (!spaces.error || redirected()) {
+		if (!spacesError() || redirected()) {
 			return;
 		}
-		const message = toMessage(spaces.error).toLowerCase();
+		const message = spacesError().toLowerCase();
 		if (
 			message.includes("401") ||
 			message.includes("authentication") ||
@@ -113,7 +102,7 @@ export default function SpacesIndexRoute() {
 			<div class="flex flex-wrap items-center justify-between gap-3">
 				<h1 class="ui-page-title">Spaces</h1>
 				<div class="flex flex-wrap items-center gap-2">
-					<Show when={!spaces.error && !showCreateForm() && !hasNoSpaces()}>
+					<Show when={!spacesError() && !showCreateForm() && !hasNoSpaces()}>
 						<button
 							type="button"
 							class="ui-button ui-button-primary text-sm"
@@ -127,15 +116,6 @@ export default function SpacesIndexRoute() {
 					</A>
 				</div>
 			</div>
-
-			<section class="ui-card ui-stack-sm">
-				<h2 class="text-lg font-semibold">Authentication</h2>
-				<p class="text-sm ui-muted">
-					Localhost and remote mode both require authentication. Use the local login flow via
-					<code>mise run dev</code> (or force refresh with
-					<code>UGOITE_DEV_AUTH_FORCE_LOGIN=true mise run dev</code>).
-				</p>
-			</section>
 
 			<section class="ui-card">
 				<h2 class="text-lg font-semibold mb-3">Available Spaces</h2>
@@ -185,7 +165,7 @@ export default function SpacesIndexRoute() {
 				<Show when={spaces.loading}>
 					<p class="text-sm ui-muted">Loading spaces...</p>
 				</Show>
-				<Show when={spaces.error}>
+				<Show when={spacesError()}>
 					<p class="ui-alert ui-alert-error text-sm">Failed to load spaces.</p>
 					<Show when={authHint()}>
 						<p class="text-sm ui-muted mt-2">{authHint()}</p>


### PR DESCRIPTION
## Summary
- remove the always-visible authentication guidance card from `/spaces`
- keep auth messaging concise and only show it when space loading actually fails
- add REQ-FE-056 coverage and requirement traceability for contextual auth guidance

## Related Issue (required)
closes #703

## Testing
- cd frontend && bun run test:run src/routes/spaces/index.test.tsx
- cd frontend && bunx --bun @biomejs/biome@2.3.15 ci src/routes/spaces/index.tsx src/routes/spaces/index.test.tsx
- uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_requirements.py -q
- Playwright check on http://localhost:3000/spaces
- mise run test
- mise run e2e
