### PR TITLE
fix: clarify docsite application docs CTA

### DIFF
--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -271,6 +271,7 @@ requirements:
     - file: e2e/docsite-onboarding.test.ts
       tests:
       - 'REQ-E2E-008: landing page explains what Ugoite is and points first-time users to getting started'
+      - 'REQ-E2E-008: landing page labels the application overview CTA as documentation'
       - 'REQ-E2E-008: desktop navigation prioritizes getting-started content before design docs'
       - 'REQ-E2E-008: run from source card opens the canonical host-dev workflow'
       - 'REQ-E2E-008: mobile navigation keeps getting-started links ahead of design content'

--- a/docsite/src/pages/app/index.astro
+++ b/docsite/src/pages/app/index.astro
@@ -9,10 +9,10 @@ const toc = [
 ];
 ---
 
-<BaseLayout title="Application | Ugoite" description="Application architecture and control surfaces." toc={toc}>
+<BaseLayout title="Application Docs | Ugoite" description="Application documentation for architecture and control surfaces." toc={toc}>
   <section id="vision" class="doc-card-hero">
     <div style="position: relative; z-index: 1;">
-      <span class="doc-pill">Application</span>
+      <span class="doc-pill">Application Docs</span>
       <h1 style="font-size: 2rem; font-weight: 800; margin-top: 0.75rem; letter-spacing: -0.02em;">
         Run Your Knowledge Space From Anywhere
       </h1>

--- a/docsite/src/pages/index.astro
+++ b/docsite/src/pages/index.astro
@@ -43,7 +43,7 @@ import {
 
         <div class="doc-cta-row">
           <a href={withBasePath("/getting-started")} class="doc-btn doc-btn-primary">Get Started</a>
-          <a href={withBasePath("/app")} class="doc-btn doc-btn-outline">Browse Application</a>
+          <a href={withBasePath("/app")} class="doc-btn doc-btn-outline">Explore Application Docs</a>
           <a href={withBasePath("/docs/spec/index")} class="doc-btn doc-btn-outline">Read Specs</a>
         </div>
       </div>

--- a/e2e/docsite-onboarding.test.ts
+++ b/e2e/docsite-onboarding.test.ts
@@ -70,6 +70,32 @@ test.describe("Docsite onboarding-first navigation", () => {
 		]);
 	});
 
+	test("REQ-E2E-008: landing page labels the application overview CTA as documentation", async ({
+		page,
+	}) => {
+		await page.goto(buildDocsiteUrl("/"), { waitUntil: "networkidle" });
+
+		const applicationDocsLink = page.getByRole("link", {
+			name: "Explore Application Docs",
+		});
+		await expect(applicationDocsLink).toBeVisible();
+		await expect(applicationDocsLink).toHaveAttribute("href", /\/app$/);
+		await expect(
+			page.getByRole("link", { name: "Browse Application" }),
+		).toHaveCount(0);
+
+		await applicationDocsLink.click();
+
+		await expect(page).toHaveURL(/\/app$/);
+		await expect(
+			page.getByRole("heading", {
+				level: 1,
+				name: /run your knowledge space from anywhere/i,
+			}),
+		).toBeVisible();
+		await expect(page.getByText("Application Docs")).toBeVisible();
+	});
+
 	test("REQ-E2E-008: desktop navigation prioritizes getting-started content before design docs", async ({
 		page,
 	}) => {


### PR DESCRIPTION
## Summary

- relabel the home-page `/app` CTA so it clearly opens application documentation instead of implying an app launch
- make the `/app` overview page metadata and hero pill consistently identify that destination as documentation
- add REQ-E2E-008 Playwright coverage and requirements traceability for the clarified CTA

## Related Issue (required)

closes #1142

## Testing

- [x] `cd docsite && bun run typecheck && bun run test:validation`
- [x] `cd e2e && E2E_AUTH_BEARER_TOKEN=dummy npx playwright test docsite-onboarding.test.ts`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -k "e2e_008" -W error`
