### PR TITLE
chore(ci): guard against git artifact bloat

### DIFF
--- a/.github/workflows/yaml-workflow-ci.yml
+++ b/.github/workflows/yaml-workflow-ci.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check root placeholder artifacts
-        run: bash scripts/check-placeholder-artifacts.sh
+      - name: Check root artifact hygiene
+        run: bash scripts/check-root-artifact-hygiene.sh
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: root-artifact-hygiene
         name: root artifact hygiene
-        entry: bash scripts/check-placeholder-artifacts.sh
+        entry: bash scripts/check-root-artifact-hygiene.sh
         language: system
         always_run: true
         pass_filenames: false

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -167,9 +167,11 @@ requirements:
   title: YAML and Workflow Lint Gates
   description: 'YAML specification/configuration files and GitHub Actions workflows
 
-    MUST be linted in both pre-commit and CI so regressions are detected before
+    MUST be linted in both pre-commit and CI, and the same local/CI gate MUST
 
-    merge.
+    run repository artifact hygiene checks that block tracked dependency trees
+
+    and oversized artifacts before merge.
 
     '
   related_spec:

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -36,6 +36,21 @@ jobs:
     - uv run --with pytest --with pyyaml --with bashlex pytest docs/tests -W error
 ```
 
+## YAML / Workflow and Repository Artifact Hygiene
+
+```yaml
+jobs:
+  ci:
+    - bash scripts/check-root-artifact-hygiene.sh
+    - yamllint ...
+    - actionlint
+```
+
+The root artifact hygiene gate blocks tracked files under generated dependency
+or build directories such as `node_modules/` and `target/`, and it rejects
+tracked files larger than `1 MiB` unless they are explicitly allowlisted in
+`scripts/check-root-artifact-hygiene.sh`.
+
 ## Rust CI
 
 ```yaml

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -93,10 +93,16 @@ REQUIRED_BACKEND_BUILD_CONTEXTS = {
 REQUIRED_FRONTEND_BUILD_CONTEXTS = {"shared=./shared"}
 REQUIRED_PRE_COMMIT_HOOKS = {"root-artifact-hygiene", "yamllint", "actionlint"}
 REQUIRED_YAML_WORKFLOW_CI_STEPS = {
-    "Check root placeholder artifacts",
+    "Check root artifact hygiene",
     "Run yamllint",
     "Run actionlint",
 }
+REQUIRED_ARTIFACT_HYGIENE_SPEC_SNIPPETS = [
+    "scripts/check-root-artifact-hygiene.sh",
+    "node_modules/",
+    "target/",
+    "1 MiB",
+]
 REQUIRED_SHARED_RUST_TARGET_DIR = "../target/rust"
 REQUIRED_RUST_PRE_COMMIT_HOOKS = {
     "rustfmt",
@@ -566,8 +572,13 @@ def test_docs_req_ops_005_yaml_workflow_lint_gates_declared() -> None:
     missing_steps = sorted(REQUIRED_YAML_WORKFLOW_CI_STEPS.difference(ci_steps))
     python_ci_steps = _collect_workflow_step_names(PYTHON_CI_WORKFLOW_PATH)
     leaked_steps = sorted(REQUIRED_YAML_WORKFLOW_CI_STEPS.intersection(python_ci_steps))
+    spec_detail = _require_file_contains(
+        CI_CD_SPEC_PATH,
+        REQUIRED_ARTIFACT_HYGIENE_SPEC_SNIPPETS,
+        "ci-cd spec must document the root artifact hygiene guard",
+    )
 
-    if missing_hooks or missing_steps or leaked_steps:
+    if missing_hooks or missing_steps or leaked_steps or spec_detail:
         details: list[str] = []
         if missing_hooks:
             details.append("pre-commit missing hooks: " + ", ".join(missing_hooks))
@@ -577,6 +588,8 @@ def test_docs_req_ops_005_yaml_workflow_lint_gates_declared() -> None:
             )
         if leaked_steps:
             details.append("python-ci should not include: " + ", ".join(leaked_steps))
+        if spec_detail:
+            details.append(spec_detail)
         raise AssertionError("; ".join(details))
 
 

--- a/scripts/check-root-artifact-hygiene.sh
+++ b/scripts/check-root-artifact-hygiene.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+bash scripts/check-placeholder-artifacts.sh
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import PurePosixPath
+
+MAX_TRACKED_FILE_BYTES = 1024 * 1024  # 1 MiB
+FORBIDDEN_SEGMENTS = {"node_modules", "target"}
+ALLOWED_LARGE_TRACKED_PATHS: set[str] = set()
+
+
+def format_bytes(size: int) -> str:
+    """Return a human-readable byte count."""
+    units = ["bytes", "KiB", "MiB", "GiB"]
+    value = float(size)
+    unit = units[0]
+    for candidate in units:
+        unit = candidate
+        if value < 1024 or candidate == units[-1]:
+            break
+        value /= 1024
+    if unit == "bytes":
+        return f"{int(value)} {unit}"
+    return f"{value:.1f} {unit}"
+
+
+tracked_paths = subprocess.check_output(
+    ["git", "ls-files", "-z"],
+    text=False,
+).decode("utf-8").split("\0")
+
+forbidden_paths: list[tuple[str, str]] = []
+oversized_paths: list[tuple[str, int]] = []
+
+for raw_path in tracked_paths:
+    if not raw_path:
+        continue
+
+    path = PurePosixPath(raw_path)
+    forbidden_segment = next(
+        (segment for segment in path.parts if segment in FORBIDDEN_SEGMENTS),
+        None,
+    )
+    if forbidden_segment is not None:
+        forbidden_paths.append((raw_path, forbidden_segment))
+        continue
+
+    try:
+        size = os.path.getsize(raw_path)
+    except FileNotFoundError:
+        continue
+
+    if size > MAX_TRACKED_FILE_BYTES and raw_path not in ALLOWED_LARGE_TRACKED_PATHS:
+        oversized_paths.append((raw_path, size))
+
+if forbidden_paths or oversized_paths:
+    messages: list[str] = []
+    if forbidden_paths:
+        lines = [
+            "Tracked files must not live under generated dependency/build directories:",
+        ]
+        lines.extend(
+            f"  - {path} (forbidden segment: {segment})"
+            for path, segment in sorted(forbidden_paths)
+        )
+        messages.append("\n".join(lines))
+    if oversized_paths:
+        lines = [
+            "Tracked files larger than 1 MiB must be explicitly allowlisted in "
+            "scripts/check-root-artifact-hygiene.sh:",
+        ]
+        lines.extend(
+            f"  - {path} ({format_bytes(size)})"
+            for path, size in sorted(oversized_paths)
+        )
+        messages.append("\n".join(lines))
+    raise SystemExit("\n\n".join(messages))
+
+print("Repository artifact hygiene check passed.")
+PY


### PR DESCRIPTION
## Summary

- add a root artifact hygiene guard that blocks tracked `node_modules` / `target` paths and oversized tracked blobs before they enter history
- wire the guard into pre-commit and YAML workflow CI
- document and test the new artifact-hygiene contract in the ops spec

## Related Issue (required)

close: #788

## Testing

- [x] `mise run test`
- [x] `mise run e2e`
