### PR TITLE
fix: freeze lockfile installs

### DIFF
--- a/.github/workflows/docsite-ci.yml
+++ b/.github/workflows/docsite-ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./docsite
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint
         working-directory: ./docsite

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run Vitest with 100% coverage gate
         working-directory: ./frontend

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Frontend (dev) example:
 
 ```bash
 cd frontend
-bun install
+bun install --frozen-lockfile
 bun dev
 ```
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -98,7 +98,7 @@ async def update_entry_endpoint(payload: EntryUpdate):
 
 ```bash
 cd backend
-uv sync
+uv sync --locked
 ```
 
 ### Development

--- a/backend/mise.toml
+++ b/backend/mise.toml
@@ -2,7 +2,7 @@
 _.python.venv = { path = ".venv" }
 
 [tasks.install]
-run = "uv sync"
+run = "uv sync --locked"
 
 [tasks.dev]
 # UGOITE_ALLOW_REMOTE=true allows remote connections in dev containers / Codespaces

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -1048,3 +1048,42 @@ requirements:
     - file: docs/tests/test_guides.py
       tests:
       - test_docs_req_ops_026_release_publish_uses_channel_changelog_sources
+- set_id: REQCAT-OPS
+  source_file: requirements/ops.yaml
+  scope: Operational quality, workflow, and automation requirements.
+  linked_policies:
+  - POL-003
+  - POL-005
+  - POL-008
+  - POL-009
+  - POL-010
+  - POL-013
+  linked_specifications:
+  - SPEC-TESTING-CICD
+  - SPEC-TESTING-STRATEGY
+  - SPEC-ARCH-STACK
+  - SPEC-PRODUCT-METRICS
+  id: REQ-OPS-027
+  title: Strict Lockfile Install Discipline
+  description: 'Local tasks, CI workflows, and contributor-facing install examples
+
+    that rely on committed lockfiles MUST fail fast on dependency drift instead
+
+    of mutating dependency resolution in place. Root Node tooling MUST use
+
+    `npm ci`, Bun projects MUST use `bun install --frozen-lockfile`, and Python
+
+    `uv.lock` environments MUST use `uv sync --locked` or an equally strict
+
+    contract.
+
+    '
+  related_spec:
+  - testing/ci-cd.md
+  priority: high
+  status: implemented
+  tests:
+    pytest:
+    - file: docs/tests/test_guides.py
+      tests:
+      - test_docs_req_ops_027_lockfile_installs_are_strict

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -53,6 +53,13 @@ exact patch versions for Node, Bun, Python, Biome, Rust, and uv. `setup-node`,
 `lts`, `lts/*`, `latest`, or minor-only pins, because REQ-OPS-001 treats local
 and CI runtime drift as a docs-tested contract failure.
 
+Lockfile-backed installs must also fail fast on dependency drift. When the
+repository commits a lockfile, local tasks, CI workflows, and contributor-facing
+examples must use the strict install form instead of mutating dependency
+resolution in place: root Node tooling uses `npm ci --no-fund --no-audit`, Bun
+projects use `bun install --frozen-lockfile`, and Python `uv.lock` environments
+use `uv sync --locked`.
+
 E2E CI selects a deterministic tier before running tests. `merge_group` and
 pushes to `main` always run the full compose-backed suite. Pull requests only
 drop to the smoke tier when every changed file stays inside docs/docsite
@@ -149,7 +156,7 @@ jobs:
 jobs:
   ci:
     - cd frontend && biome ci .
-    - cd frontend && bun install
+    - cd frontend && bun install --frozen-lockfile
     - cd frontend && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1
 ```
 
@@ -162,6 +169,7 @@ fail for the same coverage regressions.
 ```yaml
 jobs:
   ci:
+    - cd docsite && bun install --frozen-lockfile
     - cd docsite && bun run lint
     - cd docsite && bun run format:check
     - cd docsite && bun run typecheck
@@ -184,6 +192,9 @@ jobs:
     - pull_request with docs/docsite-only paths => smoke
     - all other pull_request changes => full
   e2e:
