### PR TITLE
fix: allow dependabot bump commits

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,5 +1,8 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  ignores: [
+    (message) => /^chore\(deps(?:-dev)?\): Bump .+/u.test(message),
+  ],
   rules: {
     "body-max-line-length": [0, "always", 100],
   },


### PR DESCRIPTION
## Summary
- allow Dependabot's default `chore(deps): Bump ...` and `chore(deps-dev): Bump ...` commit messages to bypass commitlint subject-case enforcement
- keep the existing commitlint rules unchanged for normal contributor commits

## Related Issue (required)
closes #725

## Testing
- [x] `printf 'chore(deps): Bump @codemirror/view from 6.39.16 to 6.39.17 in /frontend\\n' | npx commitlint`\n- [x] `printf 'feat: Bad Subject\\n' | npx commitlint` (expected failure)\n- [x] `RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`\n- [x] `RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`