### PR TITLE
fix(frontend): replace scaffold 404 guidance

### DIFF
--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -131,6 +131,11 @@ requirements:
     - file: e2e/public-pages.test.ts
       tests:
       - 'REQ-E2E-004: public pages avoid auth-only portable preference requests'
+      - 'REQ-E2E-004: unknown routes show Ugoite recovery guidance instead of scaffold copy'
+    vitest:
+    - file: frontend/src/routes/[...404].test.tsx
+      tests:
+      - 'REQ-E2E-004: unknown routes keep users inside Ugoite recovery paths'
 - set_id: REQCAT-E2E
   source_file: requirements/e2e.yaml
   scope: End-to-end confidence and cross-layer behavior requirements.

--- a/e2e/public-pages.test.ts
+++ b/e2e/public-pages.test.ts
@@ -31,13 +31,49 @@ test.describe("Public page stability", () => {
 				}
 			});
 
-			for (const pathname of ["/", "/about"]) {
+			for (const pathname of ["/", "/about", "/does-not-exist"]) {
 				await page.goto(pathname);
 				await page.waitForLoadState("networkidle");
 			}
 
 			expect(failingPreferenceRequests).toEqual([]);
 			expect(consoleErrors).toEqual([]);
+		} finally {
+			await context.close();
+		}
+	});
+
+	test("REQ-E2E-004: unknown routes show Ugoite recovery guidance instead of scaffold copy", async ({
+		browser,
+	}) => {
+		const context = await browser.newContext({
+			baseURL: process.env.FRONTEND_URL ?? "http://localhost:3000",
+		});
+		try {
+			const page = await context.newPage();
+			await page.goto("/does-not-exist");
+			await page.waitForLoadState("networkidle");
+
+			await expect(page.getByRole("heading", { name: "Page not found" })).toBeVisible();
+			await expect(page.locator("body")).toContainText("still inside Ugoite");
+			await expect(page.getByRole("link", { name: "Open Spaces" })).toHaveAttribute(
+				"href",
+				"/spaces",
+			);
+			await expect(page.getByRole("link", { name: "Go to Login" })).toHaveAttribute(
+				"href",
+				"/login",
+			);
+			await expect(page.getByRole("link", { name: "Back to Home" })).toHaveAttribute(
+				"href",
+				"/",
+			);
+			await expect(page.getByRole("link", { name: "About Ugoite" })).toHaveAttribute(
+				"href",
+				"/about",
+			);
+			await expect(page.locator("body")).not.toContainText("Visit solidjs.com");
+			await expect(page.locator("body")).not.toContainText("About Page");
 		} finally {
 			await context.close();
 		}

--- a/frontend/src/routes/[...404].test.tsx
+++ b/frontend/src/routes/[...404].test.tsx
@@ -1,0 +1,26 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import NotFoundRoute from "./[...404]";
+
+vi.mock("@solidjs/router", () => ({
+	A: (props: { href: string; class?: string; children: unknown }) => (
+		<a href={props.href} class={props.class}>
+			{props.children}
+		</a>
+	),
+}));
+
+describe("404 route", () => {
+	it("REQ-E2E-004: unknown routes keep users inside Ugoite recovery paths", () => {
+		render(() => <NotFoundRoute />);
+
+		expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument();
+		expect(screen.getByText(/still inside Ugoite/i)).toBeInTheDocument();
+		expect(screen.queryByText(/Visit solidjs.com/i)).not.toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Open Spaces" })).toHaveAttribute("href", "/spaces");
+		expect(screen.getByRole("link", { name: "Go to Login" })).toHaveAttribute("href", "/login");
+		expect(screen.getByRole("link", { name: "Back to Home" })).toHaveAttribute("href", "/");
+		expect(screen.getByRole("link", { name: "About Ugoite" })).toHaveAttribute("href", "/about");
+	});
+});

--- a/frontend/src/routes/[...404].tsx
+++ b/frontend/src/routes/[...404].tsx
@@ -2,28 +2,34 @@ import { A } from "@solidjs/router";
 
 export default function NotFound() {
 	return (
-		<main class="ui-page text-center mx-auto">
-			<h1 class="max-6-xs text-6xl font-thin uppercase my-16">Not Found</h1>
-			<p class="mt-8">
-				Visit{" "}
-				<a
-					href="https://solidjs.com"
-					target="_blank"
-					class="ui-muted hover:underline"
-					rel="noopener"
-				>
-					solidjs.com
-				</a>{" "}
-				to learn how to build Solid apps.
-			</p>
-			<p class="my-4">
-				<A href="/" class="ui-muted hover:underline">
-					Home
-				</A>
-				{" - "}
-				<A href="/about" class="ui-muted hover:underline">
-					About Page
-				</A>
+		<main class="ui-page mx-auto max-w-4xl ui-stack">
+			<section class="ui-card text-center ui-stack">
+				<p class="text-sm font-semibold uppercase tracking-[0.2em] ui-muted">404</p>
+				<div class="ui-stack-sm">
+					<h1 class="ui-page-title">Page not found</h1>
+					<p class="ui-page-subtitle mx-auto max-w-2xl">
+						This route does not exist, but you are still inside Ugoite. Choose a recovery path to
+						get back to your spaces, login flow, or product overview.
+					</p>
+				</div>
+				<div class="flex flex-wrap justify-center gap-3">
+					<A href="/spaces" class="ui-button ui-button-primary">
+						Open Spaces
+					</A>
+					<A href="/login" class="ui-button ui-button-secondary">
+						Go to Login
+					</A>
+					<A href="/" class="ui-button ui-button-secondary">
+						Back to Home
+					</A>
+					<A href="/about" class="ui-button ui-button-secondary">
+						About Ugoite
+					</A>
+				</div>
+			</section>
+			<p class="text-center text-sm ui-muted">
+				If you followed an outdated link, return to a known page above and continue with Ugoite's
+				local-first knowledge workflows.
 			</p>
 		</main>
 	);


### PR DESCRIPTION
## Summary
- replace the SolidStart scaffold 404 page with Ugoite-specific recovery guidance
- add a frontend unit test plus Playwright coverage for unknown-route recovery paths
- wire the new tests into REQ-E2E-004 traceability

## Related Issue (required)
closes #1086

## Testing
- [x] `cd frontend && npm run test:run -- 'src/routes/[...404].test.tsx'`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_requirements.py -W error`
- [x] `mise run e2e`
- [x] `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`
