### PR TITLE
feat(docsite): simplify onboarding front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Ugoite is a knowledge management system built on three core principles:
 | **Easy** | Markdown-first with automatic structure extraction |
 | **Freedom** | Your data, your storage, your AI - no vendor lock-in |
 
+## Start Here
+
+Pick the shortest path for what you want to do right now:
+
+- **Try the published release** — use [Container Quick Start](docs/guide/container-quickstart.md) to run the released browser experience without cloning the repository.
+- **Use the CLI** — use the [CLI Guide](docs/guide/cli.md) to install the released CLI or run it from source.
+- **Develop from source** — run `mise run setup`, then `mise run dev`, when you want the current backend, frontend, and docsite together.
+- **Need sign-in details?** — see [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) for the canonical `mise run dev` workflow and explicit `/login` flow.
+
 ## Key Features
 
 - **Markdown as Table**: Markdown sections map to Form-defined fields stored in Iceberg tables
@@ -52,15 +61,23 @@ e2e/                # End-to-end tests (Bun)
 
 ---
 
-## Documentation
+## Documentation Map
+
+Start with the user-facing guides:
+
+- [Container Quick Start](docs/guide/container-quickstart.md) - Run published GHCR release images
+- [CLI Guide](docs/guide/cli.md) - Install the released CLI or build it from source
+- [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) - Configure local bearer token auth
+- [Backend Healthcheck](docs/guide/backend-healthcheck.md) - Quick backend readiness check
+
+Go deeper when you need architecture or implementation contracts:
 
 - [Specification Index](docs/spec/index.md) - Technical specifications
 - [Architecture Overview](docs/spec/architecture/overview.md) - System design
 - [API Reference](docs/spec/api/rest.md) - REST API documentation
-- [Backend Healthcheck](docs/guide/backend-healthcheck.md) - Quick backend readiness check
-- [Container Quick Start](docs/guide/container-quickstart.md) - Run published GHCR release images
-- [CLI Guide](docs/guide/cli.md) - Install the released CLI or build it from source
-- [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) - Configure local bearer token auth
+
+Track ongoing work:
+
 - [Roadmap](docs/tasks/roadmap.md) - Future milestones
 - [Current Tasks](docs/tasks/tasks.md) - Active development
 

--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+
+import { nextStepCards, primaryStartCards } from "./onboarding";
+
+test("REQ-E2E-008: onboarding content keeps try, source, and CLI paths as the first entry choices", () => {
+	expect(primaryStartCards.map((card) => card.title)).toEqual([
+		"Try the published release",
+		"Run from source",
+		"Use the CLI",
+	]);
+	expect(primaryStartCards.map((card) => card.href)).toEqual([
+		"/docs/guide/container-quickstart",
+		"/docs/guide/docker-compose",
+		"/docs/guide/cli",
+	]);
+	expect(primaryStartCards.map((card) => card.badge)).toEqual([
+		"Fastest path",
+		"Contributor path",
+		"Automation path",
+	]);
+});
+
+test("REQ-E2E-008: onboarding content keeps browser, auth, and deeper reference docs available after the first step", () => {
+	expect(nextStepCards.map((card) => card.title)).toEqual([
+		"Explore the browser app",
+		"Understand auth and access",
+		"Read design and source docs",
+	]);
+	expect(nextStepCards.map((card) => card.href)).toEqual([
+		"/app/frontend",
+		"/docs/guide/auth-overview",
+		"/docs/spec/index",
+	]);
+	expect(nextStepCards.map((card) => card.badge)).toEqual([
+		"Browser",
+		"Access",
+		"Reference",
+	]);
+});

