### PR TITLE
fix(cli): clarify routing mode help

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -240,6 +240,7 @@ requirements:
     - file: ugoite-cli/tests/test_cli_endpoint_routing.rs
       tests:
       - test_entry_update_req_ops_006_help_describes_required_inputs
+      - test_form_and_search_req_ops_006_help_describes_required_inputs
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/docs/spec/requirements/storage.yaml
+++ b/docs/spec/requirements/storage.yaml
@@ -414,7 +414,7 @@ requirements:
       tests:
       - test_create_space_req_sto_010_requires_root_only_in_core_mode
       - test_space_list_req_sto_010_accepts_backend_mode_without_local_root
-      - test_entry_and_form_list_req_sto_010_use_space_id_or_path_help
+      - test_cli_help_req_sto_010_describes_space_id_or_path_routing
 - set_id: REQCAT-STORAGE
   source_file: requirements/storage.yaml
   scope: Storage architecture, data persistence, and portability requirements.

--- a/ugoite-cli/src/commands/form.rs
+++ b/ugoite-cli/src/commands/form.rs
@@ -15,6 +15,9 @@ pub struct FormCmd {
 #[derive(Subcommand)]
 pub enum FormSubCmd {
     /// List forms
+    #[command(
+        long_about = "List forms for a space.\n\nRun `ugoite config current` to check whether you should pass a local `/root/spaces/<id>` path or a bare `SPACE_ID`.\n\nExamples:\n  # Core mode\n  ugoite form list /root/spaces/my-space\n\n  # Backend mode\n  ugoite form list my-space"
+    )]
     List {
         #[arg(
             value_name = "SPACE_ID_OR_PATH",
@@ -23,21 +26,35 @@ pub enum FormSubCmd {
         space_path: String,
     },
     /// Get a form
+    #[command(
+        long_about = "Get a form.\n\nRun `ugoite config current` to check whether you should pass a local `/root/spaces/<id>` path or a bare `SPACE_ID`.\n\nExamples:\n  # Core mode\n  ugoite form get /root/spaces/my-space Note\n\n  # Backend mode\n  ugoite form get my-space Note"
+    )]
     Get {
         #[arg(
             value_name = "SPACE_ID_OR_PATH",
             help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
         )]
         space_path: String,
+        #[arg(
+            value_name = "FORM_NAME",
+            help = "Form name from the form definition (for example Note or Task)."
+        )]
         form_name: String,
     },
     /// Upsert a form from a JSON file
+    #[command(
+        long_about = "Upsert a form from a JSON file.\n\nRun `ugoite config current` to check whether you should pass a local `/root/spaces/<id>` path or a bare `SPACE_ID`.\n\nExamples:\n  # Core mode\n  ugoite form update /root/spaces/my-space ./note-form.json\n\n  # Backend mode\n  ugoite form update my-space ./note-form.json"
+    )]
     Update {
         #[arg(
             value_name = "SPACE_ID_OR_PATH",
             help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
         )]
         space_path: String,
+        #[arg(
+            value_name = "FORM_FILE",
+            help = "Path to a JSON form definition file."
+        )]
         form_file: String,
         #[arg(long)]
         strategies: Option<String>,

--- a/ugoite-cli/src/commands/search.rs
+++ b/ugoite-cli/src/commands/search.rs
@@ -15,7 +15,7 @@ pub struct SearchCmd {
 pub enum SearchSubCmd {
     /// Keyword search
     #[command(
-        long_about = "Run keyword search.\n\nExamples:\n  # Core mode\n  ugoite search keyword /root/spaces/my-space invoice\n\n  # Backend mode\n  ugoite search keyword my-space invoice"
+        long_about = "Run keyword search.\n\nRun `ugoite config current` to check whether you should pass a local `/root/spaces/<id>` path or a bare `SPACE_ID`.\n\nExamples:\n  # Core mode\n  ugoite search keyword /root/spaces/my-space invoice\n\n  # Backend mode\n  ugoite search keyword my-space invoice"
     )]
     Keyword {
         #[arg(
@@ -23,6 +23,10 @@ pub enum SearchSubCmd {
             help = "Space ID in backend/api mode, or /root/spaces/<id> in core mode."
         )]
         space_path: String,
+        #[arg(
+            value_name = "QUERY",
+            help = "Plain-text query string to match against indexed entry content."
+        )]
         query: String,
     },
 }

