### PR TITLE
fix: keep docsite theme fixed

### DIFF
--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -191,3 +191,33 @@ requirements:
     - file: e2e/docsite-links.test.ts
       tests:
       - 'REQ-E2E-006: docsite internal page links resolve without 404s'
+- set_id: REQCAT-E2E
+  source_file: requirements/e2e.yaml
+  scope: End-to-end confidence and cross-layer behavior requirements.
+  linked_policies:
+  - POL-005
+  - POL-006
+  - POL-008
+  - POL-009
+  linked_specifications:
+  - SPEC-TESTING-STRATEGY
+  - SPEC-TESTING-CICD
+  - SPEC-UI-OVERVIEW
+  id: REQ-E2E-007
+  title: Docsite Theme Controls Stay Documentation-Focused
+  description: 'Docsite pages MUST keep one canonical UI theme and only expose color
+
+    mode selection, so documentation does not inherit or advertise product UI
+
+    theme switching from app-local preferences.
+
+    '
+  related_spec:
+  - testing/strategy.md
+  priority: medium
+  status: implemented
+  tests:
+    e2e:
+    - file: e2e/docsite-theme-controls.test.ts
+      tests:
+      - 'REQ-E2E-007: docsite keeps a fixed UI theme and only exposes color mode selection'

--- a/docsite/src/components/ThemeSwitcher.astro
+++ b/docsite/src/components/ThemeSwitcher.astro
@@ -1,11 +1,4 @@
----
-import themes from "../../../shared/themes/ui-theme-definitions.json";
----
-
 <div class="flex items-center gap-2">
-  <select id="theme" class="doc-console-input" style="width: auto; padding: 0.25rem 0.5rem; font-size: 0.75rem;" data-theme-selector>
-    {themes.map((theme) => <option value={theme.id}>{theme.label}</option>)}
-  </select>
   <select id="mode" class="doc-console-input" style="width: auto; padding: 0.25rem 0.5rem; font-size: 0.75rem;" data-mode-selector>
     <option value="light">Light</option>
     <option value="dark">Dark</option>
@@ -13,31 +6,21 @@ import themes from "../../../shared/themes/ui-theme-definitions.json";
 </div>
 
 <script>
-  const themeKey = "ugoite-ui-theme";
+  const fixedTheme = "materialize";
   const modeKey = "ugoite-color-mode";
   const root = document.documentElement;
-  const themeSelect = document.querySelector("[data-theme-selector]");
   const modeSelect = document.querySelector("[data-mode-selector]");
 
   const applyThemeAndMode = () => {
-    const theme =
-      themeSelect instanceof HTMLSelectElement ? themeSelect.value : localStorage.getItem(themeKey) || "materialize";
     const mode =
       modeSelect instanceof HTMLSelectElement ? modeSelect.value : localStorage.getItem(modeKey) || "light";
 
-    root.dataset.uiTheme = theme;
+    root.dataset.uiTheme = fixedTheme;
     root.dataset.colorMode = mode;
-    localStorage.setItem(themeKey, theme);
     localStorage.setItem(modeKey, mode);
   };
 
-  const initialTheme = localStorage.getItem(themeKey) || "materialize";
   const initialMode = localStorage.getItem(modeKey) || "light";
-
-  if (themeSelect instanceof HTMLSelectElement) {
-    themeSelect.value = initialTheme;
-    themeSelect.addEventListener("change", applyThemeAndMode);
-  }
 
   if (modeSelect instanceof HTMLSelectElement) {
     modeSelect.value = initialMode;

--- a/e2e/docsite-theme-controls.test.ts
+++ b/e2e/docsite-theme-controls.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { startDocsiteServer, type DocsiteServer } from "./support/docsite-server";
+
+const docPath = "/docs/spec/index";
+const fixedTheme = "materialize";
+
+let docsiteServer: DocsiteServer | undefined;
+
+test.describe("Docsite theme controls", () => {
+	test.beforeAll(async () => {
+		test.setTimeout(180_000);
+		docsiteServer = await startDocsiteServer();
+	});
+
+	test.afterAll(async () => {
+		await docsiteServer?.stop();
+	});
+
+	test("REQ-E2E-007: docsite keeps a fixed UI theme and only exposes color mode selection", async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			localStorage.setItem("ugoite-ui-theme", "classic");
+			localStorage.setItem("ugoite-color-mode", "dark");
+		});
+
+		await page.goto(buildDocsiteUrl(docPath), { waitUntil: "networkidle" });
+
+		await expect(page.locator("[data-theme-selector]")).toHaveCount(0);
+		await expect(page.locator("[data-mode-selector]")).toBeVisible();
+		await expect(page.locator("html")).toHaveAttribute("data-ui-theme", fixedTheme);
+		await expect(page.locator("html")).toHaveAttribute("data-color-mode", "dark");
+
+		await page.locator("[data-mode-selector]").selectOption("light");
+		await expect(page.locator("html")).toHaveAttribute("data-ui-theme", fixedTheme);
+		await expect(page.locator("html")).toHaveAttribute("data-color-mode", "light");
+
+		const storage = await page.evaluate(() => ({
+			mode: localStorage.getItem("ugoite-color-mode"),
+			theme: localStorage.getItem("ugoite-ui-theme"),
+		}));
+		expect(storage).toEqual({
+			mode: "light",
+			theme: "classic",
+		});
+	});
+});
+
+function buildDocsiteUrl(path: string): string {
+	if (!docsiteServer) {
+		throw new Error("Docsite server is unavailable");
+	}
+	return docsiteServer.buildUrl(path);
+}


### PR DESCRIPTION
## Summary

- keep the docsite on one canonical UI theme instead of exposing shared app theme selection
- add a Playwright regression test that proves the docsite ignores stored app theme choices while preserving color mode changes
- register the new behavior under REQ-E2E-007

## Related Issue (required)

closes #804

## Testing

- [x] `mise run test`
- [x] `mise run e2e`
- [x] `E2E_AUTH_BEARER_TOKEN=dummy ./e2e/node_modules/.bin/playwright test e2e/docsite-theme-controls.test.ts`