--- a/docsite/src/lib/onboarding.ts
+++ b/docsite/src/lib/onboarding.ts
@@ -1,0 +1,61 @@
+export type OnboardingCard = {
+	badge: string;
+	description: string;
+	href: string;
+	icon: string;
+	title: string;
+};
+
+export const primaryStartCards = [
+	{
+		badge: "Fastest path",
+		description:
+			"Launch the released browser stack without cloning or building from source.",
+		href: "/docs/guide/container-quickstart",
+		icon: "🚀",
+		title: "Try the published release",
+	},
+	{
+		badge: "Contributor path",
+		description:
+			"Run the current workspace when you want the latest backend, frontend, and docsite together.",
+		href: "/docs/guide/docker-compose",
+		icon: "🛠️",
+		title: "Run from source",
+	},
+	{
+		badge: "Automation path",
+		description:
+			"Install the released CLI or use it from source when the terminal is your main surface.",
+		href: "/docs/guide/cli",
+		icon: "⌨️",
+		title: "Use the CLI",
+	},
+] as const satisfies readonly OnboardingCard[];
+
+export const nextStepCards = [
+	{
+		badge: "Browser",
+		description:
+			"See how spaces, entries, forms, and search fit together in the UI.",
+		href: "/app/frontend",
+		icon: "🖥️",
+		title: "Explore the browser app",
+	},
+	{
+		badge: "Access",
+		description:
+			"Review browser, CLI, and API sign-in flows before rollout or scripting.",
+		href: "/docs/guide/auth-overview",
+		icon: "🔐",
+		title: "Understand auth and access",
+	},
+	{
+		badge: "Reference",
+		description:
+			"Go deeper into philosophy, requirements, APIs, and machine-readable specs when you need the full contract.",
+		href: "/docs/spec/index",
+		icon: "📚",
+		title: "Read design and source docs",
+	},
+] as const satisfies readonly OnboardingCard[];

--- a/docsite/src/pages/getting-started/index.astro
+++ b/docsite/src/pages/getting-started/index.astro
@@ -1,67 +1,12 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { withBasePath } from "../../lib/base-path";
+import { nextStepCards, primaryStartCards } from "../../lib/onboarding";
 
 const toc = [
   { id: "overview", title: "Overview" },
-  { id: "first-steps", title: "First Steps" },
+  { id: "first-steps", title: "Choose a Path" },
   { id: "next", title: "Next" },
-];
-
-const firstSteps = [
-  {
-    icon: "🚀",
-    title: "Try the published release",
-    description:
-      "Pull published images and start Ugoite without cloning or building from source.",
-    href: "/docs/guide/container-quickstart",
-    detail: "Quickest way to try the released stack",
-  },
-  {
-    icon: "🛠️",
-    title: "Build from source with Docker Compose",
-    description:
-      "Use the source-build guide when you want to run the current workspace instead of a published release.",
-    href: "/docs/guide/docker-compose",
-    detail: "Contributor-oriented path",
-  },
-  {
-    icon: "🔐",
-    title: "Auth Overview",
-    description:
-      "Understand how browser, CLI, and API access fit together before you sign in.",
-    href: "/docs/guide/auth-overview",
-    detail: "Useful before team rollout",
-  },
-  {
-    icon: "⌨️",
-    title: "CLI Guide",
-    description:
-      "Prefer the terminal? Learn the CLI entrypoints and installation flow first.",
-    href: "/docs/guide/cli",
-    detail: "Automation-friendly",
-  },
-];
-
-const nextSteps = [
-  {
-    icon: "🖥️",
-    title: "Explore the application",
-    description: "See how the browser UI, API, CLI, and MCP surfaces fit together.",
-    href: "/app",
-  },
-  {
-    icon: "💡",
-    title: "Read the design model",
-    description: "Dive into philosophy, policies, requirements, and feature traceability.",
-    href: "/design",
-  },
-  {
-    icon: "📚",
-    title: "Browse source specs",
-    description: "Open the machine-readable docs if you want implementation-level detail.",
-    href: "/docs/spec/index",
-  },
 ];
 ---
 
