### PR TITLE
docs(forms): clarify markdown field contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ugoite is a knowledge management system built on three core principles:
 | Principle    | Description                                                 |
 | ------------ | ----------------------------------------------------------- |
 | **Low Cost** | No expensive cloud services required; runs on local storage |
-| **Easy**     | Markdown-first with automatic structure extraction          |
+| **Easy**     | Markdown-first authoring with Form-defined structure when you need queryable fields |
 | **Freedom**  | Your data, your storage, your AI - no vendor lock-in        |
 
 ## Start Here
@@ -34,7 +34,7 @@ straight to the guide that fits:
 
 ## Key Features
 
-- **Markdown as Table**: Markdown sections map to Form-defined fields stored in Iceberg tables
+- **Markdown as Table**: Markdown stays the authoring surface, while Forms define the canonical fields extracted into Iceberg tables
 - **Form Definitions**: Define entry types (Meeting, Task, etc.) with typed fields and templates
 - **AI-Programmable**: MCP protocol with resource-first integration for AI agents
 - **Local-First Storage**: Your data stays on your device or cloud storage (S3, etc.)

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -54,6 +54,10 @@ That makes forms the bridge between free-form writing and reliable structure.
 They help people enter consistent information, and they help the browser, CLI,
 and automation flows understand what each entry is supposed to contain.
 
+You can absolutely start with a lightweight note, but as soon as you want
+stable extracted fields, validation, or reliable queries, the Form becomes the
+contract Ugoite uses to interpret that Markdown.
+
 ## Markdown becomes structured data
 
 One of Ugoite's key ideas is **Markdown as Table**.
@@ -62,9 +66,11 @@ When you write an entry, Markdown headings and frontmatter can map onto the
 fields defined by a form. That means you keep a writing-friendly editing model
 without giving up typed fields, validation, or queryability.
 
-For a newcomer, the important takeaway is this: you are not filling out a rigid
-web form first and exporting later. The Markdown content is part of the real
-data model, and Ugoite extracts structure from it in a predictable way.
+For a newcomer, the important takeaway is this: Markdown remains the authoring
+surface, but the structure is still governed by the active Form definition when
+you want typed fields. You are not filling out a rigid web form first and
+exporting later, but you also are not bypassing schema contracts entirely once
+you ask Ugoite to extract predictable structure.
 
 ## Search and indexes are derived, not primary
 

--- a/docs/spec/data-model/overview.md
+++ b/docs/spec/data-model/overview.md
@@ -9,6 +9,9 @@ To ensure clarity, Ugoite distinguishes between the **System Data Model** and us
 - **System Data Model**: The underlying architecture of how data is handled, stored, and retrieved (e.g., "Filesystem = Database", directory structure, row-level integrity).
 - **Entry Forms**: User-defined table schemas stored in Iceberg; templates are fixed globally. Formerly known as "Schemas".
 
+Markdown remains the primary authoring surface, but Forms are the canonical
+contract that turns that Markdown into typed, queryable fields.
+
 ## Principles
 
 Ugoite's data model is built on these principles:
@@ -46,6 +49,10 @@ Forms define entry types with:
 - **Fields**: Content columns derived from the Iceberg table schema
 - **Types**: Iceberg column types mapped to entry fields
 - **Extra Attributes Policy**: `allow_extra_attributes` controls non-registered H2 sections
+
+Forms are optional when you are still writing an unstructured note. Once you
+want stable field extraction, validation, or queryable columns, define the Form
+first because it becomes the field contract for that entry type.
 
 ### Metadata vs Content Columns
 

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -94,7 +94,7 @@ Ugoite is a knowledge management system built on three core principles:
 ## Key Concepts
 
 ### Form
-A **Form** defines the structure of an entry type. Forms specify:
+A **Form** defines the canonical field contract for an entry type. Forms specify:
 - Required and optional fields (H2 headers)
 - Field types (string, number, date, list, markdown)
 - Fixed global template for new entries
@@ -104,6 +104,9 @@ An **Entry** is stored as a row in an Iceberg table and can be reconstructed as 
 - H2 sections map to Form-defined fields
 - YAML frontmatter carries metadata (form, tags)
 - Revision history is stored in the Form `revisions` table
+
+Markdown remains the authoring surface, but once an entry is associated with a
+Form, that Form governs which fields become canonical structured data.
 
 ### Space
 A **Space** is a self-contained data directory with:


### PR DESCRIPTION
## Summary
- make README and concept docs say more explicitly that Markdown remains the authoring surface while Forms govern extracted field contracts
- align the spec index and data-model overview with the same contract-first language
- explain when teams can stay lightweight and when they should define a Form first

## Related Issue (required)
closes #1059

## Testing
- [x] mise run test
