### PR TITLE
fix: remove deprecated Husky commit-msg bootstrap

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run commitlint:edit -- "$1"


### PR DESCRIPTION
## Summary

- remove the deprecated Husky v9 bootstrap snippet from `.husky/commit-msg`
- keep commitlint running directly from the hook without the warning spam on every commit
- align the repository hook with the format Husky expects going into v10

## Related Issue (required)

closes #1129

## Testing

- [x] `printf 'fix: test\\n' > /tmp/pr1178-commit-msg.txt && sh -e .husky/commit-msg /tmp/pr1178-commit-msg.txt`