### PR TITLE
fix(cli): stop advertising unsupported query flags

### DIFF
--- a/ugoite-cli/src/main.rs
+++ b/ugoite-cli/src/main.rs
@@ -59,10 +59,8 @@ enum Commands {
     ///   # Filter by form type
     ///   ugoite query /root/spaces/my-space --sql "SELECT id, title FROM entries WHERE form='note'"
     ///
-    ///   # Paginate results
-    ///   ugoite query my-space --sql "SELECT id FROM entries" --limit 20 --offset 40
     #[command(
-        long_about = "Query the index using SQL.\n\nThe SQL dialect is SQLite. The queryable table is `entries` with columns: id, title, body, form, tags, created_at, updated_at.\n\nExamples:\n  # Core mode (full path)\n  ugoite query /root/spaces/my-space --sql \"SELECT id, title FROM entries LIMIT 10\"\n\n  # Backend/API mode (space ID only)\n  ugoite query my-space --sql \"SELECT id, title FROM entries WHERE form='note'\"\n\n  # Paginate results\n  ugoite query my-space --sql \"SELECT id FROM entries\" --limit 20 --offset 40"
+        long_about = "Query the index using SQL.\n\nThe SQL dialect is SQLite. The queryable table is `entries` with columns: id, title, body, form, tags, created_at, updated_at.\n\nExamples:\n  # Core mode (full path)\n  ugoite query /root/spaces/my-space --sql \"SELECT id, title FROM entries LIMIT 10\"\n\n  # Backend/API mode (space ID only)\n  ugoite query my-space --sql \"SELECT id, title FROM entries WHERE form='note'\""
     )]
     Query {
         #[arg(
@@ -75,14 +73,6 @@ enum Commands {
             help = "SQL query to run against the indexed entries (SQLite dialect). Table: entries. Columns: id, title, body, form, tags, created_at, updated_at.\n\nExample: \"SELECT id, title FROM entries LIMIT 10\""
         )]
         sql: String,
-        #[arg(long, default_value_t = 100, help = "Maximum number of rows to return")]
-        limit: u64,
-        #[arg(long, default_value_t = 0, help = "Row offset for pagination")]
-        offset: u64,
-        #[arg(long, help = "Filter entries by form type (e.g. 'note', 'task')")]
-        form: Option<String>,
-        #[arg(long, help = "Filter entries by tag")]
-        tag: Option<String>,
     },
 }
 
@@ -114,13 +104,6 @@ async fn run(cli: Cli) -> Result<()> {
         } => {
             commands::space::create_space_cmd(root_path.as_deref(), &space_id, "create-space").await
         }
-        Commands::Query {
-            space_path,
-            sql,
-            limit: _,
-            offset: _,
-            form: _,
-            tag: _,
-        } => commands::index::query_cmd(&space_path, &sql).await,
+        Commands::Query { space_path, sql } => commands::index::query_cmd(&space_path, &sql).await,
     }
 }

--- a/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
+++ b/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
@@ -705,6 +705,40 @@ fn test_cli_req_ops_006_search_index_query_and_link_paths() {
         .contains("Link commands removed. Use row_reference fields instead."));
 }
 
+/// REQ-OPS-006: query CLI help must only advertise implemented flags and reject removed filters.
+#[test]
+fn test_cli_req_ops_006_query_help_rejects_removed_flags() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (_root, config_path, space_path) = setup_space_with_form(&dir, "query-space");
+
+    let help_output = cli_command(&config_path)
+        .args(["query", "--help"])
+        .output()
+        .expect("query help");
+    assert_success(&help_output, "query help");
+    let help_text = String::from_utf8_lossy(&help_output.stdout);
+    assert!(!help_text.contains("--limit"));
+    assert!(!help_text.contains("--offset"));
+    assert!(!help_text.contains("--form"));
+    assert!(!help_text.contains("--tag"));
+
+    let removed_flag_output = cli_command(&config_path)
+        .args([
+            "query",
+            &space_path,
+            "--sql",
+            "SELECT id FROM entries",
+            "--limit",
+            "10",
+        ])
+        .output()
+        .expect("query with removed limit flag");
+    assert!(!removed_flag_output.status.success());
+    let stderr = String::from_utf8_lossy(&removed_flag_output.stderr);
+    assert!(stderr.contains("--limit"));
+    assert!(stderr.contains("unexpected argument"));
+}
+
 /// REQ-OPS-006: space commands must keep local sample/test flows and remote-only routes covered.
 #[test]
 fn test_cli_req_ops_006_space_local_and_remote_paths() {


### PR DESCRIPTION
## Summary
- remove unsupported query parser flags from the public CLI interface
- keep query help aligned with the implemented SQL-only behavior
- add CLI coverage to ensure removed flags stay hidden and rejected

## Related Issue (required)
closes #1010

## Testing
- [x] `cd /workspace && cargo run -q -p ugoite-cli -- query --help`
- [x] `cd /workspace && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh cargo test -p ugoite-cli test_cli_req_ops_006_query_help_rejects_removed_flags -- --nocapture`
- [x] `cd /workspace && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh cargo test -p ugoite-cli test_cli_req_ops_006_search_index_query_and_link_paths -- --nocapture`
- [x] `cd /workspace && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`
