### PR TITLE
fix(ci): update CLI release runner labels

### DIFF
--- a/.github/workflows/cli-release-binaries.yml
+++ b/.github/workflows/cli-release-binaries.yml
@@ -27,7 +27,7 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
             rust_target: aarch64-unknown-linux-gnu
-          - runner: macos-13
+          - runner: macos-15-large
             rust_target: x86_64-apple-darwin
           - runner: macos-14
             rust_target: aarch64-apple-darwin

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -141,12 +141,14 @@ REQUIRED_CLI_RELEASE_WORKFLOW_FRAGMENTS = {
     "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",
+    "macos-15-large",
     "cargo build --locked --release --bin ugoite --target",
     "gh release upload",
     "ugoite-v${VERSION}-",
     "permissions:",
     "contents: write",
 }
+DEPRECATED_CLI_RELEASE_RUNNER_FRAGMENTS = {"macos-13"}
 REQUIRED_RELEASE_PUBLISH_CLI_FRAGMENTS = {
     "create-draft-release",
     "publish-cli-binaries",
@@ -1763,6 +1765,7 @@ def _collect_release_ci_requirement_details() -> list[str]:
 
 def _collect_cli_release_install_details() -> list[str]:
     workflow_text = RELEASE_PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8")
+    cli_release_workflow_text = CLI_RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
     workflow = _load_yaml_base_mapping(RELEASE_PUBLISH_WORKFLOW_PATH)
     jobs = workflow.get("jobs", {})
     if not isinstance(jobs, dict):
@@ -1796,8 +1799,13 @@ def _collect_cli_release_install_details() -> list[str]:
         REQUIRED_RELEASE_PUBLISH_CLI_FRAGMENTS,
     )
     missing_cli_release = _missing_required_fragments(
-        CLI_RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8"),
+        cli_release_workflow_text,
         REQUIRED_CLI_RELEASE_WORKFLOW_FRAGMENTS,
+    )
+    deprecated_cli_release_runners = sorted(
+        fragment
+        for fragment in DEPRECATED_CLI_RELEASE_RUNNER_FRAGMENTS
+        if fragment in cli_release_workflow_text
     )
     missing_install_script = _missing_required_fragments(
         INSTALL_CLI_SCRIPT_PATH.read_text(encoding="utf-8"),
@@ -1839,6 +1847,11 @@ def _collect_cli_release_install_details() -> list[str]:
             bool(missing_cli_release),
             "cli-release-binaries workflow missing fragments: "
             + ", ".join(missing_cli_release),
+        ),
+        (
+            bool(deprecated_cli_release_runners),
+            "cli-release-binaries workflow still references deprecated runners: "
+            + ", ".join(deprecated_cli_release_runners),
         ),
         (
             bool(missing_install_script),


### PR DESCRIPTION
## Summary
- move the Intel macOS CLI release job off the deprecated `macos-13` runner label
- keep REQ-OPS-018 coverage aligned so docs tests require the supported runner label and reject the deprecated one

## Related Issue (required)
closes #810

## Testing
- [x] `uvx ruff check docs/tests/test_guides.py`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -k 'req_ops_018' -q`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `mise run e2e`
