### PR TITLE
docs(philosophy): scope browser local-first claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ straight to the guide that fits:
 - [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) when you need the
   canonical sign-in and `/login` workflow details.
 
+Local-first applies most directly to Ugoite's storage model and the CLI's
+`core` mode today. The current browser path still needs a running backend +
+frontend stack and an explicit login flow, even though the data remains in
+user-controlled local storage.
+
 Today's shipped AI surface is resource-first MCP access. Read-oriented MCP
 resources are available now; broader tool-driven AI workflows remain part of
 the `v0.2` roadmap.

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -19,6 +19,11 @@ directory structure that can live on local disk today and move to other storage
 backends later. That is the "local-first" part of the philosophy: your data is
 not trapped behind a hosted database or a proprietary SaaS account.
 
+Today, that local-first promise is strongest in the storage layer and in CLI
+`core` mode, where commands talk to the local filesystem directly. The current
+browser UI still depends on a running backend/proxy and explicit login; it uses
+local-first storage underneath, but it is not yet a backend-free browser mode.
+
 If you are evaluating Ugoite, a good first question is: "What should be its own
 space?" A team wiki, a research notebook, or a project knowledge base are all
 reasonable examples.
@@ -89,9 +94,10 @@ That design matters because it keeps the system easier to reason about:
 Once the concepts make sense, choose the surface that matches your task:
 
 - Use the [Container Quick Start](container-quickstart.md) when you want the
-  fastest browser-based evaluation.
+  fastest browser-based evaluation and you are comfortable running the backend
+  + frontend stack locally.
 - Use the [CLI Guide](cli.md) when you prefer terminal-first workflows or
-  scripting.
+  scripting, or when you want the thinnest local-first workflow today.
 - Use the [Docker Compose Guide](docker-compose.md) when you want the full
   contributor stack from source.
 - Use the [Specification Index](../spec/index.md) when you need the formal


### PR DESCRIPTION
## Summary
- clarify in the README that local-first applies most directly to the storage model and CLI `core` mode today
- explain in `docs/guide/concepts.md` that the current browser path still relies on a backend/proxy even though storage remains user-controlled
- tighten the surface-choice guidance so newcomers can tell when they are choosing a browser stack versus the thinnest local-first workflow

## Related Issue (required)
closes #1114

## Testing
- [x] mise run test
- [x] Closes #1114
