### PR TITLE
fix(docsite): link design relation spec pills

### DIFF
--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -191,6 +191,7 @@ requirements:
     - file: e2e/docsite-links.test.ts
       tests:
       - 'REQ-E2E-006: docsite internal page links resolve without 404s'
+      - 'REQ-E2E-006: design relations specification pills navigate to docsite specs'
     vitest:
     - file: docsite/src/lib/base-path.test.ts
       tests:

--- a/docsite/src/pages/design/relations.astro
+++ b/docsite/src/pages/design/relations.astro
@@ -7,6 +7,7 @@ import {
   getPoliciesDetailed,
   getRequirementGroups,
   getRequirementToFeatureEdges,
+  getSpecifications,
 } from "../../lib/spec-data";
 
 const philosophies = await getPhilosophies();
@@ -14,12 +15,22 @@ const policies = await getPoliciesDetailed();
 const reqGroups = await getRequirementGroups();
 const featureGroups = await getFeatureGroups();
 const reqToFeature = await getRequirementToFeatureEdges();
+const specs = await getSpecifications();
 
 const reqToFeatureMap = new Map<string, string[]>();
 for (const edge of reqToFeature) {
   const items = reqToFeatureMap.get(edge.requirement) ?? [];
   items.push(edge.feature);
   reqToFeatureMap.set(edge.requirement, items);
+}
+
+const specPathById = new Map(specs.map((item) => [item.id, item.sourceFile]));
+
+function getSpecificationHref(specId: string): string {
+  const source = specPathById.get(specId);
+  return source
+    ? withBasePath(`/docs/spec/${source.replace(/\.(md|ya?ml)$/i, "")}`)
+    : withBasePath("/docs/spec/index");
 }
 
 const toc = [
@@ -190,7 +201,13 @@ const toc = [
               <div style="font-size: 0.6875rem; font-weight: 600; color: var(--doc-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.25rem;">Specifications</div>
               <div style="display: flex; flex-wrap: wrap; gap: 0.25rem;">
                 {pol.linkedSpecifications.map((spec) => (
-                  <span class="doc-pill doc-pill-outline" style="font-size: 0.625rem;">{spec}</span>
+                  <a
+                    href={getSpecificationHref(spec)}
+                    class="doc-pill doc-pill-outline"
+                    style="font-size: 0.625rem; text-decoration: none;"
+                  >
+                    {spec}
+                  </a>
                 ))}
               </div>
             </div>

--- a/e2e/docsite-links.test.ts
+++ b/e2e/docsite-links.test.ts
@@ -67,6 +67,27 @@ test.describe("Docsite internal links", () => {
 			"Expected to crawl a substantial set of docsite pages",
 		).toBeGreaterThan(20);
 	});
+
+	test("REQ-E2E-006: design relations specification pills navigate to docsite specs", async ({
+		page,
+	}) => {
+		await page.goto(buildDocsiteUrl("/design/relations"), {
+			waitUntil: "networkidle",
+		});
+
+		const specLink = page.locator('#policy-detail a[href*="/docs/spec/"]').first();
+		await expect(specLink).toBeVisible();
+
+		const href = await specLink.getAttribute("href");
+		expect(href, "Expected a concrete spec href").toBeTruthy();
+
+		await Promise.all([
+			page.waitForURL((url) => url.pathname.includes("/docs/spec/")),
+			specLink.click(),
+		]);
+
+		await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+	});
 });
 
 function buildDocsiteUrl(path: string): string {


### PR DESCRIPTION
## Summary
- make the design relations page render linked specification pills instead of plain text spans
- reuse the checked-in spec catalog so each pill navigates to the matching docsite spec page or falls back to the spec index
- add a Playwright regression test so the relations page keeps a clickable specification path

## Related Issue (required)
Closes #1036.

## Testing
- [x] `cd e2e && E2E_AUTH_BEARER_TOKEN=dummy E2E_BASE_URL=http://127.0.0.1:3000 E2E_FRONTEND_URL=http://127.0.0.1:3000 E2E_BACKEND_URL=http://127.0.0.1:8000 npx playwright test docsite-links.test.ts -g "design relations specification pills navigate to docsite specs"`
- [x] `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`
