### PR TITLE
fix: silence vendored reqsign seed warnings

### DIFF
--- a/vendor/reqsign/src/ctx.rs
+++ b/vendor/reqsign/src/ctx.rs
@@ -19,7 +19,7 @@ pub struct SigningContext {
 }
 
 impl SigningContext {
-    pub fn path_percent_decoded(&self) -> Cow<str> {
+    pub fn path_percent_decoded(&self) -> Cow<'_, str> {
         percent_encoding::percent_decode_str(&self.path).decode_utf8_lossy()
     }
 

--- a/vendor/reqsign/src/google/credential.rs
+++ b/vendor/reqsign/src/google/credential.rs
@@ -20,6 +20,7 @@ use crate::hash::base64_decode;
 #[derive(Clone, serde::Deserialize)]
 #[cfg_attr(test, derive(Debug))]
 #[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
 #[allow(clippy::enum_variant_names)]
 pub enum CredentialType {
     ImpersonatedServiceAccount,

--- a/vendor/reqsign/src/hash.rs
+++ b/vendor/reqsign/src/hash.rs
@@ -32,6 +32,7 @@ pub fn sha256(content: &[u8]) -> Vec<u8> {
 ///
 /// Use this function instead of `hex::encode(sha1(content))` can reduce
 /// extra copy.
+#[allow(dead_code)]
 pub fn hex_sha1(content: &[u8]) -> String {
     hex::encode(Sha1::digest(content).as_slice())
 }
@@ -64,6 +65,7 @@ pub fn base64_hmac_sha256(key: &[u8], content: &[u8]) -> String {
 ///
 /// Use this function instead of `hex::encode(hmac_sha1(key, content))` can
 /// reduce extra copy.
+#[allow(dead_code)]
 pub fn hex_hmac_sha1(key: &[u8], content: &[u8]) -> String {
     let mut h = Hmac::<Sha1>::new_from_slice(key).expect("invalid key length");
     h.update(content);


### PR DESCRIPTION
## Summary
- silence the vendored `reqsign` dead-code warnings that leak into `mise run seed`
- update the vendored lifetime signature to remove the `mismatched_lifetime_syntaxes` warning
- keep first-party lint behavior unchanged while restoring clean seed output

## Related Issue (required)
closes #898

## Testing
- [x] `mise run seed`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
