### PR TITLE
fix(cli): scope mock-oauth proxy token help

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -637,6 +637,7 @@ requirements:
       - test_cli_auth_login_req_ops_015_posts_dev_login_and_prints_export
       - test_cli_auth_login_req_ops_015_shell_escapes_bearer_token_exports
       - test_cli_auth_login_req_ops_015_quotes_empty_bearer_token_exports
+      - test_cli_auth_login_req_ops_015_help_scopes_mock_oauth_proxy_token_requirement
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/ugoite-cli/src/commands/auth.rs
+++ b/ugoite-cli/src/commands/auth.rs
@@ -22,7 +22,7 @@ pub enum AuthSubCmd {
     /// Apply the printed export in a POSIX-compatible shell with:
     ///   eval "$(ugoite auth login --username USER --totp-code CODE)"
     #[command(
-        long_about = "Authenticate via backend/API passkey + 2FA login and print POSIX-shell-safe export commands.\n\nPrerequisite: configure backend or api mode first:\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\nWhen local development auth uses `passkey-totp`, also export UGOITE_DEV_PASSKEY_CONTEXT before logging in.\n\nExamples:\n  # Login with username and TOTP code\n  ugoite auth login --username alice --totp-code 123456\n\n  # Apply the escaped token in one step (POSIX shells)\n  eval \"$(ugoite auth login --username alice --totp-code 123456)\"\n\n  # Interactive mode (prompts for username and TOTP)\n  ugoite auth login\n\n  # Development: mock OAuth flow\n  eval \"$(ugoite auth login --mock-oauth)\""
+        long_about = "Authenticate via backend/API passkey + 2FA login and print POSIX-shell-safe export commands.\n\nPrerequisite: configure backend or api mode first:\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\nWhen local development auth uses `passkey-totp`, also export UGOITE_DEV_PASSKEY_CONTEXT before logging in.\nDirect loopback backend mode does not require UGOITE_DEV_AUTH_PROXY_TOKEN for `--mock-oauth`, but proxied/container-boundary flows do.\n\nExamples:\n  # Login with username and TOTP code\n  ugoite auth login --username alice --totp-code 123456\n\n  # Apply the escaped token in one step (POSIX shells)\n  eval \"$(ugoite auth login --username alice --totp-code 123456)\"\n\n  # Interactive mode (prompts for username and TOTP)\n  ugoite auth login\n\n  # Development: mock OAuth flow\n  eval \"$(ugoite auth login --mock-oauth)\""
     )]
     Login {
         #[arg(
@@ -38,7 +38,7 @@ pub enum AuthSubCmd {
         #[arg(
             long,
             default_value_t = false,
-            help = "Use mock OAuth flow (development only, requires UGOITE_DEV_AUTH_PROXY_TOKEN)"
+            help = "Use mock OAuth flow (development only; proxied/container flows require UGOITE_DEV_AUTH_PROXY_TOKEN)"
         )]
         mock_oauth: bool,
     },

--- a/ugoite-cli/tests/test_auth.rs
+++ b/ugoite-cli/tests/test_auth.rs
@@ -250,6 +250,33 @@ fn test_cli_auth_login_req_ops_015_quotes_empty_bearer_token_exports() {
     );
 }
 
+/// REQ-OPS-015: auth login help scopes proxy-token guidance to proxied mock-oauth flows.
+#[test]
+fn test_cli_auth_login_req_ops_015_help_scopes_mock_oauth_proxy_token_requirement() {
+    let output = Command::new(ugoite_bin())
+        .args(["auth", "login", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout
+            .contains("Direct loopback backend mode does not require UGOITE_DEV_AUTH_PROXY_TOKEN"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("proxied/container flows require UGOITE_DEV_AUTH_PROXY_TOKEN"),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains(
+            "Use mock OAuth flow (development only, requires UGOITE_DEV_AUTH_PROXY_TOKEN)",
+        ),
+        "{stdout}"
+    );
+}
+
 /// REQ-SEC-003: auth overview includes the canonical channels field.
 #[test]
 fn test_cli_auth_overview_req_sec_003_includes_channels() {


### PR DESCRIPTION
## Summary
- scope `ugoite auth login --mock-oauth` help text so it no longer claims `UGOITE_DEV_AUTH_PROXY_TOKEN` is universally required
- explain in the long help that direct loopback backend mode works without the proxy token, while proxied/container-boundary flows still require it
- add REQ-OPS-015 CLI help coverage so the wording stays aligned with the actual auth flow contract

## Related Issue (required)
Closes #1141

## Testing
- [x] `cd ugoite-cli && cargo fmt --check`
- [x] `cd ugoite-cli && cargo test --no-default-features --test test_auth help_scopes_mock_oauth_proxy_token_requirement -- --nocapture`
- [x] `cd ugoite-cli && cargo run --quiet -- auth login --help | sed -n '1,80p'`
- [x] `cd /workspace/.worktrees/issue1141 && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`