### PR TITLE
docs(metrics): separate onboarding friction

### DIFF
--- a/docs/spec/product/success-metrics.md
+++ b/docs/spec/product/success-metrics.md
@@ -5,9 +5,22 @@ These metrics help evaluate whether Ugoite is delivering on its principles
 
 ## Product Metrics
 
-- **Time-to-first-entry**: new user can create a space + first entry quickly.
+- **Time-to-first-login (browser path)**: newcomer can start the published
+  browser stack and complete the explicit login flow without getting lost in
+  auth-mode or runtime setup details.
+- **Time-to-first-writable-space (browser path)**: newcomer can reach a space
+  where they are actually allowed to create content after startup and login.
+- **Time-to-first-entry**: newcomer can create a space + first entry quickly
+  once they are in a writable state. Report this separately for browser quick
+  start versus CLI/core workflows so setup/auth friction does not disappear
+  behind a single number.
 - **Time-to-first-structured-field**: user can define a Form and see extracted fields.
 - **Search usefulness**: keyword search returns expected results with low latency.
+
+Treat these three newcomer-path metrics together. For the browser route, image
+pulls, stack startup, explicit login, and arrival in the first writable space
+are all part of the Easy principle; `time-to-first-entry` alone is not an
+honest proxy for the full first-use experience.
 
 ## Reliability Metrics
 
@@ -23,4 +36,3 @@ These metrics help evaluate whether Ugoite is delivering on its principles
 
 - **Requirement traceability**: every REQ-* maps to tests (and tests map back).
 - **Doc/code consistency**: feature registry entries point to real symbols.
-


### PR DESCRIPTION
## Summary
- split the newcomer success metric into time-to-first-login, time-to-first-writable-space, and time-to-first-entry
- clarify that browser quick-start measurements must include setup and auth friction instead of hiding it behind a single number
- keep `time-to-first-entry` as a useful metric, but only when reported alongside the earlier onboarding stages

## Related Issue (required)
closes #1062

## Testing
- [x] mise run test
- [x] Closes #1062
