### PR TITLE
fix: align dependabot cli ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,12 +31,12 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "uv"
-    directory: "/ugoite-cli"
+    directory: "/ugoite-core"
     schedule:
       interval: "daily"
 
-  - package-ecosystem: "uv"
-    directory: "/ugoite-core"
+  - package-ecosystem: "cargo"
+    directory: "/ugoite-cli"
     schedule:
       interval: "daily"
 

--- a/docs/spec/security/overview.md
+++ b/docs/spec/security/overview.md
@@ -76,7 +76,7 @@ targets an **Authenticated Access by Default** model.
 
 ### Dependency Automation
 
-- Dependabot updates are enabled across GitHub Actions, Bun, npm, uv, cargo, and Docker manifests.
+- Dependabot updates are enabled across GitHub Actions, Bun, npm, Docker, uv-managed Python workspaces (`backend`, `ugoite-core`), and Cargo manifests (`ugoite-core`, `ugoite-cli`).
 - GitHub Dependency Graph and advisory alerts are expected to remain enabled for this repository.
 
 

--- a/docs/tests/test_cli_language_docs.py
+++ b/docs/tests/test_cli_language_docs.py
@@ -7,11 +7,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 INDEX_PATH = REPO_ROOT / "docs" / "spec" / "index.md"
 STACK_PATH = REPO_ROOT / "docs" / "spec" / "architecture" / "stack.md"
 SECURITY_PATH = REPO_ROOT / "docs" / "spec" / "security" / "overview.md"
 SBOM_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "sbom-ci.yml"
+DEPENDABOT_PATH = REPO_ROOT / ".github" / "dependabot.yml"
 CLI_CARGO_PATH = REPO_ROOT / "ugoite-cli" / "Cargo.toml"
 
 
@@ -26,6 +29,14 @@ def test_docs_req_ops_014_cli_language_is_consistent() -> None:
     stack_text = _read_text(STACK_PATH)
     security_text = _read_text(SECURITY_PATH)
     sbom_workflow = _read_text(SBOM_WORKFLOW_PATH)
+    dependabot = yaml.safe_load(_read_text(DEPENDABOT_PATH))
+    if not isinstance(dependabot, dict):
+        message = ".github/dependabot.yml must be a YAML mapping"
+        raise TypeError(message)
+    updates = dependabot.get("updates", [])
+    if not isinstance(updates, list):
+        message = ".github/dependabot.yml updates must be a list"
+        raise TypeError(message)
 
     details = [
         f"{name} missing expected fragment: {fragment!r}"
@@ -49,6 +60,11 @@ def test_docs_req_ops_014_cli_language_is_consistent() -> None:
                 "- Python projects (`backend`)",
             ),
             (
+                "docs/spec/security/overview.md",
+                security_text,
+                "Cargo manifests (`ugoite-core`, `ugoite-cli`)",
+            ),
+            (
                 ".github/workflows/sbom-ci.yml",
                 sbom_workflow,
                 "ugoite-cli-rust.cdx.json",
@@ -60,5 +76,19 @@ def test_docs_req_ops_014_cli_language_is_consistent() -> None:
         details.append(
             ".github/workflows/sbom-ci.yml must not classify ugoite-cli as Python",
         )
+    if not any(
+        isinstance(update, dict)
+        and update.get("package-ecosystem") == "cargo"
+        and update.get("directory") == "/ugoite-cli"
+        for update in updates
+    ):
+        details.append(".github/dependabot.yml must track /ugoite-cli with cargo")
+    if any(
+        isinstance(update, dict)
+        and update.get("package-ecosystem") == "uv"
+        and update.get("directory") == "/ugoite-cli"
+        for update in updates
+    ):
+        details.append(".github/dependabot.yml must not track /ugoite-cli with uv")
     if details:
         raise AssertionError("; ".join(details))


### PR DESCRIPTION
## Summary
- switch `ugoite-cli` Dependabot coverage from an invalid `uv` target to the correct `cargo` ecosystem
- tighten the security spec wording so dependency automation reflects the real workspace manager split
- extend the existing REQ-OPS-014 docs test to keep `ugoite-cli` classified as Rust in Dependabot config too

## Related Issue (required)
closes #744

## Testing
- [x] `uv run --with pytest --with pyyaml pytest docs/tests/test_cli_language_docs.py -W error`
- [x] `uvx pre-commit run --files .github/dependabot.yml docs/spec/security/overview.md docs/tests/test_cli_language_docs.py`
- [x] `RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