+    - cd docsite && bun install --frozen-lockfile
+    - cd e2e && npm ci
+    - cd e2e && npx playwright install --with-deps chromium
     - download and load pre-built backend/frontend images
     - Start backend (background)
     - Start frontend (background)
@@ -356,7 +367,7 @@ Hooks configured in `.pre-commit-config.yaml`:
 Conventional Commit enforcement (local):
 
 ```bash
-npm install
+npm ci --no-fund --no-audit
 npm run prepare
 ```
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -23,6 +23,7 @@ REQ-OPS-023: Public installer package must stay separate from private tooling.
 REQ-OPS-024: Docsite 100% coverage must be explicit in CI and root mise test.
 REQ-OPS-025: Published release quick-start verification must stay wired.
 REQ-OPS-026: Release changelog sources must stay channel-scoped and wired.
+REQ-OPS-027: Lockfile-backed installs must stay strict across local tasks and CI.
 """
 
 from __future__ import annotations
@@ -100,6 +101,7 @@ PR_TEMPLATE_WORKFLOW_PATH = (
 PRE_COMMIT_CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
 PR_TEMPLATE_PATH = REPO_ROOT / ".github" / "pull_request_template.md"
 README_PATH = REPO_ROOT / "README.md"
+BACKEND_README_PATH = REPO_ROOT / "backend" / "README.md"
 MISE_PATH = REPO_ROOT / "mise.toml"
 BACKEND_MISE_PATH = REPO_ROOT / "backend" / "mise.toml"
 UGOITE_MINIMUM_MISE_PATH = REPO_ROOT / "ugoite-minimum" / "mise.toml"
@@ -107,6 +109,7 @@ UGOITE_CORE_MISE_PATH = REPO_ROOT / "ugoite-core" / "mise.toml"
 UGOITE_CLI_MISE_PATH = REPO_ROOT / "ugoite-cli" / "mise.toml"
 FRONTEND_MISE_PATH = REPO_ROOT / "frontend" / "mise.toml"
 DOCSITE_MISE_PATH = REPO_ROOT / "docsite" / "mise.toml"
+E2E_MISE_PATH = REPO_ROOT / "e2e" / "mise.toml"
 CLI_GUIDE_PATH = GUIDE_DIR / "cli.md"
 INSTALL_CLI_SCRIPT_PATH = REPO_ROOT / "scripts" / "install-ugoite-cli.sh"
 RELEASE_INSTALLER_RENDERER_PATH = (
@@ -704,6 +707,16 @@ REQUIRED_DOCSITE_COVERAGE_COMMAND = (
     "node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
 )
 REQUIRED_DOCSITE_COVERAGE_STEP_NAME = "Run docsite Vitest with 100% coverage gate"
+REQUIRED_STRICT_NPM_CI_COMMAND = "npm ci"
+REQUIRED_STRICT_ROOT_NPM_CI_COMMAND = "npm ci --no-fund --no-audit"
+REQUIRED_STRICT_BUN_INSTALL_COMMAND = "bun install --frozen-lockfile"
+REQUIRED_STRICT_UV_INSTALL_COMMAND = "uv sync --locked"
+REQUIRED_LOCKFILE_INSTALL_DOC_FRAGMENTS = {
+    "fail fast on dependency drift",
+    "`npm ci --no-fund --no-audit`",
+    "`bun install --frozen-lockfile`",
+    "`uv sync --locked`",
+}
 UV_SETUP_WORKFLOW_PATHS = (
     DEVCONTAINER_CI_WORKFLOW_PATH,
     PYTHON_CI_WORKFLOW_PATH,
@@ -2872,6 +2885,156 @@ def test_docs_req_ops_024_docsite_coverage_gate_is_explicit() -> None:
             bool(missing_doc_fragments),
             "ci-cd guide missing docsite coverage fragments: "
             + ", ".join(missing_doc_fragments),
+        ),
+    )
+    details = [message for condition, message in detail_candidates if condition]
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_ops_027_lockfile_installs_are_strict() -> None:
+    """REQ-OPS-027: lockfile-backed installs must stay strict across local and CI."""
+    root_mise = tomllib.loads(MISE_PATH.read_text(encoding="utf-8"))
+    frontend_mise = tomllib.loads(FRONTEND_MISE_PATH.read_text(encoding="utf-8"))
+    docsite_mise = tomllib.loads(DOCSITE_MISE_PATH.read_text(encoding="utf-8"))
+    e2e_mise = tomllib.loads(E2E_MISE_PATH.read_text(encoding="utf-8"))
+    backend_mise = tomllib.loads(BACKEND_MISE_PATH.read_text(encoding="utf-8"))
+    core_mise = tomllib.loads(UGOITE_CORE_MISE_PATH.read_text(encoding="utf-8"))
+    ci_cd_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    backend_readme_text = BACKEND_README_PATH.read_text(encoding="utf-8")
+
+    frontend_install = _load_task_run(
+        _load_mise_task_mapping(
+            frontend_mise,
+            task_name="install",
+            path_label="frontend/mise.toml",
+        ),
+        task_label="frontend/mise.toml [tasks.install]",
+    )
+    docsite_install = _load_task_run(
+        _load_mise_task_mapping(
+            docsite_mise,
+            task_name="install",
+            path_label="docsite/mise.toml",
+        ),
+        task_label="docsite/mise.toml [tasks.install]",
+    )
+    e2e_install = _load_task_run(
+        _load_mise_task_mapping(
+            e2e_mise,
+            task_name="install",
+            path_label="e2e/mise.toml",
+        ),
+        task_label="e2e/mise.toml [tasks.install]",
+    )
+    backend_install = _load_task_run(
+        _load_mise_task_mapping(
+            backend_mise,
+            task_name="install",
+            path_label="backend/mise.toml",
+        ),
+        task_label="backend/mise.toml [tasks.install]",
+    )
+    core_install = _load_task_run(
+        _load_mise_task_mapping(
+            core_mise,
+            task_name="install",
+            path_label="ugoite-core/mise.toml",
+        ),
+        task_label="ugoite-core/mise.toml [tasks.install]",
+    )
+
+    root_setup_runs = _get_task_run_commands(root_mise, "setup")
+    frontend_ci_install = _find_workflow_step_run(
+        FRONTEND_CI_WORKFLOW_PATH,
+        job_name="ci",
+        step_name="Install dependencies",
+    )
+    docsite_ci_install = _find_workflow_step_run(
+        DOCSITE_CI_WORKFLOW_PATH,
+        job_name="ci",
+        step_name="Install dependencies",
+    )
+    e2e_docsite_install = _find_workflow_step_run(
+        E2E_CI_WORKFLOW_PATH,
+        job_name="e2e",
+        step_name="Install docsite dependencies",
+    )
+    e2e_install_step = _find_workflow_step_run(
+        E2E_CI_WORKFLOW_PATH,
+        job_name="e2e",
+        step_name="Install e2e dependencies",
+    )
+    missing_doc_fragments = sorted(
+        fragment
+        for fragment in REQUIRED_LOCKFILE_INSTALL_DOC_FRAGMENTS
+        if fragment not in ci_cd_text
+    )
+
+    detail_candidates = (
+        (
+            REQUIRED_STRICT_ROOT_NPM_CI_COMMAND not in root_setup_runs,
+            "root mise.toml tasks.setup must use npm ci --no-fund --no-audit",
+        ),
+        (
+            "npm install --no-fund --no-audit" in root_setup_runs,
+            "root mise.toml tasks.setup must not use npm install",
+        ),
+        (
+            frontend_install != REQUIRED_STRICT_BUN_INSTALL_COMMAND,
+            "frontend/mise.toml [tasks.install] must use bun install --frozen-lockfile",
+        ),
+        (
+            docsite_install != REQUIRED_STRICT_BUN_INSTALL_COMMAND,
+            "docsite/mise.toml [tasks.install] must use bun install --frozen-lockfile",
+        ),
+        (
+            e2e_install
+            != f"{REQUIRED_STRICT_NPM_CI_COMMAND} && npx playwright install",
+            "e2e/mise.toml [tasks.install] must use npm ci before Playwright install",
+        ),
+        (
+            backend_install != REQUIRED_STRICT_UV_INSTALL_COMMAND,
+            "backend/mise.toml [tasks.install] must use uv sync --locked",
+        ),
+        (
+            core_install != REQUIRED_STRICT_UV_INSTALL_COMMAND,
+            "ugoite-core/mise.toml [tasks.install] must use uv sync --locked",
+        ),
+        (
+            frontend_ci_install != REQUIRED_STRICT_BUN_INSTALL_COMMAND,
+            "frontend-ci.yml install step must use bun install --frozen-lockfile",
+        ),
+        (
+            docsite_ci_install != REQUIRED_STRICT_BUN_INSTALL_COMMAND,
+            "docsite-ci.yml install step must use bun install --frozen-lockfile",
+        ),
+        (
+            e2e_docsite_install != REQUIRED_STRICT_BUN_INSTALL_COMMAND,
+            "e2e-ci.yml docsite install step must use bun install --frozen-lockfile",
+        ),
+        (
+            e2e_install_step != REQUIRED_STRICT_NPM_CI_COMMAND,
+            "e2e-ci.yml e2e install step must use npm ci",
+        ),
+        (
+            REQUIRED_STRICT_UV_INSTALL_COMMAND
+            not in BACKEND_DOCKERFILE_PATH.read_text(encoding="utf-8"),
+            "backend/Dockerfile must keep uv sync --locked",
+        ),
+        (
+            bool(missing_doc_fragments),
+            "ci-cd guide missing strict lockfile fragments: "
+            + ", ".join(missing_doc_fragments),
+        ),
+        (
+            REQUIRED_STRICT_BUN_INSTALL_COMMAND not in readme_text,
+            "README.md frontend example must use bun install --frozen-lockfile",
+        ),
+        (
+            REQUIRED_STRICT_UV_INSTALL_COMMAND not in backend_readme_text,
+            "backend/README.md install example must use uv sync --locked",
         ),
     )
     details = [message for condition, message in detail_candidates if condition]

--- a/docsite/mise.toml
+++ b/docsite/mise.toml
@@ -1,5 +1,5 @@
 [tasks.install]
-run = "bun install"
+run = "bun install --frozen-lockfile"
 
 [tasks.lint]
 run = "bun run lint"

--- a/e2e/mise.toml
+++ b/e2e/mise.toml
@@ -1,5 +1,5 @@
 [tasks.install]
-run = "npm install && npx playwright install"
+run = "npm ci && npx playwright install"
 
 [tasks.test]
 run = "npm run test"

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -1,5 +1,5 @@
 [tasks.install]
-run = "bun install"
+run = "bun install --frozen-lockfile"
 
 [tasks.dev]
 # Ensure development waits for the backend health check before starting the UI so

--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,7 @@ uv = "0.10.10"
 
 [tasks.setup]
 run = [
-	"npm install --no-fund --no-audit",
+	"npm ci --no-fund --no-audit",
 	"mise run //backend:install",
 	"mise run //docsite:install",
 	"mise run //frontend:install",

--- a/ugoite-core/mise.toml
+++ b/ugoite-core/mise.toml
@@ -4,7 +4,7 @@ UV_PYTHON = "3.13"
 CARGO_TARGET_DIR = "../target/rust"
 
 [tasks.install]
-run = "uv sync"
+run = "uv sync --locked"
 description = "Install dependencies"
 
 [tasks.build]


### PR DESCRIPTION
## Summary
- freeze lockfile-backed installs across root, frontend, docsite, e2e, backend, and ugoite-core tasks
- align frontend/docsite CI and contributor docs with strict lockfile commands
- add REQ-OPS-027 regression coverage for frozen install enforcement

## Related Issue (required)
close: #910

## Testing
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -q -k 'req_ops_027 or req_ops_024 or req_ops_021 or req_ops_001'`
- [x] `VITEST_MAX_WORKERS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 mise run test && mise run e2e`
