### PR TITLE
docs(cli): add usage examples to priority CLI commands

### DIFF
--- a/ugoite-cli/src/commands/auth.rs
+++ b/ugoite-cli/src/commands/auth.rs
@@ -21,13 +21,25 @@ pub enum AuthSubCmd {
     ///
     /// Apply the printed export with:
     ///   eval "$(ugoite auth login --username USER --totp-code CODE)"
-    #[command(long_about = "Authenticate via backend/API login and print shell export commands.\n\nPrerequisite: configure backend or api mode first:\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\nExamples:\n  # Login with username and TOTP code\n  ugoite auth login --username alice --totp-code 123456\n\n  # Apply the token in one step\n  eval \"$(ugoite auth login --username alice --totp-code 123456)\"\n\n  # Interactive mode (prompts for username and TOTP)\n  ugoite auth login\n\n  # Development: mock OAuth flow\n  eval \"$(ugoite auth login --mock-oauth)\"")]
+    #[command(
+        long_about = "Authenticate via backend/API login and print shell export commands.\n\nPrerequisite: configure backend or api mode first:\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\nExamples:\n  # Login with username and TOTP code\n  ugoite auth login --username alice --totp-code 123456\n\n  # Apply the token in one step\n  eval \"$(ugoite auth login --username alice --totp-code 123456)\"\n\n  # Interactive mode (prompts for username and TOTP)\n  ugoite auth login\n\n  # Development: mock OAuth flow\n  eval \"$(ugoite auth login --mock-oauth)\""
+    )]
     Login {
-        #[arg(long, help = "Username to authenticate with (prompted interactively if omitted)")]
+        #[arg(
+            long,
+            help = "Username to authenticate with (prompted interactively if omitted)"
+        )]
         username: Option<String>,
-        #[arg(long, help = "6-digit TOTP code from your authenticator app (prompted interactively if omitted)")]
+        #[arg(
+            long,
+            help = "6-digit TOTP code from your authenticator app (prompted interactively if omitted)"
+        )]
         totp_code: Option<String>,
-        #[arg(long, default_value_t = false, help = "Use mock OAuth flow (development only, requires UGOITE_DEV_AUTH_PROXY_TOKEN)")]
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Use mock OAuth flow (development only, requires UGOITE_DEV_AUTH_PROXY_TOKEN)"
+        )]
         mock_oauth: bool,
     },
     /// Print unset commands for auth tokens

--- a/ugoite-cli/src/commands/config.rs
+++ b/ugoite-cli/src/commands/config.rs
@@ -13,11 +13,19 @@ pub enum ConfigSubCmd {
     /// Show saved endpoint config
     Show,
     /// Save endpoint config (mode, backend URL, API URL)
-    #[command(long_about = "Save endpoint configuration.\n\nThree modes are supported:\n  core     - Direct local filesystem access (no backend needed)\n  backend  - Connect to a running ugoite backend server\n  api      - Connect to a remote API endpoint\n\nExamples:\n  # Core mode (default, uses local filesystem)\n  ugoite config set --mode core\n\n  # Backend mode (connect to local backend)\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\n  # API mode (connect to remote API)\n  ugoite config set --mode api --api-url https://api.example.com\n\n  # Update only the backend URL (keep current mode)\n  ugoite config set --backend-url http://localhost:9000")]
+    #[command(
+        long_about = "Save endpoint configuration.\n\nThree modes are supported:\n  core     - Direct local filesystem access (no backend needed)\n  backend  - Connect to a running ugoite backend server\n  api      - Connect to a remote API endpoint\n\nExamples:\n  # Core mode (default, uses local filesystem)\n  ugoite config set --mode core\n\n  # Backend mode (connect to local backend)\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\n  # API mode (connect to remote API)\n  ugoite config set --mode api --api-url https://api.example.com\n\n  # Update only the backend URL (keep current mode)\n  ugoite config set --backend-url http://localhost:9000"
+    )]
     Set {
-        #[arg(long, help = "Endpoint mode: core (local filesystem), backend (ugoite server), or api (remote API)")]
+        #[arg(
+            long,
+            help = "Endpoint mode: core (local filesystem), backend (ugoite server), or api (remote API)"
+        )]
         mode: Option<String>,
