### PR TITLE
fix: reduce dashboard loading flicker

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1439,3 +1439,38 @@ requirements:
       tests:
       - 'REQ-FE-056: does not show persistent auth guidance during normal space listing'
       - 'REQ-FE-056: shows concise auth errors only when space loading fails'
+- set_id: REQCAT-FRONTEND
+  source_file: requirements/frontend.yaml
+  scope: Frontend route, component, and interaction requirements.
+  linked_policies:
+  - POL-006
+  - POL-009
+  - POL-013
+  - POL-014
+  linked_specifications:
+  - SPEC-UI-OVERVIEW
+  - SPEC-UI-PAGES
+  - SPEC-ARCH-INTERFACE
+  id: REQ-FE-058
+  title: Calm Dashboard Loading Treatment
+  description: 'The space dashboard MUST avoid a persistent top-of-page loading banner
+
+    during routine navigation when the route can already render meaningful shell
+
+    content. While space metadata is still loading, the dashboard MAY use a stable
+
+    fallback title such as the space identifier, and MUST replace that fallback
+
+    with the resolved space name once metadata loads successfully.
+
+    '
+  related_spec:
+  - architecture/frontend-backend-interface.md
+  priority: medium
+  status: implemented
+  tests:
+    vitest:
+    - file: frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
+      tests:
+      - 'REQ-FE-058: dashboard avoids a persistent top-level loading banner during routine navigation'
+      - 'REQ-FE-058: dashboard replaces the fallback title when space metadata loads'

--- a/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
@@ -105,4 +105,27 @@ describe("/spaces/:space_id/dashboard", () => {
 		});
 		expect(screen.getByRole("button", { name: "New entry" })).toBeDisabled();
 	});
+
+	it("REQ-FE-058: dashboard avoids a persistent top-level loading banner during routine navigation", () => {
+		(spaceApi.get as ReturnType<typeof vi.fn>).mockImplementation(
+			() => new Promise(() => undefined) as Promise<never>,
+		);
+		(formApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([meetingForm]);
+
+		render(() => <SpaceDashboardRoute />);
+
+		expect(screen.getByRole("heading", { name: "default" })).toBeInTheDocument();
+		expect(screen.queryByText("Loading space...")).not.toBeInTheDocument();
+	});
+
+	it("REQ-FE-058: dashboard replaces the fallback title when space metadata loads", async () => {
+		(formApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([meetingForm]);
+
+		render(() => <SpaceDashboardRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("heading", { name: "Default Space" })).toBeInTheDocument();
+		});
+		expect(screen.queryByRole("heading", { name: "default" })).not.toBeInTheDocument();
+	});
 });

--- a/frontend/src/routes/spaces/[space_id]/dashboard.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.tsx
@@ -51,6 +51,7 @@ export default function SpaceDashboardRoute() {
 
 	const safeForms = createMemo(() => forms() || []);
 	const entryForms = createMemo(() => filterCreatableEntryForms(safeForms()));
+	const displaySpaceName = createMemo(() => space()?.name || spaceId());
 
 	const handleCreateForm = async (payload: FormCreatePayload) => {
 		try {
@@ -109,14 +110,9 @@ export default function SpaceDashboardRoute() {
 		<SpaceShell spaceId={spaceId()} activeTopTab="dashboard">
 			<div class="mx-auto max-w-5xl ui-stack">
 				<div>
-					<Show when={space.loading}>
-						<p class="text-sm ui-muted">Loading space...</p>
-					</Show>
+					<h1 class="ui-page-title text-3xl sm:text-4xl">{displaySpaceName()}</h1>
 					<Show when={space.error}>
 						<p class="text-sm ui-text-danger">Failed to load space.</p>
-					</Show>
-					<Show when={space()}>
-						{(ws) => <h1 class="ui-page-title text-3xl sm:text-4xl">{ws().name}</h1>}
 					</Show>
 				</div>
 


### PR DESCRIPTION
## Summary
- avoid showing a persistent top-level loading banner on the dashboard during routine navigation
- render a stable fallback title from the route space id until metadata resolves, then replace it with the real space name
- cover the calmer dashboard loading treatment in route tests and requirements mapping

## Related Issue (required)
closes #705

## Testing
- [x] `cd /workspace && RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`\n- [x] `cd /workspace && mise run e2e`