### PR TITLE
fix: verify release browser quickstart via frontend proxy

### DIFF
--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -456,11 +456,12 @@ REQUIRED_RELEASE_CONTAINER_QUICKSTART_SCRIPT_FRAGMENTS = {
     "npx playwright test",
     "smoke.test.ts",
     "search-ui.test.ts",
-    "auth/dev/mock-oauth",
+    "127.0.0.1:3000/api/auth/dev/mock-oauth",
     "config set --mode backend --backend-url http://127.0.0.1:8000",
     "auth login --mock-oauth",
     "space list",
     "create-space",
+    "Host cleanup hit permission issues; retrying inside a container.",
     "Release container quick-start verification passed",
 }
 REQUIRED_RELEASE_QUICKSTART_VERIFY_DOC_FRAGMENTS = {

--- a/scripts/verify-release-container-quickstart.sh
+++ b/scripts/verify-release-container-quickstart.sh
@@ -104,7 +104,15 @@ cleanup() {
   fi
 
   if [ "$cleanup_mode" = "cleanup" ]; then
-    rm -rf "$WORK_ROOT"
+    if ! rm -rf "$WORK_ROOT" 2>/dev/null; then
+      log "Host cleanup hit permission issues; retrying inside a container."
+      docker run --rm \
+        -v "$WORK_ROOT:/work" \
+        --entrypoint /bin/sh \
+        "ghcr.io/ugoite/ugoite/backend:${VERSION_INPUT}" \
+        -c 'rm -rf /work/* /work/.[!.]* /work/..?*'
+      rm -rf "$WORK_ROOT"
+    fi
   else
     log "Retained quick-start workdir: $WORK_ROOT"
   fi
@@ -146,7 +154,7 @@ E2E_AUTH_BEARER_TOKEN="$(
 import json
 from urllib.request import Request, urlopen
 
-request = Request("http://127.0.0.1:8000/auth/dev/mock-oauth", method="POST")
+request = Request("http://127.0.0.1:3000/api/auth/dev/mock-oauth", method="POST")
 with urlopen(request) as response:
     print(json.load(response)["bearer_token"])
 PY


### PR DESCRIPTION
## Summary
- route release browser quickstart mock-oauth token minting through the frontend `/api` proxy so release verification uses the same trusted path as the documented `/login` flow
- make release quickstart cleanup retry inside a container when bind-mounted release data is root-owned
- tighten REQ-OPS-025 guide assertions so the release verifier stays wired to the frontend proxy path and cleanup fallback

## Related Issue (required)
closes #896

## Testing
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py::test_docs_req_ops_025_release_quickstart_verification_stays_wired -v`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
