### PR TITLE
docs: spell out the form-first browser workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ GitHub without comparing two different onboarding maps.
 - [Read design and source docs](docs/spec/index.md) when you need philosophy,
   requirements, APIs, or machine-readable specs.
 
+For a brand-new browser space, the first productive in-app sequence is:
+**open the space, create a form, then create entries from that form**.
+
 Local-first applies most directly to Ugoite's storage model and the CLI's
 `core` mode today. The current browser path still needs a running backend +
 frontend stack and an explicit login flow, even though the data remains in

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -59,6 +59,11 @@ That makes forms the bridge between free-form writing and reliable structure.
 They help people enter consistent information, and they help the browser, CLI,
 and automation flows understand what each entry is supposed to contain.
 
+For browser-first users, that makes the first-run workflow concrete: create or
+open a space, create a form, then create entries that use it. A new space
+becomes meaningfully authorable once at least one form exists, because the form
+is what tells Ugoite how new structured entries should start.
+
 You can absolutely start with a lightweight note, but as soon as you want
 stable extracted fields, validation, or reliable queries, the Form becomes the
 contract Ugoite uses to interpret that Markdown.

--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -58,6 +58,7 @@ test("REQ-E2E-008: onboarding content keeps browser caveats explicit on browser-
 	expect(primaryStartCards[1]?.description).toContain("mise run dev");
 	expect(primaryStartCards[1]?.description).toContain("/login");
 	expect(nextStepCards[0]?.description).toContain("completed login");
+	expect(nextStepCards[0]?.description).toContain("create a form first");
 });
 
 test("REQ-E2E-008: onboarding content offers a concepts primer before deeper guides and references", () => {

--- a/docsite/src/lib/onboarding.ts
+++ b/docsite/src/lib/onboarding.ts
@@ -54,7 +54,7 @@ export const nextStepCards = [
 	{
 		badge: "Browser",
 		description:
-			"After the stack is running and you have completed login, see how spaces, entries, forms, and search fit together in the UI.",
+			"After the stack is running and you have completed login, open a space, create a form first, then add entries and explore search from that shared structure.",
 		href: "/app/frontend",
 		icon: "🖥️",
 		title: "Explore the browser app",


### PR DESCRIPTION
## Summary
- tell newcomers that the first productive browser workflow is space -> form -> entries
- align README, docsite onboarding, and the concepts guide around that sequence
- extend the onboarding content test to keep the form-first instruction wired

## Related Issue
- Closes #1192

## Testing
- [x] `cd docsite && bun run test:run src/lib/onboarding.test.ts`
- [x] `mise run test`