### PR TITLE
perf(dev): keep ugoite-core build incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ shared Rust target cache and the legacy ugoite-core cache path:
 mise run cleanup:rust-targets
 ```
 
+If only the editable `ugoite-core` extension looks stale, use a package-local
+clean rebuild without wiping the entire shared target tree:
+
+```bash
+mise run //ugoite-core:build:clean
+```
+
 If you need to rotate/refresh the automatic token manually, run:
 
 ```bash

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -368,11 +368,13 @@ requirements:
   title: Rust Target Cache Discipline
   description: 'Local Rust build and test tasks MUST share a bounded target root,
 
-    clean package-specific crate artifacts before rebuild/test, and expose
+    keep the default ugoite-core local build path incremental, and expose
 
-    an explicit cleanup task. Rust CI MUST use the same shared target root
+    explicit clean rebuild/cleanup commands when stale artifacts need a
 
-    so repeated ugoite-core and ugoite-cli development does not balloon
+    destructive reset. Rust CI MUST use the same shared target root so
+
+    repeated ugoite-core and ugoite-cli development does not balloon
 
     target caches into tens of gigabytes.
 

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -139,10 +139,12 @@ jobs:
     - cd ugoite-cli && cargo test --no-default-features
 ```
 
-Local `mise` tasks for `ugoite-core` and `ugoite-cli` also share `target/rust`,
-clean package-specific crate artifacts before rebuild/test, and expose
-`mise run cleanup:rust-targets` to remove both the shared target root and the
-legacy `~/.cache/ugoite/ugoite-core/target` path when artifacts grow unexpectedly.
+Local `mise` tasks for `ugoite-core` and `ugoite-cli` also share `target/rust`.
+The default `ugoite-core` build path stays incremental, `mise run
+//ugoite-core:build:clean` provides a package-local destructive rebuild when the
+editable extension is stale, and `mise run cleanup:rust-targets` removes both
+the shared target root and the legacy `~/.cache/ugoite/ugoite-core/target`
+path when artifacts grow unexpectedly.
 
 ## SBOM and Supply Chain CI
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -692,8 +692,26 @@ def test_docs_req_ops_011_rust_target_cache_discipline_declared() -> None:
             _require_task_contains(
                 core_mise,
                 "build",
+                "uv run maturin develop",
+                "ugoite-core build task must build the editable Rust extension",
+            ),
+            _require_task_excludes(
+                core_mise,
+                "build",
                 "cargo clean -p ugoite-core",
-                "ugoite-core build task must clean package-local Rust artifacts",
+                "ugoite-core build task must stay incremental by default",
+            ),
+            _require_task_contains(
+                core_mise,
+                "build:clean",
+                "cargo clean -p ugoite-core",
+                "ugoite-core build:clean task must clean package-local Rust artifacts",
+            ),
+            _require_task_contains(
+                core_mise,
+                "build:clean",
+                "uv run maturin develop",
+                "ugoite-core build:clean task must rebuild the editable Rust extension",
             ),
             _require_task_contains(
                 cli_mise,
@@ -1542,6 +1560,18 @@ def _require_task_contains(
     if any(expected in command for command in commands):
         return None
     return message
+
+
+def _require_task_excludes(
+    config: dict[str, object],
+    task_name: str,
+    forbidden: str,
+    message: str,
+) -> str | None:
+    commands = _get_task_run_commands(config, task_name)
+    if any(forbidden in command for command in commands):
+        return message
+    return None
 
 
 def _require_exact_task_run(

--- a/ugoite-core/mise.toml
+++ b/ugoite-core/mise.toml
@@ -9,11 +9,18 @@ description = "Install dependencies"
 
 [tasks.build]
 run = [
-	"cargo clean -p ugoite-core",
 	"python -c \"import pathlib; [p.unlink() for p in pathlib.Path('ugoite_core').glob('_ugoite_core.*.so')]\"",
 	"RUSTFLAGS=\"-C debuginfo=0\" CARGO_BUILD_JOBS=1 PYO3_PYTHON=\"$(command -v python)\" uv run maturin develop",
 ]
 description = "Build Rust extension for local development"
+
+[tasks."build:clean"]
+run = [
+	"cargo clean -p ugoite-core",
+	"python -c \"import pathlib; [p.unlink() for p in pathlib.Path('ugoite_core').glob('_ugoite_core.*.so')]\"",
+	"RUSTFLAGS=\"-C debuginfo=0\" CARGO_BUILD_JOBS=1 PYO3_PYTHON=\"$(command -v python)\" uv run maturin develop",
+]
+description = "Clean package-local artifacts and rebuild the Rust extension"
 
 [tasks.test]
 run = [


### PR DESCRIPTION
## Summary

- make `mise run //ugoite-core:build` incremental by default for local test runs
- keep an explicit `mise run //ugoite-core:build:clean` path for full rebuilds
- document and validate the updated Rust build guidance

## Related Issue (required)

close: #786

## Testing

- [x] `mise run test`
- [x] `mise run e2e`
