### PR TITLE
fix(auth): include channels in cli overview

### DIFF
--- a/docs/spec/requirements/security.yaml
+++ b/docs/spec/requirements/security.yaml
@@ -106,6 +106,9 @@ requirements:
     - file: ugoite-core/tests/test_auth_overview_consistency.py
       tests:
       - test_auth_overview_matches_security_yaml_contract
+    - file: ugoite-cli/tests/test_auth.rs
+      tests:
+      - test_cli_auth_overview_req_sec_003_includes_channels
 - set_id: REQCAT-SECURITY
   source_file: requirements/security.yaml
   scope: Security controls, integrity protections, and isolation requirements.

--- a/ugoite-cli/tests/test_auth.rs
+++ b/ugoite-cli/tests/test_auth.rs
@@ -1,6 +1,8 @@
 //! CLI auth login tests.
 //! REQ-OPS-015
+//! REQ-SEC-003
 
+use serde_json::Value;
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::process::Command;
@@ -150,4 +152,35 @@ fn test_cli_auth_login_req_ops_015_posts_dev_login_and_prints_export() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("export UGOITE_AUTH_BEARER_TOKEN=issued-token"));
+}
+
+/// REQ-SEC-003: auth overview includes the canonical channels field.
+#[test]
+fn test_cli_auth_overview_req_sec_003_includes_channels() {
+    let output = Command::new(ugoite_bin())
+        .args(["auth", "overview"])
+        .output()
+        .expect("failed to execute auth overview");
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let payload: Value = serde_json::from_str(&stdout).expect("auth overview JSON");
+    let channels = payload
+        .get("channels")
+        .and_then(Value::as_array)
+        .expect("channels array");
+    let channel_names: Vec<_> = channels
+        .iter()
+        .map(|value| value.as_str().expect("channel string"))
+        .collect();
+
+    assert_eq!(
+        channel_names,
+        vec![
+            "backend(rest)",
+            "backend(mcp)",
+            "cli(via backend)",
+            "frontend(via backend)",
+        ],
+    );
 }

--- a/ugoite-core/src/auth.rs
+++ b/ugoite-core/src/auth.rs
@@ -488,6 +488,12 @@ pub fn auth_capabilities_snapshot(
                 "scope_enforced",
                 "service_account_id"
             ]
-        }
+        },
+        "channels": [
+            "backend(rest)",
+            "backend(mcp)",
+            "cli(via backend)",
+            "frontend(via backend)"
+        ]
     })
 }


### PR DESCRIPTION
## Summary
- add the canonical `channels` field to the Rust auth overview snapshot consumed by `ugoite auth overview`
- add REQ-SEC-003 CLI coverage so the auth overview contract stays aligned with the security spec
- verify the CLI output manually and keep the full repo validation green

## Related Issue (required)
Closes #1136

## Testing
- [x] `cd ugoite-cli && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh cargo test --no-default-features --test test_auth test_cli_auth_overview_req_sec_003_includes_channels -- --exact`
- [x] `cd ugoite-core && uv run --with pytest python -m pytest tests/test_auth_overview_consistency.py -W error`
- [x] `uv run --with pytest --with pyyaml python -m pytest docs/tests/test_requirements.py -W error`
- [x] `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 MISE_JOBS=1 VITEST_MAX_WORKERS=1 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/tmp/cc-lld-wrapper.sh mise run test`