### PR TITLE
test: align local e2e validation with CI

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -91,28 +91,7 @@ jobs:
 
       - name: Run E2E tests
         env:
+          E2E_BUILD_IMAGES: "false"
           PLAYWRIGHT_CI_REPORTER: junit
           PLAYWRIGHT_JUNIT_OUTPUT_FILE: test-results/junit.xml
-        run: bash e2e/scripts/run-e2e-compose.sh
-
-      - name: Fail on skipped e2e tests
-        run: |
-          python3 - <<'PY'
-          import sys
-          import xml.etree.ElementTree as ET
-          from pathlib import Path
-
-          report = Path("e2e/test-results/junit.xml")
-          if not report.exists():
-            raise SystemExit(f"missing junit report: {report}")
-
-          root = ET.parse(report).getroot()
-          suites = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
-          skipped = sum(int(float(s.attrib.get("skipped", "0") or 0)) for s in suites)
-          tests = sum(int(float(s.attrib.get("tests", "0") or 0)) for s in suites)
-          if tests == 0:
-            raise SystemExit("e2e tests: zero executed tests")
-          if skipped > 0:
-            raise SystemExit(f"e2e tests: skipped={skipped} is not allowed")
-          sys.stdout.write(f"e2e tests OK: tests={tests}, skipped={skipped}\n")
-          PY
+        run: bash e2e/scripts/run-e2e-compose.sh full

--- a/README.md
+++ b/README.md
@@ -250,6 +250,20 @@ Run all tests from repo root:
 mise run test
 ```
 
+Run the authoritative local E2E suite. It prefers the docker-compose path used
+by GitHub Actions when Docker is available, and otherwise falls back to a
+production-style host runner with the same Playwright JUnit/no-skips gates:
+
+```bash
+mise run e2e
+```
+
+For faster local iteration against direct dev servers (not CI parity):
+
+```bash
+mise run e2e:dev
+```
+
 Where you can run this:
 
 - Dev Container: everything needed to run tests is available; run `mise run test`.

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -4,6 +4,13 @@
 services:
   backend:
     image: ugoite-backend:e2e
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      additional_contexts:
+        core: ./ugoite-core
+        minimum: ./ugoite-minimum
+        module: ./ugoite-cli
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -21,6 +28,11 @@ services:
 
   frontend:
     image: ugoite-frontend:e2e
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      additional_contexts:
+        shared: ./shared
     ports:
       - "127.0.0.1:3000:3000"
     environment:

--- a/docs/guide/env-matrix.md
+++ b/docs/guide/env-matrix.md
@@ -1,6 +1,8 @@
 # Environment Variable Matrix
 
-This matrix summarizes primary runtime variables by mode.
+This matrix summarizes primary runtime variables by mode. `E2E runner` refers to
+the direct-process helper in `e2e/scripts/run-e2e.sh`, while `Docker Compose`
+refers to the CI-parity compose helper in `e2e/scripts/run-e2e-compose.sh`.
 
 | Variable | Local dev | E2E runner | Docker Compose | CI |
 |---|---|---|---|---|
@@ -26,6 +28,10 @@ This matrix summarizes primary runtime variables by mode.
 | E2E_BACKEND_PORT | n/a | optional | n/a | optional |
 | E2E_FRONTEND_PORT | n/a | optional | n/a | optional |
 | E2E_FRONTEND_MODE | n/a | optional | n/a | optional |
-| E2E_TEST_TIMEOUT_MS | n/a | optional | n/a | optional |
+| E2E_ENFORCE_CI_GATES | n/a | optional | n/a | n/a |
+| E2E_BUILD_IMAGES | n/a | n/a | optional (`true` for local parity runs) | set to `false` because CI pre-builds the images |
+| E2E_BACKEND_START_TIMEOUT_SECONDS | n/a | n/a | optional | optional |
+| E2E_FRONTEND_START_TIMEOUT_SECONDS | n/a | n/a | optional | optional |
+| E2E_TEST_TIMEOUT_MS | n/a | optional | optional | optional |
 
 Use mode-specific `.env` files to avoid mixing values between workflows.

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -99,12 +99,18 @@ jobs:
 ```yaml
 jobs:
   e2e:
