### PR TITLE
feat(frontend): add saved SQL recovery route

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1676,3 +1676,39 @@ requirements:
     - file: frontend/src/components/SpaceSettings.test.tsx
       tests:
       - 'REQ-FE-060: settings show the current storage topology before editing'
+- set_id: REQCAT-FRONTEND
+  source_file: requirements/frontend.yaml
+  scope: Frontend route, component, and interaction requirements.
+  linked_policies:
+  - POL-006
+  - POL-009
+  - POL-013
+  - POL-014
+  linked_specifications:
+  - SPEC-UI-OVERVIEW
+  - SPEC-UI-PAGES
+  - SPEC-ARCH-INTERFACE
+  id: REQ-FE-061
+  title: Saved SQL Placeholder Recovery Guidance
+  description: 'The `/spaces/{space_id}/sql` route MUST explain that named-query
+
+    management is not available there yet, link users to the working query flow
+
+    from Search, and provide a clear route back to the dashboard or other useful
+
+    space pages instead of acting as a dead end.
+
+    '
+  related_spec:
+  - ui/pages/space-sql.yaml
+  priority: medium
+  status: implemented
+  tests:
+    e2e:
+    - file: e2e/saved-sql-route.test.ts
+      tests:
+      - 'REQ-FE-061: saved SQL route provides recovery links instead of a dead end'
+    vitest:
+    - file: frontend/src/routes/spaces/[space_id]/sql/index.test.tsx
+      tests:
+      - 'REQ-FE-061: saved SQL route explains the missing UI and links to working recovery paths'

--- a/docs/spec/ui/pages/space-sql.yaml
+++ b/docs/spec/ui/pages/space-sql.yaml
@@ -15,6 +15,15 @@ components:
       position: top-right-floating
       icon: settings
   body:
-    - id: sql-list
-      type: list
+    - id: sql-empty-state
+      type: heading
       title: Saved SQL
+    - id: search-recovery-action
+      type: button
+      title: Open search
+    - id: dashboard-recovery-action
+      type: button
+      title: Back to dashboard
+    - id: entries-recovery-action
+      type: button
+      title: Browse entries

--- a/e2e/saved-sql-route.test.ts
+++ b/e2e/saved-sql-route.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { getFrontendUrl, waitForServers } from "./lib/client";
+
+const spaceId = "default";
+
+test.describe("Saved SQL route", () => {
+	test.beforeAll(async ({ request }) => {
+		await waitForServers(request);
+	});
+
+	test("REQ-FE-061: saved SQL route provides recovery links instead of a dead end", async ({
+		page,
+	}) => {
+		await page.goto(getFrontendUrl(`/spaces/${spaceId}/sql`), {
+			waitUntil: "domcontentloaded",
+		});
+
+		await expect(page.getByRole("heading", { level: 1, name: "Saved SQL" })).toBeVisible();
+		await expect(page.getByText(/named-query management/i)).toBeVisible();
+		await expect(page.getByRole("link", { name: "Open Search" })).toHaveAttribute(
+			"href",
+			`/spaces/${spaceId}/search`,
+		);
+		await expect(page.getByRole("link", { name: "Back to Dashboard" })).toHaveAttribute(
+			"href",
+			`/spaces/${spaceId}/dashboard`,
+		);
+		await expect(page.getByRole("link", { name: "Browse Entries" })).toHaveAttribute(
+			"href",
+			`/spaces/${spaceId}/entries`,
+		);
+		await expect(page.getByText("Saved SQL management is not yet in the UI.")).toHaveCount(0);
+	});
+});

--- a/frontend/src/routes/spaces/[space_id]/sql.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql.tsx
@@ -1,12 +1,5 @@
-import { useParams } from "@solidjs/router";
+import type { RouteSectionProps } from "@solidjs/router";
 