-        #[arg(long, help = "Backend server URL (used in backend mode, e.g. http://localhost:8000)")]
+        #[arg(
+            long,
+            help = "Backend server URL (used in backend mode, e.g. http://localhost:8000)"
+        )]
         backend_url: Option<String>,
         #[arg(long, help = "API endpoint URL (used in api mode)")]
         api_url: Option<String>,

--- a/ugoite-cli/src/commands/entry.rs
+++ b/ugoite-cli/src/commands/entry.rs
@@ -14,7 +14,9 @@ pub struct EntryCmd {
 #[derive(Subcommand)]
 pub enum EntrySubCmd {
     /// List entries in a space
-    #[command(long_about = "List entries in a space.\n\nExamples:\n  # Core mode (local filesystem)\n  ugoite entry list /root/spaces/my-space\n\n  # Backend mode (requires config set --mode backend first)\n  ugoite entry list my-space")]
+    #[command(
+        long_about = "List entries in a space.\n\nExamples:\n  # Core mode (local filesystem)\n  ugoite entry list /root/spaces/my-space\n\n  # Backend mode (requires config set --mode backend first)\n  ugoite entry list my-space"
+    )]
     List {
         #[arg(
             value_name = "SPACE_ID_OR_PATH",
@@ -23,29 +25,48 @@ pub enum EntrySubCmd {
         space_path: String,
     },
     /// Get an entry by ID
-    #[command(long_about = "Get an entry by ID.\n\nExamples:\n  # Core mode\n  ugoite entry get /root/spaces/my-space my-entry-id\n\n  # Backend mode\n  ugoite entry get my-space my-entry-id")]
+    #[command(
+        long_about = "Get an entry by ID.\n\nExamples:\n  # Core mode\n  ugoite entry get /root/spaces/my-space my-entry-id\n\n  # Backend mode\n  ugoite entry get my-space my-entry-id"
+    )]
     Get {
         #[arg(
             value_name = "SPACE_ID_OR_PATH",
             help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
         )]
         space_path: String,
-        #[arg(value_name = "ENTRY_ID", help = "Entry slug/ID (e.g. 'my-note', 'task-01')")]
+        #[arg(
+            value_name = "ENTRY_ID",
+            help = "Entry slug/ID (e.g. 'my-note', 'task-01')"
+        )]
         entry_id: String,
     },
     /// Create an entry
-    #[command(long_about = "Create an entry in a space.\n\nThe entry ID is a slug (alphanumeric + hyphens). Content is a Markdown string.\n\nExamples:\n  # Core mode - create a note\n  ugoite entry create /root/spaces/my-space my-note --content $'---\\nform: Note\\n---\\n# My Note\\n\\n## Body\\n\\nHello world.'\n\n  # Backend mode - minimal entry\n  ugoite entry create my-space task-01 --content '# Task 01'\n\n  # With custom author\n  ugoite entry create my-space my-note --content '# Note' --author alice")]
+    #[command(
+        long_about = "Create an entry in a space.\n\nThe entry ID is a slug (alphanumeric + hyphens). Content is a Markdown string.\n\nExamples:\n  # Core mode - create a note\n  ugoite entry create /root/spaces/my-space my-note --content $'---\\nform: Note\\n---\\n# My Note\\n\\n## Body\\n\\nHello world.'\n\n  # Backend mode - minimal entry\n  ugoite entry create my-space task-01 --content '# Task 01'\n\n  # With custom author\n  ugoite entry create my-space my-note --content '# Note' --author alice"
+    )]
     Create {
         #[arg(
             value_name = "SPACE_ID_OR_PATH",
             help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
         )]
         space_path: String,
-        #[arg(value_name = "ENTRY_ID", help = "Entry slug/ID (e.g. 'my-note', 'task-01')")]
+        #[arg(
+            value_name = "ENTRY_ID",
+            help = "Entry slug/ID (e.g. 'my-note', 'task-01')"
+        )]
         entry_id: String,
-        #[arg(long, default_value = "# New Entry\n", allow_hyphen_values = true, help = "Entry content as a Markdown string (supports frontmatter for form/tags)")]
+        #[arg(
+            long,
+            default_value = "# New Entry\n",
+            allow_hyphen_values = true,
+            help = "Entry content as a Markdown string (supports frontmatter for form/tags)"
+        )]
         content: String,
