### PR TITLE
fix: pin container external references

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
 	"name": "mise",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+	"image": "mcr.microsoft.com/devcontainers/base:2.1.7-ubuntu24.04",
 	"features": {
-		"ghcr.io/devcontainers-extra/features/mise:1": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/devcontainers-extra/features/mise:1.0.0": {},
+		"ghcr.io/devcontainers/features/github-cli:1.1.0": {}
 	},
 	"customizations": {
 		"vscode": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,8 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.14-slim-trixie
+FROM python:3.14.3-slim-trixie@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
 
 WORKDIR /app
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.10.10 /uv /uvx /bin/
 
 # Build essentials and Rust toolchain for compiling ugoite-core (Rust native modules)
 RUN apt-get update \

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -69,6 +69,7 @@ requirements:
     - file: docs/tests/test_guides.py
       tests:
       - test_docs_req_ops_002_docker_build_ci_declared
+      - test_docs_req_ops_002_container_external_refs_are_pinned
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.
@@ -452,6 +453,7 @@ requirements:
     - file: docs/tests/test_guides.py
       tests:
       - test_docs_req_ops_012_devcontainer_change_detection_covers_inputs
+      - test_docs_req_ops_012_devcontainer_refs_are_pinned_and_updatable
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -41,7 +41,11 @@ Backend image builds in Docker Build CI, E2E CI, and SBOM CI pass `ugoite-core`,
 resolve inside the container build. Docker Build CI, E2E CI, SBOM CI, and
 Release Publish share the reusable `.github/workflows/docker-images.yml`
 image-definition contract so image build behavior cannot silently drift between
-CI validation, local-image artifact export, and release publishing.
+CI validation, local-image artifact export, and release publishing. Repository
+Dockerfiles pin external base/tool images to exact version tags, and
+base-image references should carry digests when public registries expose them,
+so local and CI builds stay reproducible under Dependabot-managed Docker update
+PRs.
 
 E2E CI selects a deterministic tier before running tests. `merge_group` and
 pushes to `main` always run the full compose-backed suite. Pull requests only
@@ -265,7 +269,11 @@ contracts. When no tracked input changed on a pull request or `push`, the smoke
 build is skipped but the summary check still reports success with an explicit
 selection reason. `merge_group` always runs the smoke build because GitHub does
 not support `paths` filtering there and branch health cannot depend on a
-disappearing required check.
+disappearing required check. The canonical devcontainer also uses exact version
+tags for its base image and public Features, and `.github/dependabot.yml`
+tracks `package-ecosystem: "devcontainers"` at `/` so Feature updates stay
+reviewable in normal PR flow while the base image tag stays explicitly pinned
+in `devcontainer.json`.
 
 ## Rust CI
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -137,6 +137,9 @@ PUBLIC_PACKAGE_LICENSE_PATH = PUBLIC_PACKAGE_DIR / "LICENSE"
 PUBLIC_PACKAGE_INSTALLER_PATH = PUBLIC_PACKAGE_DIR / "bin" / "ugoite-install"
 CI_CD_SPEC_PATH = REPO_ROOT / "docs" / "spec" / "testing" / "ci-cd.md"
 RELEASE_COMPOSE_PATH = REPO_ROOT / "docker-compose.release.yaml"
+BACKEND_DOCKERFILE_PATH = REPO_ROOT / "backend" / "Dockerfile"
+FRONTEND_DOCKERFILE_PATH = REPO_ROOT / "frontend" / "Dockerfile"
+DEVCONTAINER_JSON_PATH = REPO_ROOT / ".devcontainer" / "devcontainer.json"
 COLUMN_COUNT_THRESHOLD = 2
 DOCKER_IMAGE_WORKFLOW_PATHS = (
     DOCKER_BUILD_WORKFLOW_PATH,
@@ -609,6 +612,16 @@ REQUIRED_DEVCONTAINER_CHANGE_DETECTION_DOC_FRAGMENTS = {
     "`DEVCONTAINER_INPUT_PATTERNS`",
     "summary check still reports success",
 }
+REQUIRED_DOCKER_PIN_DOC_FRAGMENTS = {
+    "Dockerfiles pin external base/tool images to exact version tags",
+    "base-image references should carry digests",
+    "Dependabot-managed Docker update",
+}
+REQUIRED_DEVCONTAINER_PIN_DOC_FRAGMENTS = {
+    "The canonical devcontainer also uses exact version",
+    '`package-ecosystem: "devcontainers"` at `/`',
+    "base image tag stays explicitly pinned",
+}
 REQUIRED_DEV_SEED_SCRIPT_FRAGMENTS = {
     "CARGO_TARGET_DIR",
     "UGOITE_SEED_SPACE_ID",
@@ -721,6 +734,27 @@ REQUIRED_DEVCONTAINER_TRIGGER_PATTERNS = {
     "**/bun.lock",
     "**/pyproject.toml",
     "**/uv.lock",
+}
+PINNED_FRONTEND_BASE_IMAGE_PATTERN = re.compile(
+    r"^FROM oven/bun:\d+\.\d+\.\d+@sha256:[0-9a-f]{64} AS base$",
+    re.MULTILINE,
+)
+PINNED_BACKEND_BASE_IMAGE_PATTERN = re.compile(
+    r"^FROM python:\d+\.\d+\.\d+-slim-trixie@sha256:[0-9a-f]{64}$",
+    re.MULTILINE,
+)
+PINNED_BACKEND_UV_IMAGE_PATTERN = re.compile(
+    r"^COPY --from=ghcr\.io/astral-sh/uv:\d+\.\d+\.\d+ /uv /uvx /bin/$",
+    re.MULTILINE,
+)
+PINNED_DEVCONTAINER_IMAGE_PATTERN = re.compile(
+    r"^mcr\.microsoft\.com/devcontainers/base:\d+\.\d+\.\d+-ubuntu24\.04$",
+)
+PINNED_DEVCONTAINER_FEATURE_PATTERNS = {
+    "mise": re.compile(r"^ghcr\.io/devcontainers-extra/features/mise:\d+\.\d+\.\d+$"),
+    "github-cli": re.compile(
+        r"^ghcr\.io/devcontainers/features/github-cli:\d+\.\d+\.\d+$",
+    ),
 }
 
 CODE_BLOCK_PATTERN = re.compile(
@@ -926,6 +960,44 @@ def test_docs_req_ops_002_docker_build_ci_declared() -> None:
             missing_parts,
         )
     _raise_if_missing(missing_parts)
+
+
+def test_docs_req_ops_002_container_external_refs_are_pinned() -> None:
+    """REQ-OPS-002: Dockerfiles pin external image refs to exact versions."""
+    frontend_text = FRONTEND_DOCKERFILE_PATH.read_text(encoding="utf-8")
+    backend_text = BACKEND_DOCKERFILE_PATH.read_text(encoding="utf-8")
+    guide_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
+
+    details: list[str] = []
+    if not PINNED_FRONTEND_BASE_IMAGE_PATTERN.search(frontend_text):
+        details.append(
+            "frontend/Dockerfile must pin Bun to an exact version tag with "
+            "sha256 digest",
+        )
+    if not PINNED_BACKEND_BASE_IMAGE_PATTERN.search(backend_text):
+        details.append(
+            "backend/Dockerfile must pin Python slim-trixie to an exact version tag "
+            "with sha256 digest",
+        )
+    if not PINNED_BACKEND_UV_IMAGE_PATTERN.search(backend_text):
+        details.append(
+            "backend/Dockerfile must pin the copied uv tool image to an exact "
+            "version tag",
+        )
+
+    missing_doc_fragments = sorted(
+        fragment
+        for fragment in REQUIRED_DOCKER_PIN_DOC_FRAGMENTS
+        if fragment not in guide_text
+    )
+    if missing_doc_fragments:
+        details.append(
+            "ci-cd guide missing Docker pinning fragments: "
+            + ", ".join(missing_doc_fragments),
+        )
+
+    if details:
+        raise AssertionError("; ".join(details))
 
 
 def test_docs_req_ops_005_yaml_workflow_lint_gates_declared() -> None:
@@ -1433,6 +1505,70 @@ def test_docs_req_ops_012_devcontainer_change_detection_covers_inputs() -> None:
     if missing_doc_fragments:
         details.append(
             "ci-cd guide missing devcontainer change-detection fragments: "
+            + ", ".join(missing_doc_fragments),
+        )
+
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_ops_012_devcontainer_refs_are_pinned_and_updatable() -> None:
+    """REQ-OPS-012: Devcontainer refs stay pinned and Dependabot-updatable."""
+    devcontainer = _load_json_mapping(DEVCONTAINER_JSON_PATH)
+    dependabot = _load_yaml_base_mapping(REPO_ROOT / ".github" / "dependabot.yml")
+    guide_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
+
+    details: list[str] = []
+    image = devcontainer.get("image")
+    if not isinstance(image, str) or not PINNED_DEVCONTAINER_IMAGE_PATTERN.fullmatch(
+        image,
+    ):
+        details.append(
+            ".devcontainer/devcontainer.json must pin the base image to an exact "
+            "version tag",
+        )
+
+    features = devcontainer.get("features")
+    if not isinstance(features, dict):
+        details.append(".devcontainer/devcontainer.json features must be a mapping")
+    else:
+        feature_refs = {key for key in features if isinstance(key, str)}
+        pinned_feature_checks = {
+            label: any(pattern.fullmatch(ref) for ref in feature_refs)
+            for label, pattern in PINNED_DEVCONTAINER_FEATURE_PATTERNS.items()
+        }
+        missing_feature_refs = sorted(
+            label
+            for label, is_present in pinned_feature_checks.items()
+            if not is_present
+        )
+        if missing_feature_refs:
+            details.append(
+                ".devcontainer/devcontainer.json must pin exact feature versions for: "
+                + ", ".join(missing_feature_refs),
+            )
+
+    updates = dependabot.get("updates", [])
+    has_devcontainers_update = isinstance(updates, list) and any(
+        isinstance(update, dict)
+        and update.get("package-ecosystem") == "devcontainers"
+        and update.get("directory") == "/"
+        for update in updates
+    )
+    if not has_devcontainers_update:
+        details.append(
+            ".github/dependabot.yml must track the root devcontainer with the "
+            "devcontainers ecosystem",
+        )
+
+    missing_doc_fragments = sorted(
+        fragment
+        for fragment in REQUIRED_DEVCONTAINER_PIN_DOC_FRAGMENTS
+        if fragment not in guide_text
+    )
+    if missing_doc_fragments:
+        details.append(
+            "ci-cd guide missing devcontainer pinning fragments: "
             + ", ".join(missing_doc_fragments),
         )
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS base
+FROM oven/bun:1.3.8@sha256:371d30538b69303ced927bb5915697ac7e2fa8cb409ee332c66009de64de5aa3 AS base
 WORKDIR /usr/src/app
 
 # Install dependencies into temp directory


### PR DESCRIPTION
## Summary
Pin external image and devcontainer references to exact versions, add Dependabot devcontainer coverage, and document/test the pinning policy.

## Related Issue (required)
closes #907

## Testing
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py::test_docs_req_ops_002_container_external_refs_are_pinned docs/tests/test_guides.py::test_docs_req_ops_012_devcontainer_refs_are_pinned_and_updatable docs/tests/test_guides.py::test_docs_req_ops_012_devcontainer_change_detection_covers_inputs -v
- [x] VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test
- [x] VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e
