### PR TITLE
fix: sanitize raw 500 error details

### DIFF
--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -32,6 +32,10 @@ ALLOWED_CORS_HEADERS = [
     "X-Request-Id",
     "X-Ugoite-Dev-Auth-Proxy-Token",
 ]
+INTERNAL_SERVER_ERROR_DETAIL = {
+    "code": "internal_error",
+    "message": "Internal server error",
+}
 
 
 def _cors_allowed_origins() -> list[str]:
@@ -49,6 +53,20 @@ def _validate_cors_configuration(allowed_origins: list[str]) -> None:
             "credentialed CORS is enabled."
         )
         raise RuntimeError(message)
+
+
+def _public_http_error_detail(exc: HTTPException) -> object:
+    """Return a client-safe HTTP error detail payload."""
+    detail = exc.detail
+    if exc.status_code != status.HTTP_500_INTERNAL_SERVER_ERROR:
+        return detail
+    if detail != INTERNAL_SERVER_ERROR_DETAIL:
+        logger.error(
+            "Sanitized HTTP %s detail for client response: %r",
+            exc.status_code,
+            detail,
+        )
+    return dict(INTERNAL_SERVER_ERROR_DETAIL)
 
 
 @asynccontextmanager
@@ -107,19 +125,9 @@ app.middleware("http")(security_middleware)
 @app.exception_handler(HTTPException)
 async def handle_http_exception(_request: Request, exc: HTTPException) -> JSONResponse:
     """Sanitize server-side HTTP error details before returning to clients."""
-    detail = exc.detail
-    if (
-        exc.status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR
-        and isinstance(detail, str)
-        and not detail.startswith("Failed to ")
-    ):
-        detail = {
-            "code": "internal_error",
-            "message": "Internal server error",
-        }
     return JSONResponse(
         status_code=exc.status_code,
-        content={"detail": detail},
+        content={"detail": _public_http_error_detail(exc)},
         headers=exc.headers,
     )
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -293,7 +293,7 @@ def test_list_spaces_handles_core_failure(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REQ-STO-009: /spaces returns explicit error on core failure."""
+    """REQ-STO-009: /spaces sanitizes unexpected 500 details on core failure."""
 
     async def _raise(_config: dict[str, str]) -> list[str]:
         msg = "boom"
@@ -303,14 +303,17 @@ def test_list_spaces_handles_core_failure(
 
     response = test_client.get("/spaces")
     assert response.status_code == 500
-    assert response.json()["detail"] == "Failed to list spaces"
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_list_spaces_fails_when_space_meta_read_errors(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REQ-STO-009: /spaces fails explicitly when per-space metadata read fails."""
+    """REQ-STO-009: /spaces sanitizes 500 detail when space metadata read fails."""
 
     async def _list_spaces(_config: dict[str, str]) -> list[str]:
         return ["ws-a"]
@@ -328,7 +331,10 @@ def test_list_spaces_fails_when_space_meta_read_errors(
 
     response = test_client.get("/spaces")
     assert response.status_code == 500
-    assert response.json()["detail"] == "Failed to read space metadata"
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_get_space(

--- a/backend/tests/test_error_sanitization.py
+++ b/backend/tests/test_error_sanitization.py
@@ -1,5 +1,7 @@
 """Regression tests for API error sanitization."""
 
+import logging
+
 import pytest
 import ugoite_core
 from fastapi.testclient import TestClient
@@ -9,7 +11,7 @@ def test_server_error_detail_is_sanitized(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REQ-API-001: 5xx HTTP details must be sanitized into stable public schema."""
+    """REQ-API-001: 500 HTTP details must be sanitized into stable public schema."""
     test_client.post("/spaces", json={"name": "test-ws"})
 
     async def _raise(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
@@ -24,3 +26,31 @@ def test_server_error_detail_is_sanitized(
         "code": "internal_error",
         "message": "Internal server error",
     }
+
+
+def test_server_error_detail_with_failed_prefix_is_sanitized_and_logged(
+    test_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """REQ-API-001: raw 500 detail stays in server logs.
+
+    Operator-facing text must not leak back to clients.
+    """
+    test_client.post("/spaces", json={"name": "members-ws"})
+
+    async def _raise(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        msg = "Failed to list members for /workspace/backend/private-path"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(ugoite_core, "list_members", _raise)
+    caplog.set_level(logging.ERROR, logger="app.main")
+
+    response = test_client.get("/spaces/members-ws/members")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
+    assert "Failed to list members for /workspace/backend/private-path" in caplog.text

--- a/backend/tests/test_preferences.py
+++ b/backend/tests/test_preferences.py
@@ -86,7 +86,7 @@ def test_preferences_me_get_returns_explicit_error_on_core_failure(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REQ-API-011: /preferences/me GET returns explicit errors on core failure."""
+    """REQ-API-011: /preferences/me GET sanitizes unexpected 500 details."""
 
     async def _raise(*_args: object, **_kwargs: object) -> dict[str, object]:
         msg = "boom"
@@ -96,14 +96,17 @@ def test_preferences_me_get_returns_explicit_error_on_core_failure(
 
     response = test_client.get("/preferences/me")
     assert response.status_code == 500
-    assert response.json()["detail"] == "Failed to load preferences"
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_preferences_me_patch_returns_explicit_error_on_core_failure(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """REQ-API-011: /preferences/me PATCH returns explicit errors on core failure."""
+    """REQ-API-011: /preferences/me PATCH sanitizes unexpected 500 details."""
 
     async def _raise(*_args: object, **_kwargs: object) -> dict[str, object]:
         msg = "boom"
@@ -113,4 +116,7 @@ def test_preferences_me_patch_returns_explicit_error_on_core_failure(
 
     response = test_client.patch("/preferences/me", json={"locale": "ja"})
     assert response.status_code == 500
-    assert response.json()["detail"] == "Failed to update preferences"
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }


### PR DESCRIPTION
## Summary
- sanitize backend HTTP 500 details in one place so raw exception strings never leak to clients
- log sanitized raw 500 details on the server side and cover the `Failed to ...` regression path
- update backend tests that intentionally exercised the old leaking behavior

## Related Issue (required)
closes #1090

## Testing
- [x] `cd backend && uv run pytest tests/test_error_sanitization.py -q --no-cov`
- [x] `cd /workspace && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`
- [x] `cd /workspace && uvx pre-commit run --files backend/src/app/main.py backend/tests/test_api.py backend/tests/test_error_sanitization.py backend/tests/test_preferences.py`