-        #[arg(long, default_value = "cli", help = "Author name to record in the revision history")]
+        #[arg(
+            long,
+            default_value = "cli",
+            help = "Author name to record in the revision history"
+        )]
         author: String,
     },
     /// Update an entry

--- a/ugoite-cli/src/commands/space.rs
+++ b/ugoite-cli/src/commands/space.rs
@@ -13,9 +13,15 @@ pub struct SpaceCmd {
 #[derive(Subcommand)]
 pub enum SpaceSubCmd {
     /// List spaces
-    #[command(long_about = "List all spaces.\n\nExamples:\n  # Core mode (local filesystem root)\n  ugoite space list --root /root/spaces\n\n  # Core mode using UGOITE_ROOT env var\n  ugoite space list\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite space list")]
+    #[command(
+        long_about = "List all spaces.\n\nExamples:\n  # Core mode (local filesystem root)\n  ugoite space list --root /root/spaces\n\n  # Core mode using UGOITE_ROOT env var\n  ugoite space list\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite space list"
+    )]
     List {
-        #[arg(long = "root", value_name = "LOCAL_ROOT", help = "Local filesystem root containing space directories (core mode only). Falls back to UGOITE_ROOT env var.")]
+        #[arg(
+            long = "root",
+            value_name = "LOCAL_ROOT",
+            help = "Local filesystem root containing space directories (core mode only). Falls back to UGOITE_ROOT env var."
+        )]
         root_path: Option<String>,
     },
     /// Get space metadata

--- a/ugoite-cli/src/main.rs
+++ b/ugoite-cli/src/main.rs
@@ -32,11 +32,20 @@ enum Commands {
     /// Link management commands (deprecated: use row_reference fields)
     Link(commands::link::LinkCmd),
     /// Create a new space
-    #[command(long_about = "Create a new space.\n\nExamples:\n  # Core mode (local filesystem)\n  ugoite create-space my-space --root /root/spaces\n\n  # Using UGOITE_ROOT env var\n  ugoite create-space my-space\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite create-space my-space")]
+    #[command(
+        long_about = "Create a new space.\n\nExamples:\n  # Core mode (local filesystem)\n  ugoite create-space my-space --root /root/spaces\n\n  # Using UGOITE_ROOT env var\n  ugoite create-space my-space\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite create-space my-space"
+    )]
     CreateSpace {
-        #[arg(long = "root", value_name = "LOCAL_ROOT", help = "Local filesystem root for spaces (core mode). Falls back to UGOITE_ROOT env var.")]
+        #[arg(
+            long = "root",
+            value_name = "LOCAL_ROOT",
+            help = "Local filesystem root for spaces (core mode). Falls back to UGOITE_ROOT env var."
+        )]
         root_path: Option<String>,
-        #[arg(value_name = "SPACE_ID", help = "New space ID (alphanumeric + hyphens, e.g. 'my-project')")]
+        #[arg(
+            value_name = "SPACE_ID",
+            help = "New space ID (alphanumeric + hyphens, e.g. 'my-project')"
+        )]
         space_id: String,
     },
     /// Query the index


### PR DESCRIPTION
## Summary

Addresses the lack of usage examples in CLI help text (#983). Adds `long_about` with mode-specific examples to the most-used commands so new users can understand valid input formats without reading documentation.

Changes:
- **`entry list/get/create`**: Examples for both core mode (`/root/spaces/<id>`) and backend mode
- **`entry create`**: Shows `--content` format (Markdown with frontmatter), `--author` flag
- **`space list`**: `--root` usage and `UGOITE_ROOT` env var fallback
- **`create-space`**: Core and backend mode examples
- **`config set`**: All three modes (core/backend/api) with all flags documented
- **`auth login`**: Interactive, explicit, eval-pattern, and mock-oauth examples
- Added descriptive help text to previously undocumented args (entry_id, content, author, config flags, auth flags)

## Related Issue (required)

closes #983

## Testing

- [x] `ugoite entry create --help` shows core-mode and backend-mode examples
- [x] `ugoite space list --help` shows a core-mode example with `--root`
- [x] `ugoite config set --help` shows examples for each mode
- [x] `ugoite auth login --help` shows interactive, explicit, and eval patterns
- [x] `cargo check --no-default-features -p ugoite-cli` passes