### PR TITLE
feat: unify explicit passwordless auth

### DIFF
--- a/backend/src/app/api/endpoints/auth.py
+++ b/backend/src/app/api/endpoints/auth.py
@@ -1,4 +1,4 @@
-"""Local development authentication endpoints."""
+"""Explicit passwordless login endpoints."""
 
 import os
 import secrets
@@ -12,9 +12,9 @@ from ugoite_core.auth import mint_signed_bearer_token, validate_totp_code
 from app.core.config import get_root_path
 from app.core.security import is_local_host, resolve_client_host
 from app.core.storage import storage_config_from_root
-from app.models.payloads import DevAuthLogin
+from app.models.payloads import AuthLogin
 
-router = APIRouter(prefix="/auth/dev", tags=["auth"])
+router = APIRouter(prefix="/auth", tags=["auth"])
 
 AuthMode = Literal["manual-totp", "mock-oauth"]
 DEFAULT_DEV_AUTH_MODE: AuthMode = "manual-totp"
@@ -42,7 +42,7 @@ def _resolve_dev_auth_mode() -> AuthMode:
 def _dev_user_id() -> str:
     user_id = os.environ.get("UGOITE_DEV_USER_ID", "dev-local-user").strip()
     if not user_id:
-        message = "UGOITE_DEV_USER_ID must be configured for local development login."
+        message = "UGOITE_DEV_USER_ID must be configured for explicit login."
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=message,
@@ -55,8 +55,7 @@ def _dev_signing_material() -> tuple[str, str]:
     secret = os.environ.get("UGOITE_DEV_SIGNING_SECRET", "").strip()
     if not key_id or not secret:
         message = (
-            "Local development login is unavailable because signing material "
-            "is missing."
+            "Passwordless login is unavailable because signing material is missing."
         )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -123,9 +122,7 @@ def _ensure_local_dev_auth_request(request: Request) -> None:
 
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
-        detail=(
-            "Local development auth endpoints are only available from loopback clients."
-        ),
+        detail="Explicit login endpoints are only available from loopback clients.",
     )
 
 
@@ -145,13 +142,13 @@ def _issue_dev_bearer_token(user_id: str) -> dict[str, int | str]:
 
 
 def _storage_config() -> dict[str, str]:
-    """Build storage config for local dev auth bootstrap operations."""
+    """Build storage config for login bootstrap operations."""
     return storage_config_from_root(get_root_path())
 
 
 @router.get("/config")
-async def dev_auth_config_endpoint(request: Request) -> dict[str, object]:
-    """Expose the current local development login mode to browser/CLI clients."""
+async def auth_config_endpoint(request: Request) -> dict[str, object]:
+    """Expose the current passwordless login mode to browser/CLI clients."""
     _ensure_local_dev_auth_request(request)
     mode = _resolve_dev_auth_mode()
     await ugoite_core.ensure_admin_space(_storage_config(), _dev_user_id())
@@ -164,14 +161,14 @@ async def dev_auth_config_endpoint(request: Request) -> dict[str, object]:
 
 
 @router.post("/login")
