### PR TITLE
fix(frontend): make test origin matching lazy

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -627,9 +627,18 @@ requirements:
       - 'REQ-OPS-015: forwards SSR auth headers to local auth requests'
       - 'REQ-OPS-015: preserves explicit request auth headers during SSR'
       - 'REQ-OPS-015: skips SSR auth forwarding without a request event'
+      - 'REQ-OPS-015: uses FRONTEND_TEST_ORIGIN for the frontend test API base'
       - 'REQ-OPS-015: uses FRONTEND_URL for the SSR API origin when frontend origin env vars are unset'
       - 'REQ-OPS-015: falls back to the default SSR origin when no frontend origin env is configured'
       - 'REQ-OPS-015: does not derive the SSR API origin from the incoming request'
+    - file: frontend/src/lib/frontend-origin.test.ts
+      tests:
+      - 'REQ-OPS-015: falls back to the default frontend test origin when process env is unavailable'
+      - 'REQ-OPS-015: trims and applies FRONTEND_TEST_ORIGIN overrides'
+      - 'REQ-OPS-015: prefers runtime frontend origin env vars in documented order'
+    - file: frontend/src/test/mocks/handlers.test.ts
+      tests:
+      - 'REQ-OPS-015: MSW handlers honor FRONTEND_TEST_ORIGIN'
     - file: frontend/src/lib/auth-api.test.ts
       tests:
       - 'REQ-OPS-015: surfaces local auth config and login response errors clearly'

--- a/frontend/src/components/HelloWorld.test.tsx
+++ b/frontend/src/components/HelloWorld.test.tsx
@@ -5,13 +5,12 @@ import { render, screen, waitFor } from "@solidjs/testing-library";
 import { http, HttpResponse } from "msw";
 import HelloWorld from "./HelloWorld";
 import { server } from "~/test/mocks/server";
