### PR TITLE
fix: stop public routes from hitting portable preferences API

### DIFF
--- a/e2e/public-pages.test.ts
+++ b/e2e/public-pages.test.ts
@@ -14,15 +14,12 @@ test.describe("Public page stability", () => {
 		});
 		try {
 			const page = await context.newPage();
-			const failingPreferenceRequests: string[] = [];
+			const preferenceRequests: string[] = [];
 			const consoleErrors: string[] = [];
 
-			page.on("response", (response) => {
-				if (
-					response.url().includes("/api/preferences/me") &&
-					response.status() >= 400
-				) {
-					failingPreferenceRequests.push(`${response.status()} ${response.url()}`);
+			page.on("request", (request) => {
+				if (request.url().includes("/api/preferences/me")) {
+					preferenceRequests.push(`${request.method()} ${request.url()}`);
 				}
 			});
 			page.on("console", (message) => {
@@ -36,7 +33,7 @@ test.describe("Public page stability", () => {
 				await page.waitForLoadState("networkidle");
 			}
 
-			expect(failingPreferenceRequests).toEqual([]);
+			expect(preferenceRequests).toEqual([]);
 			expect(consoleErrors).toEqual([]);
 		} finally {
 			await context.close();

--- a/frontend/src/lib/preferences-store.test.ts
+++ b/frontend/src/lib/preferences-store.test.ts
@@ -161,7 +161,9 @@ describe("preferencesStore", () => {
 
 		const { initializePortablePreferencesForPath } = await import("./preferences-store");
 		const { colorMode, primaryColor, uiTheme } = await import("./ui-theme");
-		await initializePortablePreferencesForPath("/about/");
+		for (const pathname of ["/about/", "/does-not-exist"]) {
+			await initializePortablePreferencesForPath(pathname);
+		}
 
 		expect(requestCount).toBe(0);
 		expect(uiTheme()).toBe("pop");

--- a/frontend/src/lib/preferences-store.ts
+++ b/frontend/src/lib/preferences-store.ts
@@ -71,9 +71,13 @@ const normalizePathname = (pathname: string): string => {
 	return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
 };
 
+const AUTHENTICATED_PORTABLE_PREFERENCES_PREFIXES = ["/entries", "/spaces"] as const;
+
 const isPublicPortablePreferencesPath = (pathname: string): boolean => {
 	const normalized = normalizePathname(pathname);
-	return normalized === "/" || normalized === "/about" || normalized === "/login";
+	return !AUTHENTICATED_PORTABLE_PREFERENCES_PREFIXES.some(
+		(prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+	);
 };
 
 const applyUiPreferences = (preferences: UserPreferences): void => {


### PR DESCRIPTION
## Summary

- detect any public-page requests to `/api/preferences/me` in the Playwright regression
- keep first-load remote portable preference hydration scoped to authenticated `/spaces*` and `/entries*` routes
- cover unknown public routes in the frontend preference-store tests

## Related Issue (required)

closes #1173

## Testing

- [x] `cd frontend && bun run test:run src/lib/preferences-store.test.ts`
- [ ] `mise run e2e`
- [ ] `mise run test`