### PR TITLE
docs(guide): add quickstart next steps

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -105,7 +105,27 @@ ugoite space create ./spaces/demo
 If you are actively developing inside the repository, you can swap those for
 `cargo run -q -p ugoite-cli -- ...` instead.
 
-## Seed local sample data
+## Next steps after your first command
+
+`./spaces/demo` is now your local workspace example. A good next step is to add
+one plain Markdown entry there:
+
+```bash
+ugoite entry create ./spaces/demo first-note --content '# First note'
+ugoite entry get ./spaces/demo first-note
+```
+
+You do **not** need Forms or sample data before this first note. Read
+[Core Concepts](concepts.md) next if you want the mental model for spaces,
+entries, forms, and search, or jump to
+[Endpoint routing mode](#endpoint-routing-mode) when you want the CLI to talk to
+a backend or API instead of the local filesystem.
+
+## Contributor-only shortcut: seed local sample data
+
+If you installed a released CLI and only want the basic local workflow, you can
+skip this section. `mise run seed` is a repository task for contributors and
+repeatable demos, not a required first step for end users.
 
 Use the root developer task when you want a quick local dataset without
 remembering the lower-level CLI arguments:

--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -53,6 +53,18 @@ bootstraps the `default` space at startup so the first browser and CLI session
 both have a ready workspace. For more detail on the explicit browser login
 flow, see [Local Dev Auth Login](local-dev-auth-login.md).
 
+## Next steps
+
+- The `default` space is the starter workspace that the published quick start
+  bootstraps for you after login.
+- Try creating one plain Markdown entry in that space first. You do **not** need
+  to define a Form before the first note.
+- Read [Core Concepts](concepts.md) next if you want the mental model for
+  spaces, entries, forms, and search before exploring more of the UI.
+- Switch to the [CLI Guide](cli.md) when you want a lighter terminal-first
+  workflow, or to the [Docker Compose Guide](docker-compose.md) when you want
+  the full contributor stack from source.
+
 To stop the stack:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a `Next steps` handoff to the browser quick start that explains the `default` space, first-entry path, and when forms become optional
- add a `Next steps after your first command` section to the CLI guide with a minimal first-entry example
- mark `mise run seed` as a contributor-only shortcut so released-binary users do not mistake it for the basic happy path

## Related Issue (required)
closes #1102

## Testing
- [x] mise run test
- [x] Closes #1102
