### PR TITLE
fix: make root mise run dev usable in mock-oauth mode

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -557,6 +557,7 @@ requirements:
       tests:
       - test_docs_req_ops_015_local_dev_auth_docs_cover_manual_modes
       - test_docs_req_ops_015_dev_auth_script_declares_manual_modes
+      - test_docs_req_ops_015_mock_oauth_startup_avoids_terminal_prompts
     - file: backend/tests/test_dev_auth.py
       tests:
       - test_dev_auth_req_ops_015_config_exposes_manual_totp_mode

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 import textwrap
 from pathlib import Path, PurePosixPath
 
@@ -1152,6 +1153,68 @@ def test_docs_req_ops_015_dev_auth_script_declares_manual_modes() -> None:
         message = "dev-auth-env.sh missing manual auth mode fragments: " + ", ".join(
             missing,
         )
+        raise AssertionError(message)
+
+
+def test_docs_req_ops_015_mock_oauth_startup_avoids_terminal_prompts(
+    tmp_path: Path,
+) -> None:
+    """REQ-OPS-015: mock-oauth startup stays explicit without terminal prompts."""
+    auth_file = tmp_path / "dev-auth.json"
+    script_path = REPO_ROOT / "scripts" / "dev-auth-env.sh"
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "UGOITE_DEV_AUTH_MODE": "mock-oauth",
+            "UGOITE_DEV_AUTH_FILE": str(auth_file),
+            "UGOITE_DEV_SIGNING_KID": "mock-oauth-test-kid",
+            "UGOITE_DEV_SIGNING_SECRET": "mock-oauth-test-secret",
+        },
+    )
+    env.pop("UGOITE_DEV_USER_ID", None)
+    env.pop("UGOITE_DEV_TOTP_CODE", None)
+
+    result = subprocess.run(
+        ["/bin/bash", str(script_path)],
+        cwd=REPO_ROOT,
+        env=env,
+        input="",
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        message = (
+            "mock-oauth startup should not block on terminal input; "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        raise AssertionError(message)
+
+    if "Local dev username:" in result.stdout or "Local dev username:" in result.stderr:
+        message = "mock-oauth startup must not prompt for a local username"
+        raise AssertionError(message)
+
+    if "Current 2FA code:" in result.stdout or "Current 2FA code:" in result.stderr:
+        message = "mock-oauth startup must not prompt for a TOTP code"
+        raise AssertionError(message)
+
+    exports = result.stdout
+    if "export UGOITE_DEV_AUTH_MODE=mock-oauth" not in exports:
+        message = "mock-oauth startup must export the selected auth mode"
+        raise AssertionError(message)
+    if "export UGOITE_DEV_USER_ID=dev-local-user" not in exports:
+        message = "mock-oauth startup must default UGOITE_DEV_USER_ID"
+        raise AssertionError(message)
+
+    auth_payload = json.loads(auth_file.read_text(encoding="utf-8"))
+    if auth_payload["mode"] != "mock-oauth":
+        message = "mock-oauth startup must persist the selected mode"
+        raise AssertionError(message)
+    if auth_payload["user_id"] != "dev-local-user":
+        message = "mock-oauth startup must persist the default dev user"
         raise AssertionError(message)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,4 @@
 [tool.ruff.lint.per-file-ignores]
 "docs/tests/test_storage_docs.py" = ["S603", "S607"]
 "docs/tests/test_artifact_hygiene.py" = ["S101", "S603", "S607"]
+"docs/tests/test_guides.py" = ["S603"]

--- a/scripts/dev-auth-env.sh
+++ b/scripts/dev-auth-env.sh
@@ -14,6 +14,7 @@ AUTH_FILE="${UGOITE_DEV_AUTH_FILE:-${HOME}/.ugoite/dev-auth.json}"
 AUTH_TTL_SECONDS="${UGOITE_DEV_AUTH_TTL_SECONDS:-43200}"
 DEV_2FA_SECRET="${UGOITE_DEV_2FA_SECRET:-JBSWY3DPEHPK3PXP}"
 DEV_USER_ID="${UGOITE_DEV_USER_ID:-}"
+DEFAULT_DEV_USER_ID="dev-local-user"
 DEV_SIGNING_KID="${UGOITE_DEV_SIGNING_KID:-dev-local-v1}"
 
 announce_mode() {
@@ -170,10 +171,10 @@ reuse_or_create_context() {
     return 0
   fi
 
-  if [ -z "$DEV_USER_ID" ]; then
-    DEV_USER_ID="$(prompt_non_empty 'Local dev username: ')"
-  fi
   if [ "$requested_mode" = "manual-totp" ]; then
+    if [ -z "$DEV_USER_ID" ]; then
+      DEV_USER_ID="$(prompt_non_empty 'Local dev username: ')"
+    fi
     entered_totp="${UGOITE_DEV_TOTP_CODE:-}"
     if [ -z "$entered_totp" ]; then
       entered_totp="$(prompt_non_empty 'Current 2FA code: ')"
@@ -182,6 +183,8 @@ reuse_or_create_context() {
       echo "The provided 2FA code is invalid for UGOITE_DEV_2FA_SECRET." >&2
       exit 1
     fi
+  elif [ -z "$DEV_USER_ID" ]; then
+    DEV_USER_ID="$DEFAULT_DEV_USER_ID"
   fi
 
   local signing_secret signing_kid


### PR DESCRIPTION
## Summary
- stop `scripts/dev-auth-env.sh` from prompting for username/TOTP in `mock-oauth` mode
- default the mock OAuth dev user to `dev-local-user` so root `mise run dev` can start without terminal input in mock OAuth flows
- add REQ-OPS-015 coverage for promptless mock-oauth startup and register the trusted subprocess Ruff exception for this docs test

## Related Issue (required)
closes #806

## Testing
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
- [x] Manual verification: `UGOITE_DEV_AUTH_MODE=mock-oauth mise run dev`, then confirmed backend `/health`, frontend `/login`, and docsite responses
