### PR TITLE
docs: unify docsite markdown presentation

### DIFF
--- a/docsite/src/pages/docs/[...slug].astro
+++ b/docsite/src/pages/docs/[...slug].astro
@@ -122,7 +122,7 @@ safeMarked.use({
       if (depth <= 3 && raw.length > 0 && id.length > 0) {
         toc.push({ id, title: raw });
       }
-      return `<h${depth} id="${id}">${text}</h${depth}>`;
+      return `<h${depth} id="${id}"><a class="doc-heading-anchor" href="#${id}" aria-label="Link to ${escapeAttribute(raw)}">#</a><span class="doc-heading-text">${text}</span></h${depth}>`;
     },
   },
 });
@@ -359,8 +359,8 @@ async function getRelatedLinks(sourceFile: string): Promise<Array<{ href: string
 ---
 
 <BaseLayout title={`Docs: ${relativePath}`} description={`Repository source: /docs/${relativePath}`} toc={toc} related={related}>
-  <div class="doc-card" style="padding: 0.75rem 1rem; margin-bottom: 1rem;">
-    <nav style="font-size: 0.75rem; color: var(--doc-muted);">
+  <div class="doc-card doc-source-meta">
+    <nav class="doc-breadcrumbs">
       <a href={withBasePath("/")}>home</a>
       <span> / </span>
       <a href={withBasePath("/docs/spec/index")}>docs</a>
@@ -371,7 +371,7 @@ async function getRelatedLinks(sourceFile: string): Promise<Array<{ href: string
         </>
       ))}
     </nav>
-    <p style="font-size: 0.6875rem; color: var(--doc-muted); margin-top: 0.375rem;">
+    <p class="doc-source-note">
       Source: /docs/{relativePath}
     </p>
   </div>

