### PR TITLE
fix(docs): surface browser onboarding caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,21 @@ The docsite getting-started flow is the canonical newcomer decision tree. This
 README mirrors the same top-level path names so you can choose a first step on
 GitHub without comparing two different onboarding maps.
 
+> **Browser path today:** the current browser route still needs a running
+> backend + frontend stack and an explicit `/login` flow. If you want the
+> thinnest local-first path, start with the CLI in `core` mode.
+
 ### Choose your first step
 
 - [Understand core concepts](docs/guide/concepts.md) before you choose a
   surface.
 - [Try the published release](docs/guide/container-quickstart.md) for the
-  fastest browser-based evaluation path.
+  fastest browser-based evaluation path, while still running the browser stack
+  with an explicit login step.
 - [Run from source](docs/guide/local-dev-auth-login.md) when you want the current
   backend, frontend, and docsite together; the shortest contributor path is
-  `mise run setup` (dependencies + repo hooks), then `mise run dev`.
+  `mise run setup` (dependencies + repo hooks), then `mise run dev`, followed
+  by the explicit `/login` flow.
 - [Use the CLI](docs/guide/cli.md) for terminal-first workflows and scripting.
 
 ### After your first step

--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -274,10 +274,18 @@ requirements:
       - 'REQ-E2E-008: desktop navigation prioritizes getting-started content before design docs'
       - 'REQ-E2E-008: run from source card opens the canonical host-dev workflow'
       - 'REQ-E2E-008: mobile navigation keeps getting-started links ahead of design content'
+    vitest:
+    - file: docsite/src/lib/onboarding.test.ts
+      tests:
+      - 'REQ-E2E-008: onboarding content keeps try, source, and CLI paths as the first entry choices'
+      - 'REQ-E2E-008: onboarding content keeps browser, auth, and deeper reference docs available after the first step'
+      - 'REQ-E2E-008: onboarding content keeps browser caveats explicit on browser-first paths'
+      - 'REQ-E2E-008: onboarding content offers a concepts primer before deeper guides and references'
     pytest:
     - file: docs/tests/test_guides.py
       tests:
       - test_docs_req_e2e_008_readme_start_here_mirrors_docsite_taxonomy
+      - test_docs_req_e2e_008_readme_start_here_surfaces_browser_caveat
 - set_id: REQCAT-E2E
   source_file: requirements/e2e.yaml
   scope: End-to-end confidence and cross-layer behavior requirements.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -1136,6 +1136,30 @@ def test_docs_req_e2e_008_readme_start_here_mirrors_docsite_taxonomy() -> None:
         raise AssertionError(message)
 
 
+def test_docs_req_e2e_008_readme_start_here_surfaces_browser_caveat() -> None:
+    """REQ-E2E-008: README start-here keeps the browser caveat prominent."""
+    readme = README_PATH.read_text(encoding="utf-8")
+    match = re.search(r"## Start Here\n(?P<section>.*?)(?:\n## |\Z)", readme, re.DOTALL)
+    if match is None:
+        message = "README must keep a Start Here section"
+        raise AssertionError(message)
+
+    section = match.group("section")
+    required_fragments = [
+        "**Browser path today:**",
+        "backend + frontend stack",
+        "explicit `/login` flow",
+        "CLI in `core` mode",
+    ]
+    missing = [fragment for fragment in required_fragments if fragment not in section]
+    if missing:
+        message = (
+            "README Start Here browser caveat is missing required fragments: "
+            + ", ".join(missing)
+        )
+        raise AssertionError(message)
+
+
 def test_docs_req_ops_001_env_matrix_matches_runtime_usage() -> None:
     """REQ-OPS-001: Environment matrix must track runtime variables used by tooling."""
     matrix_text = ENV_MATRIX_PATH.read_text(encoding="utf-8")

--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 
 import {
+	browserPathCaveat,
 	conceptPrimerCard,
 	nextStepCards,
 	primaryStartCards,
@@ -40,6 +41,23 @@ test("REQ-E2E-008: onboarding content keeps browser, auth, and deeper reference 
 		"Access",
 		"Reference",
 	]);
