### PR TITLE
fix(cli): describe help for update and sample data

### DIFF
--- a/docs/spec/requirements/api.yaml
+++ b/docs/spec/requirements/api.yaml
@@ -426,6 +426,9 @@ requirements:
     - file: ugoite-cli/tests/test_space.rs
       tests:
       - test_create_sample_space_req_api_009
+    - file: ugoite-cli/tests/test_cli_endpoint_routing.rs
+      tests:
+      - test_space_sample_data_req_api_009_help_describes_inputs
     rust:
     - file: ugoite-core/tests/test_sample_data.rs
       tests:

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -233,6 +233,10 @@ requirements:
     - file: docs/tests/test_guides.py
       tests:
       - test_docs_req_ops_006_rust_precommit_parity
+    rust:
+    - file: ugoite-cli/tests/test_cli_endpoint_routing.rs
+      tests:
+      - test_entry_update_req_ops_006_help_describes_required_inputs
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/ugoite-cli/src/commands/entry.rs
+++ b/ugoite-cli/src/commands/entry.rs
@@ -80,14 +80,31 @@ pub enum EntrySubCmd {
             help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
         )]
         space_path: String,
+        #[arg(
+            value_name = "ENTRY_ID",
+            help = "Entry slug/ID (e.g. 'my-note', 'task-01')"
+        )]
         entry_id: String,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Updated entry content as a Markdown string (must keep the same form frontmatter)"
+        )]
         markdown: String,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Expected current revision ID to enforce optimistic concurrency checks"
+        )]
         parent_revision_id: Option<String>,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "JSON array of asset objects to persist with the updated entry revision"
+        )]
         assets: Option<String>,
-        #[arg(long, default_value = "cli")]
+        #[arg(
+            long,
+            default_value = "cli",
+            help = "Author name to record in the revision history"
+        )]
         author: String,
     },
     /// Delete an entry

--- a/ugoite-cli/src/commands/space.rs
+++ b/ugoite-cli/src/commands/space.rs
@@ -71,15 +71,28 @@ pub enum SpaceSubCmd {
     },
     /// Create sample data
     SampleData {
-        #[arg(value_name = "LOCAL_ROOT")]
+        #[arg(
+            value_name = "LOCAL_ROOT",
+            help = "Local workspace root (for example . or /root) where spaces/<SPACE_ID> will be created"
+        )]
         root_path: String,
-        #[arg(value_name = "SPACE_ID")]
+        #[arg(
+            value_name = "SPACE_ID",
+            help = "Space ID for the generated sample-data space"
+        )]
         space_id: String,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Sample-data scenario ID (run `ugoite space sample-scenarios` to list options)"
+        )]
         scenario: Option<String>,
-        #[arg(long, default_value_t = 50)]
+        #[arg(
+            long,
+            default_value_t = 50,
+            help = "Approximate number of generated entries for the seeded space"
+        )]
         entry_count: usize,
-        #[arg(long)]
+        #[arg(long, help = "Deterministic random seed for reproducible sample data")]
         seed: Option<u64>,
         /// Bootstrap this user ID as the active admin owner of the seeded space.
         /// Defaults to the UGOITE_DEV_USER_ID environment variable when unset.
@@ -90,15 +103,28 @@ pub enum SpaceSubCmd {
     SampleScenarios,
     /// Create a sample data job
     SampleJob {
-        #[arg(value_name = "LOCAL_ROOT")]
+        #[arg(
+            value_name = "LOCAL_ROOT",
+            help = "Local workspace root (for example . or /root) where spaces/<SPACE_ID> will be created"
+        )]
         root_path: String,
-        #[arg(value_name = "SPACE_ID")]
+        #[arg(
+            value_name = "SPACE_ID",
+            help = "Space ID for the generated sample-data space"
+        )]
         space_id: String,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Sample-data scenario ID (run `ugoite space sample-scenarios` to list options)"
+        )]
         scenario: Option<String>,