-async def dev_login_endpoint(
-    payload: DevAuthLogin,
+async def login_endpoint(
+    payload: AuthLogin,
     request: Request,
 ) -> dict[str, int | str]:
-    """Validate local development username + TOTP and issue a signed bearer token."""
+    """Validate username + TOTP and issue a signed bearer token."""
     _ensure_local_dev_auth_request(request)
     if _resolve_dev_auth_mode() != "manual-totp":
-        message = "manual-totp login is not enabled for this local development session."
+        message = "manual-totp login is not enabled for this session."
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=message,
@@ -202,11 +199,11 @@ async def dev_login_endpoint(
 
 
 @router.post("/mock-oauth")
-async def dev_mock_oauth_login_endpoint(request: Request) -> dict[str, int | str]:
+async def mock_oauth_login_endpoint(request: Request) -> dict[str, int | str]:
     """Issue a signed bearer token for explicit mock OAuth login."""
     _ensure_local_dev_auth_request(request)
     if _resolve_dev_auth_mode() != "mock-oauth":
-        message = "mock-oauth login is not enabled for this local development session."
+        message = "mock-oauth login is not enabled for this session."
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=message,

--- a/backend/src/app/api/endpoints/members.py
+++ b/backend/src/app/api/endpoints/members.py
@@ -188,6 +188,11 @@ async def update_member_role_endpoint(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=message,
             ) from exc
+        if "at least one active admin" in lowered:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=message,
+            ) from exc
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=message,
@@ -230,6 +235,11 @@ async def revoke_member_endpoint(
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
+                detail=message,
+            ) from exc
+        if "at least one active admin" in lowered:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
                 detail=message,
             ) from exc
         raise HTTPException(

--- a/backend/src/app/core/middleware.py
+++ b/backend/src/app/core/middleware.py
@@ -36,6 +36,9 @@ _AUTH_EXEMPT_PATHS = {
     "/openapi.json",
     "/redoc",
     "/health",
+    "/auth/config",
+    "/auth/login",
+    "/auth/mock-oauth",
 }
 _DEFAULT_SIGNATURE_SPACE_ID = "default"
 
@@ -43,7 +46,7 @@ _DEFAULT_SIGNATURE_SPACE_ID = "default"
 def _is_auth_exempt(path: str) -> bool:
     if path in _AUTH_EXEMPT_PATHS:
         return True
-    return path.startswith(("/auth/dev/", "/docs/", "/redoc/"))
+    return path.startswith(("/docs/", "/redoc/"))
 
 
 def _space_id_from_path(path: str) -> str | None:

--- a/backend/src/app/models/payloads.py
+++ b/backend/src/app/models/payloads.py
@@ -29,8 +29,8 @@ class SpaceCreate(BaseModel):
     name: Identifier
 
 
-class DevAuthLogin(BaseModel):
-    """Local development username + TOTP login payload."""
+class AuthLogin(BaseModel):
+    """Username + TOTP login payload."""
 
     username: Identifier
     totp_code: TotpCode

--- a/backend/tests/test_dev_auth.py
+++ b/backend/tests/test_dev_auth.py
@@ -79,7 +79,7 @@ def test_dev_auth_req_ops_015_config_exposes_manual_totp_mode(
     clear_auth_manager_cache()
 
     client = TestClient(app)
-    response = client.get("/auth/dev/config")
+    response = client.get("/auth/config")
 
     assert response.status_code == 200
     assert response.json() == {
@@ -109,7 +109,7 @@ def test_dev_auth_req_ops_015_manual_totp_login_issues_signed_token(
 
     client = TestClient(app)
     login_response = client.post(
-        "/auth/dev/login",
+        "/auth/login",
         json={
             "username": "dev-alice",
             "totp_code": _totp_code(secret, timestamp),
@@ -131,7 +131,7 @@ def test_dev_auth_req_ops_015_manual_totp_login_issues_signed_token(
     )
     assert admin_space_response.status_code == 200
     admin_settings = admin_space_response.json()["settings"]
-    assert admin_settings["members"]["dev-alice"]["role"] in {"owner", "admin"}
+    assert admin_settings["members"]["dev-alice"]["role"] == "admin"
     assert admin_settings["members"]["dev-alice"]["state"] == "active"
 
 
@@ -159,7 +159,7 @@ def test_dev_auth_req_ops_015_mock_oauth_login_issues_signed_token(
     clear_auth_manager_cache()
 
     client = TestClient(app)
-    login_response = client.post("/auth/dev/mock-oauth")
+    login_response = client.post("/auth/mock-oauth")
 
     assert login_response.status_code == 200
     token = login_response.json()["bearer_token"]
@@ -176,7 +176,7 @@ def test_dev_auth_req_ops_015_mock_oauth_login_issues_signed_token(
     )
     assert admin_space_response.status_code == 200
     admin_settings = admin_space_response.json()["settings"]
-    assert admin_settings["members"]["dev-oauth-user"]["role"] in {"owner", "admin"}
+    assert admin_settings["members"]["dev-oauth-user"]["role"] == "admin"
     assert admin_settings["members"]["dev-oauth-user"]["state"] == "active"
 
 
@@ -194,7 +194,7 @@ def test_dev_auth_req_ops_015_startup_bootstraps_admin_space(
     clear_auth_manager_cache()
 
     with TestClient(app) as client:
-        login_response = client.post("/auth/dev/mock-oauth")
+        login_response = client.post("/auth/mock-oauth")
         assert login_response.status_code == 200
         token = login_response.json()["bearer_token"]
 
@@ -220,7 +220,7 @@ def test_dev_auth_req_ops_015_config_rejects_unsupported_mode(
     )
     clear_auth_manager_cache()
 
-    response = TestClient(app).get("/auth/dev/config")
+    response = TestClient(app).get("/auth/config")
 
     assert response.status_code == 503
 
@@ -238,7 +238,7 @@ def test_dev_auth_req_ops_015_config_requires_non_empty_user_id(
     )
     clear_auth_manager_cache()
 
-    response = TestClient(app).get("/auth/dev/config")
+    response = TestClient(app).get("/auth/config")
 
     assert response.status_code == 503
 
@@ -256,7 +256,7 @@ def test_dev_auth_req_ops_015_manual_login_rejects_non_manual_mode(
     clear_auth_manager_cache()
 
     response = TestClient(app).post(
-        "/auth/dev/login",
+        "/auth/login",
         json={"username": "dev-alice", "totp_code": "123456"},
     )
 
@@ -281,7 +281,7 @@ def test_dev_auth_req_ops_015_manual_login_rejects_wrong_username(
     clear_auth_manager_cache()
 
     response = TestClient(app).post(
-        "/auth/dev/login",
+        "/auth/login",
         json={"username": "other-user", "totp_code": _totp_code(secret, timestamp)},
     )
 
@@ -303,10 +303,13 @@ def test_dev_auth_req_ops_015_rejects_remote_clients(
     clear_auth_manager_cache()
 
     client = TestClient(app, client=("198.51.100.20", 50000))
-    response = client.get("/auth/dev/config")
+    response = client.get("/auth/config")
 
     assert response.status_code == 403
-    assert "loopback clients" in response.json()["detail"]
+    assert (
+        response.json()["detail"]
+        == "Explicit login endpoints are only available from loopback clients."
+    )
 
 
 def test_dev_auth_req_ops_015_allows_trusted_proxy_token(
@@ -325,7 +328,7 @@ def test_dev_auth_req_ops_015_allows_trusted_proxy_token(
 
     client = TestClient(app, client=("198.51.100.20", 50000))
     response = client.get(
-        "/auth/dev/config",
+        "/auth/config",
         headers={"x-ugoite-dev-auth-proxy-token": "proxy-secret"},
     )
 
@@ -349,12 +352,15 @@ def test_dev_auth_req_ops_015_rejects_invalid_trusted_proxy_token(
 
     client = TestClient(app, client=("198.51.100.20", 50000))
     response = client.get(
-        "/auth/dev/config",
+        "/auth/config",
         headers={"x-ugoite-dev-auth-proxy-token": "wrong-secret"},
     )
 
     assert response.status_code == 403
-    assert "loopback clients" in response.json()["detail"]
+    assert (
+        response.json()["detail"]
+        == "Explicit login endpoints are only available from loopback clients."
+    )
 
 
 def test_dev_auth_req_ops_015_rejects_missing_trusted_proxy_token(
@@ -372,10 +378,13 @@ def test_dev_auth_req_ops_015_rejects_missing_trusted_proxy_token(
     clear_auth_manager_cache()
 
     client = TestClient(app, client=("198.51.100.20", 50000))
-    response = client.get("/auth/dev/config")
+    response = client.get("/auth/config")
 
     assert response.status_code == 403
-    assert "loopback clients" in response.json()["detail"]
+    assert (
+        response.json()["detail"]
+        == "Explicit login endpoints are only available from loopback clients."
+    )
 
 
 def test_dev_auth_req_ops_015_rejects_unknown_client_host(
@@ -401,10 +410,13 @@ def test_dev_auth_req_ops_015_rejects_unknown_client_host(
     )
     clear_auth_manager_cache()
 
-    response = TestClient(app).get("/auth/dev/config")
+    response = TestClient(app).get("/auth/config")
 
     assert response.status_code == 403
-    assert "loopback clients" in response.json()["detail"]
+    assert (
+        response.json()["detail"]
+        == "Explicit login endpoints are only available from loopback clients."
+    )
 
 
 def test_dev_auth_req_ops_015_manual_login_requires_totp_secret(
@@ -421,7 +433,7 @@ def test_dev_auth_req_ops_015_manual_login_requires_totp_secret(
     clear_auth_manager_cache()
 
     response = TestClient(app).post(
-        "/auth/dev/login",
+        "/auth/login",
         json={"username": "dev-alice", "totp_code": "123456"},
     )
 
@@ -442,7 +454,7 @@ def test_dev_auth_req_ops_015_manual_login_rejects_invalid_totp_code(
     clear_auth_manager_cache()
 
     response = TestClient(app).post(
-        "/auth/dev/login",
+        "/auth/login",
         json={"username": "dev-alice", "totp_code": "000000"},
     )
 
@@ -469,7 +481,7 @@ def test_dev_auth_req_ops_015_manual_login_requires_signing_material(
     clear_auth_manager_cache()
 
     response = TestClient(app).post(
-        "/auth/dev/login",
+        "/auth/login",
         json={"username": "dev-alice", "totp_code": _totp_code(secret, timestamp)},
     )
 
@@ -503,7 +515,7 @@ def test_dev_auth_req_ops_015_manual_login_validates_ttl(
     clear_auth_manager_cache()
 
     response = TestClient(app).post(
-        "/auth/dev/login",
+        "/auth/login",
         json={"username": "dev-alice", "totp_code": _totp_code(secret, timestamp)},
     )
 
@@ -522,7 +534,7 @@ def test_dev_auth_req_ops_015_mock_oauth_rejects_manual_totp_mode(
     )
     clear_auth_manager_cache()
 
-    response = TestClient(app).post("/auth/dev/mock-oauth")
+    response = TestClient(app).post("/auth/mock-oauth")
 
     assert response.status_code == 409
     assert "mock-oauth login is not enabled" in response.json()["detail"]

--- a/backend/tests/test_forms_reserved_identity.py
+++ b/backend/tests/test_forms_reserved_identity.py
@@ -1,14 +1,50 @@
-"""Planned reserved identity Form tests.
+"""Reserved identity Form tests.
 
 REQ-FORM-008: Reserved Identity Metadata Forms.
 """
 
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app, headers={"Authorization": "Bearer test-suite-token"})
+
+
+def _space_id() -> str:
+    response = client.post("/spaces", json={"name": f"reserved-id-{uuid.uuid4().hex}"})
+    assert response.status_code == 201
+    return response.json()["id"]
+
 
 def test_form_req_form_008_reject_user_form_name() -> None:
     """REQ-FORM-008: user-authored Form name `User` is rejected."""
-    assert True
+    response = client.post(
+        f"/spaces/{_space_id()}/forms",
+        json={
+            "name": "User",
+            "version": 1,
+            "template": "# User\n\n## DisplayName\n",
+            "fields": {"DisplayName": {"type": "string"}},
+        },
+    )
+
+    assert response.status_code == 422
+    assert "reserved" in response.json()["detail"].lower()
 
 
 def test_form_req_form_008_reject_usergroup_form_name() -> None:
     """REQ-FORM-008: user-authored Form name `UserGroup` is rejected."""
-    assert True
+    response = client.post(
+        f"/spaces/{_space_id()}/forms",
+        json={
+            "name": "UserGroup",
+            "version": 1,
+            "template": "# UserGroup\n\n## Name\n",
+            "fields": {"Name": {"type": "string"}},
+        },
+    )
+
+    assert response.status_code == 422
+    assert "reserved" in response.json()["detail"].lower()

--- a/backend/tests/test_space_members.py
+++ b/backend/tests/test_space_members.py
@@ -67,6 +67,49 @@ def _create_space(owner_client: TestClient) -> str:
     return response.json()["id"]
 
 
+def test_space_creator_is_bootstrapped_as_active_admin(
+    member_clients: dict[str, TestClient],
+) -> None:
+    """REQ-SEC-006: space creator becomes the initial active admin member."""
+    owner = member_clients["owner"]
+    space_id = _create_space(owner)
+
+    response = owner.get(f"/spaces/{space_id}")
+    assert response.status_code == 200
+    members = response.json()["settings"]["members"]
+    assert members["owner-user"]["role"] == "admin"
+    assert members["owner-user"]["state"] == "active"
+
+
+def test_space_rejects_demoting_last_active_admin(
+    member_clients: dict[str, TestClient],
+) -> None:
+    """REQ-SEC-006: a space must retain at least one active admin."""
+    owner = member_clients["owner"]
+    space_id = _create_space(owner)
+
+    response = owner.post(
+        f"/spaces/{space_id}/members/owner-user/role",
+        json={"role": "viewer"},
+    )
+
+    assert response.status_code == 409
+    assert "at least one active admin" in response.json()["detail"]
+
+
+def test_space_rejects_revoking_last_active_admin(
+    member_clients: dict[str, TestClient],
+) -> None:
+    """REQ-SEC-006: revocation cannot remove the last active admin."""
+    owner = member_clients["owner"]
+    space_id = _create_space(owner)
+
+    response = owner.delete(f"/spaces/{space_id}/members/owner-user")
+
+    assert response.status_code == 409
+    assert "at least one active admin" in response.json()["detail"]
+
+
 def test_space_member_invite_and_accept_transitions_to_active(
     member_clients: dict[str, TestClient],
 ) -> None:
@@ -403,6 +446,33 @@ def test_revoke_member_generic_runtime_error(test_client: TestClient) -> None:
             "/spaces/members-revoke-rt-ws/members/alice",
         )
     assert response.status_code == 400
+
+
+def test_update_member_role_last_admin_conflict(test_client: TestClient) -> None:
+    """REQ-SEC-006: role updates return 409 when removing the last admin."""
+    test_client.post("/spaces", json={"name": "members-role-admin-conflict-ws"})
+    with patch(
+        "ugoite_core.update_member_role",
+        _amock(side_effect=RuntimeError("space must retain at least one active admin")),
+    ):
+        response = test_client.post(
+            "/spaces/members-role-admin-conflict-ws/members/alice/role",
+            json={"role": "viewer"},
+        )
+    assert response.status_code == 409
+
+
+def test_revoke_member_last_admin_conflict(test_client: TestClient) -> None:
+    """REQ-SEC-006: revoke member returns 409 when it would remove the last admin."""
+    test_client.post("/spaces", json={"name": "members-revoke-admin-conflict-ws"})
+    with patch(
+        "ugoite_core.revoke_member",
+        _amock(side_effect=RuntimeError("space must retain at least one active admin")),
+    ):
+        response = test_client.delete(
+            "/spaces/members-revoke-admin-conflict-ws/members/alice",
+        )
+    assert response.status_code == 409
 
 
 def test_revoke_member_authorization_error(test_client: TestClient) -> None:

--- a/docs/guide/local-dev-auth-login.md
+++ b/docs/guide/local-dev-auth-login.md
@@ -82,7 +82,7 @@ bearer token and it does **not** start the app already logged in.
 
 At backend startup, that configured user is also bootstrapped into the reserved
 `admin-space`. Only active admins of `admin-space` can create additional spaces,
-and each new space still makes its creator the initial owner/admin for that
+and each new space still makes its creator the initial admin for that
 space.
 
 Force a fresh prompt:

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -39,20 +39,19 @@ Planned endpoint surface (exact payloads may evolve during implementation):
 - `POST /spaces/{space_id}/service-accounts/{service_account_id}/keys/{key_id}/rotate`
 - `DELETE /spaces/{space_id}/service-accounts/{service_account_id}/keys/{key_id}`
 
-### Local Development Login Endpoints
+### Explicit Login Endpoints
 
-These endpoints are intentionally limited to the local development workflow and
-are unauthenticated so the browser and CLI can complete an explicit sign-in
-step after startup.
+These endpoints expose the current explicit passwordless login flow and stay
+unauthenticated so the browser and CLI can complete sign-in after startup.
 
-- `GET /auth/dev/config`
-- `POST /auth/dev/login`
-- `POST /auth/dev/mock-oauth`
+- `GET /auth/config`
+- `POST /auth/login`
+- `POST /auth/mock-oauth`
 
 Example manual TOTP login:
 
 ```http
-POST /auth/dev/login
+POST /auth/login
 Content-Type: application/json
 
 {

--- a/docs/spec/features/auth.yaml
+++ b/docs/spec/features/auth.yaml
@@ -1,16 +1,16 @@
-# Local Development Auth APIs
+# Explicit Login APIs
 
 version: "0.1"
 updated: "2026-03"
 kind: auth
 
 apis:
-  - id: auth.dev.config
+  - id: auth.config
     method: GET
     backend:
-      path: /auth/dev/config
+      path: /auth/config
       file: backend/src/app/api/endpoints/auth.py
-      function: dev_auth_config_endpoint
+      function: auth_config_endpoint
     frontend:
       path: /login
       file: frontend/src/routes/login.tsx
@@ -19,12 +19,12 @@ apis:
       file: ugoite-core/ugoite_core/auth.py
       function: validate_totp_code
 
-  - id: auth.dev.login
+  - id: auth.login
     method: POST
     backend:
-      path: /auth/dev/login
+      path: /auth/login
       file: backend/src/app/api/endpoints/auth.py
-      function: dev_login_endpoint
+      function: login_endpoint
     frontend:
       path: /login
       file: frontend/src/routes/login.tsx
@@ -37,12 +37,12 @@ apis:
       file: ugoite-cli/src/commands/auth.rs
       function: run
 
-  - id: auth.dev.mock-oauth
+  - id: auth.mock-oauth
     method: POST
     backend:
-      path: /auth/dev/mock-oauth
+      path: /auth/mock-oauth
       file: backend/src/app/api/endpoints/auth.py
-      function: dev_mock_oauth_login_endpoint
+      function: mock_oauth_login_endpoint
     frontend:
       path: /login
       file: frontend/src/routes/login.tsx

--- a/docs/spec/security/overview.md
+++ b/docs/spec/security/overview.md
@@ -23,7 +23,7 @@ targets an **Authenticated Access by Default** model.
   injecting an authenticated token before the app starts.
 - Space creation is further restricted to active admins of the reserved
   `admin-space`, and the creator of each non-admin space becomes that space's
-  initial owner/admin.
+  initial admin.
 
 ## Network Isolation
 

--- a/docs/spec/stories/experimental.yaml
+++ b/docs/spec/stories/experimental.yaml
@@ -19,7 +19,7 @@ stories:
       - Primary login uses passkey/WebAuthn without passwords
       - Admin can issue one-time invite token for first-time registration
       - Optional OAuth2 account linking is supported and can auto-provision users
-      - Space owner is initial admin and can delegate admin privileges
+      - Space creator is initial admin and can delegate admin privileges
       - Form-level read/write permissions can target User or UserGroup
       - Materialized views inherit access policy from source Forms
       - Admin can execute forced reset and backup-code issuance with audit visibility

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -461,7 +461,7 @@ REQUIRED_RELEASE_CONTAINER_QUICKSTART_SCRIPT_FRAGMENTS = {
     "npx playwright test",
     "smoke.test.ts",
     "search-ui.test.ts",
-    "127.0.0.1:3000/api/auth/dev/mock-oauth",
+    "127.0.0.1:3000/api/auth/mock-oauth",
     "config set --mode backend --backend-url http://127.0.0.1:8000",
     "auth login --mock-oauth",
     "space list",

--- a/e2e/scripts/run-e2e-compose.sh
+++ b/e2e/scripts/run-e2e-compose.sh
@@ -76,7 +76,7 @@ E2E_AUTH_BEARER_TOKEN="$(
 import json
 from urllib.request import Request, urlopen
 
-request = Request("http://127.0.0.1:8000/auth/dev/mock-oauth", method="POST")
+request = Request("http://127.0.0.1:8000/auth/mock-oauth", method="POST")
 with urlopen(request) as response:
     print(json.load(response)["bearer_token"])
 '

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -128,7 +128,7 @@ for i in {1..30}; do
 done
 
 E2E_AUTH_BEARER_TOKEN="$(
-  curl -fsS -X POST http://localhost:8000/auth/dev/mock-oauth | python -c 'import json, sys; print(json.load(sys.stdin)["bearer_token"])'
+  curl -fsS -X POST http://localhost:8000/auth/mock-oauth | python -c 'import json, sys; print(json.load(sys.stdin)["bearer_token"])'
 )"
 export E2E_AUTH_BEARER_TOKEN
 

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -23,7 +23,7 @@ describe("apiFetch auth forwarding", () => {
 		let seenCookie: string | null = null;
 		let seenAuthorization: string | null = null;
 		server.use(
-			http.get("http://localhost:3000/api/auth/dev/config", ({ request }) => {
+			http.get("http://localhost:3000/api/auth/config", ({ request }) => {
 				seenCookie = request.headers.get("cookie");
 				seenAuthorization = request.headers.get("authorization");
 				return HttpResponse.json({
@@ -45,7 +45,7 @@ describe("apiFetch auth forwarding", () => {
 		});
 
 		const { apiFetch } = await import("./api");
-		const response = await apiFetch("/auth/dev/config", { trackLoading: false });
+		const response = await apiFetch("/auth/config", { trackLoading: false });
 
 		expect(response.status).toBe(200);
 		expect(seenCookie).toBe("ugoite_auth_bearer_token=server-token");
@@ -56,7 +56,7 @@ describe("apiFetch auth forwarding", () => {
 		let seenCookie: string | null = null;
 		let seenAuthorization: string | null = null;
 		server.use(
-			http.get("http://localhost:3000/api/auth/dev/config", ({ request }) => {
+			http.get("http://localhost:3000/api/auth/config", ({ request }) => {
 				seenCookie = request.headers.get("cookie");
 				seenAuthorization = request.headers.get("authorization");
 				return HttpResponse.json({
@@ -78,7 +78,7 @@ describe("apiFetch auth forwarding", () => {
 		});
 
 		const { apiFetch } = await import("./api");
-		const response = await apiFetch("/auth/dev/config", {
+		const response = await apiFetch("/auth/config", {
 			trackLoading: false,
 			headers: {
 				cookie: "ugoite_auth_bearer_token=explicit-token",
@@ -95,7 +95,7 @@ describe("apiFetch auth forwarding", () => {
 		let seenCookie: string | null = "unexpected";
 		let seenAuthorization: string | null = "unexpected";
 		server.use(
-			http.get("http://localhost:3000/api/auth/dev/config", ({ request }) => {
+			http.get("http://localhost:3000/api/auth/config", ({ request }) => {
 				seenCookie = request.headers.get("cookie");
 				seenAuthorization = request.headers.get("authorization");
 				return HttpResponse.json({
@@ -110,7 +110,7 @@ describe("apiFetch auth forwarding", () => {
 		getRequestEventMock.mockReturnValue(undefined);
 
 		const { apiFetch } = await import("./api");
-		const response = await apiFetch("/auth/dev/config", { trackLoading: false });
+		const response = await apiFetch("/auth/config", { trackLoading: false });
 
 		expect(response.status).toBe(200);
 		expect(seenCookie).toBeNull();

--- a/frontend/src/lib/auth-api.test.ts
+++ b/frontend/src/lib/auth-api.test.ts
@@ -20,7 +20,7 @@ describe("authApi", () => {
 			supports_mock_oauth: false,
 		});
 
-		await expect(authApi.getDevConfig()).resolves.toEqual({
+		await expect(authApi.getConfig()).resolves.toEqual({
 			mode: "manual-totp",
 			usernameHint: "dev-alice",
 			supportsManualTotp: true,
@@ -32,11 +32,11 @@ describe("authApi", () => {
 			expiresAt: 1_900_000_000,
 		});
 		await expect(authApi.loginWithMockOauth()).rejects.toThrow(
-			"mock-oauth login is not enabled for this local development session.",
+			"mock-oauth login is not enabled for this session.",
 		);
 
 		server.use(
-			http.get("http://localhost:3000/api/auth/dev/config", () =>
+			http.get("http://localhost:3000/api/auth/config", () =>
 				HttpResponse.json(
 					{
 						mode: "manual-totp",
@@ -48,36 +48,36 @@ describe("authApi", () => {
 				),
 			),
 		);
-		await expect(authApi.getDevConfig()).rejects.toThrow(
+		await expect(authApi.getConfig()).rejects.toThrow(
 			"Invalid auth response: supports_manual_totp must be a boolean.",
 		);
 
 		server.use(
 			http.get(
-				"http://localhost:3000/api/auth/dev/config",
+				"http://localhost:3000/api/auth/config",
 				() => new HttpResponse(null, { status: 500, statusText: "Internal Server Error" }),
 			),
 		);
-		await expect(authApi.getDevConfig()).rejects.toThrow(
-			"Failed to load local auth config: Internal Server Error",
+		await expect(authApi.getConfig()).rejects.toThrow(
+			"Failed to load auth config: Internal Server Error",
 		);
 
 		server.use(
-			http.get("http://localhost:3000/api/auth/dev/config", () =>
+			http.get("http://localhost:3000/api/auth/config", () =>
 				HttpResponse.json(
 					{
-						detail: "Local development auth endpoints are only available from loopback clients.",
+						detail: "Explicit login endpoints are only available from loopback clients.",
 					},
 					{ status: 403, statusText: "Forbidden" },
 				),
 			),
 		);
-		await expect(authApi.getDevConfig()).rejects.toThrow(
-			"Local development auth endpoints are only available from loopback clients.",
+		await expect(authApi.getConfig()).rejects.toThrow(
+			"Explicit login endpoints are only available from loopback clients.",
 		);
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/dev/login", () =>
+			http.post("http://localhost:3000/api/auth/login", () =>
 				HttpResponse.json(
 					{
 						bearer_token: 42,
@@ -94,7 +94,7 @@ describe("authApi", () => {
 
 		server.use(
 			http.post(
-				"http://localhost:3000/api/auth/dev/login",
+				"http://localhost:3000/api/auth/login",
 				() => new HttpResponse("backend down", { status: 502, statusText: "Bad Gateway" }),
 			),
 		);
@@ -103,14 +103,14 @@ describe("authApi", () => {
 		);
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/dev/mock-oauth", () =>
+			http.post("http://localhost:3000/api/auth/mock-oauth", () =>
 				HttpResponse.json({ detail: { reason: "blocked" } }, { status: 409 }),
 			),
 		);
 		await expect(authApi.loginWithMockOauth()).rejects.toThrow('{"reason":"blocked"}');
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/dev/mock-oauth", () =>
+			http.post("http://localhost:3000/api/auth/mock-oauth", () =>
 				HttpResponse.json({ detail: 123 }, { status: 409, statusText: "Conflict" }),
 			),
 		);
@@ -119,7 +119,7 @@ describe("authApi", () => {
 		);
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/dev/mock-oauth", () =>
+			http.post("http://localhost:3000/api/auth/mock-oauth", () =>
 				HttpResponse.json(
 					{
 						bearer_token: "frontend-test-token",

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -1,13 +1,13 @@
 import { apiFetch } from "./api";
 
-export type DevAuthConfig = {
+export type AuthConfig = {
 	mode: "manual-totp" | "mock-oauth";
 	usernameHint: string;
 	supportsManualTotp: boolean;
 	supportsMockOauth: boolean;
 };
 
-export type DevAuthLoginResponse = {
+export type AuthLoginResponse = {
 	bearerToken: string;
 	userId: string;
 	expiresAt: number;
@@ -53,28 +53,28 @@ const readNumber = (payload: Record<string, unknown>, key: string): number => {
 };
 
 export const authApi = {
-	async getDevConfig(): Promise<DevAuthConfig> {
-		const response = await apiFetch("/auth/dev/config", { trackLoading: false });
+	async getConfig(): Promise<AuthConfig> {
+		const response = await apiFetch("/auth/config", { trackLoading: false });
 		if (!response.ok) {
 			throw new Error(
-				await formatAuthError(response, `Failed to load local auth config: ${response.statusText}`),
+				await formatAuthError(response, `Failed to load auth config: ${response.statusText}`),
 			);
 		}
 		const payload = (await response.json()) as Record<string, unknown>;
 		return {
-			mode: readString(payload, "mode") as DevAuthConfig["mode"],
+			mode: readString(payload, "mode") as AuthConfig["mode"],
 			usernameHint: readString(payload, "username_hint"),
 			supportsManualTotp: readBoolean(payload, "supports_manual_totp"),
 			supportsMockOauth: readBoolean(payload, "supports_mock_oauth"),
 		};
 	},
 
-	async loginWithTotp(username: string, totpCode: string): Promise<DevAuthLoginResponse> {
+	async loginWithTotp(username: string, totpCode: string): Promise<AuthLoginResponse> {
 		const loginPayload = Object.fromEntries([
 			["username", username],
 			["totp_code", totpCode],
 		]);
-		const response = await apiFetch("/auth/dev/login", {
+		const response = await apiFetch("/auth/login", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(loginPayload),
@@ -90,8 +90,8 @@ export const authApi = {
 		};
 	},
 
-	async loginWithMockOauth(): Promise<DevAuthLoginResponse> {
-		const response = await apiFetch("/auth/dev/mock-oauth", {
+	async loginWithMockOauth(): Promise<AuthLoginResponse> {
+		const response = await apiFetch("/auth/mock-oauth", {
 			method: "POST",
 		});
 		if (!response.ok) {

--- a/frontend/src/routes/api/[...path].ts
+++ b/frontend/src/routes/api/[...path].ts
@@ -5,6 +5,7 @@ const defaultProxyTimeoutMs = 15_000;
 const authCookieName = "ugoite_auth_bearer_token";
 const devAuthProxyToken = process.env.UGOITE_DEV_AUTH_PROXY_TOKEN;
 const devAuthProxyTokenHeader = "x-ugoite-dev-auth-proxy-token";
+const proxyTokenAuthPaths = new Set(["/auth/config", "/auth/login", "/auth/mock-oauth"]);
 
 const hopByHopHeaders = new Set([
 	"connection",
@@ -130,7 +131,7 @@ const applyProxyCredentials = (headers: Headers, cookieHeader: string | null): v
 };
 
 const applyDevAuthProxyToken = (headers: Headers, pathname: string): void => {
-	if (!pathname.startsWith("/auth/dev/")) {
+	if (!proxyTokenAuthPaths.has(pathname)) {
 		return;
 	}
 	if (!devAuthProxyToken?.trim()) {

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -19,8 +19,8 @@ export default function LoginRoute() {
 	const [isSubmitting, setIsSubmitting] = createSignal(false);
 	const redirectTarget = () => searchParams.next || "/spaces";
 
-	const [devConfig] = createResource(async () => {
-		const config = await authApi.getDevConfig();
+	const [authConfig] = createResource(async () => {
+		const config = await authApi.getConfig();
 		setUsername(config.usernameHint);
 		return config;
 	});
@@ -62,22 +62,21 @@ export default function LoginRoute() {
 				<div>
 					<h1 class="ui-page-title">Login</h1>
 					<p class="ui-page-subtitle mt-2">
-						Local development uses explicit login flows so browser and CLI authentication match the
-						production mental model.
+						Use the same explicit passwordless login flow that browser and CLI sessions share.
 					</p>
 				</div>
 
-				<Show when={devConfig.loading}>
-					<p class="text-sm ui-muted">Loading local auth mode...</p>
+				<Show when={authConfig.loading}>
+					<p class="text-sm ui-muted">Loading auth mode...</p>
 				</Show>
 
-				<Show when={devConfig.error}>
+				<Show when={authConfig.error}>
 					<p class="ui-alert ui-alert-error text-sm">
-						Failed to load local auth mode. Re-run <code>mise run dev</code> and try again.
+						Failed to load the current auth mode. Re-run <code>mise run dev</code> and try again.
 					</p>
 				</Show>
 
-				<Show when={devConfig()}>
+				<Show when={authConfig()}>
 					{(config) => (
 						<>
 							<Show when={config().mode === "manual-totp"}>

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -121,11 +121,11 @@ export const seedDevAuthConfig = (
 export const getPreferencePatches = () => preferencePatches.slice();
 
 export const handlers = [
-	http.get("http://localhost:3000/api/auth/dev/config", () => {
+	http.get("http://localhost:3000/api/auth/config", () => {
 		return HttpResponse.json(mockDevAuthConfig);
 	}),
 
-	http.post("http://localhost:3000/api/auth/dev/login", async ({ request }) => {
+	http.post("http://localhost:3000/api/auth/login", async ({ request }) => {
 		const body = (await request.json()) as { username?: string; totp_code?: string };
 		if (
 			mockDevAuthConfig.mode !== "manual-totp" ||
@@ -141,10 +141,10 @@ export const handlers = [
 		});
 	}),
 
-	http.post("http://localhost:3000/api/auth/dev/mock-oauth", () => {
+	http.post("http://localhost:3000/api/auth/mock-oauth", () => {
 		if (mockDevAuthConfig.mode !== "mock-oauth") {
 			return HttpResponse.json(
-				{ detail: "mock-oauth login is not enabled for this local development session." },
+				{ detail: "mock-oauth login is not enabled for this session." },
 				{ status: 409 },
 			);
 		}

--- a/scripts/verify-release-container-quickstart.sh
+++ b/scripts/verify-release-container-quickstart.sh
@@ -154,7 +154,7 @@ E2E_AUTH_BEARER_TOKEN="$(
 import json
 from urllib.request import Request, urlopen
 
-request = Request("http://127.0.0.1:3000/api/auth/dev/mock-oauth", method="POST")
+request = Request("http://127.0.0.1:3000/api/auth/mock-oauth", method="POST")
 with urlopen(request) as response:
     print(json.load(response)["bearer_token"])
 PY

--- a/ugoite-cli/src/commands/auth.rs
+++ b/ugoite-cli/src/commands/auth.rs
@@ -49,16 +49,12 @@ pub async fn run(cmd: AuthCmd) -> Result<()> {
                 .unwrap_or_else(|| config.backend_url.trim_end_matches('/').to_string());
 
             let result = if mock_oauth {
-                http::http_post(
-                    &format!("{base}/auth/dev/mock-oauth"),
-                    &serde_json::json!({}),
-                )
-                .await?
+                http::http_post(&format!("{base}/auth/mock-oauth"), &serde_json::json!({})).await?
             } else {
                 let resolved_username = prompt_non_empty_value("Username", username)?;
                 let resolved_totp_code = prompt_totp_code(totp_code)?;
                 http::http_post(
-                    &format!("{base}/auth/dev/login"),
+                    &format!("{base}/auth/login"),
                     &serde_json::json!({
                         "username": resolved_username,
                         "totp_code": resolved_totp_code,

--- a/ugoite-cli/tests/test_auth.rs
+++ b/ugoite-cli/tests/test_auth.rs
@@ -136,7 +136,7 @@ fn test_cli_auth_login_req_ops_015_posts_dev_login_and_prints_export() {
     let request_text = requests.recv_timeout(Duration::from_secs(5)).unwrap();
     handle.join().unwrap();
 
-    assert!(request_text.starts_with("POST /auth/dev/login HTTP/1.1"));
+    assert!(request_text.starts_with("POST /auth/login HTTP/1.1"));
     assert!(request_text.contains(r#""username":"dev-alice""#));
     assert!(request_text.contains(r#""totp_code":"123456""#));
 

--- a/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
+++ b/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
@@ -150,7 +150,7 @@ fn test_cli_req_ops_006_main_auth_and_config_error_paths() {
         .recv_timeout(Duration::from_secs(5))
         .expect("core mode request");
     handle.join().expect("join core mode server");
-    assert!(core_mode_request.starts_with("POST /auth/dev/login HTTP/1.1"));
+    assert!(core_mode_request.starts_with("POST /auth/login HTTP/1.1"));
     assert!(String::from_utf8_lossy(&core_mode_login.stdout)
         .contains("export UGOITE_AUTH_BEARER_TOKEN=core-mode-token"));
 
@@ -198,7 +198,7 @@ fn test_cli_req_ops_006_main_auth_and_config_error_paths() {
         .recv_timeout(Duration::from_secs(5))
         .expect("interactive request");
     handle.join().expect("join interactive server");
-    assert!(interactive_request.starts_with("POST /auth/dev/login HTTP/1.1"));
+    assert!(interactive_request.starts_with("POST /auth/login HTTP/1.1"));
     assert!(interactive_request.contains(r#""username":"alice""#));
     assert!(interactive_request.contains(r#""totp_code":"123456""#));
 
@@ -234,7 +234,7 @@ fn test_cli_req_ops_006_main_auth_and_config_error_paths() {
         .recv_timeout(Duration::from_secs(5))
         .expect("mock oauth request");
     handle.join().expect("join mock oauth server");
-    assert!(mock_oauth_request.starts_with("POST /auth/dev/mock-oauth HTTP/1.1"));
+    assert!(mock_oauth_request.starts_with("POST /auth/mock-oauth HTTP/1.1"));
 }
 
 /// REQ-OPS-006: auxiliary auth commands must keep masking, overview, and token clearing covered.

--- a/ugoite-core/tests/test_form_reserved_identity.rs
+++ b/ugoite-core/tests/test_form_reserved_identity.rs
@@ -1,13 +1,46 @@
-// REQ-FORM-008 planned placeholders for reserved identity Form names.
+mod common;
+use _ugoite_core::form;
+use _ugoite_core::space;
+use common::setup_operator;
 
-#[test]
-fn test_form_req_form_008_reject_user_form_name() {
-    // REQ-FORM-008
-    assert!(true);
+#[tokio::test]
+/// REQ-FORM-008
+async fn test_form_req_form_008_reject_user_form_name() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "test-user-meta-form", "/tmp").await?;
+    let ws_path = "spaces/test-user-meta-form";
+
+    let form_def = serde_json::json!({
+        "name": "User",
+        "fields": {
+            "DisplayName": {"type": "string"}
+        }
+    });
+
+    let result = form::upsert_form(&op, ws_path, &form_def).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("reserved"));
+
+    Ok(())
 }
 
-#[test]
-fn test_form_req_form_008_reject_usergroup_form_name() {
-    // REQ-FORM-008
-    assert!(true);
+#[tokio::test]
+/// REQ-FORM-008
+async fn test_form_req_form_008_reject_usergroup_form_name() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "test-usergroup-meta-form", "/tmp").await?;
+    let ws_path = "spaces/test-usergroup-meta-form";
+
+    let form_def = serde_json::json!({
+        "name": "UserGroup",
+        "fields": {
+            "Name": {"type": "string"}
+        }
+    });
+
+    let result = form::upsert_form(&op, ws_path, &form_def).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("reserved"));
+
+    Ok(())
 }

--- a/ugoite-core/ugoite_core/authz.py
+++ b/ugoite-core/ugoite_core/authz.py
@@ -196,18 +196,6 @@ def _resolve_role(
     if identity.principal_type == "service":
         return _default_service_role()
 
-    owner_user_id = space_meta.get("owner_user_id")
-    if not isinstance(owner_user_id, str):
-        owner_user_id = settings_map.get("owner_user_id")
-    if isinstance(owner_user_id, str) and owner_user_id == identity.user_id:
-        return "owner"
-
-    admin_user_ids = space_meta.get("admin_user_ids")
-    if not isinstance(admin_user_ids, list):
-        admin_user_ids = settings_map.get("admin_user_ids")
-    if isinstance(admin_user_ids, list) and identity.user_id in admin_user_ids:
-        return "admin"
-
     membership_configured = any(
         key in space_meta or key in settings_map
         for key in ("members", "member_roles", "owner_user_id", "admin_user_ids")
@@ -242,6 +230,18 @@ def _resolve_role(
         explicit = settings_roles.get(identity.user_id)
         if isinstance(explicit, str) and explicit in _VALID_ROLES:
             return cast("RoleName", explicit)
+
+    owner_user_id = space_meta.get("owner_user_id")
+    if not isinstance(owner_user_id, str):
+        owner_user_id = settings_map.get("owner_user_id")
+    if isinstance(owner_user_id, str) and owner_user_id == identity.user_id:
+        return "owner"
+
+    admin_user_ids = space_meta.get("admin_user_ids")
+    if not isinstance(admin_user_ids, list):
+        admin_user_ids = settings_map.get("admin_user_ids")
+    if isinstance(admin_user_ids, list) and identity.user_id in admin_user_ids:
+        return "admin"
 
     if membership_configured:
         return None

--- a/ugoite-core/ugoite_core/membership.py
+++ b/ugoite-core/ugoite_core/membership.py
@@ -177,6 +177,43 @@ def _legacy_maps(
     return owner_user_id, deduped_admin_ids, member_roles
 
 
+def _active_space_admin_user_ids(
+    space_meta: dict[str, Any],
+    settings: dict[str, Any],
+) -> set[str]:
+    members = settings.get("members")
+    active_admins: set[str] = set()
+    if isinstance(members, dict):
+        for user_id, member in members.items():
+            if not isinstance(user_id, str) or not isinstance(member, dict):
+                continue
+            if member.get("state") != "active":
+                continue
+            role = member.get("role")
+            if role in {"owner", "admin"}:
+                active_admins.add(user_id)
+
+    owner_user_id = _owner_user_id(space_meta, settings)
+    if isinstance(owner_user_id, str) and owner_user_id:
+        owner_record = members.get(owner_user_id) if isinstance(members, dict) else None
+        if not isinstance(owner_record, dict):
+            active_admins.add(owner_user_id)
+
+    return active_admins
+
+
+def _ensure_space_retains_active_admin(
+    *,
+    space_id: str,
+    space_meta: dict[str, Any],
+    settings: dict[str, Any],
+) -> None:
+    if _active_space_admin_user_ids(space_meta, settings):
+        return
+    msg = f"Space '{space_id}' must retain at least one active admin."
+    raise RuntimeError(msg)
+
+
 async def _space_lock(space_id: str) -> asyncio.Lock:
     async with _space_locks_guard:
         existing = _space_locks.get(space_id)
@@ -275,7 +312,7 @@ async def bootstrap_space_owner(
     space_id: str,
     owner_user_id: str,
 ) -> dict[str, Any]:
-    """Seed a space owner/admin membership record using the shared metadata model."""
+    """Seed an initial active admin membership record using shared metadata."""
     normalized_owner = owner_user_id.strip()
     if not normalized_owner:
         msg = "owner_user_id must not be empty"
@@ -294,21 +331,20 @@ async def bootstrap_space_owner(
         else:
             member = _build_member_record(
                 user_id=normalized_owner,
-                role="owner",
+                role="admin",
                 invited_by=normalized_owner,
                 invited_at=invited_at,
                 state="active",
             )
 
         member["user_id"] = normalized_owner
-        member["role"] = "owner"
+        member["role"] = "admin"
         member["state"] = "active"
         member["invited_by"] = normalized_owner
         member["invited_at"] = member.get("invited_at") or invited_at
         member["activated_at"] = member.get("activated_at") or "bootstrap"
         member["revoked_at"] = None
         members[normalized_owner] = member
-        settings["owner_user_id"] = normalized_owner
         _increment_membership_version(settings)
         await _patch_settings(storage_config, space_id, space_meta, settings)
         return member
@@ -336,23 +372,13 @@ async def ensure_admin_space(
         space_meta_obj = await _core_any.get_space(storage_config, space_id)
         space_meta = cast("dict[str, Any]", space_meta_obj)
         settings = _normalize_settings(space_meta)
-        owner_user = _owner_user_id(space_meta, settings)
-        desired_role = "owner" if owner_user in {None, normalized_user_id} else "admin"
         current = settings["members"].get(normalized_user_id)
         current_role = current.get("role") if isinstance(current, dict) else None
         current_state = current.get("state") if isinstance(current, dict) else None
 
         if (
-            owner_user == normalized_user_id
-            and isinstance(current, dict)
-            and current_role == "owner"
-            and current_state == "active"
-        ):
-            return current
-        if (
-            desired_role == "admin"
-            and isinstance(current, dict)
-            and current_role in {"admin", "owner"}
+            isinstance(current, dict)
+            and current_role == "admin"
             and current_state == "active"
         ):
             return current
@@ -360,15 +386,13 @@ async def ensure_admin_space(
         invited_at = _now_iso()
         member = dict(current) if isinstance(current, dict) else {}
         member["user_id"] = normalized_user_id
-        member["role"] = desired_role
+        member["role"] = "admin"
         member["state"] = "active"
         member["invited_by"] = normalized_user_id
         member["invited_at"] = member.get("invited_at") or invited_at
         member["activated_at"] = member.get("activated_at") or "bootstrap"
         member["revoked_at"] = None
         settings["members"][normalized_user_id] = member
-        if desired_role == "owner":
-            settings["owner_user_id"] = normalized_user_id
         _increment_membership_version(settings)
         await _patch_settings(storage_config, space_id, space_meta, settings)
         return member
@@ -600,6 +624,11 @@ async def update_member_role(
         member_obj["role"] = payload.role
         member_obj["updated_at"] = _now_iso()
         members[payload.member_user_id] = member_obj
+        _ensure_space_retains_active_admin(
+            space_id=space_id,
+            space_meta=space_meta,
+            settings=settings,
+        )
         _increment_membership_version(settings)
         await _patch_settings(storage_config, space_id, space_meta, settings)
 
@@ -656,6 +685,11 @@ async def revoke_member(
                 invitation["revoked_by"] = payload.revoked_by_user_id
                 invitations[token] = invitation
 
+        _ensure_space_retains_active_admin(
+            space_id=space_id,
+            space_meta=space_meta,
+            settings=settings,
+        )
         _increment_membership_version(settings)
         await _patch_settings(storage_config, space_id, space_meta, settings)
 

--- a/ugoite-minimum/src/metadata.rs
+++ b/ugoite-minimum/src/metadata.rs
@@ -21,7 +21,7 @@ const DEFAULT_METADATA_COLUMNS: &[&str] = &[
     "word_count",
 ];
 
-const DEFAULT_METADATA_FORMS: &[&str] = &["SQL", "Assets"];
+const DEFAULT_METADATA_FORMS: &[&str] = &["SQL", "Assets", "User", "UserGroup"];
 
 static METADATA_COLUMNS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 static METADATA_FORMS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();


### PR DESCRIPTION
## Summary
- unify the explicit passwordless auth endpoints under `/auth/*` across backend, frontend, CLI, docs, scripts, and tests
- bootstrap the admin space and new spaces with active `admin` memberships, and reject changes that would remove the last active admin
- reserve `User` and `UserGroup` metadata form names to align the identity-form contract with REQ-FORM-008

## Related Issue (required)
closes #925

## Testing
- [x] `mise run test`
- [x] `mise run e2e`
- [x] focused frontend, backend, CLI, and core auth/regression checks
- [x] manual CLI verification with `ugoite auth login --mock-oauth` against a local backend
