### PR TITLE
fix(docsite): retarget run-from-source onboarding

### DIFF
--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -266,6 +266,7 @@ requirements:
       tests:
       - 'REQ-E2E-008: landing page explains what Ugoite is and points first-time users to getting started'
       - 'REQ-E2E-008: desktop navigation prioritizes getting-started content before design docs'
+      - 'REQ-E2E-008: run from source card opens the canonical host-dev workflow'
       - 'REQ-E2E-008: mobile navigation keeps getting-started links ahead of design content'
 - set_id: REQCAT-E2E
   source_file: requirements/e2e.yaml

--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -14,7 +14,7 @@ test("REQ-E2E-008: onboarding content keeps try, source, and CLI paths as the fi
 	]);
 	expect(primaryStartCards.map((card) => card.href)).toEqual([
 		"/docs/guide/container-quickstart",
-		"/docs/guide/docker-compose",
+		"/docs/guide/local-dev-auth-login",
 		"/docs/guide/cli",
 	]);
 	expect(primaryStartCards.map((card) => card.badge)).toEqual([

--- a/docsite/src/lib/onboarding.ts
+++ b/docsite/src/lib/onboarding.ts
@@ -27,8 +27,8 @@ export const primaryStartCards = [
 	{
 		badge: "Contributor path",
 		description:
-			"Run the current workspace when you want the latest backend, frontend, and docsite together.",
-		href: "/docs/guide/docker-compose",
+			"Run the current workspace with mise run dev when you want the latest backend, frontend, and docsite together.",
+		href: "/docs/guide/local-dev-auth-login",
 		icon: "🛠️",
 		title: "Run from source",
 	},

--- a/e2e/docsite-onboarding.test.ts
+++ b/e2e/docsite-onboarding.test.ts
@@ -94,6 +94,30 @@ test.describe("Docsite onboarding-first navigation", () => {
 		).toHaveCount(0);
 	});
 
+	test("REQ-E2E-008: run from source card opens the canonical host-dev workflow", async ({
+		page,
+	}) => {
+		await page.goto(buildDocsiteUrl("/getting-started"), {
+			waitUntil: "networkidle",
+		});
+
+		const card = page.locator("#first-steps a", { hasText: "Run from source" });
+		await expect(card).toHaveAttribute(
+			"href",
+			/\/docs\/guide\/local-dev-auth-login$/,
+		);
+
+		await card.click();
+
+		await expect(page).toHaveURL(/\/docs\/guide\/local-dev-auth-login$/);
+		await expect(
+			page.getByRole("heading", {
+				level: 1,
+				name: /local development authentication and login/i,
+			}),
+		).toBeVisible();
+	});
+
 	test("REQ-E2E-008: mobile navigation keeps getting-started links ahead of design content", async ({
 		page,
 	}) => {


### PR DESCRIPTION
## Summary
- retarget the Run from source onboarding card to the canonical Local Dev Auth/Login guide
- keep the docsite onboarding flow aligned with the guide that owns the `mise run dev` walkthrough
- preserve the focused onboarding test/build coverage around the updated route target

## Related Issue (required)

close: #1027

## Testing

- [x] `cd docsite && node ./node_modules/vitest/vitest.mjs run src/lib/onboarding.test.ts --maxWorkers=1`
- [x] `cd docsite && bun run build`