-    - Start backend (background)
-    - Start frontend (background)
-    - Wait for servers
-    - cd e2e && npm run test
+    - Build backend image
+    - Build frontend image
+    - bash e2e/scripts/run-e2e-compose.sh full
     timeout: 30 minutes
 ```
+
+The shared compose runner remains the CI path. Local `mise run e2e` prefers
+that same compose runner when Docker is available, and otherwise falls back to a
+production-style host runner that keeps the same Playwright JUnit/no-skips
+validation contract. CI reuses pre-built images by setting
+`E2E_BUILD_IMAGES=false`, while Docker-enabled local runs build the images from
+the current workspace before starting the compose stack.
 
 ## Devcontainer CI
 
@@ -265,8 +271,11 @@ cd docsite && bun run lint && bun run format:check && bun run typecheck && bun r
 # Frontend
 cd ../frontend && biome ci . && bun run test:run --coverage
 
-# E2E (requires servers running)
+# E2E (authoritative local parity path)
 cd .. && mise run e2e
+
+# Fast local iteration only (not CI parity)
+cd .. && mise run e2e:dev
 
 # Conventional commits + release metadata
 npm run commitlint:range

--- a/docs/spec/testing/strategy.md
+++ b/docs/spec/testing/strategy.md
@@ -65,14 +65,17 @@ mise run e2e
 ```
 
 This command:
-1. Starts backend server on port 8000
-2. Starts frontend server on port 3000
-3. Waits for servers to be ready
-4. Executes E2E tests
-5. Shuts down servers
+1. Prefers the Docker Compose path used in CI when Docker is available locally
+2. Falls back to a production-style host runner when Docker is unavailable
+3. Uses CI-equivalent Playwright JUnit/no-skipped-tests gates in either mode
+4. Executes the full Playwright E2E suite
+5. Shuts down any services it started
 
 ### Fast E2E Iteration
 ```bash
+# Single-command fast path (not CI parity)
+mise run e2e:dev
+
 # Terminal 1: Backend
 mise run //backend:dev
 
@@ -82,6 +85,10 @@ mise run //frontend:dev
 # Terminal 3: Run E2E tests
 cd e2e && npm run test
 ```
+
+Use `mise run e2e` before pushing when you need CI-equivalent validation. Use
+`mise run e2e:dev`, `mise run e2e:smoke`, or the three-terminal flow above when
+you need a faster local feedback loop.
 
 ## Coverage Requirements
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -465,6 +465,17 @@ def test_docs_req_ops_001_readme_core_commands_match_mise() -> None:
             message = f"README command drift detected: missing mise task `{task}`"
             raise AssertionError(message)
 
+    mise_data = tomllib.loads(mise)
+    e2e_run = mise_data.get("tasks", {}).get("e2e", {}).get("run")
+    if e2e_run != "bash e2e/scripts/run-e2e-parity.sh full":
+        message = "Root `mise run e2e` must use the shared E2E parity wrapper"
+        raise AssertionError(message)
+
+    e2e_ci_workflow = E2E_CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+    if "bash e2e/scripts/run-e2e-compose.sh full" not in e2e_ci_workflow:
+        message = "E2E CI workflow must use the shared docker-compose E2E runner"
+        raise AssertionError(message)
+
 
 def test_docs_req_ops_001_env_matrix_matches_runtime_usage() -> None:
     """REQ-OPS-001: Environment matrix must track runtime variables used by tooling."""
