### PR TITLE
fix(ci): use supported artifact action

### DIFF
--- a/.github/workflows/release-quickstart-verify.yml
+++ b/.github/workflows/release-quickstart-verify.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload Playwright test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: release-quickstart-playwright-results
           path: e2e/test-results

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -433,7 +433,7 @@ REQUIRED_RELEASE_QUICKSTART_VERIFY_WORKFLOW_FRAGMENTS = {
     "Verify released browser quick start",
     "actions/cache@v5",
     "actions/setup-node@v6",
-    "actions/upload-artifact@v8",
+    "actions/upload-artifact@v7",
     "bash scripts/verify-release-cli-quickstart.sh",
     "bash scripts/verify-release-container-quickstart.sh",
     "PLAYWRIGHT_JUNIT_OUTPUT_FILE",


### PR DESCRIPTION
## Summary
- replace the invalid `actions/upload-artifact@v8` reference in the release quick-start verification workflow with the supported `@v7` action
- keep the REQ-OPS-025 docs gate aligned with the workflow contract so release validation stays green

## Related Issue (required)
close: #881

## Testing
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -k test_docs_req_ops_025_release_quickstart_verification_stays_wired -v`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
