### PR TITLE
fix: enable release container browser login

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ gzip -dc "ugoite-frontend-v${UGOITE_VERSION}.docker.tar.gz" | docker load
 UGOITE_VERSION="$UGOITE_VERSION" docker compose -f docker-compose.release.yaml up -d
 ```
 
+Then open `http://localhost:3000/login`, click **Continue with Mock OAuth**,
+and you will land on `/spaces`. For more background on the explicit browser
+login flow, see [Local Dev Auth Login](docs/guide/local-dev-auth-login.md).
+
 The downloaded archives load the canonical release image names used by
 `docker-compose.release.yaml`:
 

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -8,12 +8,20 @@ services:
     environment:
       - UGOITE_ROOT=/data
       - UGOITE_ALLOW_REMOTE=true
+      - UGOITE_DEV_AUTH_MODE=mock-oauth
+      - UGOITE_DEV_USER_ID=dev-local-user
+      - UGOITE_DEV_SIGNING_KID=release-compose-local-v1
+      - UGOITE_DEV_SIGNING_SECRET=release-compose-local-secret
+      - UGOITE_AUTH_BEARER_SECRETS=release-compose-local-v1:release-compose-local-secret
+      - UGOITE_AUTH_BEARER_ACTIVE_KIDS=release-compose-local-v1
+      - UGOITE_DEV_AUTH_PROXY_TOKEN=release-compose-auth-proxy
 
   frontend:
     image: ghcr.io/ugoite/ugoite/frontend:${UGOITE_VERSION:?set UGOITE_VERSION}
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       - BACKEND_URL=http://backend:8000
+      - UGOITE_DEV_AUTH_PROXY_TOKEN=release-compose-auth-proxy
     depends_on:
       - backend

--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -57,8 +57,12 @@ UGOITE_VERSION="$UGOITE_VERSION" docker compose -f docker-compose.release.yaml u
 
 Then open:
 
-- Frontend UI: http://localhost:3000
+- Frontend UI login: http://localhost:3000/login
 - Backend API: http://localhost:8000
+
+Then click **Continue with Mock OAuth** to reach `/spaces`. For more detail on
+the explicit browser login flow, see
+[Local Dev Auth Login](local-dev-auth-login.md).
 
 To stop the stack:
 
@@ -94,6 +98,10 @@ docker pull ghcr.io/ugoite/ugoite/frontend:0.0.1
 
 - The release compose file keeps data on the host under `./spaces` to preserve
   the local-first storage model.
+- The published quick start binds both services to `127.0.0.1`, wires the dev
+  auth proxy token between frontend and backend, and enables explicit
+  `mock-oauth` browser login so `/login` works without editing the Compose
+  file.
 - The frontend container talks to the backend through the Compose network via
   `http://backend:8000`.
 - Release image archives are attached to every GitHub Release so the public

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -328,6 +328,8 @@ REQUIRED_RELEASE_QUICKSTART_README_FRAGMENTS = {
         'UGOITE_VERSION="$UGOITE_VERSION" docker compose -f '
         "docker-compose.release.yaml up -d"
     ),
+    "http://localhost:3000/login",
+    "Continue with Mock OAuth",
 }
 REQUIRED_RELEASE_QUICKSTART_GUIDE_FRAGMENTS = {
     "releases/download/v${UGOITE_VERSION}/docker-compose.release.yaml",
@@ -344,12 +346,22 @@ REQUIRED_RELEASE_QUICKSTART_GUIDE_FRAGMENTS = {
     "stable",
     "alpha",
     "beta",
+    "http://localhost:3000/login",
+    "Continue with Mock OAuth",
 }
 REQUIRED_RELEASE_COMPOSE_FRAGMENTS = {
     "ghcr.io/ugoite/ugoite/backend:${UGOITE_VERSION:?set UGOITE_VERSION}",
     "ghcr.io/ugoite/ugoite/frontend:${UGOITE_VERSION:?set UGOITE_VERSION}",
+    "127.0.0.1:3000:3000",
     "UGOITE_ROOT=/data",
     "BACKEND_URL=http://backend:8000",
+    "UGOITE_DEV_AUTH_MODE=mock-oauth",
+    "UGOITE_DEV_USER_ID=dev-local-user",
+    "UGOITE_DEV_SIGNING_KID=release-compose-local-v1",
+    "UGOITE_DEV_SIGNING_SECRET=release-compose-local-secret",
+    "UGOITE_AUTH_BEARER_SECRETS=release-compose-local-v1:release-compose-local-secret",
+    "UGOITE_AUTH_BEARER_ACTIVE_KIDS=release-compose-local-v1",
+    "UGOITE_DEV_AUTH_PROXY_TOKEN=release-compose-auth-proxy",
 }
 REQUIRED_RELEASE_QUICKSTART_CICD_FRAGMENTS = {
     "ghcr.io/ugoite/ugoite/backend",


### PR DESCRIPTION
## Summary
- configure `docker-compose.release.yaml` with explicit mock-oauth browser login settings
- forward the dev-auth proxy token between the release frontend and backend and keep the published quick start local-only on loopback
- document the release login step and lock it into the release quick-start docs test

## Related Issue (required)
closes #834

## Testing
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=1 MISE_JOBS=1 MALLOC_ARENA_MAX=2 RUSTFLAGS='-C debuginfo=0 -C link-arg=-Wl,--no-keep-memory' mise run test`
- [x] `E2E_AUTH_BEARER_TOKEN=local-dev-token VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_BUILD_JOBS=1 MISE_JOBS=1 MALLOC_ARENA_MAX=2 RUSTFLAGS='-C debuginfo=0 -C link-arg=-Wl,--no-keep-memory' mise run e2e`
- [x] `uvx pre-commit run --all-files`
- [x] release-like browser login repro/validation via Playwright against source backend + frontend using the release compose auth env