-        #[arg(long, default_value_t = 50)]
+        #[arg(
+            long,
+            default_value_t = 50,
+            help = "Approximate number of generated entries for the seeded space"
+        )]
         entry_count: usize,
-        #[arg(long)]
+        #[arg(long, help = "Deterministic random seed for reproducible sample data")]
         seed: Option<u64>,
         /// Bootstrap this user ID as the active admin owner of the seeded space.
         /// Defaults to the UGOITE_DEV_USER_ID environment variable when unset.
@@ -107,8 +133,12 @@ pub enum SpaceSubCmd {
     },
     /// Get sample data job status
     SampleJobStatus {
-        #[arg(value_name = "LOCAL_ROOT")]
+        #[arg(
+            value_name = "LOCAL_ROOT",
+            help = "Local workspace root that stores sample-data job state"
+        )]
         root_path: String,
+        #[arg(help = "Job ID returned by `ugoite space sample-job`")]
         job_id: String,
     },
     /// Test storage connection

--- a/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -464,6 +464,56 @@ fn test_entry_and_form_list_req_sto_010_use_space_id_or_path_help() {
     assert!(list_stdout.contains("/root/spaces"), "{list_stdout}");
 }
 
+/// REQ-OPS-006: entry update help must describe its required IDs and Markdown payload flags.
+#[test]
+fn test_entry_update_req_ops_006_help_describes_required_inputs() {
+    let help = Command::new(ugoite_bin())
+        .args(["entry", "update", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(help.status.success());
+    let stdout = String::from_utf8_lossy(&help.stdout);
+    for needle in [
+        "ENTRY_ID",
+        "Entry slug/ID",
+        "--markdown <MARKDOWN>",
+        "Updated entry content as a Markdown string",
+        "--parent-revision-id <PARENT_REVISION_ID>",
+        "optimistic concurrency checks",
+        "--assets <ASSETS>",
+        "JSON array of asset objects",
+        "--author <AUTHOR>",
+        "Author name to record in the revision history",
+    ] {
+        assert!(stdout.contains(needle), "{stdout}");
+    }
+}
+
+/// REQ-API-009: sample-data help must describe the local root, target space, scenario, and seed inputs.
+#[test]
+fn test_space_sample_data_req_api_009_help_describes_inputs() {
+    let help = Command::new(ugoite_bin())
+        .args(["space", "sample-data", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(help.status.success());
+    let stdout = String::from_utf8_lossy(&help.stdout);
+    for needle in [
+        "LOCAL_ROOT",
+        "Local workspace root",
+        "SPACE_ID",
+        "Space ID for the generated sample-data space",
+        "--scenario <SCENARIO>",
+        "Sample-data scenario ID",
+        "--entry-count <ENTRY_COUNT>",
+        "Approximate number of generated entries",
+        "--seed <SEED>",
+        "Deterministic random seed for reproducible sample data",
+    ] {
+        assert!(stdout.contains(needle), "{stdout}");
+    }
+}
+
 /// REQ-SEC-003: Service account create routes to backend when in backend mode.
 #[test]
 fn test_space_service_account_create_routes_to_backend() {


### PR DESCRIPTION
## Summary
- add explicit help text for `ugoite entry update` positional arguments and flags
- add matching help text for `ugoite space sample-data` and adjacent sample job commands
- add regression tests plus REQ-OPS-006 / REQ-API-009 traceability entries

## Related Issue (required)
closes #1088

## Testing
- [x] `cargo test -p ugoite-cli --test test_cli_endpoint_routing`
- [x] `cargo test -p ugoite-cli --test test_cli_req_ops_006_coverage test_cli_req_ops_006_entry_local_and_remote_paths -- --exact`
- [x] `cargo test -p ugoite-cli --test test_cli_req_ops_006_coverage test_cli_req_ops_006_space_local_and_remote_paths -- --exact`
- [x] `cargo test -p ugoite-cli --test test_cli_req_ops_006_coverage test_cli_req_ops_016_sample_data_owner_flag_trims_bootstrap_membership -- --exact`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_requirements.py -W error`
- [x] `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`
