### PR TITLE
fix: ignore routine validation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,11 @@ spaces/
 .vscode/mcp.json
 backend/.coverage
 frontend/coverage/
+frontend/.vinxi/
+frontend/.output/
+frontend/dist/
 docsite/coverage/
+e2e/test-results/
 /uv.lock
 __pycache__/
 /target/

--- a/docs/tests/test_artifact_hygiene.py
+++ b/docs/tests/test_artifact_hygiene.py
@@ -120,7 +120,11 @@ def test_req_ops_005_root_gitignore_covers_validation_artifacts() -> None:
     required_pattern_sets = {
         "root uv lockfile": {"/uv.lock", "uv.lock"},
         "Python bytecode caches": {"__pycache__/", "scripts/__pycache__/"},
+        "frontend vinxi output": {"frontend/.vinxi/", "/frontend/.vinxi/"},
+        "frontend output bundle": {"frontend/.output/", "/frontend/.output/"},
+        "frontend dist bundle": {"frontend/dist/", "/frontend/dist/"},
         "docsite coverage output": {"docsite/coverage/", "/docsite/coverage/"},
+        "e2e test results": {"e2e/test-results/", "/e2e/test-results/"},
     }
 
     missing = [


### PR DESCRIPTION
## Summary
- ignore the routine frontend, docsite, e2e, and workspace lockfile outputs that standard validation commands generate
- keep the root artifact-hygiene regression test aligned with those expected validation artifacts

## Related Issue (required)
closes #1198

## Testing
- [x] `uv run --with pytest pytest docs/tests/test_artifact_hygiene.py -v -W error`
- [x] `mise run test`