--- a/ugoite-cli/src/commands/space.rs
+++ b/ugoite-cli/src/commands/space.rs
@@ -21,7 +21,7 @@ pub struct SpaceCmd {
 pub enum SpaceSubCmd {
     /// Create a new space
     #[command(
-        long_about = "Create a new space.\n\nExamples:\n  # Core mode (full local space path)\n  ugoite space create /root/spaces/my-space\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite space create my-space"
+        long_about = "Create a new space.\n\nRun `ugoite config current` to check whether you should pass a local `/root/spaces/<id>` path or a bare `SPACE_ID`.\n\nExamples:\n  # Core mode (full local space path)\n  ugoite space create /root/spaces/my-space\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite space create my-space"
     )]
     Create {
         #[arg(
@@ -32,7 +32,7 @@ pub enum SpaceSubCmd {
     },
     /// List spaces
     #[command(
-        long_about = "List all spaces.\n\nExamples:\n  # Core mode (workspace root)\n  ugoite space list /root\n\n  # Core mode (spaces directory also accepted)\n  ugoite space list /root/spaces\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite space list"
+        long_about = "List all spaces.\n\nRun `ugoite config current` to check whether you should pass a local `ROOT_PATH` or omit it entirely.\nUse `ROOT_PATH` in core mode and omit it in backend/api mode.\n\nExamples:\n  # Core mode (workspace root)\n  ugoite space list /root\n\n  # Core mode (spaces directory also accepted)\n  ugoite space list /root/spaces\n\n  # Backend mode (requires: ugoite config set --mode backend ...)\n  ugoite space list"
     )]
     List {
         #[arg(
@@ -43,7 +43,7 @@ pub enum SpaceSubCmd {
     },
     /// Get space metadata
     #[command(
-        long_about = "Get space metadata.\n\nExamples:\n  # Core mode\n  ugoite space get /root/spaces/my-space\n\n  # Backend mode\n  ugoite space get my-space"
+        long_about = "Get space metadata.\n\nRun `ugoite config current` to check whether you should pass a local `/root/spaces/<id>` path or a bare `SPACE_ID`.\n\nExamples:\n  # Core mode\n  ugoite space get /root/spaces/my-space\n\n  # Backend mode\n  ugoite space get my-space"
     )]
     Get {
         #[arg(
@@ -54,7 +54,7 @@ pub enum SpaceSubCmd {
     },
     /// Patch space metadata
     #[command(
-        long_about = "Patch space metadata.\n\nExamples:\n  # Core mode\n  ugoite space patch /root/spaces/my-space --name \"Renamed Space\"\n\n  # Backend mode\n  ugoite space patch my-space --settings '{\"theme\":\"dark\"}'"
+        long_about = "Patch space metadata.\n\nRun `ugoite config current` to check whether you should pass a local `/root/spaces/<id>` path or a bare `SPACE_ID`.\n\nExamples:\n  # Core mode\n  ugoite space patch /root/spaces/my-space --name \"Renamed Space\"\n\n  # Backend mode\n  ugoite space patch my-space --settings '{\"theme\":\"dark\"}'"
     )]
     Patch {
         #[arg(

--- a/ugoite-cli/src/main.rs
+++ b/ugoite-cli/src/main.rs
@@ -19,15 +19,24 @@ enum Commands {
     Auth(commands::auth::AuthCmd),
     /// CLI endpoint routing settings
     Config(commands::config::ConfigCmd),
-    /// Space management commands
+    /// Space management commands.
+    ///
+    /// Run `ugoite config current` to check whether you are in core, backend, or api mode before choosing positional arguments.
+    /// Use `/root/spaces/<id>` for `SPACE_ID_OR_PATH` arguments in core mode.
+    /// Use a bare `SPACE_ID` in backend/api mode.
+    /// For `ugoite space list`, pass `ROOT_PATH` in core mode and omit it in backend/api mode.
     Space(commands::space::SpaceCmd),
     /// Entry management commands
     Entry(commands::entry::EntryCmd),
-    /// Form management commands
+    /// Form management commands.
+    ///
+    /// Run `ugoite config current` to check whether you should pass `/root/spaces/<id>` in core mode or a bare `SPACE_ID` in backend/api mode.
     Form(commands::form::FormCmd),
     /// Asset management commands
     Asset(commands::asset::AssetCmd),
-    /// Search commands
+    /// Search commands.
+    ///
+    /// Run `ugoite config current` to check whether you should pass `/root/spaces/<id>` in core mode or a bare `SPACE_ID` in backend/api mode.
     Search(commands::search::SearchCmd),
     /// SQL linting and completion commands
     Sql(commands::sql::SqlCmd),

--- a/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -491,9 +491,9 @@ fn test_space_list_req_sto_010_accepts_backend_mode_without_local_root() {
     assert_eq!(value[0]["id"].as_str(), Some("remote-space"));
 }
 
-/// REQ-STO-010: space help describes the shared core-mode path convention with concrete examples.
+/// REQ-STO-010: CLI help must explain when to use local space paths versus bare IDs.
 #[test]
-fn test_entry_and_form_list_req_sto_010_use_space_id_or_path_help() {
+fn test_cli_help_req_sto_010_describes_space_id_or_path_routing() {
     for args in [
         ["entry", "list", "--help"],
         ["form", "list", "--help"],
@@ -513,6 +513,44 @@ fn test_entry_and_form_list_req_sto_010_use_space_id_or_path_help() {
         assert!(stdout.contains("SPACE_ID_OR_PATH"), "{stdout}");
         assert!(!stdout.contains("SPACE_PATH"), "{stdout}");
         assert!(stdout.contains("/root/spaces/"), "{stdout}");
+    }
+
+    for args in [
+        &["space", "--help"][..],
+        &["form", "--help"][..],
+        &["search", "--help"][..],
+        &["space", "create", "--help"][..],
+        &["space", "list", "--help"][..],
+        &["space", "get", "--help"][..],
+        &["space", "patch", "--help"][..],
+        &["form", "list", "--help"][..],
+        &["form", "get", "--help"][..],
+        &["form", "update", "--help"][..],
+        &["search", "keyword", "--help"][..],
+    ] {
+        let help = Command::new(ugoite_bin())
+            .args(args)
+            .output()
+            .expect("failed to execute");
+        assert!(help.status.success());
+        let stdout = String::from_utf8_lossy(&help.stdout);
+        assert!(stdout.contains("ugoite config current"), "{stdout}");
+    }
+
+    for args in [
+        &["space", "--help"][..],
+        &["form", "--help"][..],
+        &["search", "--help"][..],
+    ] {
+        let help = Command::new(ugoite_bin())
+            .args(args)
+            .output()
+            .expect("failed to execute");
+        assert!(help.status.success());
+        let stdout = String::from_utf8_lossy(&help.stdout);
+        for needle in ["/root/spaces/<id>", "SPACE_ID"] {
+            assert!(stdout.contains(needle), "{stdout}");
+        }
     }
 
     let list_help = Command::new(ugoite_bin())
@@ -547,6 +585,52 @@ fn test_entry_update_req_ops_006_help_describes_required_inputs() {
         "Author name to record in the revision history",
     ] {
         assert!(stdout.contains(needle), "{stdout}");
+    }
+}
+
+/// REQ-OPS-006: form and search help must describe required positional inputs before execution.
+#[test]
+fn test_form_and_search_req_ops_006_help_describes_required_inputs() {
+    let form_get_help = Command::new(ugoite_bin())
+        .args(["form", "get", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(form_get_help.status.success());
+    let form_get_stdout = String::from_utf8_lossy(&form_get_help.stdout);
+    for needle in [
+        "FORM_NAME",
+        "Form name from the form definition",
+        "ugoite config current",
+    ] {
+        assert!(form_get_stdout.contains(needle), "{form_get_stdout}");
+    }
+
+    let form_update_help = Command::new(ugoite_bin())
+        .args(["form", "update", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(form_update_help.status.success());
+    let form_update_stdout = String::from_utf8_lossy(&form_update_help.stdout);
+    for needle in [
+        "FORM_FILE",
+        "Path to a JSON form definition file",
+        "ugoite config current",
+    ] {
+        assert!(form_update_stdout.contains(needle), "{form_update_stdout}");
+    }
+
+    let search_help = Command::new(ugoite_bin())
+        .args(["search", "keyword", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(search_help.status.success());
+    let search_stdout = String::from_utf8_lossy(&search_help.stdout);
+    for needle in [
+        "QUERY",
+        "Plain-text query string to match against indexed entry content",
+        "ugoite config current",
+    ] {
+        assert!(search_stdout.contains(needle), "{search_stdout}");
     }
 }
 


### PR DESCRIPTION
## Summary

- add newcomer-friendly routing notes to `ugoite space`, `ugoite form`, and `ugoite search` top-level help
- clarify subcommand help for when to use `/root/spaces/<id>` versus a bare `SPACE_ID` before commands fail
- add missing positional argument descriptions for `FORM_NAME`, `FORM_FILE`, and `QUERY`, plus REQ traceability/tests
- keep the top-level help guidance on clap doc comments so the CLI stays compatible with the 100% coverage gate

## Related Issue (required)

closes #1112

## Testing

- [x] `cd ugoite-cli && cargo test --no-default-features --test test_cli_endpoint_routing`
- [x] `cd ugoite-cli && cargo clippy --no-default-features -- -D warnings`
- [x] `cd ugoite-cli && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' cargo llvm-cov --summary-only --fail-under-lines 100 --no-default-features --jobs 1`
- [x] `git commit` (pre-commit hooks)
- [ ] `mise run test`