### PR TITLE
feat(frontend): delay reserved warning guidance

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1220,6 +1220,11 @@ requirements:
 
     collide with reserved metadata column names (e.g., title, form, tags).
 
+
+    Reserved-name guidance MUST stay hidden until a reserved metadata field or
+
+    form name is entered, and MUST hide again after the reserved name is removed.
+
     '
   related_spec:
   - data-model/overview.md#metadata-vs-content-columns
@@ -1231,6 +1236,8 @@ requirements:
     - file: frontend/src/components/create-dialogs.test.tsx
       tests:
       - 'REQ-FE-039: blocks reserved metadata column names'
+      - 'REQ-FE-039: hides reserved-name guidance until a reserved name is entered in create form'
+      - 'REQ-FE-039: hides reserved-name guidance until a reserved name is entered in edit form'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.

--- a/frontend/src/components/create-dialogs.test.tsx
+++ b/frontend/src/components/create-dialogs.test.tsx
@@ -76,6 +76,46 @@ describe("CreateFormDialog", () => {
 		expect(screen.getByRole("button", { name: "Create Form" })).toBeDisabled();
 	});
 
+	it("REQ-FE-039: hides reserved-name guidance until a reserved name is entered in create form", async () => {
+		const onSubmit = vi.fn();
+		const onClose = vi.fn();
+
+		render(() => (
+			<CreateFormDialog
+				open={true}
+				columnTypes={columnTypes}
+				formNames={[]}
+				onClose={onClose}
+				onSubmit={onSubmit}
+			/>
+		));
+
+		fireEvent.input(screen.getByPlaceholderText("e.g. Meeting, Task"), {
+			target: { value: "TestForm" },
+		});
+		fireEvent.click(screen.getByText("+ Add Column"));
+		const columnInput = screen.getByPlaceholderText("Column Name") as HTMLInputElement;
+
+		expect(
+			screen.queryByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).not.toBeInTheDocument();
+
+		fireEvent.input(columnInput, { target: { value: "title" } });
+		expect(
+			screen.getByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).toBeInTheDocument();
+
+		fireEvent.input(columnInput, { target: { value: "summary" } });
+		expect(
+			screen.queryByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).not.toBeInTheDocument();
+
+		fireEvent.input(columnInput, { target: { value: "title" } });
+		expect(
+			screen.getByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).toBeInTheDocument();
+	});
+
 	it("REQ-FE-055: keeps create-form column inputs readable on narrow layouts", async () => {
 		const onSubmit = vi.fn();
 		const onClose = vi.fn();
@@ -1133,6 +1173,47 @@ describe("EditFormDialog", () => {
 
 		// New field should have default value input
 		expect(screen.getByPlaceholderText("(Optional) e.g. Pending")).toBeInTheDocument();
+	});
+
+	it("REQ-FE-039: hides reserved-name guidance until a reserved name is entered in edit form", async () => {
+		const onSubmit = vi.fn();
+		const onClose = vi.fn();
+
+		render(() => (
+			<EditFormDialog
+				open={true}
+				entryForm={mockForm}
+				columnTypes={columnTypes}
+				formNames={["ExistingForm"]}
+				onClose={onClose}
+				onSubmit={onSubmit}
+			/>
+		));
+
+		fireEvent.click(screen.getByText("+ Add Column"));
+
+		const inputs = screen.getAllByPlaceholderText("Column Name") as HTMLInputElement[];
+		const newInput = inputs.find((input) => input.value === "");
+		if (!newInput) throw new Error("Could not find new edit-dialog column input");
+
+		expect(
+			screen.queryByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).not.toBeInTheDocument();
+
+		fireEvent.input(newInput, { target: { value: "title" } });
+		expect(
+			screen.getByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).toBeInTheDocument();
+
+		fireEvent.input(newInput, { target: { value: "summary" } });
+		expect(
+			screen.queryByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).not.toBeInTheDocument();
+
+		fireEvent.input(newInput, { target: { value: "title" } });
+		expect(
+			screen.getByText(/Reserved metadata columns are system-owned and cannot be used/),
+		).toBeInTheDocument();
 	});
 
 	it("REQ-FE-032: submits the edited form successfully", async () => {

--- a/frontend/src/components/create-dialogs.tsx
+++ b/frontend/src/components/create-dialogs.tsx
@@ -125,6 +125,12 @@ const buildFieldIssues = (fields: FieldIssueSource[], context?: FieldIssueContex
 	return issues;
 };
 
+const hasReservedMetadataFieldName = (fields: FieldIssueSource[]) =>
+	fields.some((field) => {
+		const trimmed = field.name.trim();
+		return trimmed ? isReservedMetadataColumn(trimmed) : false;
+	});
+
 export interface CreateEntryDialogProps {
 	open: boolean;
 	forms: Form[];
@@ -809,6 +815,10 @@ export function CreateFormDialog(props: CreateFormDialogProps) {
 		/* v8 ignore stop */
 	);
 
+	const showReservedNameGuidance = createMemo(
+		() => hasReservedMetadataFieldName(fields()) || Boolean(nameIssue()),
+	);
+
 	const hasFieldIssues = createMemo(() => fieldIssues().size > 0);
 
 	// Handle escape key
@@ -1008,20 +1018,22 @@ export function CreateFormDialog(props: CreateFormDialogProps) {
 									{t("createDialog.form.noColumnsDefined")}
 								</div>
 							</Show>
-							<div class="ui-alert ui-alert-warning text-xs space-y-1">
-								<p>
-									{t("createDialog.form.warning.reservedColumns", {
-										columns: RESERVED_METADATA_COLUMNS.join(", "),
-									})}
-								</p>
-								<p>
-									{t("createDialog.form.warning.reservedForms", {
-										forms: RESERVED_METADATA_CLASSES.join(", "),
-									})}
-								</p>
-								<p>{t("createDialog.form.warning.listFields")}</p>
-								<p>{t("createDialog.form.warning.booleanFields")}</p>
-							</div>
+							<Show when={showReservedNameGuidance()}>
+								<div class="ui-alert ui-alert-warning text-xs space-y-1">
+									<p>
+										{t("createDialog.form.warning.reservedColumns", {
+											columns: RESERVED_METADATA_COLUMNS.join(", "),
+										})}
+									</p>
+									<p>
+										{t("createDialog.form.warning.reservedForms", {
+											forms: RESERVED_METADATA_CLASSES.join(", "),
+										})}
+									</p>
+									<p>{t("createDialog.form.warning.listFields")}</p>
+									<p>{t("createDialog.form.warning.booleanFields")}</p>
+								</div>
+							</Show>
 						</div>
 
 						<div class="flex justify-end gap-3 pt-4">
@@ -1125,6 +1137,9 @@ export function EditFormDialog(props: EditFormDialogProps) {
 			/* v8 ignore start */
 			props.entryForm ? isReservedMetadataForm(props.entryForm.name) : false,
 		/* v8 ignore stop */
+	);
+	const showReservedNameGuidance = createMemo(
+		() => hasReservedMetadataFieldName(fields()) || nameIssue(),
 	);
 
 	/* v8 ignore start */
@@ -1335,22 +1350,24 @@ export function EditFormDialog(props: EditFormDialogProps) {
 									{t("createDialog.form.noColumnsDefined")}
 								</div>
 							</Show>
-							<div class="ui-alert ui-alert-warning text-xs space-y-1">
-								<p>
-									{t("createDialog.form.warning.reservedColumns", {
-										columns: RESERVED_METADATA_COLUMNS.join(", "),
-									})}
-								</p>
-								<Show when={nameIssue()}>
+							<Show when={showReservedNameGuidance()}>
+								<div class="ui-alert ui-alert-warning text-xs space-y-1">
 									<p>
-										{t("createDialog.form.warning.reservedFormsEdit", {
-											forms: RESERVED_METADATA_CLASSES.join(", "),
+										{t("createDialog.form.warning.reservedColumns", {
+											columns: RESERVED_METADATA_COLUMNS.join(", "),
 										})}
 									</p>
-								</Show>
-								<p>{t("createDialog.form.warning.listFields")}</p>
-								<p>{t("createDialog.form.warning.booleanFields")}</p>
-							</div>
+									<Show when={nameIssue()}>
+										<p>
+											{t("createDialog.form.warning.reservedFormsEdit", {
+												forms: RESERVED_METADATA_CLASSES.join(", "),
+											})}
+										</p>
+									</Show>
+									<p>{t("createDialog.form.warning.listFields")}</p>
+									<p>{t("createDialog.form.warning.booleanFields")}</p>
+								</div>
+							</Show>
 						</div>
 
 						<div class="flex justify-end gap-3 pt-4">


### PR DESCRIPTION
## Summary
- hide the reserved-name guidance block in the create/edit form dialogs until a reserved metadata name is actually present
- hide the guidance again once the reserved-name conflict is removed, then show it again if the user re-enters a reserved name
- update `REQ-FE-039` and add focused coverage for the create/edit dialog behavior

## Related Issue (required)
close: #878

## Testing
- [x] `cd frontend && bunx vitest run src/components/create-dialogs.test.tsx`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test && VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
