### PR TITLE
fix: bootstrap local dev auth once for root dev

### DIFF
--- a/docs/guide/local-dev-auth-login.md
+++ b/docs/guide/local-dev-auth-login.md
@@ -56,6 +56,10 @@ export UGOITE_DEV_2FA_SECRET="YOUR_BASE32_SECRET"
 mise run dev
 ```
 
+The root task prepares the local auth context **once** before it fans out to the
+backend, frontend, and docsite dev tasks. On a first `manual-totp` run, expect a
+single username + 2FA prompt sequence before the backend and frontend start.
+
 The helper waits for `http://localhost:8000/health` before the frontend dev
 server starts, so `/api/*` requests do not race the backend startup.
 
@@ -174,4 +178,5 @@ mise run dev:docsite
 
 The backend and frontend tasks still source `scripts/dev-auth-env.sh`, and the
 frontend task still waits for `http://localhost:8000/health` before it starts
-proxying `/api/*` requests.
+proxying `/api/*` requests. The root `mise run dev` task simply prepares that
+auth context once up front so the shared startup flow stays deterministic.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -489,6 +489,8 @@ REQUIRED_WAIT_FOR_HTTP_FRAGMENTS = {
 }
 REQUIRED_LOCAL_DEV_AUTH_GUIDE_FRAGMENTS = {
     "/api/*",
+    "prepares the local auth context **once**",
+    "single username + 2FA prompt sequence",
     "waits for `http://localhost:8000/health`",
 }
 REQUIRED_LOCAL_DEV_AUTH_MODE_GUIDE_FRAGMENTS = {
@@ -1491,6 +1493,43 @@ def test_docs_req_ops_015_dev_auth_script_declares_manual_modes() -> None:
             missing,
         )
         raise AssertionError(message)
+
+
+def test_docs_req_ops_015_root_dev_bootstraps_auth_before_fanout() -> None:
+    """REQ-OPS-015: Root `mise run dev` must prepare auth context once before fanout."""
+    root_mise = tomllib.loads(MISE_PATH.read_text(encoding="utf-8"))
+    guide_text = LOCAL_DEV_AUTH_GUIDE_PATH.read_text(encoding="utf-8")
+    expected_root_dev_run = (
+        'eval "$(cd backend && uv run bash ../scripts/dev-auth-env.sh)" '
+        "&& mise run //backend:dev ::: //frontend:dev ::: //docsite:dev"
+    )
+
+    details = [
+        detail
+        for detail in [
+            _require_exact_task_run(
+                root_mise,
+                "dev",
+                [expected_root_dev_run],
+                "root mise.toml tasks.dev must bootstrap auth once before fanning out",
+            ),
+            _require_file_contains(
+                LOCAL_DEV_AUTH_GUIDE_PATH,
+                [
+                    "prepares the local auth context **once**",
+                    "single username + 2FA prompt sequence",
+                ],
+                "local-dev-auth-login.md must describe the single root auth bootstrap",
+            ),
+        ]
+        if detail is not None
+    ]
+
+    if "The root task prepares the local auth context **once**" not in guide_text:
+        details.append("local-dev-auth-login.md must explain root auth bootstrap")
+
+    if details:
+        raise AssertionError("; ".join(details))
 
 
 def test_docs_req_ops_015_mock_oauth_startup_avoids_terminal_prompts(

--- a/mise.toml
+++ b/mise.toml
@@ -36,7 +36,7 @@ run = [
 ]
 
 [tasks.dev]
-depends = ["//backend:dev", "//frontend:dev", "//docsite:dev"]
+run = "eval \"$(cd backend && uv run bash ../scripts/dev-auth-env.sh)\" && mise run //backend:dev ::: //frontend:dev ::: //docsite:dev"
 
 [tasks."dev:backend"]
 description = "Run backend dev server only"


### PR DESCRIPTION
## Summary

- bootstrap the root `mise run dev` auth context once in the backend `uv` environment before fanning out to backend, frontend, and docsite dev tasks
- document the single `manual-totp` prompt flow in the canonical local dev auth guide
- add a `REQ-OPS-015` guide test that locks the root dev orchestration contract in place

## Related Issue (required)

close: #868

## Testing

- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test && VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
- [x] `uvx pre-commit run --all-files`
- [x] `UGOITE_DEV_AUTH_MODE=mock-oauth mise run dev`
- [x] fresh `manual-totp` bootstrap via root `mise run dev` with a new `UGOITE_DEV_AUTH_FILE`
