### PR TITLE
docs(auth): explain entry-path defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ straight to the guide that fits:
 - [Core Concepts](docs/guide/concepts.md) if you want the mental model for
   spaces, entries, forms, and search before choosing a surface.
 - [Container Quick Start](docs/guide/container-quickstart.md) for the released
-  browser experience without cloning the repository.
+  browser experience without cloning the repository (`mock-oauth` by default).
 - [CLI Guide](docs/guide/cli.md) for terminal-first workflows and scripting.
 - `mise run setup`, then `mise run dev`, for the current backend, frontend, and
-  docsite together from source.
+  docsite together from source (`passkey-totp` by default).
 - [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) when you need the
   canonical sign-in and `/login` workflow details.
 
@@ -36,6 +36,12 @@ Local-first applies most directly to Ugoite's storage model and the CLI's
 `core` mode today. The current browser path still needs a running backend +
 frontend stack and an explicit login flow, even though the data remains in
 user-controlled local storage.
+
+Auth defaults differ by entry path: `mise run dev` uses `passkey-totp` by
+default so source contributors exercise the explicit local passkey + 2FA flow,
+while the published `docker-compose.release.yaml` quick start uses `mock-oauth`
+by default so browser evaluators can reach `/login` and `/spaces` with fewer
+setup steps.
 
 Today's shipped AI surface is resource-first MCP access. Read-oriented MCP
 resources are available now; broader tool-driven AI workflows remain part of

--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -53,6 +53,11 @@ bootstraps the `default` space at startup so the first browser and CLI session
 both have a ready workspace. For more detail on the explicit browser login
 flow, see [Local Dev Auth Login](local-dev-auth-login.md).
 
+This published quick start intentionally differs from `mise run dev`: it
+defaults to `mock-oauth` so first-time browser evaluators can reach `/spaces`
+with fewer steps, while source development keeps `passkey-totp` as the default
+so contributors exercise the explicit passkey + 2FA flow.
+
 ## Next steps
 
 - The `default` space is the starter workspace that the published quick start

--- a/docs/guide/local-dev-auth-login.md
+++ b/docs/guide/local-dev-auth-login.md
@@ -14,6 +14,14 @@ The default path remains `passkey-totp`, and you can opt into `mock-oauth`
 when you want to exercise an explicit OAuth-style login flow. In every case,
 the browser and CLI must sign in explicitly after startup.
 
+That default intentionally differs from the published
+[`docker-compose.release.yaml` quick start](container-quickstart.md), which
+uses `mock-oauth` so newcomers can evaluate the browser flow faster. Source
+development keeps `passkey-totp` on by default so contributors exercise the
+explicit passkey + 2FA login path that `mise run dev` wires through
+`scripts/dev-auth-env.sh`. If you want source development to mirror the release
+quick start instead, set `UGOITE_DEV_AUTH_MODE=mock-oauth` before startup.
+
 ## 1) Auth modes at a glance
 
 | Mode | How to enable | What it does |


### PR DESCRIPTION
## Summary
- add a newcomer-facing note in the README that compares the default auth mode for source development and the published browser quick start
- explain in `local-dev-auth-login.md` why `mise run dev` defaults to `passkey-totp` while the release compose path defaults to `mock-oauth`
- call out the same trade-off directly in `container-quickstart.md` so readers understand the difference without backtracking

## Related Issue (required)
closes #1061

## Testing
- [x] mise run test:docs -- -k req_ops_015_local_dev_auth_docs_cover_manual_modes
- [x] mise run test
- [x] Closes #1061