-export default function SpaceSqlRoute() {
-	const params = useParams();
-	return (
-		<div class="ui-page">
-			<h1 class="text-xl font-semibold">Saved SQL</h1>
-			<p class="text-sm ui-muted">Space: {params.space_id}</p>
-			<p class="text-sm ui-muted mt-2">Saved SQL management is not yet in the UI.</p>
-		</div>
-	);
+export default function SpaceSqlRoute(props: RouteSectionProps) {
+	return props.children;
 }

--- a/frontend/src/routes/spaces/[space_id]/sql/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/index.test.tsx
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import SpaceSqlRoute from "./index";
+
+vi.mock("@solidjs/router", () => ({
+	A: (props: { href: string; class?: string; children: unknown }) => (
+		<a href={props.href} class={props.class}>
+			{props.children}
+		</a>
+	),
+	useParams: () => ({ space_id: "default" }),
+}));
+
+vi.mock("~/components/SpaceShell", () => ({
+	SpaceShell: (props: { children: unknown; spaceId: string; activeTopTab?: string }) => (
+		<div data-space-id={props.spaceId} data-active-top-tab={props.activeTopTab}>
+			{props.children}
+		</div>
+	),
+}));
+
+describe("/spaces/:space_id/sql", () => {
+	it("REQ-FE-061: saved SQL route explains the missing UI and links to working recovery paths", () => {
+		const { container } = render(() => <SpaceSqlRoute />);
+
+		expect(screen.getByRole("heading", { name: "Saved SQL" })).toBeInTheDocument();
+		expect(screen.getByText(/named-query management/i)).toBeInTheDocument();
+		expect(
+			screen.queryByText("Saved SQL management is not yet in the UI."),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Open Search" })).toHaveAttribute(
+			"href",
+			"/spaces/default/search",
+		);
+		expect(screen.getByRole("link", { name: "Back to Dashboard" })).toHaveAttribute(
+			"href",
+			"/spaces/default/dashboard",
+		);
+		expect(screen.getByRole("link", { name: "Browse Entries" })).toHaveAttribute(
+			"href",
+			"/spaces/default/entries",
+		);
+		expect(container.firstElementChild).toHaveAttribute("data-space-id", "default");
+		expect(container.firstElementChild).toHaveAttribute("data-active-top-tab", "search");
+	});
+});

--- a/frontend/src/routes/spaces/[space_id]/sql/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/index.tsx
@@ -1,0 +1,49 @@
+import { A, useParams } from "@solidjs/router";
+import { SpaceShell } from "~/components/SpaceShell";
+
+export default function SpaceSqlIndexRoute() {
+	const params = useParams();
+	const spaceId = () => params.space_id;
+	return (
+		<SpaceShell spaceId={spaceId()} activeTopTab="search">
+			<div class="mx-auto max-w-4xl ui-stack">
+				<section class="ui-card ui-stack">
+					<div class="ui-stack-sm">
+						<p class="text-sm ui-muted">Space: {spaceId()}</p>
+						<h1 class="ui-page-title">Saved SQL</h1>
+						<p class="ui-page-subtitle max-w-2xl">
+							This route is reserved for named-query management, but that dedicated UI is not
+							shipped yet. You can still run and revisit queries from Search today, then return here
+							once saved-query management lands.
+						</p>
+					</div>
+
+					<div class="ui-stack-sm">
+						<h2 class="text-lg font-semibold">What works today</h2>
+						<ul class="list-disc space-y-2 pl-5 text-sm ui-muted">
+							<li>Run keyword and advanced searches from the Search tab.</li>
+							<li>
+								Reuse the current space dashboard when you need to switch back to entries or forms.
+							</li>
+							<li>
+								Keep working in this space without guessing which route is actually supported.
+							</li>
+						</ul>
+					</div>
+
+					<div class="flex flex-wrap gap-3">
+						<A href={`/spaces/${spaceId()}/search`} class="ui-button ui-button-primary">
+							Open Search
+						</A>
+						<A href={`/spaces/${spaceId()}/dashboard`} class="ui-button ui-button-secondary">
+							Back to Dashboard
+						</A>
+						<A href={`/spaces/${spaceId()}/entries`} class="ui-button ui-button-secondary">
+							Browse Entries
+						</A>
+					</div>
+				</section>
+			</div>
+		</SpaceShell>
+	);
+}


### PR DESCRIPTION
## Summary
- turn `/spaces/:space_id/sql` into a real index route instead of a dead 404 edge
- replace the Saved SQL stub with recovery guidance and links to working space flows
- add REQ-FE-061 unit, E2E, and spec coverage for the placeholder UX

## Related Issue (required)
closes #1052

## Testing
- [x] `cd frontend && bun run test:run src/routes/spaces/[space_id]/sql/index.test.tsx`
- [x] `mise run test:docs`
- [x] `bunx playwright test saved-sql-route.test.ts`