### PR TITLE
fix: pin runtime tool versions

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -131,12 +131,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 22.12.0
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.8
 
       - name: Download Docker image archives
         uses: actions/download-artifact@v8

--- a/.github/workflows/release-quickstart-verify.yml
+++ b/.github/workflows/release-quickstart-verify.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 22.12.0
 
       - name: Verify released browser quick start
         env:

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -48,7 +48,7 @@ jobs:
           check-compliance: true
           compliance-fail-level: "ERROR"
           compliance-fail-on-vulnerabilities: true
-          python-version: "3.12"
+          python-version: "3.12.13"
         env:
           VULNERABLECODE_URL: "https://public.vulnerablecode.io/"
 

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -47,6 +47,12 @@ base-image references should carry digests when public registries expose them,
 so local and CI builds stay reproducible under Dependabot-managed Docker update
 PRs.
 
+The root `mise.toml` `[tools]` table and workflow bootstrap steps also pin
+exact patch versions for Node, Bun, Python, Biome, Rust, and uv. `setup-node`,
+`setup-bun`, and `python-version` inputs must not use floating aliases such as
+`lts`, `lts/*`, `latest`, or minor-only pins, because REQ-OPS-001 treats local
+and CI runtime drift as a docs-tested contract failure.
+
 E2E CI selects a deterministic tier before running tests. `merge_group` and
 pushes to `main` always run the full compose-backed suite. Pull requests only
 drop to the smoke tier when every changed file stays inside docs/docsite

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -621,6 +621,15 @@ REQUIRED_DEVCONTAINER_PIN_DOC_FRAGMENTS = {
     '`package-ecosystem: "devcontainers"` at `/`',
     "base image tag stays explicitly pinned",
 }
+REQUIRED_RUNTIME_PIN_DOC_FRAGMENTS = {
+    "root `mise.toml` `[tools]` table",
+    "exact patch versions",
+    "`setup-node`",
+    "`setup-bun`",
+    "`python-version`",
+    "`lts/*`",
+    "`latest`",
+}
 REQUIRED_DEV_SEED_SCRIPT_FRAGMENTS = {
     "CARGO_TARGET_DIR",
     "UGOITE_SEED_SPACE_ID",
@@ -755,6 +764,7 @@ PINNED_DEVCONTAINER_FEATURE_PATTERNS = {
         r"^ghcr\.io/devcontainers/features/github-cli:\d+\.\d+\.\d+$",
     ),
 }
+EXACT_PATCH_VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
 CODE_BLOCK_PATTERN = re.compile(
     r"```(?:bash|sh|shell)\s*\n(.*?)\n```",
@@ -876,13 +886,14 @@ def test_docs_req_ops_001_env_matrix_matches_runtime_usage() -> None:
 
 
 def test_docs_req_ops_001_mise_versions_match_ci_pins() -> None:
-    """REQ-OPS-001: mise tool versions must match pinned versions in CI workflows."""
+    """REQ-OPS-001: mise tool versions must match exact runtime pins in CI."""
     mise_data = tomllib.loads(MISE_PATH.read_text(encoding="utf-8"))
     tools = mise_data.get("tools", {})
     if not isinstance(tools, dict):
         message = "mise.toml must define [tools]"
         raise TypeError(message)
 
+    guide_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
     expected_tools = {
         "biome": _extract_single_workflow_pin_value(
             [FRONTEND_CI_WORKFLOW_PATH],
@@ -891,10 +902,20 @@ def test_docs_req_ops_001_mise_versions_match_ci_pins() -> None:
             label="CI biome pins",
         ),
         "bun": _extract_single_workflow_pin_value(
-            [DOCSITE_CI_WORKFLOW_PATH, FRONTEND_CI_WORKFLOW_PATH],
+            [DOCSITE_CI_WORKFLOW_PATH, FRONTEND_CI_WORKFLOW_PATH, E2E_CI_WORKFLOW_PATH],
             uses_fragment="setup-bun",
             key="bun-version",
             label="CI bun-version pins",
+        ),
+        "node": _extract_single_workflow_pin_value(
+            [
+                DOCSITE_CI_WORKFLOW_PATH,
+                E2E_CI_WORKFLOW_PATH,
+                RELEASE_QUICKSTART_VERIFY_WORKFLOW_PATH,
+            ],
+            uses_fragment="setup-node",
+            key="node-version",
+            label="CI node-version pins",
         ),
         "python": _extract_single_workflow_pin_value(
             [SCANCODE_WORKFLOW_PATH],
@@ -916,14 +937,51 @@ def test_docs_req_ops_001_mise_versions_match_ci_pins() -> None:
         ),
     }
 
+    details: list[str] = []
     mismatches = sorted(
         f"{tool}={tools.get(tool)!r} (expected {expected})"
         for tool, expected in expected_tools.items()
         if str(tools.get(tool)) != expected
     )
     if mismatches:
-        message = "mise.toml [tools] drift: " + "; ".join(mismatches)
-        raise AssertionError(message)
+        details.append("mise.toml [tools] drift: " + "; ".join(mismatches))
+
+    non_exact_mise_tools = sorted(
+        tool
+        for tool, value in tools.items()
+        if tool in expected_tools
+        and not EXACT_PATCH_VERSION_PATTERN.fullmatch(str(value))
+    )
+    if non_exact_mise_tools:
+        details.append(
+            "mise.toml [tools] must use exact patch versions for: "
+            + ", ".join(non_exact_mise_tools),
+        )
+
+    non_exact_ci_tools = sorted(
+        tool
+        for tool, value in expected_tools.items()
+        if not EXACT_PATCH_VERSION_PATTERN.fullmatch(value)
+    )
+    if non_exact_ci_tools:
+        details.append(
+            "CI runtime pins must use exact patch versions for: "
+            + ", ".join(non_exact_ci_tools),
+        )
+
+    missing_doc_fragments = sorted(
+        fragment
+        for fragment in REQUIRED_RUNTIME_PIN_DOC_FRAGMENTS
+        if fragment not in guide_text
+    )
+    if missing_doc_fragments:
+        details.append(
+            "ci-cd guide missing runtime pinning fragments: "
+            + ", ".join(missing_doc_fragments),
+        )
+
+    if details:
+        raise AssertionError("; ".join(details))
 
 
 def test_docs_req_ops_002_docker_build_ci_declared() -> None:

--- a/mise.toml
+++ b/mise.toml
@@ -18,8 +18,8 @@ BROWSERSLIST_IGNORE_OLD_DATA = "true"
 [tools]
 biome = "2.3.15"
 bun = "1.3.8"
-node = "lts"
-python = "3.12"
+node = "22.12.0"
+python = "3.12.13"
 rust = "1.93.0"
 uv = "0.10.10"
 


### PR DESCRIPTION
## Summary
Pin exact Node, Bun, and Python runtime versions in the root `mise.toml` and workflow bootstrap steps, then extend the REQ-OPS-001 docs test so floating aliases fail CI.

## Related Issue (required)
closes #908

## Testing
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py::test_docs_req_ops_001_mise_versions_match_ci_pins -v
- [x] VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test
- [x] VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run e2e