+import { testApiUrl } from "~/test/http-origin";
 
 describe("HelloWorld", () => {
 	it("displays message from backend", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/", () =>
-				HttpResponse.json({ message: "Hello from backend!" }),
-			),
+			http.get(testApiUrl("/"), () => HttpResponse.json({ message: "Hello from backend!" })),
 		);
 		render(() => <HelloWorld />);
 		await waitFor(() => {
@@ -20,7 +19,7 @@ describe("HelloWorld", () => {
 	});
 
 	it("shows fallback on missing message", async () => {
-		server.use(http.get("http://localhost:3000/api/", () => HttpResponse.json({})));
+		server.use(http.get(testApiUrl("/"), () => HttpResponse.json({})));
 		render(() => <HelloWorld />);
 		await waitFor(() => {
 			expect(screen.getByText("No message")).toBeInTheDocument();
@@ -28,7 +27,7 @@ describe("HelloWorld", () => {
 	});
 
 	it("shows error message on fetch failure", async () => {
-		server.use(http.get("http://localhost:3000/api/", () => HttpResponse.error()));
+		server.use(http.get(testApiUrl("/"), () => HttpResponse.error()));
 		render(() => <HelloWorld />);
 		await waitFor(() => {
 			expect(screen.getByText("Error fetching")).toBeInTheDocument();

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "~/test/mocks/server";
+import { testApiUrl } from "~/test/http-origin";
 
 const getRequestEventMock = vi.fn();
 
@@ -24,7 +25,7 @@ describe("apiFetch auth forwarding", () => {
 		let seenCookie: string | null = null;
 		let seenAuthorization: string | null = null;
 		server.use(
-			http.get("http://localhost:3000/api/auth/config", ({ request }) => {
+			http.get(testApiUrl("/auth/config"), ({ request }) => {
 				seenCookie = request.headers.get("cookie");
 				seenAuthorization = request.headers.get("authorization");
 				return HttpResponse.json({
@@ -57,7 +58,7 @@ describe("apiFetch auth forwarding", () => {
 		let seenCookie: string | null = null;
 		let seenAuthorization: string | null = null;
 		server.use(
-			http.get("http://localhost:3000/api/auth/config", ({ request }) => {
+			http.get(testApiUrl("/auth/config"), ({ request }) => {
 				seenCookie = request.headers.get("cookie");
 				seenAuthorization = request.headers.get("authorization");
 				return HttpResponse.json({
@@ -96,7 +97,7 @@ describe("apiFetch auth forwarding", () => {
 		let seenCookie: string | null = "unexpected";
 		let seenAuthorization: string | null = "unexpected";
 		server.use(
-			http.get("http://localhost:3000/api/auth/config", ({ request }) => {
+			http.get(testApiUrl("/auth/config"), ({ request }) => {
 				seenCookie = request.headers.get("cookie");
 				seenAuthorization = request.headers.get("authorization");
 				return HttpResponse.json({
@@ -152,6 +153,30 @@ describe("apiFetch auth forwarding", () => {
 		expect(response.status).toBe(200);
 		expect(seenOrigin).toBe("http://localhost:13000");
 		expect(seenCookie).toBe("ugoite_auth_bearer_token=server-token");
+	});
+
+	it("REQ-OPS-015: uses FRONTEND_TEST_ORIGIN for the frontend test API base", async () => {
+		let seenOrigin: string | null = null;
+		vi.stubEnv("NODE_ENV", "test");
+		vi.stubEnv("FRONTEND_TEST_ORIGIN", "http://127.0.0.1:4310");
+		server.use(
+			http.get(testApiUrl("/auth/config"), ({ request }) => {
+				seenOrigin = new URL(request.url).origin;
+				return HttpResponse.json({
+					mode: "passkey-totp",
+					username_hint: "dev-alice",
+					supports_passkey_totp: true,
+					supports_mock_oauth: false,
+				});
+			}),
+		);
+
+		const { apiFetch, getBackendBase } = await import("./api");
+		const response = await apiFetch("/auth/config", { trackLoading: false });
+
+		expect(getBackendBase()).toBe("http://127.0.0.1:4310/api");
+		expect(response.status).toBe(200);
+		expect(seenOrigin).toBe("http://127.0.0.1:4310");
 	});
 
 	it("REQ-OPS-015: falls back to the default SSR origin when no frontend origin env is configured", async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,20 +1,19 @@
 import { loadingState } from "./loading";
 import { getRequestEvent } from "solid-js/web";
+import { getFrontendTestApiBase, getRuntimeFrontendApiBase } from "./frontend-origin";
 
 export const getBackendBase = (): string => {
 	// In test environment, use absolute URL for MSW to intercept
 	/* v8 ignore start */
 	if (typeof process !== "undefined" && process.env?.NODE_ENV === "test") {
-		return "http://localhost:3000/api";
+		return getFrontendTestApiBase();
 	}
 	/* v8 ignore stop */
 	/* v8 ignore start */
 	// In SSR, Node's fetch requires an absolute URL.
 	// Default to the frontend dev server origin used in e2e/dev.
 	if (typeof window === "undefined") {
-		const env = process.env ?? {};
-		const origin = env.FRONTEND_ORIGIN || env.ORIGIN || env.FRONTEND_URL || "http://localhost:3000";
-		return `${origin.replace(/\/$/, "")}/api`;
+		return getRuntimeFrontendApiBase();
 	}
 	// Always use /api which is proxied to the backend in development
 	// and should be served by the backend or a reverse proxy in production.

--- a/frontend/src/lib/asset-store.test.ts
+++ b/frontend/src/lib/asset-store.test.ts
@@ -6,6 +6,7 @@ import { createAssetStore } from "./asset-store";
 import { resetMockData, seedSpace } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Space } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 const testSpace: Space = {
 	id: "asset-store-ws",
@@ -54,7 +55,7 @@ describe("createAssetStore", () => {
 
 	it("sets error state on load failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/asset-store-ws/assets", () =>
+			http.get(testApiUrl("/spaces/asset-store-ws/assets"), () =>
 				HttpResponse.json({ detail: "Server error" }, { status: 500 }),
 			),
 		);

--- a/frontend/src/lib/auth-api.test.ts
+++ b/frontend/src/lib/auth-api.test.ts
@@ -5,6 +5,7 @@ import { authApi } from "./auth-api";
 import { clearAuthTokenCookie, setAuthTokenCookie } from "./auth-session";
 import { resetMockData, seedDevAuthConfig } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
+import { testApiUrl } from "~/test/http-origin";
 
 describe("authApi", () => {
 	beforeEach(() => {
@@ -36,7 +37,7 @@ describe("authApi", () => {
 		);
 
 		server.use(
-			http.get("http://localhost:3000/api/auth/config", () =>
+			http.get(testApiUrl("/auth/config"), () =>
 				HttpResponse.json(
 					{
 						mode: "passkey-totp",
@@ -54,7 +55,7 @@ describe("authApi", () => {
 
 		server.use(
 			http.get(
-				"http://localhost:3000/api/auth/config",
+				testApiUrl("/auth/config"),
 				() => new HttpResponse(null, { status: 500, statusText: "Internal Server Error" }),
 			),
 		);
@@ -63,7 +64,7 @@ describe("authApi", () => {
 		);
 
 		server.use(
-			http.get("http://localhost:3000/api/auth/config", () =>
+			http.get(testApiUrl("/auth/config"), () =>
 				HttpResponse.json(
 					{
 						detail: "Explicit login endpoints are only available from loopback clients.",
@@ -77,7 +78,7 @@ describe("authApi", () => {
 		);
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/login", () =>
+			http.post(testApiUrl("/auth/login"), () =>
 				HttpResponse.json(
 					{
 						bearer_token: 42,
@@ -94,7 +95,7 @@ describe("authApi", () => {
 
 		server.use(
 			http.post(
-				"http://localhost:3000/api/auth/login",
+				testApiUrl("/auth/login"),
 				() => new HttpResponse("backend down", { status: 502, statusText: "Bad Gateway" }),
 			),
 		);
@@ -103,14 +104,14 @@ describe("authApi", () => {
 		);
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/mock-oauth", () =>
+			http.post(testApiUrl("/auth/mock-oauth"), () =>
 				HttpResponse.json({ detail: { reason: "blocked" } }, { status: 409 }),
 			),
 		);
 		await expect(authApi.loginWithMockOauth()).rejects.toThrow('{"reason":"blocked"}');
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/mock-oauth", () =>
+			http.post(testApiUrl("/auth/mock-oauth"), () =>
 				HttpResponse.json({ detail: 123 }, { status: 409, statusText: "Conflict" }),
 			),
 		);
@@ -119,7 +120,7 @@ describe("authApi", () => {
 		);
 
 		server.use(
-			http.post("http://localhost:3000/api/auth/mock-oauth", () =>
+			http.post(testApiUrl("/auth/mock-oauth"), () =>
 				HttpResponse.json(
 					{
 						bearer_token: "frontend-test-token",

--- a/frontend/src/lib/client.test.ts
+++ b/frontend/src/lib/client.test.ts
@@ -11,6 +11,7 @@ import { joinUrl } from "./api";
 import { resetMockData, seedSpace, seedEntry } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Entry, EntryRecord, Space } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 describe("spaceApi", () => {
 	beforeEach(() => {
@@ -54,7 +55,7 @@ describe("spaceApi", () => {
 
 		it("should surface validation errors without object placeholders [REQ-FE-043]", async () => {
 			server.use(
-				http.post("http://localhost:3000/api/spaces", () =>
+				http.post(testApiUrl("/spaces"), () =>
 					HttpResponse.json(
 						{
 							detail: [
@@ -140,7 +141,7 @@ describe("entryApi", () => {
 
 		it("REQ-FE-054: entryApi normalizes unix-second timestamps for entry lists", async () => {
 			server.use(
-				http.get("http://localhost:3000/api/spaces/test-ws/entries", () =>
+				http.get(testApiUrl("/spaces/test-ws/entries"), () =>
 					HttpResponse.json([
 						{
 							id: "entry-1",
@@ -396,7 +397,7 @@ describe("spaceApi members", () => {
 describe("error paths", () => {
 	it("spaceApi.list throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces", () =>
+			http.get(testApiUrl("/spaces"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -405,7 +406,7 @@ describe("error paths", () => {
 
 	it("spaceApi.get throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/nonexistent", () =>
+			http.get(testApiUrl("/spaces/nonexistent"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -421,7 +422,7 @@ describe("error paths", () => {
 
 	it("spaceApi.patch throws on failure", async () => {
 		server.use(
-			http.patch("http://localhost:3000/api/spaces/nonexistent", () =>
+			http.patch(testApiUrl("/spaces/nonexistent"), () =>
 				HttpResponse.json({ detail: "Space not found" }, { status: 404 }),
 			),
 		);
@@ -430,7 +431,7 @@ describe("error paths", () => {
 
 	it("spaceApi.testConnection throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/nonexistent/test-connection", () =>
+			http.post(testApiUrl("/spaces/nonexistent/test-connection"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -441,7 +442,7 @@ describe("error paths", () => {
 
 	it("spaceApi.listMembers throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/nonexistent/members", () =>
+			http.get(testApiUrl("/spaces/nonexistent/members"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -450,7 +451,7 @@ describe("error paths", () => {
 
 	it("spaceApi.inviteMember throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/nonexistent/members/invitations", () =>
+			http.post(testApiUrl("/spaces/nonexistent/members/invitations"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -461,7 +462,7 @@ describe("error paths", () => {
 
 	it("spaceApi.acceptInvitation throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/nonexistent/members/accept", () =>
+			http.post(testApiUrl("/spaces/nonexistent/members/accept"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -472,7 +473,7 @@ describe("error paths", () => {
 
 	it("spaceApi.updateMemberRole throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/nonexistent/members/u1/role", () =>
+			http.post(testApiUrl("/spaces/nonexistent/members/u1/role"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -483,7 +484,7 @@ describe("error paths", () => {
 
 	it("spaceApi.revokeMember throws on failure", async () => {
 		server.use(
-			http.delete("http://localhost:3000/api/spaces/nonexistent/members/u1", () =>
+			http.delete(testApiUrl("/spaces/nonexistent/members/u1"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -553,7 +554,7 @@ describe("error paths", () => {
 
 	it("entryApi.get includes detail in error", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-err/entries/bad-id", () =>
+			http.get(testApiUrl("/spaces/ws-err/entries/bad-id"), () =>
 				HttpResponse.json({ detail: "Custom error detail" }, { status: 404 }),
 			),
 		);
@@ -562,7 +563,7 @@ describe("error paths", () => {
 
 	it("entryApi.get uses statusText fallback when no detail in error", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-err/entries/no-detail-entry", () =>
+			http.get(testApiUrl("/spaces/ws-err/entries/no-detail-entry"), () =>
 				HttpResponse.json({ message: "Generic error" }, { status: 404 }),
 			),
 		);
@@ -571,7 +572,7 @@ describe("error paths", () => {
 
 	it("entryApi.update throws generic error on non-409 failure", async () => {
 		server.use(
-			http.put("http://localhost:3000/api/spaces/ws-err/entries/bad-id", () =>
+			http.put(testApiUrl("/spaces/ws-err/entries/bad-id"), () =>
 				HttpResponse.json({ detail: "Server error" }, { status: 500 }),
 			),
 		);
@@ -582,7 +583,7 @@ describe("error paths", () => {
 
 	it("entryApi.delete throws on failure", async () => {
 		server.use(
-			http.delete("http://localhost:3000/api/spaces/ws-err/entries/bad-id", () =>
+			http.delete(testApiUrl("/spaces/ws-err/entries/bad-id"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -591,7 +592,7 @@ describe("error paths", () => {
 
 	it("entryApi.restore throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/ws-err/entries/bad-id/restore", () =>
+			http.post(testApiUrl("/spaces/ws-err/entries/bad-id/restore"), () =>
 				HttpResponse.json({ detail: "Restore failed" }, { status: 500 }),
 			),
 		);
@@ -600,7 +601,7 @@ describe("error paths", () => {
 
 	it("entryApi.history throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-err/entries/bad-id/history", () =>
+			http.get(testApiUrl("/spaces/ws-err/entries/bad-id/history"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -611,7 +612,7 @@ describe("error paths", () => {
 
 	it("entryApi.getRevision throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-err/entries/bad-id/history/rev-1", () =>
+			http.get(testApiUrl("/spaces/ws-err/entries/bad-id/history/rev-1"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -629,7 +630,7 @@ describe("error paths", () => {
 
 	it("assetApi.list throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-asset-err/assets", () =>
+			http.get(testApiUrl("/spaces/ws-asset-err/assets"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -638,7 +639,7 @@ describe("error paths", () => {
 
 	it("assetApi.upload throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/ws-asset-err/assets", () =>
+			http.post(testApiUrl("/spaces/ws-asset-err/assets"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -648,7 +649,7 @@ describe("error paths", () => {
 
 	it("assetApi.delete throws with detail on failure", async () => {
 		server.use(
-			http.delete("http://localhost:3000/api/spaces/ws-asset-err/assets/bad-id", () =>
+			http.delete(testApiUrl("/spaces/ws-asset-err/assets/bad-id"), () =>
 				HttpResponse.json({ detail: "Asset is referenced" }, { status: 409 }),
 			),
 		);
@@ -664,7 +665,7 @@ describe("error paths", () => {
 
 	it("formApi.listTypes throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-types-err/forms/types", () =>
+			http.get(testApiUrl("/spaces/ws-types-err/forms/types"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -673,7 +674,7 @@ describe("error paths", () => {
 
 	it("formApi.list throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-form-err/forms", () =>
+			http.get(testApiUrl("/spaces/ws-form-err/forms"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -682,7 +683,7 @@ describe("error paths", () => {
 
 	it("formApi.get throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-form-err/forms/nonexistent", () =>
+			http.get(testApiUrl("/spaces/ws-form-err/forms/nonexistent"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -691,7 +692,7 @@ describe("error paths", () => {
 
 	it("formApi.create throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/ws-form-err/forms", () =>
+			http.post(testApiUrl("/spaces/ws-form-err/forms"), () =>
 				HttpResponse.json({ detail: "Invalid" }, { status: 422 }),
 			),
 		);
@@ -702,7 +703,7 @@ describe("error paths", () => {
 
 	it("searchApi.keyword throws on failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/ws-search-err/search", () =>
+			http.get(testApiUrl("/spaces/ws-search-err/search"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -713,7 +714,7 @@ describe("error paths", () => {
 
 	it("searchApi.query throws on failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/ws-search-err/query", () =>
+			http.post(testApiUrl("/spaces/ws-search-err/query"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -722,7 +723,7 @@ describe("error paths", () => {
 
 	it("spaceApi.create uses fallback message when error response has no detail", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces", () =>
+			http.post(testApiUrl("/spaces"), () =>
 				HttpResponse.json({ message: "No detail here" }, { status: 422 }),
 			),
 		);

--- a/frontend/src/lib/form-store.test.ts
+++ b/frontend/src/lib/form-store.test.ts
@@ -6,6 +6,7 @@ import { createFormStore } from "./form-store";
 import { resetMockData, seedSpace } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Space } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 const testSpace: Space = {
 	id: "form-store-ws",
@@ -66,7 +67,7 @@ describe("createFormStore", () => {
 
 	it("sets error on load failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/form-store-ws/forms", () =>
+			http.get(testApiUrl("/spaces/form-store-ws/forms"), () =>
 				HttpResponse.json({ detail: "Server error" }, { status: 500 }),
 			),
 		);

--- a/frontend/src/lib/frontend-origin.test.ts
+++ b/frontend/src/lib/frontend-origin.test.ts
@@ -1,0 +1,43 @@
+// REQ-OPS-015: Frontend test origin selection follows explicit environment configuration.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	getFrontendApiBase,
+	getFrontendTestApiBase,
+	getFrontendTestOrigin,
+	getRuntimeFrontendApiBase,
+	getRuntimeFrontendOrigin,
+} from "./frontend-origin";
+
+describe("frontend origin helpers", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.unstubAllEnvs();
+	});
+
+	it("REQ-OPS-015: falls back to the default frontend test origin when process env is unavailable", () => {
+		vi.stubGlobal("process", undefined);
+
+		expect(getFrontendTestOrigin()).toBe("http://localhost:3000");
+		expect(getFrontendTestApiBase()).toBe("http://localhost:3000/api");
+	});
+
+	it("REQ-OPS-015: trims and applies FRONTEND_TEST_ORIGIN overrides", () => {
+		const env = {
+			FRONTEND_TEST_ORIGIN: " http://127.0.0.1:4310/ ",
+		};
+
+		expect(getFrontendTestOrigin(env)).toBe("http://127.0.0.1:4310");
+		expect(getFrontendApiBase(getFrontendTestOrigin(env))).toBe("http://127.0.0.1:4310/api");
+	});
+
+	it("REQ-OPS-015: prefers runtime frontend origin env vars in documented order", () => {
+		const env = {
+			FRONTEND_ORIGIN: " https://front.example.test/ ",
+			ORIGIN: "https://origin.example.test",
+			FRONTEND_URL: "https://url.example.test",
+		};
+
+		expect(getRuntimeFrontendOrigin(env)).toBe("https://front.example.test");
+		expect(getRuntimeFrontendApiBase(env)).toBe("https://front.example.test/api");
+	});
+});

--- a/frontend/src/lib/frontend-origin.ts
+++ b/frontend/src/lib/frontend-origin.ts
@@ -1,0 +1,37 @@
+const defaultFrontendOrigin = "http://localhost:3000";
+
+const normalizeOrigin = (origin: string): string => origin.replace(/\/$/, "");
+
+const readEnvValue = (
+	env: Record<string, string | undefined>,
+	keys: readonly string[],
+): string | undefined => {
+	for (const key of keys) {
+		const value = env[key]?.trim();
+		if (value) {
+			return value;
+		}
+	}
+	return undefined;
+};
+
+const getEnvMap = (): Record<string, string | undefined> =>
+	typeof process !== "undefined" && process.env
+		? (process.env as Record<string, string | undefined>)
+		: {};
+
+export const getFrontendTestOrigin = (env = getEnvMap()): string =>
+	normalizeOrigin(readEnvValue(env, ["FRONTEND_TEST_ORIGIN"]) ?? defaultFrontendOrigin);
+
+export const getRuntimeFrontendOrigin = (env = getEnvMap()): string =>
+	normalizeOrigin(
+		readEnvValue(env, ["FRONTEND_ORIGIN", "ORIGIN", "FRONTEND_URL"]) ?? defaultFrontendOrigin,
+	);
+
+export const getFrontendApiBase = (origin: string): string => `${normalizeOrigin(origin)}/api`;
+
+export const getFrontendTestApiBase = (env = getEnvMap()): string =>
+	getFrontendApiBase(getFrontendTestOrigin(env));
+
+export const getRuntimeFrontendApiBase = (env = getEnvMap()): string =>
+	getFrontendApiBase(getRuntimeFrontendOrigin(env));

--- a/frontend/src/lib/preferences-api.test.ts
+++ b/frontend/src/lib/preferences-api.test.ts
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { preferencesApi } from "./preferences-api";
 import { resetMockData } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
+import { testApiUrl } from "~/test/http-origin";
 
 describe("preferencesApi", () => {
 	beforeEach(() => {
@@ -13,7 +14,7 @@ describe("preferencesApi", () => {
 
 	it("REQ-FE-044: surfaces string detail on portable preference load failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/preferences/me", () =>
+			http.get(testApiUrl("/preferences/me"), () =>
 				HttpResponse.json({ detail: "Load failed" }, { status: 500 }),
 			),
 		);
@@ -23,7 +24,7 @@ describe("preferencesApi", () => {
 
 	it("REQ-FE-059: stringifies structured detail on portable preference update failure", async () => {
 		server.use(
-			http.patch("http://localhost:3000/api/preferences/me", () =>
+			http.patch(testApiUrl("/preferences/me"), () =>
 				HttpResponse.json({ detail: { field: "ui_theme" } }, { status: 422 }),
 			),
 		);
@@ -36,7 +37,7 @@ describe("preferencesApi", () => {
 	it("REQ-FE-059: falls back to status text when portable preference errors are not JSON", async () => {
 		server.use(
 			http.patch(
-				"http://localhost:3000/api/preferences/me",
+				testApiUrl("/preferences/me"),
 				() => new HttpResponse("boom", { status: 500, statusText: "Server Error" }),
 			),
 		);
@@ -48,7 +49,7 @@ describe("preferencesApi", () => {
 
 	it("REQ-FE-059: falls back to status text when portable preference detail is empty", async () => {
 		server.use(
-			http.patch("http://localhost:3000/api/preferences/me", () =>
+			http.patch(testApiUrl("/preferences/me"), () =>
 				HttpResponse.json({ detail: "" }, { status: 500, statusText: "Server Error" }),
 			),
 		);

--- a/frontend/src/lib/preferences-store.test.ts
+++ b/frontend/src/lib/preferences-store.test.ts
@@ -3,6 +3,7 @@
 // REQ-FE-059: Portable theme preferences with local fallback
 import { beforeEach, describe, expect, it } from "vitest";
 import { getPreferencePatches, resetMockData, seedPreferences } from "~/test/mocks/handlers";
+import { testApiUrl } from "~/test/http-origin";
 
 const resetUiState = async () => {
 	const { setLocale } = await import("./i18n");
@@ -124,7 +125,7 @@ describe("preferencesStore", () => {
 		const { server } = await import("~/test/mocks/server");
 		const { http, HttpResponse } = await import("msw");
 		server.use(
-			http.get("http://localhost:3000/api/preferences/me", () => {
+			http.get(testApiUrl("/preferences/me"), () => {
 				requestCount += 1;
 				return HttpResponse.json({ locale: "ja" });
 			}),
@@ -146,7 +147,7 @@ describe("preferencesStore", () => {
 		const { server } = await import("~/test/mocks/server");
 		const { http, HttpResponse } = await import("msw");
 		server.use(
-			http.get("http://localhost:3000/api/preferences/me", () => {
+			http.get(testApiUrl("/preferences/me"), () => {
 				requestCount += 1;
 				return HttpResponse.json({
 					ui_theme: "classic",
@@ -205,7 +206,7 @@ describe("preferencesStore", () => {
 		const { server } = await import("~/test/mocks/server");
 		const { http, HttpResponse, delay } = await import("msw");
 		server.use(
-			http.get("http://localhost:3000/api/preferences/me", async () => {
+			http.get(testApiUrl("/preferences/me"), async () => {
 				requestCount += 1;
 				await delay(50);
 				return HttpResponse.json({ selected_space_id: "space-remote" });

--- a/frontend/src/lib/search-store.test.ts
+++ b/frontend/src/lib/search-store.test.ts
@@ -6,6 +6,7 @@ import { createSearchStore } from "./search-store";
 import { resetMockData, seedEntry, seedSpace } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Entry, EntryRecord, Space } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 const testSpace: Space = {
 	id: "search-store-ws",
@@ -58,7 +59,7 @@ describe("createSearchStore", () => {
 
 	it("sets error on keyword search failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/search-store-ws/search", () =>
+			http.get(testApiUrl("/spaces/search-store-ws/search"), () =>
 				HttpResponse.json({ detail: "Server error" }, { status: 500 }),
 			),
 		);
@@ -72,7 +73,7 @@ describe("createSearchStore", () => {
 
 	it("sets error on query index failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/search-store-ws/query", () =>
+			http.post(testApiUrl("/spaces/search-store-ws/query"), () =>
 				HttpResponse.json({ detail: "Server error" }, { status: 500 }),
 			),
 		);

--- a/frontend/src/lib/space-store.test.ts
+++ b/frontend/src/lib/space-store.test.ts
@@ -14,6 +14,7 @@ import {
 } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Space } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -208,7 +209,7 @@ describe("createSpaceStore", () => {
 
 	it("should throw and set error on loadSpaces failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces", () =>
+			http.get(testApiUrl("/spaces"), () =>
 				HttpResponse.json({ detail: "Server error" }, { status: 500 }),
 			),
 		);

--- a/frontend/src/lib/sql-api.test.ts
+++ b/frontend/src/lib/sql-api.test.ts
@@ -5,6 +5,7 @@ import { sqlApi } from "./sql-api";
 import { resetMockData, seedSpace } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Space } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 const testSpace: Space = { id: "sql-ws", name: "SQL Space", created_at: "2025-01-01T00:00:00Z" };
 
@@ -21,7 +22,7 @@ describe("sqlApi", () => {
 
 	it("REQ-FE-054: sqlApi normalizes unix-second timestamps for saved queries", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/sql-ws/sql", () =>
+			http.get(testApiUrl("/spaces/sql-ws/sql"), () =>
 				HttpResponse.json([
 					{
 						id: "query-1",
@@ -68,7 +69,7 @@ describe("sqlApi", () => {
 
 	it("throws on list failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/sql-ws/sql", () =>
+			http.get(testApiUrl("/spaces/sql-ws/sql"), () =>
 				HttpResponse.json({ detail: "Server error" }, { status: 500 }),
 			),
 		);
@@ -77,7 +78,7 @@ describe("sqlApi", () => {
 
 	it("throws on get failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/sql-ws/sql/bad-id", () =>
+			http.get(testApiUrl("/spaces/sql-ws/sql/bad-id"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -86,7 +87,7 @@ describe("sqlApi", () => {
 
 	it("throws on create failure with detail", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/sql-ws/sql", () =>
+			http.post(testApiUrl("/spaces/sql-ws/sql"), () =>
 				HttpResponse.json({ detail: "Invalid SQL" }, { status: 422 }),
 			),
 		);
@@ -97,7 +98,7 @@ describe("sqlApi", () => {
 
 	it("throws on update failure with detail", async () => {
 		server.use(
-			http.put("http://localhost:3000/api/spaces/sql-ws/sql/bad-id", () =>
+			http.put(testApiUrl("/spaces/sql-ws/sql/bad-id"), () =>
 				HttpResponse.json({ detail: "Update failed" }, { status: 500 }),
 			),
 		);
@@ -106,7 +107,7 @@ describe("sqlApi", () => {
 
 	it("throws on delete failure", async () => {
 		server.use(
-			http.delete("http://localhost:3000/api/spaces/sql-ws/sql/bad-id", () =>
+			http.delete(testApiUrl("/spaces/sql-ws/sql/bad-id"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);

--- a/frontend/src/lib/sql-session-api.test.ts
+++ b/frontend/src/lib/sql-session-api.test.ts
@@ -5,6 +5,7 @@ import { sqlSessionApi } from "./sql-session-api";
 import { resetMockData, seedSpace } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Space } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 const testSpace: Space = {
 	id: "sess-ws",
@@ -47,7 +48,7 @@ describe("sqlSessionApi", () => {
 
 	it("REQ-FE-054: sqlSessionApi normalizes unix-second timestamps for session rows", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/sess-ws/sql-sessions/sess-1/rows", () =>
+			http.get(testApiUrl("/spaces/sess-ws/sql-sessions/sess-1/rows"), () =>
 				HttpResponse.json({
 					rows: [
 						{
@@ -73,7 +74,7 @@ describe("sqlSessionApi", () => {
 
 	it("throws on create failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/sess-ws/sql-sessions", () =>
+			http.post(testApiUrl("/spaces/sess-ws/sql-sessions"), () =>
 				HttpResponse.json({ detail: "Failed" }, { status: 500 }),
 			),
 		);
@@ -84,7 +85,7 @@ describe("sqlSessionApi", () => {
 
 	it("throws on get failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/sess-ws/sql-sessions/bad", () =>
+			http.get(testApiUrl("/spaces/sess-ws/sql-sessions/bad"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -93,7 +94,7 @@ describe("sqlSessionApi", () => {
 
 	it("throws on count failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/sess-ws/sql-sessions/bad/count", () =>
+			http.get(testApiUrl("/spaces/sess-ws/sql-sessions/bad/count"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
@@ -104,7 +105,7 @@ describe("sqlSessionApi", () => {
 
 	it("throws on rows failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/sess-ws/sql-sessions/bad/rows", () =>
+			http.get(testApiUrl("/spaces/sess-ws/sql-sessions/bad/rows"), () =>
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);

--- a/frontend/src/lib/store.test.ts
+++ b/frontend/src/lib/store.test.ts
@@ -6,6 +6,7 @@ import { createEntryStore } from "./entry-store";
 import { resetMockData, seedSpace, seedEntry } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Entry, EntryRecord } from "./types";
+import { testApiUrl } from "~/test/http-origin";
 
 const space = { id: "es-ws", name: "Entry Store Space", created_at: "2025-01-01T00:00:00Z" };
 
@@ -27,7 +28,7 @@ describe("createEntryStore", () => {
 
 	it("sets error on load failure", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/es-ws/entries", () =>
+			http.get(testApiUrl("/spaces/es-ws/entries"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -51,7 +52,7 @@ describe("createEntryStore", () => {
 
 	it("sets error on create failure", async () => {
 		server.use(
-			http.post("http://localhost:3000/api/spaces/es-ws/entries", () =>
+			http.post(testApiUrl("/spaces/es-ws/entries"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -83,7 +84,7 @@ describe("createEntryStore", () => {
 			await store.createEntry("# Entry To Fail");
 			const entry = store.entries()[0];
 			server.use(
-				http.put(`http://localhost:3000/api/spaces/es-ws/entries/${entry.id}`, () =>
+				http.put(testApiUrl(`/spaces/es-ws/entries/${entry.id}`), () =>
 					HttpResponse.json({ detail: "Error" }, { status: 500 }),
 				),
 			);
@@ -114,7 +115,7 @@ describe("createEntryStore", () => {
 			await store.createEntry("# Entry");
 			const entry = store.entries()[0];
 			server.use(
-				http.delete(`http://localhost:3000/api/spaces/es-ws/entries/${entry.id}`, () =>
+				http.delete(testApiUrl(`/spaces/es-ws/entries/${entry.id}`), () =>
 					HttpResponse.json({ detail: "Error" }, { status: 500 }),
 				),
 			);
@@ -163,7 +164,7 @@ describe("createEntryStore", () => {
 
 	it("throws on search failure and sets error", async () => {
 		server.use(
-			http.get("http://localhost:3000/api/spaces/es-ws/search", () =>
+			http.get(testApiUrl("/spaces/es-ws/search"), () =>
 				HttpResponse.json({ detail: "Error" }, { status: 500 }),
 			),
 		);
@@ -195,7 +196,7 @@ describe("createEntryStore", () => {
 			const entry = store.entries()[0];
 			store.selectEntry(entry.id);
 			server.use(
-				http.put(`http://localhost:3000/api/spaces/es-ws/entries/${entry.id}`, () =>
+				http.put(testApiUrl(`/spaces/es-ws/entries/${entry.id}`), () =>
 					HttpResponse.json(
 						{ detail: "Revision conflict", revision_id: "server-rev" },
 						{ status: 409 },
@@ -247,7 +248,7 @@ describe("createEntryStore", () => {
 			const r2 = await store.createEntry("# Entry Two");
 			store.selectEntry(r2.id);
 			server.use(
-				http.put(`http://localhost:3000/api/spaces/es-ws/entries/${r1.id}`, () =>
+				http.put(testApiUrl(`/spaces/es-ws/entries/${r1.id}`), () =>
 					HttpResponse.json({ detail: "Conflict", revision_id: "server-rev" }, { status: 409 }),
 				),
 			);

--- a/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
@@ -12,6 +12,7 @@ import { createMemo, createSignal } from "solid-js";
 import type { Form } from "~/lib/types";
 import { server } from "~/test/mocks/server";
 import { setLocale } from "~/lib/i18n";
+import { testApiUrl } from "~/test/http-origin";
 
 const navigateMock = vi.fn();
 const searchParamsMock: Record<string, string> = {};
@@ -123,7 +124,7 @@ describe("/spaces/:space_id/entries", () => {
 	it("REQ-FE-054: renders human-readable updated dates for query result cards", async () => {
 		searchParamsMock.session = "session-1";
 		server.use(
-			http.get("http://localhost:3000/api/spaces/default/sql-sessions/session-1", () =>
+			http.get(testApiUrl("/spaces/default/sql-sessions/session-1"), () =>
 				HttpResponse.json({
 					id: "session-1",
 					space_id: "default",
@@ -134,7 +135,7 @@ describe("/spaces/:space_id/entries", () => {
 					expires_at: "2026-03-01T01:00:00Z",
 				}),
 			),
-			http.get("http://localhost:3000/api/spaces/default/sql-sessions/session-1/rows", () =>
+			http.get(testApiUrl("/spaces/default/sql-sessions/session-1/rows"), () =>
 				HttpResponse.json({
 					rows: [
 						{

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -6,6 +6,7 @@ import SpaceSearchRoute from "./search";
 import { resetMockData, seedEntry, seedForm, seedSpace, seedSqlEntry } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Entry, EntryRecord, Form, Space } from "~/lib/types";
+import { testApiUrl } from "~/test/http-origin";
 
 const navigateMock = vi.fn();
 
@@ -76,17 +77,15 @@ describe("/spaces/:space_id/search", () => {
 		seedEntry("default", entry, record);
 		let metadataSql: string | null = null;
 		server.use(
-			http.get("http://localhost:3000/api/spaces/default/search", () =>
-				HttpResponse.json([{ id: entry.id }]),
-			),
+			http.get(testApiUrl("/spaces/default/search"), () => HttpResponse.json([{ id: entry.id }])),
 			http.get(
-				"http://localhost:3000/api/spaces/default/entries",
+				testApiUrl("/spaces/default/entries"),
 				() =>
 					new HttpResponse("bulk entry list should not be used for keyword search", {
 						status: 500,
 					}),
 			),
-			http.post("http://localhost:3000/api/spaces/default/sql-sessions", async ({ request }) => {
+			http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
 				const body = (await request.json()) as { sql?: string };
 				metadataSql = body.sql ?? null;
 				return HttpResponse.json(
@@ -94,7 +93,7 @@ describe("/spaces/:space_id/search", () => {
 					{ status: 201 },
 				);
 			}),
-			http.get("http://localhost:3000/api/spaces/default/sql-sessions/keyword-session/rows", () =>
+			http.get(testApiUrl("/spaces/default/sql-sessions/keyword-session/rows"), () =>
 				HttpResponse.json({
 					rows: [record],
 					offset: 0,
@@ -131,11 +130,11 @@ describe("/spaces/:space_id/search", () => {
 		let sessionSqlBody: { sql?: string } | null = null;
 
 		server.use(
-			http.post("http://localhost:3000/api/spaces/default/sql", async ({ request }) => {
+			http.post(testApiUrl("/spaces/default/sql"), async ({ request }) => {
 				savedSqlBody = (await request.json()) as { name?: string; sql?: string };
 				return HttpResponse.json({ id: "saved-search-1", revision_id: "rev-2" }, { status: 201 });
 			}),
-			http.post("http://localhost:3000/api/spaces/default/sql-sessions", async ({ request }) => {
+			http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
 				sessionSqlBody = (await request.json()) as { sql?: string };
 				return HttpResponse.json(
 					{ id: "advanced-session", status: "ready", error: null },
@@ -199,7 +198,7 @@ describe("/spaces/:space_id/search", () => {
 
 		let sessionSqlBody: { sql?: string } | null = null;
 		server.use(
-			http.post("http://localhost:3000/api/spaces/default/sql-sessions", async ({ request }) => {
+			http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
 				sessionSqlBody = (await request.json()) as { sql?: string };
 				return HttpResponse.json(
 					{ id: "history-session", status: "ready", error: null },

--- a/frontend/src/test/http-origin.ts
+++ b/frontend/src/test/http-origin.ts
@@ -1,0 +1,15 @@
+import { getFrontendTestApiBase, getFrontendTestOrigin } from "~/lib/frontend-origin";
+
+export const getConfiguredFrontendTestOrigin = (): string => getFrontendTestOrigin();
+
+export const getConfiguredFrontendTestApiBase = (): string => getFrontendTestApiBase();
+
+const normalizeTestPath = (path = "/"): string => (path.startsWith("/") ? path : `/${path}`);
+
+export const testApiPath = (path = "/"): string => `/api${normalizeTestPath(path)}`;
+
+export const testApiUrl = (path = "/"): string =>
+	`${getConfiguredFrontendTestApiBase()}${normalizeTestPath(path)}`;
+
+export const testAppUrl = (path = "/"): string =>
+	`${getConfiguredFrontendTestOrigin()}${normalizeTestPath(path)}`;

--- a/frontend/src/test/mocks/handlers.test.ts
+++ b/frontend/src/test/mocks/handlers.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { testApiUrl } from "~/test/http-origin";
+import { resetMockData, seedDevAuthConfig } from "./handlers";
+
+describe("MSW handlers", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("REQ-OPS-015: MSW handlers honor FRONTEND_TEST_ORIGIN", async () => {
+		vi.stubEnv("FRONTEND_TEST_ORIGIN", "http://127.0.0.1:4310");
+		resetMockData();
+		seedDevAuthConfig({
+			mode: "mock-oauth",
+			username_hint: "dev-oauth-user",
+			supports_passkey_totp: false,
+			supports_mock_oauth: true,
+		});
+
+		const response = await fetch(testApiUrl("/auth/config"));
+		const payload = (await response.json()) as { mode: string; username_hint: string };
+
+		expect(response.ok).toBe(true);
+		expect(payload).toMatchObject({
+			mode: "mock-oauth",
+			username_hint: "dev-oauth-user",
+		});
+	});
+});

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,4 +1,11 @@
-import { http, HttpResponse } from "msw";
+import {
+	http,
+	HttpResponse,
+	matchRequestUrl,
+	type HttpResponseResolver,
+	type PathParams,
+} from "msw";
+import { testApiPath } from "~/test/http-origin";
 import type {
 	Asset,
 	Entry,
@@ -37,6 +44,41 @@ let preferencePatches: UserPreferencesPatchPayload[] = [];
 let revisionCounter = 0;
 
 const generateRevisionId = () => `rev-${++revisionCounter}`;
+
+const createTestApiPredicate = <Params extends PathParams = PathParams>(path: string) => {
+	const testApiPathname = testApiPath(path);
+	return ({ request }: { request: Request }) => {
+		const requestUrl = new URL(request.url);
+		const match = matchRequestUrl(requestUrl, testApiPathname, requestUrl.origin);
+		return {
+			matches: match.matches,
+			params: match.params as Params,
+		};
+	};
+};
+
+const testHttp = {
+	get: <Params extends PathParams = PathParams>(
+		path: string,
+		resolver: HttpResponseResolver<Params>,
+	) => http.get<Params>(createTestApiPredicate<Params>(path), resolver),
+	post: <Params extends PathParams = PathParams>(
+		path: string,
+		resolver: HttpResponseResolver<Params>,
+	) => http.post<Params>(createTestApiPredicate<Params>(path), resolver),
+	put: <Params extends PathParams = PathParams>(
+		path: string,
+		resolver: HttpResponseResolver<Params>,
+	) => http.put<Params>(createTestApiPredicate<Params>(path), resolver),
+	patch: <Params extends PathParams = PathParams>(
+		path: string,
+		resolver: HttpResponseResolver<Params>,
+	) => http.patch<Params>(createTestApiPredicate<Params>(path), resolver),
+	delete: <Params extends PathParams = PathParams>(
+		path: string,
+		resolver: HttpResponseResolver<Params>,
+	) => http.delete<Params>(createTestApiPredicate<Params>(path), resolver),
+};
 
 // Reset function for tests
 export const resetMockData = () => {
@@ -121,11 +163,11 @@ export const seedDevAuthConfig = (
 export const getPreferencePatches = () => preferencePatches.slice();
 
 export const handlers = [
-	http.get("http://localhost:3000/api/auth/config", () => {
+	testHttp.get("/auth/config", () => {
 		return HttpResponse.json(mockDevAuthConfig);
 	}),
 
-	http.post("http://localhost:3000/api/auth/login", async ({ request }) => {
+	testHttp.post("/auth/login", async ({ request }) => {
 		const body = (await request.json()) as { username?: string; totp_code?: string };
 		if (
 			mockDevAuthConfig.mode !== "passkey-totp" ||
@@ -141,7 +183,7 @@ export const handlers = [
 		});
 	}),
 
-	http.post("http://localhost:3000/api/auth/mock-oauth", () => {
+	testHttp.post("/auth/mock-oauth", () => {
 		if (mockDevAuthConfig.mode !== "mock-oauth") {
 			return HttpResponse.json(
 				{ detail: "mock-oauth login is not enabled for this session." },
@@ -155,11 +197,11 @@ export const handlers = [
 		});
 	}),
 
-	http.get("http://localhost:3000/api/preferences/me", () => {
+	testHttp.get("/preferences/me", () => {
 		return HttpResponse.json(mockPreferences);
 	}),
 
-	http.patch("http://localhost:3000/api/preferences/me", async ({ request }) => {
+	testHttp.patch("/preferences/me", async ({ request }) => {
 		const body = (await request.json()) as UserPreferencesPatchPayload;
 		preferencePatches.push(body);
 		mockPreferences = {
@@ -170,13 +212,13 @@ export const handlers = [
 	}),
 
 	// List spaces
-	http.get("http://localhost:3000/api/spaces", () => {
+	testHttp.get("/spaces", () => {
 		const spaces = Array.from(mockSpaces.values());
 		return HttpResponse.json(spaces);
 	}),
 
 	// Create space
-	http.post("http://localhost:3000/api/spaces", async ({ request }) => {
+	testHttp.post("/spaces", async ({ request }) => {
 		const body = (await request.json()) as { name: string };
 		const id = body.name;
 
@@ -199,7 +241,7 @@ export const handlers = [
 	}),
 
 	// List forms
-	http.get("http://localhost:3000/api/spaces/:spaceId/forms", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/forms", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -209,7 +251,7 @@ export const handlers = [
 	}),
 
 	// List form types (must be before forms/:formName to avoid capture)
-	http.get("http://localhost:3000/api/spaces/:spaceId/forms/types", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/forms/types", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -218,7 +260,7 @@ export const handlers = [
 	}),
 
 	// Get form
-	http.get("http://localhost:3000/api/spaces/:spaceId/forms/:formName", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/forms/:formName", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const formName = params.formName as string;
 		if (!mockSpaces.has(spaceId)) {
@@ -232,7 +274,7 @@ export const handlers = [
 	}),
 
 	// Create form
-	http.post("http://localhost:3000/api/spaces/:spaceId/forms", async ({ params, request }) => {
+	testHttp.post("/spaces/:spaceId/forms", async ({ params, request }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -250,7 +292,7 @@ export const handlers = [
 	}),
 
 	// Get space
-	http.get("http://localhost:3000/api/spaces/:spaceId", ({ params }) => {
+	testHttp.get("/spaces/:spaceId", ({ params }) => {
 		const space = mockSpaces.get(params.spaceId as string);
 		if (!space) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -259,7 +301,7 @@ export const handlers = [
 	}),
 
 	// Patch space
-	http.patch("http://localhost:3000/api/spaces/:spaceId", async ({ params, request }) => {
+	testHttp.patch("/spaces/:spaceId", async ({ params, request }) => {
 		const spaceId = params.spaceId as string;
 		const space = mockSpaces.get(spaceId);
 		if (!space) {
@@ -277,23 +319,20 @@ export const handlers = [
 	}),
 
 	// Test connection
-	http.post(
-		"http://localhost:3000/api/spaces/:spaceId/test-connection",
-		async ({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			if (!mockSpaces.has(spaceId)) {
-				return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
-			}
-			const body = (await request.json()) as { storage_config?: { uri?: string } };
-			if (!body.storage_config?.uri) {
-				return HttpResponse.json({ detail: "Missing uri" }, { status: 400 });
-			}
-			return HttpResponse.json({ status: "ok" });
-		},
-	),
+	testHttp.post("/spaces/:spaceId/test-connection", async ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		if (!mockSpaces.has(spaceId)) {
+			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
+		}
+		const body = (await request.json()) as { storage_config?: { uri?: string } };
+		if (!body.storage_config?.uri) {
+			return HttpResponse.json({ detail: "Missing uri" }, { status: 400 });
+		}
+		return HttpResponse.json({ status: "ok" });
+	}),
 
 	// List entries in space
-	http.get("http://localhost:3000/api/spaces/:spaceId/entries", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/entries", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -303,7 +342,7 @@ export const handlers = [
 	}),
 
 	// Create entry
-	http.post("http://localhost:3000/api/spaces/:spaceId/entries", async ({ params, request }) => {
+	testHttp.post("/spaces/:spaceId/entries", async ({ params, request }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -354,7 +393,7 @@ export const handlers = [
 	}),
 
 	// Get entry
-	http.get("http://localhost:3000/api/spaces/:spaceId/entries/:entryId", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/entries/:entryId", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const entryId = params.entryId as string;
 
@@ -366,75 +405,72 @@ export const handlers = [
 	}),
 
 	// Update entry
-	http.put(
-		"http://localhost:3000/api/spaces/:spaceId/entries/:entryId",
-		async ({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			const entryId = params.entryId as string;
+	testHttp.put("/spaces/:spaceId/entries/:entryId", async ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		const entryId = params.entryId as string;
 
-			const entry = mockEntries.get(spaceId)?.get(entryId);
-			if (!entry) {
-				return HttpResponse.json({ detail: "Entry not found" }, { status: 404 });
+		const entry = mockEntries.get(spaceId)?.get(entryId);
+		if (!entry) {
+			return HttpResponse.json({ detail: "Entry not found" }, { status: 404 });
+		}
+
+		const body = (await request.json()) as EntryUpdatePayload;
+
+		// Check revision (optimistic concurrency)
+		if (body.parent_revision_id !== entry.revision_id) {
+			return HttpResponse.json(
+				{
+					detail: "Revision mismatch",
+					current_revision_id: entry.revision_id,
+				},
+				{ status: 409 },
+			);
+		}
+
+		const newRevisionId = generateRevisionId();
+		const now = new Date().toISOString();
+
+		// Extract title from markdown
+		const titleMatch = body.markdown.match(/^#\s+(.+)$/m);
+		const title = titleMatch ? titleMatch[1] : body.markdown.split("\n")[0] || "Untitled";
+
+		// Extract properties from H2 headers
+		const properties: Record<string, string> = {};
+		const h2Regex = /^##\s+(.+)\n([\s\S]*?)(?=^##\s|$(?![\r\n]))/gm;
+		for (const match of body.markdown.matchAll(h2Regex)) {
+			const key = match[1].trim();
+			const value = match[2].trim();
+			properties[key] = value;
+		}
+
+		// Update entry
+		entry.content = body.markdown;
+		entry.revision_id = newRevisionId;
+		entry.updated_at = now;
+		entry.assets = body.assets ?? entry.assets ?? [];
+
+		// Update index
+		const record = mockEntryIndex.get(spaceId)?.get(entryId);
+		if (record) {
+			record.title = title;
+			record.updated_at = now;
+			record.properties = properties;
+			if (body.canvas_position) {
+				record.canvas_position = body.canvas_position;
 			}
-
-			const body = (await request.json()) as EntryUpdatePayload;
-
-			// Check revision (optimistic concurrency)
-			if (body.parent_revision_id !== entry.revision_id) {
-				return HttpResponse.json(
-					{
-						detail: "Revision mismatch",
-						current_revision_id: entry.revision_id,
-					},
-					{ status: 409 },
-				);
+			if (body.assets) {
+				record.assets = body.assets;
 			}
+		}
 
-			const newRevisionId = generateRevisionId();
-			const now = new Date().toISOString();
-
-			// Extract title from markdown
-			const titleMatch = body.markdown.match(/^#\s+(.+)$/m);
-			const title = titleMatch ? titleMatch[1] : body.markdown.split("\n")[0] || "Untitled";
-
-			// Extract properties from H2 headers
-			const properties: Record<string, string> = {};
-			const h2Regex = /^##\s+(.+)\n([\s\S]*?)(?=^##\s|$(?![\r\n]))/gm;
-			for (const match of body.markdown.matchAll(h2Regex)) {
-				const key = match[1].trim();
-				const value = match[2].trim();
-				properties[key] = value;
-			}
-
-			// Update entry
-			entry.content = body.markdown;
-			entry.revision_id = newRevisionId;
-			entry.updated_at = now;
-			entry.assets = body.assets ?? entry.assets ?? [];
-
-			// Update index
-			const record = mockEntryIndex.get(spaceId)?.get(entryId);
-			if (record) {
-				record.title = title;
-				record.updated_at = now;
-				record.properties = properties;
-				if (body.canvas_position) {
-					record.canvas_position = body.canvas_position;
-				}
-				if (body.assets) {
-					record.assets = body.assets;
-				}
-			}
-
-			return HttpResponse.json({
-				id: entryId,
-				revision_id: newRevisionId,
-			});
-		},
-	),
+		return HttpResponse.json({
+			id: entryId,
+			revision_id: newRevisionId,
+		});
+	}),
 
 	// Delete entry
-	http.delete("http://localhost:3000/api/spaces/:spaceId/entries/:entryId", ({ params }) => {
+	testHttp.delete("/spaces/:spaceId/entries/:entryId", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const entryId = params.entryId as string;
 
@@ -449,7 +485,7 @@ export const handlers = [
 	}),
 
 	// Query entries
-	http.post("http://localhost:3000/api/spaces/:spaceId/query", async ({ params, request }) => {
+	testHttp.post("/spaces/:spaceId/query", async ({ params, request }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -471,7 +507,7 @@ export const handlers = [
 	}),
 
 	// Search entries
-	http.get("http://localhost:3000/api/spaces/:spaceId/search", ({ params, request }) => {
+	testHttp.get("/spaces/:spaceId/search", ({ params, request }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -490,7 +526,7 @@ export const handlers = [
 	}),
 
 	// Upload asset
-	http.post("http://localhost:3000/api/spaces/:spaceId/assets", async ({ params }) => {
+	testHttp.post("/spaces/:spaceId/assets", async ({ params }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -506,7 +542,7 @@ export const handlers = [
 	}),
 
 	// Delete asset
-	http.delete("http://localhost:3000/api/spaces/:spaceId/assets/:assetId", ({ params }) => {
+	testHttp.delete("/spaces/:spaceId/assets/:assetId", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const assetId = params.assetId as string;
 		const store = mockAssets.get(spaceId);
@@ -527,7 +563,7 @@ export const handlers = [
 	}),
 
 	// List assets
-	http.get("http://localhost:3000/api/spaces/:spaceId/assets", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/assets", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId)) {
 			return HttpResponse.json({ detail: "Space not found" }, { status: 404 });
@@ -537,7 +573,7 @@ export const handlers = [
 	}),
 
 	// Entry history
-	http.get("http://localhost:3000/api/spaces/:spaceId/entries/:entryId/history", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/entries/:entryId/history", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const entryId = params.entryId as string;
 		const entry = mockEntries.get(spaceId)?.get(entryId);
@@ -550,51 +586,45 @@ export const handlers = [
 	}),
 
 	// Get specific revision
-	http.get(
-		"http://localhost:3000/api/spaces/:spaceId/entries/:entryId/history/:revisionId",
-		({ params }) => {
-			const spaceId = params.spaceId as string;
-			const entryId = params.entryId as string;
-			const revisionId = params.revisionId as string;
-			const entry = mockEntries.get(spaceId)?.get(entryId);
-			if (!entry || entry.revision_id !== revisionId) {
-				return HttpResponse.json({ detail: "Revision not found" }, { status: 404 });
-			}
-			return HttpResponse.json(entry);
-		},
-	),
+	testHttp.get("/spaces/:spaceId/entries/:entryId/history/:revisionId", ({ params }) => {
+		const spaceId = params.spaceId as string;
+		const entryId = params.entryId as string;
+		const revisionId = params.revisionId as string;
+		const entry = mockEntries.get(spaceId)?.get(entryId);
+		if (!entry || entry.revision_id !== revisionId) {
+			return HttpResponse.json({ detail: "Revision not found" }, { status: 404 });
+		}
+		return HttpResponse.json(entry);
+	}),
 
 	// Restore entry
-	http.post(
-		"http://localhost:3000/api/spaces/:spaceId/entries/:entryId/restore",
-		async ({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			const entryId = params.entryId as string;
-			const entry = mockEntries.get(spaceId)?.get(entryId);
-			if (!entry) {
-				return HttpResponse.json({ detail: "Entry not found" }, { status: 404 });
-			}
-			const _body = (await request.json()) as { revision_id: string };
-			const newRevisionId = generateRevisionId();
-			entry.revision_id = newRevisionId;
-			return HttpResponse.json({ ...entry, revision_id: newRevisionId });
-		},
-	),
+	testHttp.post("/spaces/:spaceId/entries/:entryId/restore", async ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		const entryId = params.entryId as string;
+		const entry = mockEntries.get(spaceId)?.get(entryId);
+		if (!entry) {
+			return HttpResponse.json({ detail: "Entry not found" }, { status: 404 });
+		}
+		const _body = (await request.json()) as { revision_id: string };
+		const newRevisionId = generateRevisionId();
+		entry.revision_id = newRevisionId;
+		return HttpResponse.json({ ...entry, revision_id: newRevisionId });
+	}),
 
 	// SQL CRUD
-	http.get("http://localhost:3000/api/spaces/:spaceId/sql", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/sql", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const entries = Array.from(mockSqlEntries.get(spaceId)?.values() || []);
 		return HttpResponse.json(entries);
 	}),
-	http.get("http://localhost:3000/api/spaces/:spaceId/sql/:sqlId", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/sql/:sqlId", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const sqlId = params.sqlId as string;
 		const entry = mockSqlEntries.get(spaceId)?.get(sqlId);
 		if (!entry) return HttpResponse.json({ detail: "Not found" }, { status: 404 });
 		return HttpResponse.json(entry);
 	}),
-	http.post("http://localhost:3000/api/spaces/:spaceId/sql", async ({ params, request }) => {
+	testHttp.post("/spaces/:spaceId/sql", async ({ params, request }) => {
 		const spaceId = params.spaceId as string;
 		const body = (await request.json()) as { name: string; sql: string; variables?: string[] };
 		const id = crypto.randomUUID();
@@ -610,7 +640,7 @@ export const handlers = [
 		mockSqlEntries.get(spaceId)?.set(id, entry);
 		return HttpResponse.json({ id, revision_id: revisionId }, { status: 201 });
 	}),
-	http.put("http://localhost:3000/api/spaces/:spaceId/sql/:sqlId", async ({ params, request }) => {
+	testHttp.put("/spaces/:spaceId/sql/:sqlId", async ({ params, request }) => {
 		const spaceId = params.spaceId as string;
 		const sqlId = params.sqlId as string;
 		const entry = mockSqlEntries.get(spaceId)?.get(sqlId);
@@ -620,7 +650,7 @@ export const handlers = [
 		const revisionId = generateRevisionId();
 		return HttpResponse.json({ id: sqlId, revision_id: revisionId });
 	}),
-	http.delete("http://localhost:3000/api/spaces/:spaceId/sql/:sqlId", ({ params }) => {
+	testHttp.delete("/spaces/:spaceId/sql/:sqlId", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const sqlId = params.sqlId as string;
 		const store = mockSqlEntries.get(spaceId);
@@ -631,107 +661,89 @@ export const handlers = [
 	}),
 
 	// SQL Sessions
-	http.post(
-		"http://localhost:3000/api/spaces/:spaceId/sql-sessions",
-		async ({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			const body = (await request.json()) as { sql: string };
-			const id = crypto.randomUUID();
-			const session = {
-				id,
-				sql: body.sql,
-				status: "ready",
-				error: null,
-				created_at: new Date().toISOString(),
-			};
-			if (!mockSqlSessions.has(spaceId)) mockSqlSessions.set(spaceId, new Map());
-			mockSqlSessions.get(spaceId)?.set(id, session);
-			return HttpResponse.json(session, { status: 201 });
-		},
-	),
-	http.get("http://localhost:3000/api/spaces/:spaceId/sql-sessions/:sessionId", ({ params }) => {
+	testHttp.post("/spaces/:spaceId/sql-sessions", async ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		const body = (await request.json()) as { sql: string };
+		const id = crypto.randomUUID();
+		const session = {
+			id,
+			sql: body.sql,
+			status: "ready",
+			error: null,
+			created_at: new Date().toISOString(),
+		};
+		if (!mockSqlSessions.has(spaceId)) mockSqlSessions.set(spaceId, new Map());
+		mockSqlSessions.get(spaceId)?.set(id, session);
+		return HttpResponse.json(session, { status: 201 });
+	}),
+	testHttp.get("/spaces/:spaceId/sql-sessions/:sessionId", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		const sessionId = params.sessionId as string;
 		const session = mockSqlSessions.get(spaceId)?.get(sessionId);
 		if (!session) return HttpResponse.json({ detail: "Not found" }, { status: 404 });
 		return HttpResponse.json(session);
 	}),
-	http.get(
-		"http://localhost:3000/api/spaces/:spaceId/sql-sessions/:sessionId/count",
-		({ params }) => {
-			const spaceId = params.spaceId as string;
-			const sessionId = params.sessionId as string;
-			if (!mockSqlSessions.get(spaceId)?.has(sessionId))
-				return HttpResponse.json({ detail: "Not found" }, { status: 404 });
-			return HttpResponse.json({ count: 3 });
-		},
-	),
-	http.get(
-		"http://localhost:3000/api/spaces/:spaceId/sql-sessions/:sessionId/rows",
-		({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			const sessionId = params.sessionId as string;
-			if (!mockSqlSessions.get(spaceId)?.has(sessionId))
-				return HttpResponse.json({ detail: "Not found" }, { status: 404 });
-			const url = new URL(request.url);
-			const offset = Number(url.searchParams.get("offset") || 0);
-			const limit = Number(url.searchParams.get("limit") || 25);
-			return HttpResponse.json({ rows: [], offset, limit, total_count: 3 });
-		},
-	),
+	testHttp.get("/spaces/:spaceId/sql-sessions/:sessionId/count", ({ params }) => {
+		const spaceId = params.spaceId as string;
+		const sessionId = params.sessionId as string;
+		if (!mockSqlSessions.get(spaceId)?.has(sessionId))
+			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+		return HttpResponse.json({ count: 3 });
+	}),
+	testHttp.get("/spaces/:spaceId/sql-sessions/:sessionId/rows", ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		const sessionId = params.sessionId as string;
+		if (!mockSqlSessions.get(spaceId)?.has(sessionId))
+			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+		const url = new URL(request.url);
+		const offset = Number(url.searchParams.get("offset") || 0);
+		const limit = Number(url.searchParams.get("limit") || 25);
+		return HttpResponse.json({ rows: [], offset, limit, total_count: 3 });
+	}),
 
 	// Space Members
-	http.get("http://localhost:3000/api/spaces/:spaceId/members", ({ params }) => {
+	testHttp.get("/spaces/:spaceId/members", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId))
 			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
 		return HttpResponse.json([]);
 	}),
-	http.post(
-		"http://localhost:3000/api/spaces/:spaceId/members/invitations",
-		async ({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			if (!mockSpaces.has(spaceId))
-				return HttpResponse.json({ detail: "Not found" }, { status: 404 });
-			const body = (await request.json()) as { user_id: string; role: string };
-			return HttpResponse.json(
-				{
-					invitation: {
-						token: "test-token",
-						user_id: body.user_id,
-						role: body.role,
-						state: "pending",
-					},
+	testHttp.post("/spaces/:spaceId/members/invitations", async ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		if (!mockSpaces.has(spaceId))
+			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+		const body = (await request.json()) as { user_id: string; role: string };
+		return HttpResponse.json(
+			{
+				invitation: {
+					token: "test-token",
+					user_id: body.user_id,
+					role: body.role,
+					state: "pending",
 				},
-				{ status: 201 },
-			);
-		},
-	),
-	http.post(
-		"http://localhost:3000/api/spaces/:spaceId/members/accept",
-		async ({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			if (!mockSpaces.has(spaceId))
-				return HttpResponse.json({ detail: "Not found" }, { status: 404 });
-			const body = (await request.json()) as { token: string; user_id: string };
-			return HttpResponse.json({
-				member: { user_id: body.user_id, role: "editor", state: "active" },
-			});
-		},
-	),
-	http.post(
-		"http://localhost:3000/api/spaces/:spaceId/members/:userId/role",
-		async ({ params, request }) => {
-			const spaceId = params.spaceId as string;
-			if (!mockSpaces.has(spaceId))
-				return HttpResponse.json({ detail: "Not found" }, { status: 404 });
-			const body = (await request.json()) as { role: string };
-			return HttpResponse.json({
-				member: { user_id: params.userId, role: body.role, state: "active" },
-			});
-		},
-	),
-	http.delete("http://localhost:3000/api/spaces/:spaceId/members/:userId", ({ params }) => {
+			},
+			{ status: 201 },
+		);
+	}),
+	testHttp.post("/spaces/:spaceId/members/accept", async ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		if (!mockSpaces.has(spaceId))
+			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+		const body = (await request.json()) as { token: string; user_id: string };
+		return HttpResponse.json({
+			member: { user_id: body.user_id, role: "editor", state: "active" },
+		});
+	}),
+	testHttp.post("/spaces/:spaceId/members/:userId/role", async ({ params, request }) => {
+		const spaceId = params.spaceId as string;
+		if (!mockSpaces.has(spaceId))
+			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+		const body = (await request.json()) as { role: string };
+		return HttpResponse.json({
+			member: { user_id: params.userId, role: body.role, state: "active" },
+		});
+	}),
+	testHttp.delete("/spaces/:spaceId/members/:userId", ({ params }) => {
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId))
 			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
@@ -739,7 +751,7 @@ export const handlers = [
 	}),
 
 	// Root API endpoint (used by HelloWorld)
-	http.get("http://localhost:3000/api/", () => {
+	testHttp.get("/", () => {
 		return HttpResponse.json({ message: "Hello from mock backend!" });
 	}),
 ];

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,15 +1,21 @@
 import { defineConfig } from "vitest/config";
 import solidPlugin from "vite-plugin-solid";
 
+const frontendTestOrigin = process.env.FRONTEND_TEST_ORIGIN ?? "http://localhost:3000";
+
 export default defineConfig({
 	plugins: [solidPlugin() as never],
 	define: {
 		"process.env.NODE_ENV": JSON.stringify("test"),
+		"process.env.FRONTEND_TEST_ORIGIN": JSON.stringify(frontendTestOrigin),
 	},
 	test: {
 		environment: "jsdom",
 		globals: true,
 		setupFiles: ["./src/test/setup.ts"],
+		env: {
+			FRONTEND_TEST_ORIGIN: frontendTestOrigin,
+		},
 		include: ["src/**/*.{test,spec}.{js,ts,tsx}"],
 		testTimeout: 10000,
 		coverage: {


### PR DESCRIPTION
## Summary

- centralize frontend test origin helpers for frontend tests and MSW routing
- make shared MSW handlers match `/api/...` lazily so per-test `FRONTEND_TEST_ORIGIN` overrides work without re-importing the handler table
- keep REQ-OPS-015 coverage around configurable frontend test origins

## Related Issue (required)

closes #1140

## Testing

- [ ] `mise run test`
- [x] `cd frontend && bun run test:run --coverage`
- [x] `cd frontend && bun run build`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -W error`