@@ -77,31 +22,35 @@ const nextSteps = [
         Start with Ugoite before diving into design docs
       </h1>
       <p style="color: var(--doc-muted); margin-top: 0.5rem; max-width: 42rem; line-height: 1.6;">
-        Ugoite gives you a private, portable knowledge space that runs on infrastructure you control.
-        Start by launching the app, understanding how you sign in, and choosing the surface that fits your workflow.
+        Pick the shortest path for what you want to do right now, then move to the browser, auth guide, or deeper reference docs only when you actually need them.
       </p>
     </div>
   </section>
 
   <section id="first-steps">
     <div class="doc-grid">
-      {firstSteps.map((step) => (
+      {primaryStartCards.map((step) => (
         <a href={withBasePath(step.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
           <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">{step.icon}</div>
           <h2 style="font-size: 1rem; font-weight: 700; margin: 0;">{step.title}</h2>
           <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{step.description}</p>
-          <span class="doc-pill" style="margin-top: 0.75rem;">{step.detail}</span>
+          <span class="doc-pill" style="margin-top: 0.75rem;">{step.badge}</span>
         </a>
       ))}
     </div>
   </section>
 
   <section id="next" class="doc-card">
-    <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Once you are running, here is where to go next</h2>
+    <p class="doc-pill" style="margin-bottom: 0.75rem;">After You Start</p>
+    <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 0.75rem;">Keep the next move simple</h2>
+    <p style="font-size: 0.875rem; color: var(--doc-muted); line-height: 1.7;">
+      Go straight to the surface or reference you need instead of reading the full spec tree front to back.
+    </p>
     <div class="doc-grid">
-      {nextSteps.map((step) => (
+      {nextStepCards.map((step) => (
         <a href={withBasePath(step.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
           <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">{step.icon}</div>
+          <div class="doc-pill" style="margin-bottom: 0.5rem;">{step.badge}</div>
           <h3 style="font-size: 1rem; font-weight: 700; margin: 0;">{step.title}</h3>
           <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{step.description}</p>
         </a>

--- a/docsite/src/pages/index.astro
+++ b/docsite/src/pages/index.astro
@@ -1,67 +1,10 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { withBasePath } from "../lib/base-path";
-
-const features = [
-  {
-    icon: "🗄️",
-    title: "Local-First Storage",
-    description: "Your knowledge lives on portable block storage — S3, local filesystem, or any compatible backend. No mandatory SaaS dependency.",
-  },
-  {
-    icon: "🤖",
-    title: "AI-Native Workflows",
-    description: "MCP integration, spec-driven governance, and traceable AI actions. Every operation is auditable through linked requirements.",
-  },
-  {
-    icon: "🖥️",
-    title: "Multi-Surface Control",
-    description: "Operate from API, CLI, or browser UI. All surfaces share one durable core logic layer and data model.",
-  },
-  {
-    icon: "⚡",
-    title: "Serverless Ready",
-    description: "Thin FastAPI adapter with zero business logic — deploy as a serverless function or traditional service.",
-  },
-  {
-    icon: "🔒",
-    title: "Privacy by Design",
-    description: "Data stays where you put it. No telemetry, no cloud lock-in. Full control over your knowledge infrastructure.",
-  },
-  {
-    icon: "📐",
-    title: "Spec-Driven Development",
-    description: "Every feature traces to YAML specs: philosophy → policy → requirement → implementation. Machine-readable, human-friendly.",
-  },
-];
-
-const startCards = [
-  {
-    icon: "🚀",
-    title: "Try the published release",
-    description: "Pull published images and run Ugoite without cloning the repo.",
-    href: "/docs/guide/container-quickstart",
-    badge: "Start here",
-  },
-  {
-    icon: "🛠️",
-    title: "Build from source with Docker Compose",
-    description: "Spin up the current backend and frontend workspace together.",
-    href: "/docs/guide/docker-compose",
-    badge: "Build from source",
-  },
-  {
-    icon: "🔐",
-    title: "Understand auth and access",
-    description: "See how browser, CLI, and API access fit together before you log in.",
-    href: "/docs/guide/auth-overview",
-    badge: "User guide",
-  },
-];
+import { nextStepCards, primaryStartCards } from "../lib/onboarding";
 ---
 
 <BaseLayout title="Ugoite — Local-First Knowledge Space" fullWidth={true}>
-  <!-- Hero -->
   <section class="doc-card-hero" style="text-align: center; padding: 5rem 2rem 4rem;">
     <div style="position: relative; z-index: 1;">
       <p class="doc-pill" style="margin-bottom: 1.5rem;">Start Here &middot; Local-First &middot; AI-Native</p>
@@ -75,28 +18,34 @@ const startCards = [
       </p>
 
       <p style="max-width: 36rem; margin: 1.5rem auto 0; font-size: 0.9375rem; line-height: 1.7; color: var(--doc-muted);">
-        A private, portable knowledge space you can run with Docker, explore in the browser, or automate from the CLI — without handing your data to a SaaS.
+        A private, portable knowledge space you can run with Docker, automate from the CLI, and keep on infrastructure you control.
       </p>
+
+      <div style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-top: 1.5rem;">
+        <span class="doc-pill">Local-first data</span>
+        <span class="doc-pill">Browser + CLI surfaces</span>
+        <span class="doc-pill">Design and specs one step deeper</span>
+      </div>
 
       <div style="display: flex; gap: 0.75rem; justify-content: center; margin-top: 2rem; flex-wrap: wrap;">
         <a href={withBasePath("/getting-started")} class="doc-btn doc-btn-primary">Get Started</a>
-        <a href={withBasePath("/app")} class="doc-btn doc-btn-outline">See the App</a>
-        <a href={withBasePath("/design")} class="doc-btn doc-btn-outline">Design Principles</a>
+        <a href={withBasePath("/app")} class="doc-btn doc-btn-outline">Browse Application</a>
+        <a href={withBasePath("/docs/spec/index")} class="doc-btn doc-btn-outline">Read Specs</a>
       </div>
     </div>
   </section>
 
-  <section class="doc-card" style="margin-top: 2rem;">
+  <section id="start-paths" class="doc-card" style="margin-top: 2rem;">
     <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; flex-wrap: wrap;">
       <div>
-        <p class="doc-pill" style="margin-bottom: 0.75rem;">Getting Started</p>
-        <h2 style="font-size: 1.5rem; font-weight: 800; margin: 0;">Pick the path that fits how you want to try Ugoite</h2>
+        <p class="doc-pill" style="margin-bottom: 0.75rem;">Choose Your Path</p>
+        <h2 style="font-size: 1.5rem; font-weight: 800; margin: 0;">Most people only need one of these three entry points</h2>
       </div>
       <a href={withBasePath("/getting-started")} class="doc-btn doc-btn-outline">Open the getting-started guide</a>
     </div>
 
     <div class="doc-grid" style="margin-top: 1.5rem;">
-      {startCards.map((card) => (
+      {primaryStartCards.map((card) => (
         <a href={withBasePath(card.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
           <div style="font-size: 1.75rem; margin-bottom: 0.75rem;">{card.icon}</div>
           <div class="doc-pill" style="margin-bottom: 0.75rem;">{card.badge}</div>
@@ -107,38 +56,26 @@ const startCards = [
     </div>
   </section>
 
-  <!-- Feature grid -->
-  <section style="margin-top: 3rem;">
-    <div class="doc-grid">
-      {features.map((f) => (
-        <article class="doc-card doc-card-hover">
-          <div style="font-size: 1.75rem; margin-bottom: 0.75rem;">{f.icon}</div>
-          <h3 style="font-size: 1rem; font-weight: 700; margin: 0;">{f.title}</h3>
-          <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{f.description}</p>
-        </article>
-      ))}
+  <section id="next-steps" class="doc-card" style="margin-top: 2rem;">
+    <div>
+      <p class="doc-pill" style="margin-bottom: 0.75rem;">Then Go Deeper Only Where It Helps</p>
+      <h2 style="font-size: 1.5rem; font-weight: 800; margin: 0;">
+        Once you are running, jump straight to the browser, auth, or deeper docs
+      </h2>
+      <p style="font-size: 0.875rem; color: var(--doc-muted); margin-top: 0.75rem; line-height: 1.7;">
+        The main navigation keeps <strong>Application</strong>, <strong>Design</strong>, and <strong>Source Docs</strong> available without forcing first-time users through the whole spec tree.
+      </p>
     </div>
-  </section>
 
-  <!-- Quick stats -->
-  <section class="doc-card" style="margin-top: 2rem;">
-    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr)); gap: 1rem;">
-      <div class="doc-stat">
-        <div class="doc-stat-value">3</div>
-        <div class="doc-stat-label">Ways to use it</div>
-      </div>
-      <div class="doc-stat">
-        <div class="doc-stat-value">0</div>
-        <div class="doc-stat-label">Mandatory SaaS services</div>
-      </div>
-      <div class="doc-stat">
-        <div class="doc-stat-value">1</div>
-        <div class="doc-stat-label">Shared core logic layer</div>
-      </div>
-      <div class="doc-stat">
-        <div class="doc-stat-value">Any</div>
-        <div class="doc-stat-label">Portable storage target</div>
-      </div>
+    <div class="doc-grid" style="margin-top: 1.5rem;">
+      {nextStepCards.map((card) => (
+        <a href={withBasePath(card.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
+          <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">{card.icon}</div>
+          <div class="doc-pill" style="margin-bottom: 0.5rem;">{card.badge}</div>
+          <h3 style="font-size: 1rem; font-weight: 700; margin: 0;">{card.title}</h3>
+          <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{card.description}</p>
+        </a>
+      ))}
     </div>
   </section>
 </BaseLayout>

--- a/e2e/docsite-onboarding.test.ts
+++ b/e2e/docsite-onboarding.test.ts
@@ -26,6 +26,16 @@ test.describe("Docsite onboarding-first navigation", () => {
 				/a private, portable knowledge space you can run with docker/i,
 			),
 		).toBeVisible();
+		await expect(page.locator("#start-paths a h3")).toHaveText([
+			"Try the published release",
+			"Run from source",
+			"Use the CLI",
+		]);
+		await expect(page.locator("#next-steps a h3")).toHaveText([
+			"Explore the browser app",
+			"Understand auth and access",
+			"Read design and source docs",
+		]);
 
 		const getStartedLink = page.getByRole("link", { name: "Get Started" });
 		await expect(getStartedLink).toBeVisible();
@@ -39,9 +49,13 @@ test.describe("Docsite onboarding-first navigation", () => {
 		).toBeVisible();
 		await expect(page.locator("#first-steps .doc-card h2")).toHaveText([
 			"Try the published release",
-			"Build from source with Docker Compose",
-			"Auth Overview",
-			"CLI Guide",
+			"Run from source",
+			"Use the CLI",
+		]);
+		await expect(page.locator("#next .doc-card h3")).toHaveText([
+			"Explore the browser app",
+			"Understand auth and access",
+			"Read design and source docs",
 		]);
 	});
 


### PR DESCRIPTION
## Summary

- simplify the docsite home and getting-started pages around three clear user entry paths
- mirror the same user-first guidance in `README.md` and keep deeper design/source docs one step away
- add `REQ-E2E-008`-traceable docsite unit and Playwright coverage for the updated onboarding flow

## Related Issue (required)

close: #870

## Testing

- [x] `mise run test`
- [x] `mise run e2e`
- [x] `cd e2e && E2E_AUTH_BEARER_TOKEN=test-token npx playwright test docsite-onboarding.test.ts`