--- a/docsite/src/pages/getting-started/index.astro
+++ b/docsite/src/pages/getting-started/index.astro
@@ -15,46 +15,60 @@ const toc = [
   description="A user-first path for understanding Ugoite and starting it locally."
   toc={toc}
 >
-  <section id="overview" class="doc-card-hero">
-    <div style="position: relative; z-index: 1;">
-      <span class="doc-pill">Getting Started</span>
-      <h1 style="font-size: 2rem; font-weight: 800; margin-top: 0.75rem; letter-spacing: -0.02em;">
-        Start with Ugoite before diving into design docs
-      </h1>
-      <p style="color: var(--doc-muted); margin-top: 0.5rem; max-width: 42rem; line-height: 1.6;">
-        Pick the shortest path for what you want to do right now, then move to the browser, auth guide, or deeper reference docs only when you actually need them.
-      </p>
-    </div>
-  </section>
+  <div class="doc-page-stack">
+    <section id="overview" class="doc-card-hero">
+      <div class="doc-hero-content">
+        <span class="doc-pill doc-kicker">Getting Started</span>
+        <h1 class="doc-section-title">Start with Ugoite before diving into design docs</h1>
+        <p class="doc-lead">
+          Pick the shortest path for what you want to do right now, then move to the browser, auth guide, or deeper reference docs only when you actually need them.
+        </p>
+      </div>
+    </section>
 
-  <section id="first-steps">
-    <div class="doc-grid">
-      {primaryStartCards.map((step) => (
-        <a href={withBasePath(step.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
-          <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">{step.icon}</div>
-          <h2 style="font-size: 1rem; font-weight: 700; margin: 0;">{step.title}</h2>
-          <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{step.description}</p>
-          <span class="doc-pill" style="margin-top: 0.75rem;">{step.badge}</span>
-        </a>
-      ))}
-    </div>
-  </section>
+    <section id="first-steps" class="doc-section-stack">
+      <div class="doc-section-copy">
+        <p class="doc-pill doc-kicker">Choose a Path</p>
+        <h2 class="doc-section-title">Start with the path that matches what you need today</h2>
+      </div>
 
-  <section id="next" class="doc-card">
-    <p class="doc-pill" style="margin-bottom: 0.75rem;">After You Start</p>
-    <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 0.75rem;">Keep the next move simple</h2>
-    <p style="font-size: 0.875rem; color: var(--doc-muted); line-height: 1.7;">
-      Go straight to the surface or reference you need instead of reading the full spec tree front to back.
-    </p>
-    <div class="doc-grid">
-      {nextStepCards.map((step) => (
-        <a href={withBasePath(step.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
-          <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">{step.icon}</div>
-          <div class="doc-pill" style="margin-bottom: 0.5rem;">{step.badge}</div>
-          <h3 style="font-size: 1rem; font-weight: 700; margin: 0;">{step.title}</h3>
-          <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{step.description}</p>
-        </a>
-      ))}
-    </div>
-  </section>
+      <div class="doc-grid">
+        {primaryStartCards.map((step) => (
+          <a href={withBasePath(step.href)} class="doc-card doc-card-hover doc-link-card">
+            <div class="doc-link-card__icon" aria-hidden="true">{step.icon}</div>
+            <div class="doc-link-card__eyebrow">
+              <span class="doc-pill">{step.badge}</span>
+            </div>
+            <h2 class="doc-link-card__title">{step.title}</h2>
+            <p class="doc-link-card__body">{step.description}</p>
+            <div class="doc-link-card__footer">Open guide</div>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <section id="next" class="doc-card doc-section-stack">
+      <div class="doc-section-copy">
+        <p class="doc-pill doc-kicker">After You Start</p>
+        <h2 class="doc-section-title">Keep the next move simple</h2>
+        <p class="doc-lead">
+          Go straight to the surface or reference you need instead of reading the full spec tree front to back.
+        </p>
+      </div>
+
+      <div class="doc-grid">
+        {nextStepCards.map((step) => (
+          <a href={withBasePath(step.href)} class="doc-card doc-card-hover doc-link-card">
+            <div class="doc-link-card__icon" aria-hidden="true">{step.icon}</div>
+            <div class="doc-link-card__eyebrow">
+              <span class="doc-pill">{step.badge}</span>
+            </div>
+            <h3 class="doc-link-card__title">{step.title}</h3>
+            <p class="doc-link-card__body">{step.description}</p>
+            <div class="doc-link-card__footer">Open next step</div>
+          </a>
+        ))}
+      </div>
+    </section>
+  </div>
 </BaseLayout>

--- a/docsite/src/pages/index.astro
+++ b/docsite/src/pages/index.astro
@@ -5,77 +5,81 @@ import { nextStepCards, primaryStartCards } from "../lib/onboarding";
 ---
 
 <BaseLayout title="Ugoite — Local-First Knowledge Space" fullWidth={true}>
-  <section class="doc-card-hero" style="text-align: center; padding: 5rem 2rem 4rem;">
-    <div style="position: relative; z-index: 1;">
-      <p class="doc-pill" style="margin-bottom: 1.5rem;">Start Here &middot; Local-First &middot; AI-Native</p>
+  <div class="doc-page-stack">
+    <section class="doc-card-hero">
+      <div class="doc-hero-content doc-hero-content--center">
+        <p class="doc-pill doc-kicker">Start Here &middot; Local-First &middot; AI-Native</p>
 
-      <h1 style="font-size: clamp(3rem, 8vw, 5.5rem); font-weight: 900; letter-spacing: -0.04em; line-height: 1; margin: 0;">
-        <span style="background: var(--doc-accent-gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">Ugoite</span>
-      </h1>
+        <h1 class="doc-display-title">
+          <span class="doc-gradient-text">Ugoite</span>
+        </h1>
 
-      <p style="font-size: clamp(1rem, 2.5vw, 1.5rem); font-weight: 500; color: var(--doc-muted); margin-top: 1rem; letter-spacing: -0.01em;">
-        your private, portable knowledge space
-      </p>
+        <p class="doc-lead">
+          A private, portable knowledge space you can run with Docker, automate from the CLI, and keep on infrastructure you control.
+        </p>
 
-      <p style="max-width: 36rem; margin: 1.5rem auto 0; font-size: 0.9375rem; line-height: 1.7; color: var(--doc-muted);">
-        A private, portable knowledge space you can run with Docker, automate from the CLI, and keep on infrastructure you control.
-      </p>
+        <div class="doc-pill-row">
+          <span class="doc-pill">Local-first data</span>
+          <span class="doc-pill">Browser + CLI surfaces</span>
+          <span class="doc-pill">Design and specs one step deeper</span>
+        </div>
 
-      <div style="display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; margin-top: 1.5rem;">
-        <span class="doc-pill">Local-first data</span>
-        <span class="doc-pill">Browser + CLI surfaces</span>
-        <span class="doc-pill">Design and specs one step deeper</span>
+        <div class="doc-cta-row">
+          <a href={withBasePath("/getting-started")} class="doc-btn doc-btn-primary">Get Started</a>
+          <a href={withBasePath("/app")} class="doc-btn doc-btn-outline">Browse Application</a>
+          <a href={withBasePath("/docs/spec/index")} class="doc-btn doc-btn-outline">Read Specs</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="start-paths" class="doc-card doc-section-stack">
+      <div class="doc-section-header">
+        <div class="doc-section-copy">
+          <p class="doc-pill doc-kicker">Choose Your Path</p>
+          <h2 class="doc-section-title">Most people only need one of these three entry points</h2>
+        </div>
+        <a href={withBasePath("/getting-started")} class="doc-btn doc-btn-outline">Open the getting-started guide</a>
       </div>
 
-      <div style="display: flex; gap: 0.75rem; justify-content: center; margin-top: 2rem; flex-wrap: wrap;">
-        <a href={withBasePath("/getting-started")} class="doc-btn doc-btn-primary">Get Started</a>
-        <a href={withBasePath("/app")} class="doc-btn doc-btn-outline">Browse Application</a>
-        <a href={withBasePath("/docs/spec/index")} class="doc-btn doc-btn-outline">Read Specs</a>
+      <div class="doc-grid doc-card-list">
+        {primaryStartCards.map((card) => (
+          <a href={withBasePath(card.href)} class="doc-card doc-card-hover doc-link-card">
+            <div class="doc-link-card__icon" aria-hidden="true">{card.icon}</div>
+            <div class="doc-link-card__eyebrow">
+              <span class="doc-pill">{card.badge}</span>
+            </div>
+            <h3 class="doc-link-card__title">{card.title}</h3>
+            <p class="doc-link-card__body">{card.description}</p>
+            <div class="doc-link-card__footer">Open guide</div>
+          </a>
+        ))}
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section id="start-paths" class="doc-card" style="margin-top: 2rem;">
-    <div style="display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; flex-wrap: wrap;">
-      <div>
-        <p class="doc-pill" style="margin-bottom: 0.75rem;">Choose Your Path</p>
-        <h2 style="font-size: 1.5rem; font-weight: 800; margin: 0;">Most people only need one of these three entry points</h2>
+    <section id="next-steps" class="doc-card doc-section-stack">
+      <div class="doc-section-copy">
+        <p class="doc-pill doc-kicker">Then Go Deeper Only Where It Helps</p>
+        <h2 class="doc-section-title">
+          Once you are running, jump straight to the browser, auth, or deeper docs
+        </h2>
+        <p class="doc-lead">
+          The main navigation keeps <strong>Application</strong>, <strong>Design</strong>, and <strong>Source Docs</strong> available without forcing first-time users through the whole spec tree.
+        </p>
       </div>
-      <a href={withBasePath("/getting-started")} class="doc-btn doc-btn-outline">Open the getting-started guide</a>
-    </div>
 
-    <div class="doc-grid" style="margin-top: 1.5rem;">
-      {primaryStartCards.map((card) => (
-        <a href={withBasePath(card.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
-          <div style="font-size: 1.75rem; margin-bottom: 0.75rem;">{card.icon}</div>
-          <div class="doc-pill" style="margin-bottom: 0.75rem;">{card.badge}</div>
-          <h3 style="font-size: 1rem; font-weight: 700; margin: 0;">{card.title}</h3>
-          <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{card.description}</p>
-        </a>
-      ))}
-    </div>
-  </section>
-
-  <section id="next-steps" class="doc-card" style="margin-top: 2rem;">
-    <div>
-      <p class="doc-pill" style="margin-bottom: 0.75rem;">Then Go Deeper Only Where It Helps</p>
-      <h2 style="font-size: 1.5rem; font-weight: 800; margin: 0;">
-        Once you are running, jump straight to the browser, auth, or deeper docs
-      </h2>
-      <p style="font-size: 0.875rem; color: var(--doc-muted); margin-top: 0.75rem; line-height: 1.7;">
-        The main navigation keeps <strong>Application</strong>, <strong>Design</strong>, and <strong>Source Docs</strong> available without forcing first-time users through the whole spec tree.
-      </p>
-    </div>
-
-    <div class="doc-grid" style="margin-top: 1.5rem;">
-      {nextStepCards.map((card) => (
-        <a href={withBasePath(card.href)} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
-          <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">{card.icon}</div>
-          <div class="doc-pill" style="margin-bottom: 0.5rem;">{card.badge}</div>
-          <h3 style="font-size: 1rem; font-weight: 700; margin: 0;">{card.title}</h3>
-          <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">{card.description}</p>
-        </a>
-      ))}
-    </div>
-  </section>
+      <div class="doc-grid doc-card-list">
+        {nextStepCards.map((card) => (
+          <a href={withBasePath(card.href)} class="doc-card doc-card-hover doc-link-card">
+            <div class="doc-link-card__icon" aria-hidden="true">{card.icon}</div>
+            <div class="doc-link-card__eyebrow">
+              <span class="doc-pill">{card.badge}</span>
+            </div>
+            <h3 class="doc-link-card__title">{card.title}</h3>
+            <p class="doc-link-card__body">{card.description}</p>
+            <div class="doc-link-card__footer">Open next step</div>
+          </a>
+        ))}
+      </div>
+    </section>
+  </div>
 </BaseLayout>

--- a/docsite/src/styles.css
+++ b/docsite/src/styles.css
@@ -551,6 +551,180 @@ a:hover {
 		background: var(--doc-accent-soft);
 	}
 
+	/* Page composition */
+	.doc-page-stack {
+		display: grid;
+		gap: 1.75rem;
+	}
+
+	.doc-section-stack {
+		display: grid;
+		gap: 1.25rem;
+	}
+
+	.doc-section-header {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.doc-section-copy {
+		max-width: 48rem;
+	}
+
+	.doc-hero-content {
+		position: relative;
+		z-index: 1;
+		max-width: var(--doc-reading-width);
+	}
+
+	.doc-hero-content--center {
+		margin: 0 auto;
+		text-align: center;
+	}
+
+	.doc-kicker {
+		margin-bottom: 0.875rem;
+	}
+
+	.doc-display-title {
+		margin: 0;
+		font-size: clamp(2.5rem, 7vw, 5rem);
+		font-weight: 900;
+		letter-spacing: -0.04em;
+		line-height: 0.98;
+	}
+
+	.doc-section-title {
+		margin: 0;
+		font-size: clamp(1.5rem, 3vw, 2rem);
+		font-weight: 800;
+		letter-spacing: -0.03em;
+		line-height: 1.08;
+	}
+
+	.doc-gradient-text {
+		background: var(--doc-accent-gradient);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+	}
+
+	.doc-lead {
+		margin: 0.875rem 0 0;
+		max-width: var(--doc-reading-width);
+		font-size: clamp(0.95rem, 2vw, 1.125rem);
+		line-height: 1.75;
+		color: var(--doc-muted);
+	}
+
+	.doc-hero-content--center .doc-lead {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.doc-pill-row,
+	.doc-cta-row {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	.doc-pill-row {
+		gap: 0.5rem;
+		margin-top: 1.25rem;
+	}
+
+	.doc-cta-row {
+		gap: 0.75rem;
+		margin-top: 2rem;
+	}
+
+	.doc-hero-content--center .doc-pill-row,
+	.doc-hero-content--center .doc-cta-row {
+		justify-content: center;
+	}
+
+	.doc-card-list {
+		margin-top: 1.5rem;
+	}
+
+	.doc-link-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		height: 100%;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.doc-link-card__icon {
+		font-size: 1.75rem;
+		line-height: 1;
+	}
+
+	.doc-link-card__eyebrow {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.doc-link-card__title {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.2;
+	}
+
+	.doc-link-card__body {
+		margin: 0;
+		font-size: 0.875rem;
+		line-height: 1.7;
+		color: var(--doc-muted);
+	}
+
+	.doc-link-card__footer {
+		margin-top: auto;
+		padding-top: 0.5rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--doc-accent);
+	}
+
+	.doc-link-card__footer::after {
+		content: " →";
+	}
+
+	.doc-source-meta {
+		padding: 0.875rem 1rem;
+		margin-bottom: 1rem;
+	}
+
+	.doc-breadcrumbs {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		font-size: 0.75rem;
+		color: var(--doc-muted);
+	}
+
+	.doc-breadcrumbs a {
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.doc-breadcrumbs a:hover {
+		color: var(--doc-accent);
+	}
+
+	.doc-source-note {
+		margin-top: 0.375rem;
+		font-size: 0.6875rem;
+		color: var(--doc-muted);
+	}
+
 	/* Tables */
 	.doc-table-wrap {
 		overflow-x: auto;
@@ -749,41 +923,193 @@ a:hover {
 		background: var(--doc-card);
 		border: var(--doc-border-width) solid var(--doc-border);
 		border-radius: var(--doc-radius-lg);
-		padding: 1.5rem;
+		padding: clamp(1.25rem, 3vw, 2rem);
+		box-shadow: var(--doc-shadow-sm);
+		overflow-wrap: anywhere;
+	}
+
+	.doc-prose > :first-child {
+		margin-top: 0;
+	}
+
+	.doc-prose > :last-child {
+		margin-bottom: 0;
+	}
+
+	.doc-prose > * + * {
+		margin-top: 1rem;
+	}
+
+	.doc-prose :is(h1, h2, h3, h4, h5, h6) {
+		margin-bottom: 0;
+		scroll-margin-top: 6rem;
+		font-weight: 800;
+		letter-spacing: -0.03em;
+		line-height: 1.12;
+		color: var(--doc-fg);
+	}
+
+	.doc-prose h1 {
+		font-size: clamp(2rem, 4vw, 3rem);
+	}
+
+	.doc-prose > h2 {
+		margin-top: 2rem;
+		padding-top: 1rem;
+		border-top: var(--doc-border-width) solid var(--doc-border);
+		font-size: clamp(1.45rem, 2.5vw, 2rem);
+	}
+
+	.doc-prose > h3 {
+		margin-top: 1.5rem;
+		font-size: clamp(1.15rem, 2vw, 1.4rem);
+	}
+
+	.doc-prose > :is(p, ul, ol, blockquote, pre, table, hr, img) {
+		margin-top: 0.95rem;
+	}
+
+	.doc-prose p,
+	.doc-prose li {
+		line-height: 1.75;
+		color: var(--doc-fg);
+	}
+
+	.doc-prose h1 + p {
+		max-width: var(--doc-reading-width);
+		font-size: 1.1rem;
+		color: var(--doc-muted);
+	}
+
+	.doc-prose :is(ul, ol) {
+		padding-left: 1.35rem;
+	}
+
+	.doc-prose li + li {
+		margin-top: 0.45rem;
+	}
+
+	.doc-prose li > :is(p, ul, ol) {
+		margin-top: 0.45rem;
+	}
+
+	.doc-prose a {
+		color: var(--doc-accent);
+		text-decoration-thickness: 0.08em;
+		text-underline-offset: 0.18em;
+		font-weight: 600;
+	}
+
+	.doc-prose a:hover {
+		color: var(--doc-accent-hover);
+	}
+
+	.doc-prose strong {
+		font-weight: 700;
+	}
+
+	.doc-prose blockquote {
+		padding: 1rem 1.125rem;
+		border-left: 3px solid var(--doc-accent);
+		border-radius: var(--doc-radius-md);
+		background: var(--doc-accent-soft);
+	}
+
+	.doc-prose hr {
+		border: 0;
+		border-top: var(--doc-border-width) solid var(--doc-border);
+	}
+
+	.doc-prose img {
+		max-width: 100%;
+		height: auto;
+		border-radius: var(--doc-radius-md);
+		border: var(--doc-border-width) solid var(--doc-border);
 		box-shadow: var(--doc-shadow-sm);
 	}
 
-	.doc-prose h1,
-	.doc-prose h2,
-	.doc-prose h3 {
-		margin-top: 1.5em;
-		margin-bottom: 0.5em;
+	.doc-prose table {
+		width: 100%;
+		border-collapse: collapse;
+		overflow: hidden;
+		border: var(--doc-border-width) solid var(--doc-border);
+		border-radius: var(--doc-radius-lg);
+		font-size: 0.875rem;
 	}
 
-	.doc-prose p {
-		margin-bottom: 0.75em;
-		line-height: 1.7;
+	.doc-prose thead {
+		background: var(--doc-bg-subtle);
+	}
+
+	.doc-prose th,
+	.doc-prose td {
+		padding: 0.75rem 0.875rem;
+		text-align: left;
+		border-bottom: var(--doc-border-width) solid var(--doc-border);
+		vertical-align: top;
+	}
+
+	.doc-prose tbody tr:last-child td {
+		border-bottom: none;
 	}
 
 	.doc-prose pre {
 		overflow-x: auto;
-		background: #1e1e2e;
-		color: #cdd6f4;
-		padding: 1rem;
+		padding: 1rem 1.125rem;
 		border-radius: var(--doc-radius-md);
-		font-size: 0.8125rem;
+		border: 1px solid var(--doc-code-border);
+		background: var(--doc-code-bg);
+		color: var(--doc-code-fg);
+		box-shadow: var(--doc-shadow-sm);
+		font-size: 0.875rem;
+		line-height: 1.7;
 	}
 
 	.doc-prose code {
-		background: var(--doc-bg-subtle);
 		padding: 0.125rem 0.375rem;
 		border-radius: var(--doc-radius-sm);
+		border: 1px solid var(--doc-code-inline-border);
+		background: var(--doc-code-inline-bg);
+		color: var(--doc-code-inline-fg);
 		font-size: 0.875em;
+		font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
 	}
 
 	.doc-prose pre code {
 		background: transparent;
+		border: none;
 		padding: 0;
+		color: inherit;
+		font-size: inherit;
+	}
+
+	.doc-heading-anchor {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.25rem;
+		margin-right: 0.25rem;
+		color: var(--doc-muted);
+		text-decoration: none;
+		opacity: 0;
+		pointer-events: none;
+		transition:
+			opacity 0.15s ease,
+			color 0.15s ease;
+	}
+
+	.doc-heading-text {
+		display: inline;
+	}
+
+	.doc-prose :is(h1, h2, h3, h4, h5, h6):hover .doc-heading-anchor,
+	.doc-heading-anchor:focus-visible {
+		opacity: 0.8;
+		pointer-events: auto;
+	}
+
+	.doc-heading-anchor:hover {
+		color: var(--doc-accent);
 	}
 
 	/* KPI / Stats */
@@ -1046,6 +1372,31 @@ a:hover {
 
 		.doc-card-hero {
 			padding: 1.5rem 1rem;
+		}
+
+		.doc-page-stack {
+			gap: 1.25rem;
+		}
+
+		.doc-section-header {
+			align-items: flex-start;
+		}
+
+		.doc-display-title {
+			font-size: clamp(2.25rem, 12vw, 3.5rem);
+		}
+
+		.doc-cta-row,
+		.doc-pill-row {
+			justify-content: flex-start;
+		}
+
+		.doc-link-card {
+			gap: 0.625rem;
+		}
+
+		.doc-prose {
+			padding: 1.125rem;
 		}
 
 		.doc-grid,

--- a/shared/themes/ui-theme-docsite.css
+++ b/shared/themes/ui-theme-docsite.css
@@ -14,6 +14,7 @@
 	--doc-success-soft: rgba(16, 185, 129, 0.08);
 	--doc-warning: #f59e0b;
 	--doc-warning-soft: rgba(245, 158, 11, 0.08);
+	--doc-reading-width: 68ch;
 }
 
 /* ─── Theme: Materialize (default) ─── rounded, elevated, material-depth ─── */
@@ -35,6 +36,12 @@
 	--doc-muted: #64748b;
 	--doc-border: #e2e8f0;
 	--doc-card: #ffffff;
+	--doc-code-bg: #0f172a;
+	--doc-code-fg: #e2e8f0;
+	--doc-code-border: rgb(15 23 42 / 0.12);
+	--doc-code-inline-bg: rgb(15 23 42 / 0.06);
+	--doc-code-inline-border: rgb(15 23 42 / 0.08);
+	--doc-code-inline-fg: #0f172a;
 
 	--doc-header-bg: rgba(255, 255, 255, 0.82);
 	--doc-header-blur: 14px;
@@ -59,6 +66,12 @@
 	--doc-muted: #6b7280;
 	--doc-border: #d1d5db;
 	--doc-card: #ffffff;
+	--doc-code-bg: #111827;
+	--doc-code-fg: #f9fafb;
+	--doc-code-border: rgb(17 24 39 / 0.12);
+	--doc-code-inline-bg: rgb(17 24 39 / 0.05);
+	--doc-code-inline-border: rgb(17 24 39 / 0.08);
+	--doc-code-inline-fg: #111827;
 
 	--doc-header-bg: rgba(255, 255, 255, 0.95);
 	--doc-header-blur: 4px;
@@ -83,6 +96,12 @@
 	--doc-muted: #475569;
 	--doc-border: #c7d2fe;
 	--doc-card: #ffffff;
+	--doc-code-bg: #172554;
+	--doc-code-fg: #e0e7ff;
+	--doc-code-border: rgb(23 37 84 / 0.16);
+	--doc-code-inline-bg: rgb(99 102 241 / 0.08);
+	--doc-code-inline-border: rgb(99 102 241 / 0.12);
+	--doc-code-inline-fg: #1e1b4b;
 
 	--doc-header-bg: rgba(248, 250, 255, 0.88);
 	--doc-header-blur: 20px;
@@ -105,6 +124,12 @@
 	--doc-success-soft: rgba(52, 211, 153, 0.12);
 	--doc-warning: #fbbf24;
 	--doc-warning-soft: rgba(251, 191, 36, 0.12);
+	--doc-code-bg: #020617;
+	--doc-code-fg: #e2e8f0;
+	--doc-code-border: rgb(148 163 184 / 0.12);
+	--doc-code-inline-bg: rgb(148 163 184 / 0.12);
+	--doc-code-inline-border: rgb(148 163 184 / 0.16);
+	--doc-code-inline-fg: #e2e8f0;
 
 	--doc-header-bg: rgba(11, 15, 26, 0.88);
 	--doc-header-blur: 12px;


### PR DESCRIPTION
## Summary
- introduce shared docsite typography, layout, card, and prose primitives backed by shared theme tokens
- refactor the landing page and getting-started page onto the shared presentation system instead of one-off inline styles
- unify rendered docs pages with polished markdown prose, anchored headings, and consistent theme behavior across supported docsite themes

## Related Issue (required)
closes #905

## Testing
- [x] `cd /workspace/docsite && bun run validate`
- [x] `cd /workspace/e2e && E2E_AUTH_BEARER_TOKEN=docsite-static-token npx playwright test docsite-onboarding.test.ts docsite-links.test.ts docsite-mobile-nav.test.ts docsite-theme-controls.test.ts`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e`