+});
+
+test("REQ-E2E-008: onboarding content keeps browser caveats explicit on browser-first paths", () => {
+	expect(browserPathCaveat).toEqual({
+		badge: "Browser caveat today",
+		description:
+			"The current browser route still needs a running backend + frontend stack and an explicit login flow. The CLI in `core` mode is the thinnest local-first path right now.",
+		headline:
+			"The browser path is still server-backed and login-gated, even though the data stays local-first.",
+	});
+	expect(primaryStartCards[0]?.description).toContain(
+		"frontend + backend stack",
+	);
+	expect(primaryStartCards[0]?.description).toContain("explicit browser login");
+	expect(primaryStartCards[1]?.description).toContain("mise run dev");
+	expect(primaryStartCards[1]?.description).toContain("/login");
+	expect(nextStepCards[0]?.description).toContain("completed login");
 });
 
 test("REQ-E2E-008: onboarding content offers a concepts primer before deeper guides and references", () => {

--- a/docsite/src/lib/onboarding.ts
+++ b/docsite/src/lib/onboarding.ts
@@ -6,6 +6,14 @@ export type OnboardingCard = {
 	title: string;
 };
 
+export const browserPathCaveat = {
+	badge: "Browser caveat today",
+	description:
+		"The current browser route still needs a running backend + frontend stack and an explicit login flow. The CLI in `core` mode is the thinnest local-first path right now.",
+	headline:
+		"The browser path is still server-backed and login-gated, even though the data stays local-first.",
+} as const;
+
 export const conceptPrimerCard = {
 	badge: "Learn First",
 	description:
@@ -19,7 +27,7 @@ export const primaryStartCards = [
 	{
 		badge: "Fastest path",
 		description:
-			"Launch the released browser stack without cloning or building from source.",
+			"Launch the released frontend + backend stack without cloning or building from source, then continue through the explicit browser login.",
 		href: "/docs/guide/container-quickstart",
 		icon: "🚀",
 		title: "Try the published release",
@@ -27,7 +35,7 @@ export const primaryStartCards = [
 	{
 		badge: "Contributor path",
 		description:
-			"Run the current workspace with mise run dev when you want the latest backend, frontend, and docsite together.",
+			"Run the current workspace with mise run dev when you want the latest backend, frontend, and docsite together, then sign in explicitly at /login.",
 		href: "/docs/guide/local-dev-auth-login",
 		icon: "🛠️",
 		title: "Run from source",
@@ -46,7 +54,7 @@ export const nextStepCards = [
 	{
 		badge: "Browser",
 		description:
-			"See how spaces, entries, forms, and search fit together in the UI.",
+			"After the stack is running and you have completed login, see how spaces, entries, forms, and search fit together in the UI.",
 		href: "/app/frontend",
 		icon: "🖥️",
 		title: "Explore the browser app",

--- a/docsite/src/pages/index.astro
+++ b/docsite/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { withBasePath } from "../lib/base-path";
 import {
+  browserPathCaveat,
   conceptPrimerCard,
   nextStepCards,
   primaryStartCards,
@@ -20,6 +21,18 @@ import {
 
         <p class="doc-lead">
           A private, portable knowledge space you can run with Docker, automate from the CLI, and keep on infrastructure you control.
+        </p>
+
+        <div class="doc-pill-row">
+          <span class="doc-pill doc-pill-warning">{browserPathCaveat.badge}</span>
+        </div>
+
+        <p class="doc-lead">
+          {browserPathCaveat.headline}
+        </p>
+
+        <p>
+          {browserPathCaveat.description}
         </p>
 
         <div class="doc-pill-row">

--- a/e2e/docsite-onboarding.test.ts
+++ b/e2e/docsite-onboarding.test.ts
@@ -26,6 +26,17 @@ test.describe("Docsite onboarding-first navigation", () => {
 				/a private, portable knowledge space you can run with docker/i,
 			),
 		).toBeVisible();
+		await expect(page.getByText("Browser caveat today")).toBeVisible();
+		await expect(
+			page.getByText(
+				/the browser path is still server-backed and login-gated, even though the data stays local-first/i,
+			),
+		).toBeVisible();
+		await expect(
+			page.getByText(
+				/the current browser route still needs a running backend \+ frontend stack and an explicit login flow/i,
+			),
+		).toBeVisible();
 		await expect(page.locator("#start-paths a h3")).toHaveText([
 			"Try the published release",
 			"Run from source",


### PR DESCRIPTION
## Summary
- promote the browser/backend and explicit-login caveat into the README Start Here section and docsite hero
- update shared onboarding copy so browser-first cards describe the current server-backed login flow accurately
- add REQ-E2E-008 regression coverage across docsite vitest, docs tests, and Playwright

## Related Issue (required)
closes #1170

## Testing
- [x] `cd /workspace/docsite && bun run test:run src/lib/onboarding.test.ts`
- [x] `cd /workspace && uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -k "e2e_008"`
- [x] `cd /workspace/e2e && E2E_AUTH_BEARER_TOKEN=dummy bunx playwright test docsite-onboarding.test.ts`
