### PR TITLE
docs(readme): align backend python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ the `v0.2` roadmap.
 | Component    | Technology                           |
 | ------------ | ------------------------------------ |
 | Frontend     | Bun + SolidStart + TailwindCSS       |
-| Backend      | Python 3.12+ (FastAPI)               |
+| Backend      | Python 3.13+ (FastAPI)               |
 | Core         | Rust (ugoite-core via pyo3 bindings) |
 | Storage      | OpenDAL + Apache Iceberg             |
 | AI Interface | MCP (resource-first integration today) |

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -36,6 +36,7 @@ requirements:
       - test_docs_req_ops_001_shell_blocks_parse
       - test_docs_req_ops_001_env_matrix_matches_runtime_usage
       - test_docs_req_ops_001_mise_versions_match_ci_pins
+      - test_docs_req_ops_001_readme_backend_python_version_matches_metadata
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -109,6 +109,7 @@ PRE_COMMIT_CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
 PR_TEMPLATE_PATH = REPO_ROOT / ".github" / "pull_request_template.md"
 README_PATH = REPO_ROOT / "README.md"
 BACKEND_README_PATH = REPO_ROOT / "backend" / "README.md"
+BACKEND_PYPROJECT_PATH = REPO_ROOT / "backend" / "pyproject.toml"
 MISE_PATH = REPO_ROOT / "mise.toml"
 BACKEND_MISE_PATH = REPO_ROOT / "backend" / "mise.toml"
 UGOITE_MINIMUM_MISE_PATH = REPO_ROOT / "ugoite-minimum" / "mise.toml"
@@ -1112,6 +1113,47 @@ def test_docs_req_ops_001_mise_versions_match_ci_pins() -> None:
 
     if details:
         raise AssertionError("; ".join(details))
+
+
+def test_docs_req_ops_001_readme_backend_python_version_matches_metadata() -> None:
+    """REQ-OPS-001: README backend stack version must match package metadata."""
+    readme_text = README_PATH.read_text(encoding="utf-8")
+    backend_pyproject = tomllib.loads(
+        BACKEND_PYPROJECT_PATH.read_text(encoding="utf-8"),
+    )
+    project = backend_pyproject.get("project")
+    if not isinstance(project, dict):
+        message = "backend/pyproject.toml must define a [project] table"
+        raise TypeError(message)
+
+    requires_python = project.get("requires-python")
+    if not isinstance(requires_python, str) or not requires_python.strip():
+        message = "backend/pyproject.toml must define project.requires-python"
+        raise AssertionError(message)
+
+    backend_stack_match = re.search(
+        r"^\| Backend\s+\|\s+(Python [^|]+)\s+\|$",
+        readme_text,
+        re.MULTILINE,
+    )
+    if backend_stack_match is None:
+        message = "README.md must include a Backend stack-overview row"
+        raise AssertionError(message)
+
+    if requires_python.startswith(">="):
+        expected_version = requires_python.removeprefix(">=").strip()
+        expected_backend_stack = f"Python {expected_version}+ (FastAPI)"
+    else:
+        expected_backend_stack = f"Python {requires_python.strip()} (FastAPI)"
+
+    documented_backend_stack = backend_stack_match.group(1).strip()
+    if documented_backend_stack != expected_backend_stack:
+        message = (
+            "README.md Backend stack row must match backend/pyproject.toml "
+            f"requires-python: expected {expected_backend_stack!r}, got "
+            f"{documented_backend_stack!r}"
+        )
+        raise AssertionError(message)
 
 
 def test_docs_req_ops_002_docker_build_ci_declared() -> None:


### PR DESCRIPTION
## Summary
- align the README Stack Overview backend row with the backend package's Python 3.13 minimum
- add REQ-OPS-001 docs coverage so the README backend version cannot drift from `backend/pyproject.toml`
- keep contributor-facing stack guidance consistent with the enforced runtime metadata

## Related Issue (required)
Closes #1137

## Testing
- [x] `uvx ruff check --select ALL --ignore-noqa docs/tests/test_guides.py`
- [x] `uv run --with pytest --with pyyaml --with bashlex python -m pytest docs/tests/test_guides.py docs/tests/test_requirements.py -W error -k 'readme_backend_python_version_matches_metadata or test_requirements'`
- [x] `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`