### PR TITLE
fix(frontend): use explicit SSR frontend origin

### DIFF
--- a/docs/guide/env-matrix.md
+++ b/docs/guide/env-matrix.md
@@ -7,6 +7,7 @@ refers to the CI-parity compose helper in `e2e/scripts/run-e2e-compose.sh`.
 | Variable | Local dev | E2E runner | Docker Compose | CI |
 |---|---|---|---|---|
 | BACKEND_URL | required for frontend proxy | set by runner | set to backend service URL | required in frontend jobs |
+| FRONTEND_URL | optional explicit frontend origin for SSR `/api` fetches when framework origin envs are unavailable | set by runner | optional | optional |
 | UGOITE_ROOT | optional | required | volume-backed path | test workspace path |
 | UGOITE_ALLOW_REMOTE | optional | required | required | required for API tests |
 | UGOITE_AUTH_API_KEY | optional | optional | optional | optional |

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -611,9 +611,9 @@ requirements:
       - 'REQ-OPS-015: forwards SSR auth headers to local auth requests'
       - 'REQ-OPS-015: preserves explicit request auth headers during SSR'
       - 'REQ-OPS-015: skips SSR auth forwarding without a request event'
-      - 'REQ-OPS-015: derives the SSR API origin from the incoming request when FRONTEND_ORIGIN is unset'
-      - 'REQ-OPS-015: falls back to the default SSR origin when no request event is available'
-      - 'REQ-OPS-015: ignores malformed SSR request URLs when deriving the API origin'
+      - 'REQ-OPS-015: uses FRONTEND_URL for the SSR API origin when frontend origin env vars are unset'
+      - 'REQ-OPS-015: falls back to the default SSR origin when no frontend origin env is configured'
+      - 'REQ-OPS-015: does not derive the SSR API origin from the incoming request'
     - file: frontend/src/lib/auth-api.test.ts
       tests:
       - 'REQ-OPS-015: surfaces local auth config and login response errors clearly'

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -118,11 +118,13 @@ describe("apiFetch auth forwarding", () => {
 		expect(seenAuthorization).toBeNull();
 	});
 
-	it("REQ-OPS-015: derives the SSR API origin from the incoming request when FRONTEND_ORIGIN is unset", async () => {
+	it("REQ-OPS-015: uses FRONTEND_URL for the SSR API origin when frontend origin env vars are unset", async () => {
 		let seenOrigin: string | null = null;
+		let seenCookie: string | null = null;
 		server.use(
 			http.get("http://localhost:13000/api/auth/config", ({ request }) => {
 				seenOrigin = new URL(request.url).origin;
+				seenCookie = request.headers.get("cookie");
 				return HttpResponse.json({
 					mode: "passkey-totp",
 					username_hint: "dev-alice",
@@ -135,8 +137,9 @@ describe("apiFetch auth forwarding", () => {
 		vi.stubEnv("NODE_ENV", "development");
 		vi.stubEnv("FRONTEND_ORIGIN", "");
 		vi.stubEnv("ORIGIN", "");
+		vi.stubEnv("FRONTEND_URL", "http://localhost:13000");
 		getRequestEventMock.mockReturnValue({
-			request: new Request("http://localhost:13000/login", {
+			request: new Request("http://attacker.invalid/login", {
 				headers: {
 					cookie: "ugoite_auth_bearer_token=server-token",
 				},
@@ -148,13 +151,15 @@ describe("apiFetch auth forwarding", () => {
 
 		expect(response.status).toBe(200);
 		expect(seenOrigin).toBe("http://localhost:13000");
+		expect(seenCookie).toBe("ugoite_auth_bearer_token=server-token");
 	});
 
-	it("REQ-OPS-015: falls back to the default SSR origin when no request event is available", async () => {
+	it("REQ-OPS-015: falls back to the default SSR origin when no frontend origin env is configured", async () => {
 		vi.stubGlobal("window", undefined);
 		vi.stubEnv("NODE_ENV", "development");
 		vi.stubEnv("FRONTEND_ORIGIN", "");
 		vi.stubEnv("ORIGIN", "");
+		vi.stubEnv("FRONTEND_URL", "");
 		getRequestEventMock.mockReturnValue(undefined);
 
 		const { getBackendBase } = await import("./api");
@@ -162,15 +167,14 @@ describe("apiFetch auth forwarding", () => {
 		expect(getBackendBase()).toBe("http://localhost:3000/api");
 	});
 
-	it("REQ-OPS-015: ignores malformed SSR request URLs when deriving the API origin", async () => {
+	it("REQ-OPS-015: does not derive the SSR API origin from the incoming request", async () => {
 		vi.stubGlobal("window", undefined);
 		vi.stubEnv("NODE_ENV", "development");
 		vi.stubEnv("FRONTEND_ORIGIN", "");
 		vi.stubEnv("ORIGIN", "");
+		vi.stubEnv("FRONTEND_URL", "");
 		getRequestEventMock.mockReturnValue({
-			request: {
-				url: "::not-a-url::",
-			},
+			request: new Request("http://attacker.invalid/login"),
 		});
 
 		const { getBackendBase } = await import("./api");

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,6 @@
 import { loadingState } from "./loading";
 import { getRequestEvent } from "solid-js/web";
 
-const getServerRequestOrigin = (): string | null => {
-	const event = getRequestEvent();
-	if (!event) {
-		return null;
-	}
-
-	try {
-		return new URL(event.request.url).origin;
-	} catch {
-		return null;
-	}
-};
-
 export const getBackendBase = (): string => {
 	// In test environment, use absolute URL for MSW to intercept
 	/* v8 ignore start */
@@ -26,8 +13,7 @@ export const getBackendBase = (): string => {
 	// Default to the frontend dev server origin used in e2e/dev.
 	if (typeof window === "undefined") {
 		const env = process.env ?? {};
-		const origin =
-			env.FRONTEND_ORIGIN || env.ORIGIN || getServerRequestOrigin() || "http://localhost:3000";
+		const origin = env.FRONTEND_ORIGIN || env.ORIGIN || env.FRONTEND_URL || "http://localhost:3000";
 		return `${origin.replace(/\/$/, "")}/api`;
 	}
 	// Always use /api which is proxied to the backend in development


### PR DESCRIPTION
## Summary
- stop deriving the SSR `/api` origin from request-controlled host data when `FRONTEND_ORIGIN` and `ORIGIN` are unset
- honor the existing explicit `FRONTEND_URL` server setting before falling back to `http://localhost:3000`
- add REQ-OPS-015 regression coverage for the explicit env override, the default fallback, and rejecting request-derived SSR origins

## Related Issue (required)
Closes #1028.

## Testing
- [x] `cd frontend && node ./node_modules/vitest/vitest.mjs run src/lib/api.test.ts --maxWorkers=1`
- [x] `cd frontend && node ./node_modules/@biomejs/biome/bin/biome check src/lib/api.ts src/lib/api.test.ts`
- [x] `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`