@@ -480,6 +491,7 @@ def test_docs_req_ops_001_env_matrix_matches_runtime_usage() -> None:
     source_paths = [
         REPO_ROOT / "docker-compose.yaml",
         REPO_ROOT / "e2e/scripts/run-e2e.sh",
+        REPO_ROOT / "e2e/scripts/run-e2e-compose.sh",
         REPO_ROOT / ".github/workflows/e2e-ci.yml",
         REPO_ROOT / ".github/workflows/frontend-ci.yml",
         REPO_ROOT / "frontend/src/routes/api/[...path].ts",

--- a/e2e/docsite-links.test.ts
+++ b/e2e/docsite-links.test.ts
@@ -14,44 +14,52 @@ test.describe("Docsite internal links", () => {
 		await docsiteServer?.stop();
 	});
 
-	test("REQ-E2E-006: docsite internal page links resolve without 404s", async ({ page, request }) => {
+	test("REQ-E2E-006: docsite internal page links resolve without 404s", async ({
+		browser,
+		request,
+	}) => {
 		test.setTimeout(180_000);
 		const queue = [buildDocsiteUrl("/")];
 		const visited = new Set<string>();
+		const parserPage = await browser.newPage();
 
-		while (queue.length > 0) {
-			const currentUrl = queue.shift();
-			if (!currentUrl) {
-				continue;
-			}
-
-			const normalizedCurrentUrl = normalizeCrawlUrl(currentUrl);
-			if (visited.has(normalizedCurrentUrl)) {
-				continue;
-			}
-			const response = await request.get(currentUrl);
-			expect(response.status(), `Expected ${currentUrl} to resolve`).toBeLessThan(400);
-
-			const resolvedUrl = normalizeCrawlUrl(response.url());
-			visited.add(normalizedCurrentUrl);
-			visited.add(resolvedUrl);
-
-			const contentType = response.headers()["content-type"] ?? "";
-			if (!contentType.includes("text/html")) {
-				continue;
-			}
-
-			const hrefs = await extractPageHrefs(page, await response.text());
-
-			for (const href of hrefs) {
-				const normalizedHref = normalizeDocsiteHref(href, response.url());
-				if (!normalizedHref) {
+		try {
+			while (queue.length > 0) {
+				const currentUrl = queue.shift();
+				if (!currentUrl) {
 					continue;
 				}
-				if (!visited.has(normalizedHref)) {
-					queue.push(normalizedHref);
+
+				const normalizedCurrentUrl = normalizeCrawlUrl(currentUrl);
+				if (visited.has(normalizedCurrentUrl)) {
+					continue;
+				}
+				const response = await request.get(currentUrl);
+				expect(response.status(), `Expected ${currentUrl} to resolve`).toBeLessThan(400);
+
+				const resolvedUrl = normalizeCrawlUrl(response.url());
+				visited.add(normalizedCurrentUrl);
+				visited.add(resolvedUrl);
+
+				const contentType = response.headers()["content-type"] ?? "";
+				if (!contentType.includes("text/html")) {
+					continue;
+				}
+
+				const hrefs = await extractPageHrefs(parserPage, await response.text());
+
+				for (const href of hrefs) {
+					const normalizedHref = normalizeDocsiteHref(href, response.url());
+					if (!normalizedHref) {
+						continue;
+					}
+					if (!visited.has(normalizedHref)) {
+						queue.push(normalizedHref);
+					}
 				}
 			}
+		} finally {
+			await parserPage.close();
 		}
 
 		expect(
@@ -107,10 +115,10 @@ function normalizeDocsiteHref(rawHref: string, currentUrl: string): string | nul
 }
 
 async function extractPageHrefs(page: Page, html: string): Promise<string[]> {
-	return page.evaluate((markup) => {
-		const document = new DOMParser().parseFromString(markup, "text/html");
-		return Array.from(document.querySelectorAll("a[href]"), (anchor) =>
+	await page.setContent(html, { waitUntil: "domcontentloaded" });
+	return page.locator("a[href]").evaluateAll((anchors) =>
+		anchors.map((anchor) =>
 			anchor instanceof HTMLAnchorElement ? anchor.getAttribute("href") ?? "" : "",
-		);
-	}, html);
+		),
+	);
 }

--- a/e2e/scripts/run-e2e-compose.sh
+++ b/e2e/scripts/run-e2e-compose.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
-# E2E test runner using Docker Compose with pre-built images.
-# Used by e2e-ci.yml; relies on ugoite-backend:e2e and ugoite-frontend:e2e
-# images already loaded into the local Docker daemon.
+# E2E test runner using Docker Compose with locally built or pre-built images.
+# Used by local `mise run e2e` and by GitHub Actions e2e-ci.yml.
+#
+# Usage: ./e2e/scripts/run-e2e-compose.sh [test-type]
+#   test-type: "smoke", "entries", "screenshot", or "full" (default)
 #
 # Environment variables:
-#   PLAYWRIGHT_CI_REPORTER / PLAYWRIGHT_JUNIT_OUTPUT_FILE: passed through to tests
+#   E2E_BUILD_IMAGES: "true" (default) to build local images before startup;
+#     "false" to reuse pre-built images (used in CI)
 #   E2E_BACKEND_START_TIMEOUT_SECONDS / E2E_FRONTEND_START_TIMEOUT_SECONDS:
 #     optional startup wait budgets for compose services (defaults: 120 seconds)
+#   E2E_TEST_TIMEOUT_MS: optional per-test timeout passed to Playwright
 
 set -e
 
+TEST_TYPE="${1:-full}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.e2e.yml"
 DEV_SIGNING_KID="${UGOITE_DEV_SIGNING_KID:-dev-local-v1}"
 DEV_SIGNING_SECRET="${UGOITE_DEV_SIGNING_SECRET:-e2e-local-signing-secret}"
 PROXY_TIMEOUT_MS="${UGOITE_PROXY_TIMEOUT_MS:-30000}"
+BUILD_IMAGES="${E2E_BUILD_IMAGES:-true}"
 STATIC_E2E_TOKENS_JSON='{"alice-token":{"user_id":"alice-user","principal_type":"user"},"bob-token":{"user_id":"bob-user","principal_type":"user"}}'
 DEV_AUTH_PROXY_TOKEN="${UGOITE_DEV_AUTH_PROXY_TOKEN:-e2e-dev-auth-proxy-token}"
 export UGOITE_DEV_AUTH_MODE=mock-oauth
@@ -29,17 +36,26 @@ export UGOITE_PROXY_TIMEOUT_MS="$PROXY_TIMEOUT_MS"
 
 backend_start_timeout="${E2E_BACKEND_START_TIMEOUT_SECONDS:-120}"
 frontend_start_timeout="${E2E_FRONTEND_START_TIMEOUT_SECONDS:-120}"
+export PLAYWRIGHT_CI_REPORTER=junit
+export PLAYWRIGHT_JUNIT_OUTPUT_FILE="${PLAYWRIGHT_JUNIT_OUTPUT_FILE:-test-results/junit.xml}"
+
+compose_cmd=(docker compose -f "$COMPOSE_FILE")
 
 cleanup() {
   echo ""
   echo "Stopping services..."
-  docker compose -f "$ROOT_DIR/docker-compose.e2e.yml" down -v 2>/dev/null || true
+  "${compose_cmd[@]}" down -v 2>/dev/null || true
   echo "Services stopped."
 }
 trap cleanup EXIT INT TERM
 
+if [ "$BUILD_IMAGES" = "true" ]; then
+  echo "Building services via docker-compose.e2e.yml..."
+  "${compose_cmd[@]}" build
+fi
+
 echo "Starting services via docker-compose.e2e.yml..."
-docker compose -f "$ROOT_DIR/docker-compose.e2e.yml" up -d
+"${compose_cmd[@]}" up -d
 
 echo "Waiting for backend (port 8000)..."
 for i in $(seq 1 "$backend_start_timeout"); do
@@ -49,14 +65,14 @@ for i in $(seq 1 "$backend_start_timeout"); do
   fi
   if [ "$i" -eq "$backend_start_timeout" ]; then
     echo "✗ ERROR: Backend failed to start within ${backend_start_timeout} seconds"
-    docker compose -f "$ROOT_DIR/docker-compose.e2e.yml" logs backend
+    "${compose_cmd[@]}" logs backend
     exit 1
   fi
   sleep 1
 done
 
 E2E_AUTH_BEARER_TOKEN="$(
-  docker compose -f "$ROOT_DIR/docker-compose.e2e.yml" exec -T backend python -c '
+  "${compose_cmd[@]}" exec -T backend python -c '
 import json
 from urllib.request import Request, urlopen
 
@@ -75,7 +91,7 @@ for i in $(seq 1 "$frontend_start_timeout"); do
   fi
   if [ "$i" -eq "$frontend_start_timeout" ]; then
     echo "✗ ERROR: Frontend failed to start within ${frontend_start_timeout} seconds"
-    docker compose -f "$ROOT_DIR/docker-compose.e2e.yml" logs frontend
+    "${compose_cmd[@]}" logs frontend
     exit 1
   fi
   sleep 1
@@ -87,11 +103,54 @@ echo "Running E2E tests..."
 echo "=========================================="
 
 cd "$ROOT_DIR/e2e"
-cmd=(npm run test --)
+mkdir -p "$(dirname "$PLAYWRIGHT_JUNIT_OUTPUT_FILE")"
+rm -f "$PLAYWRIGHT_JUNIT_OUTPUT_FILE"
+
+case "$TEST_TYPE" in
+  smoke)
+    cmd=(npm run test:smoke --)
+    ;;
+  entries)
+    cmd=(npm run test:entries --)
+    ;;
+  screenshot)
+    cmd=(npm run test:screenshot --)
+    ;;
+  full)
+    cmd=(npm run test --)
+    ;;
+  *)
+    echo "Unknown test type: $TEST_TYPE"
+    echo "Usage: ./e2e/scripts/run-e2e-compose.sh [smoke|entries|screenshot|full]"
+    exit 1
+    ;;
+esac
+
 if [ -n "${E2E_TEST_TIMEOUT_MS:-}" ]; then
   cmd+=(--timeout "$E2E_TEST_TIMEOUT_MS")
 fi
 "${cmd[@]}"
+
+python3 - <<'PY'
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+report = Path(os.environ["PLAYWRIGHT_JUNIT_OUTPUT_FILE"])
+if not report.exists():
+    raise SystemExit(f"missing junit report: {report}")
+
+root = ET.parse(report).getroot()
+suites = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
+skipped = sum(int(float(s.attrib.get("skipped", "0") or 0)) for s in suites)
+tests = sum(int(float(s.attrib.get("tests", "0") or 0)) for s in suites)
+if tests == 0:
+    raise SystemExit("e2e tests: zero executed tests")
+if skipped > 0:
+    raise SystemExit(f"e2e tests: skipped={skipped} is not allowed")
+sys.stdout.write(f"e2e tests OK: tests={tests}, skipped={skipped}\n")
+PY
 
 echo ""
 echo "=========================================="

--- a/e2e/scripts/run-e2e-parity.sh
+++ b/e2e/scripts/run-e2e-parity.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Authoritative local E2E runner.
+# Prefer the same docker-compose path as CI when Docker is available. Fall back
+# to a production-style host runner with CI-equivalent Playwright gates when
+# Docker is unavailable.
+
+set -e
+
+TEST_TYPE="${1:-full}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if command -v docker >/dev/null 2>&1; then
+  exec bash "$SCRIPT_DIR/run-e2e-compose.sh" "$TEST_TYPE"
+fi
+
+echo "docker not found; falling back to direct-process parity mode."
+echo "This fallback still builds the production frontend and enforces CI-style Playwright gates."
+export E2E_FRONTEND_MODE="${E2E_FRONTEND_MODE:-prod}"
+export E2E_ENFORCE_CI_GATES=true
+exec bash "$SCRIPT_DIR/run-e2e.sh" "$TEST_TYPE"

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# E2E test runner script
+# Direct-process E2E runner for fast local iteration and for no-Docker parity
+# fallback via `run-e2e-parity.sh`.
+#
 # Usage: ./e2e/scripts/run-e2e.sh [test-type]
 #   test-type: "smoke", "entries", "screenshot", or "full" (runs standard tests)
 #
 # Environment variables:
 #   E2E_TEST_TIMEOUT_MS: per-test timeout passed to `playwright test --timeout`
 #   E2E_FRONTEND_MODE: "dev" (default) or "prod" to use build+start for SSR speed
+#   E2E_ENFORCE_CI_GATES: "true" to emit JUnit output and fail on skipped tests
 
 set -e
 
@@ -22,6 +25,12 @@ DEV_SIGNING_KID="${UGOITE_DEV_SIGNING_KID:-dev-local-v1}"
 DEV_SIGNING_SECRET="${UGOITE_DEV_SIGNING_SECRET:-e2e-local-signing-secret}"
 PROXY_TIMEOUT_MS="${UGOITE_PROXY_TIMEOUT_MS:-30000}"
 STATIC_E2E_TOKENS_JSON='{"alice-token":{"user_id":"alice-user","principal_type":"user"},"bob-token":{"user_id":"bob-user","principal_type":"user"}}'
+ENFORCE_CI_GATES="${E2E_ENFORCE_CI_GATES:-false}"
+
+if [ "$ENFORCE_CI_GATES" = "true" ]; then
+  export PLAYWRIGHT_CI_REPORTER=junit
+  export PLAYWRIGHT_JUNIT_OUTPUT_FILE="${PLAYWRIGHT_JUNIT_OUTPUT_FILE:-test-results/junit.xml}"
+fi
 
 echo "Checking for existing processes on ports 8000 and 3000..."
 fuser -k 8000/tcp 2>/dev/null || true
@@ -143,6 +152,11 @@ echo "=========================================="
 
 cd "$ROOT_DIR/e2e"
 
+if [ "$ENFORCE_CI_GATES" = "true" ]; then
+  mkdir -p "$(dirname "$PLAYWRIGHT_JUNIT_OUTPUT_FILE")"
+  rm -f "$PLAYWRIGHT_JUNIT_OUTPUT_FILE"
+fi
+
 TEST_TIMEOUT_ARGS=()
 if [ -n "${E2E_TEST_TIMEOUT_MS:-}" ]; then
   TEST_TIMEOUT_ARGS=(--timeout "${E2E_TEST_TIMEOUT_MS}")
@@ -167,6 +181,29 @@ case "$TEST_TYPE" in
     exit 1
     ;;
 esac
+
+if [ "$ENFORCE_CI_GATES" = "true" ]; then
+  python3 - <<'PY'
+import os
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+report = Path(os.environ["PLAYWRIGHT_JUNIT_OUTPUT_FILE"])
+if not report.exists():
+    raise SystemExit(f"missing junit report: {report}")
+
+root = ET.parse(report).getroot()
+suites = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
+skipped = sum(int(float(s.attrib.get("skipped", "0") or 0)) for s in suites)
+tests = sum(int(float(s.attrib.get("tests", "0") or 0)) for s in suites)
+if tests == 0:
+    raise SystemExit("e2e tests: zero executed tests")
+if skipped > 0:
+    raise SystemExit(f"e2e tests: skipped={skipped} is not allowed")
+sys.stdout.write(f"e2e tests OK: tests={tests}, skipped={skipped}\n")
+PY
+fi
 
 echo ""
 echo "=========================================="

--- a/mise.toml
+++ b/mise.toml
@@ -67,20 +67,24 @@ description = "Check consistency between documentation and implementation"
 run = "uv run --with pytest --with pyyaml --with bashlex pytest docs/tests -v"
 
 [tasks.e2e]
-description = "Run E2E tests with backend and frontend servers"
-run = "bash e2e/scripts/run-e2e.sh full"
+description = "Run the authoritative E2E path (docker-compose when available, parity fallback otherwise)"
+run = "bash e2e/scripts/run-e2e-parity.sh full"
 
 [tasks.screenshot]
-description = "Capture UI page screenshots for docsite"
+description = "Capture UI page screenshots for docsite with local dev servers"
 run = "bash e2e/scripts/run-e2e.sh screenshot"
 
 [tasks."e2e:smoke"]
-description = "Run only smoke E2E tests (fast verification)"
+description = "Run smoke E2E tests against local dev servers (fast, not CI parity)"
 run = "bash e2e/scripts/run-e2e.sh smoke"
 
 [tasks."e2e:entries"]
-description = "Run entries E2E tests"
+description = "Run entries E2E tests against local dev servers (fast, not CI parity)"
 run = "bash e2e/scripts/run-e2e.sh entries"
+
+[tasks."e2e:dev"]
+description = "Run full E2E tests against local dev servers (fast, not CI parity)"
+run = "bash e2e/scripts/run-e2e.sh full"
 
 [tasks.seed]
 description = "Seed a local development space with sample data"


### PR DESCRIPTION
## Summary

- align root `mise run e2e` with a shared parity flow that prefers the CI docker-compose path and falls back to a production-style host runner when Docker is unavailable
- reuse the same Playwright JUnit / no-skipped-tests gate in local parity runs and CI, and teach the compose runner to build local images when needed
- update testing docs and guide guards, and harden `docsite-links` parsing so the local parity run catches the same failures cleanly

## Related Issue (required)

close: #802

## Testing

- [x] `mise run test`
- [x] `mise run e2e`
- [x] `cd e2e && E2E_AUTH_BEARER_TOKEN=dummy npx playwright test docsite-links.test.ts`
