### PR TITLE
feat: guide empty entries routes to form creation

### DIFF
--- a/e2e/entries.test.ts
+++ b/e2e/entries.test.ts
@@ -7,8 +7,18 @@
  * - Delete entries
  */
 
-import { expect, test } from "@playwright/test";
-import { ensureDefaultForm, getBackendUrl, waitForServers } from "./lib/client";
+import { expect, test, type Page } from "@playwright/test";
+import { ensureDefaultForm, getBackendUrl, getFrontendUrl, waitForServers } from "./lib/client";
+
+async function settleUiLoading(page: Page): Promise<void> {
+	await page.waitForTimeout(150);
+	await page
+		.waitForFunction(() => !document.querySelector(".ui-loading-bar"), undefined, {
+			timeout: 5_000,
+		})
+		.catch(() => undefined);
+	await page.waitForTimeout(150);
+}
 
 test.describe("Entries CRUD", () => {
 	test.beforeAll(async ({ request }) => {
@@ -165,6 +175,37 @@ test.describe("Entries CRUD", () => {
 		await request.delete(
 			getBackendUrl(`/spaces/default/entries/${created.id}`),
 		);
+	});
+
+	test("REQ-FE-037: entries route guides first-run spaces toward form creation", async ({
+		page,
+		request,
+	}) => {
+		const spaceId = `entries-first-form-${Date.now()}`;
+		const createSpace = await request.post(getBackendUrl("/spaces"), {
+			data: { name: spaceId },
+		});
+		expect([200, 201, 409]).toContain(createSpace.status());
+
+		await page.goto(getFrontendUrl(`/spaces/${spaceId}/entries`), {
+			waitUntil: "domcontentloaded",
+		});
+		await expect(page.locator("body")).toBeVisible();
+		await settleUiLoading(page);
+
+		await expect(page.getByText("Start by creating your first form.")).toBeVisible();
+		await expect(
+			page.getByText(
+				"Entries depend on form templates and fields. Create one form first, then come back to add entries.",
+			),
+		).toBeVisible();
+		await expect(page.getByRole("button", { name: "New entry" })).toBeDisabled();
+
+		await page.getByRole("button", { name: "Create your first form" }).click();
+
+		await expect(page.getByRole("heading", { name: "Create New Form" })).toBeVisible({
+			timeout: 10_000,
+		});
 	});
 
 	test("REQ-FE-033: frontend entry detail route renders (not SolidJS Not Found)", async ({ page, request }) => {

--- a/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
@@ -17,6 +17,18 @@ import { testApiUrl } from "~/test/http-origin";
 const navigateMock = vi.fn();
 const searchParamsMock: Record<string, string> = {};
 const setSearchParamsMock = vi.fn();
+const createdAt = "2025-01-01T00:00:00Z";
+
+const assetsForm: Form = {
+	name: "Assets",
+	version: 1,
+	template: "",
+	fields: {
+		link: { type: "string", required: true },
+		name: { type: "string", required: true },
+		uploaded_at: { type: "timestamp", required: true },
+	},
+};
 
 vi.mock("@solidjs/router", () => ({
 	useNavigate: () => navigateMock,
@@ -28,6 +40,53 @@ vi.mock("@solidjs/router", () => ({
 	),
 }));
 
+function renderEntriesRoute(options?: {
+	spaceId?: string;
+	forms?: Form[];
+	loadingForms?: boolean;
+	columnTypes?: string[];
+	refetchForms?: () => void;
+}) {
+	const {
+		spaceId = "default",
+		forms = [],
+		loadingForms = false,
+		columnTypes = [],
+		refetchForms = () => undefined,
+	} = options ?? {};
+	render(() => {
+		const entryStore = createEntryStore(() => spaceId);
+		const spaceStore = createSpaceStore();
+		const [formsSignal] = createSignal<Form[]>(forms);
+		const [loadingFormsSignal] = createSignal(loadingForms);
+		const [columnTypesSignal] = createSignal<string[]>(columnTypes);
+		return (
+			<EntriesRouteContext.Provider
+				value={{
+					spaceStore,
+					spaceId: () => spaceId,
+					entryStore,
+					forms: createMemo(() => formsSignal()),
+					loadingForms: loadingFormsSignal,
+					columnTypes: columnTypesSignal,
+					refetchForms,
+				}}
+			>
+				<SpaceEntriesIndexPane />
+			</EntriesRouteContext.Provider>
+		);
+	});
+}
+
+function seedTestSpace(id: string, name = id) {
+	const space: Space = {
+		id,
+		name,
+		created_at: createdAt,
+	};
+	seedSpace(space);
+}
+
 describe("/spaces/:space_id/entries", () => {
 	beforeEach(() => {
 		navigateMock.mockReset();
@@ -37,12 +96,7 @@ describe("/spaces/:space_id/entries", () => {
 		}
 		setSearchParamsMock.mockReset();
 		resetMockData();
-		const ws: Space = {
-			id: "default",
-			name: "Default",
-			created_at: "2025-01-01T00:00:00Z",
-		};
-		seedSpace(ws);
+		seedTestSpace("default", "Default");
 
 		const entry: Entry = {
 			id: "entry/with space",
@@ -62,28 +116,7 @@ describe("/spaces/:space_id/entries", () => {
 	});
 
 	it("REQ-FE-033: selecting an entry navigates with encoded id", async () => {
-		render(() => {
-			const entryStore = createEntryStore(() => "default");
-			const spaceStore = createSpaceStore();
-			const [forms] = createSignal<Form[]>([]);
-			const [loadingForms] = createSignal(false);
-			const [columnTypes] = createSignal<string[]>([]);
-			return (
-				<EntriesRouteContext.Provider
-					value={{
-						spaceStore,
-						spaceId: () => "default",
-						entryStore,
-						forms: createMemo(() => forms()),
-						loadingForms,
-						columnTypes,
-						refetchForms: () => undefined,
-					}}
-				>
-					<SpaceEntriesIndexPane />
-				</EntriesRouteContext.Provider>
-			);
-		});
+		renderEntriesRoute();
 
 		await waitFor(() => {
 			expect(screen.getByText("Test Entry")).toBeInTheDocument();
@@ -94,31 +127,40 @@ describe("/spaces/:space_id/entries", () => {
 	});
 
 	it("selecting an entry form navigates correctly", async () => {
-		render(() => {
-			const entryStore = createEntryStore(() => "default");
-			const spaceStore = createSpaceStore();
-			const [forms] = createSignal<Form[]>([]);
-			const [loadingForms] = createSignal(false);
-			const [columnTypes] = createSignal<string[]>([]);
-			return (
-				<EntriesRouteContext.Provider
-					value={{
-						spaceStore,
-						spaceId: () => "default",
-						entryStore,
-						forms: createMemo(() => forms()),
-						loadingForms,
-						columnTypes,
-						refetchForms: () => undefined,
-					}}
-				>
-					<SpaceEntriesIndexPane />
-				</EntriesRouteContext.Provider>
-			);
-		});
+		renderEntriesRoute();
 
 		const formsTab = await screen.findByRole("link", { name: "Forms" });
 		expect(formsTab).toHaveAttribute("href", "/spaces/default/forms");
+	});
+
+	it("REQ-FE-037: entries route disables entry creation when only reserved metadata forms exist", async () => {
+		seedTestSpace("reserved-only", "Reserved Only");
+		renderEntriesRoute({ spaceId: "reserved-only", forms: [assetsForm] });
+
+		await waitFor(() => {
+			expect(screen.getByText("Start by creating your first form.")).toBeInTheDocument();
+		});
+		expect(screen.getByRole("button", { name: "New entry" })).toBeDisabled();
+		expect(screen.queryByText("No entries found.")).not.toBeInTheDocument();
+	});
+
+	it("REQ-FE-037: entries route guides first-run spaces toward form creation", async () => {
+		seedTestSpace("empty-space", "Empty Space");
+		renderEntriesRoute({ spaceId: "empty-space" });
+
+		await waitFor(() => {
+			expect(screen.getByText("Start by creating your first form.")).toBeInTheDocument();
+		});
+		expect(
+			screen.getByText(
+				"Entries depend on form templates and fields. Create one form first, then come back to add entries.",
+			),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "New entry" })).toBeDisabled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Create your first form" }));
+
+		expect(screen.getByRole("heading", { name: "Create New Form" })).toBeInTheDocument();
 	});
 
 	it("REQ-FE-054: renders human-readable updated dates for query result cards", async () => {
@@ -155,28 +197,7 @@ describe("/spaces/:space_id/entries", () => {
 			),
 		);
 
-		render(() => {
-			const entryStore = createEntryStore(() => "default");
-			const spaceStore = createSpaceStore();
-			const [forms] = createSignal<Form[]>([]);
-			const [loadingForms] = createSignal(false);
-			const [columnTypes] = createSignal<string[]>([]);
-			return (
-				<EntriesRouteContext.Provider
-					value={{
-						spaceStore,
-						spaceId: () => "default",
-						entryStore,
-						forms: createMemo(() => forms()),
-						loadingForms,
-						columnTypes,
-						refetchForms: () => undefined,
-					}}
-				>
-					<SpaceEntriesIndexPane />
-				</EntriesRouteContext.Provider>
-			);
-		});
+		renderEntriesRoute();
 
 		const expectedDate = new Date(1772960822.056 * 1000).toLocaleDateString();
 		expect(await screen.findByText("Query Entry")).toBeInTheDocument();
@@ -186,30 +207,17 @@ describe("/spaces/:space_id/entries", () => {
 
 	it("REQ-FE-044: localizes entries route CTA copy in Japanese", async () => {
 		setLocale("ja");
-		render(() => {
-			const entryStore = createEntryStore(() => "default");
-			const spaceStore = createSpaceStore();
-			const [forms] = createSignal<Form[]>([]);
-			const [loadingForms] = createSignal(false);
-			const [columnTypes] = createSignal<string[]>([]);
-			return (
-				<EntriesRouteContext.Provider
-					value={{
-						spaceStore,
-						spaceId: () => "default",
-						entryStore,
-						forms: createMemo(() => forms()),
-						loadingForms,
-						columnTypes,
-						refetchForms: () => undefined,
-					}}
-				>
-					<SpaceEntriesIndexPane />
-				</EntriesRouteContext.Provider>
-			);
-		});
+		seedTestSpace("empty-ja", "empty-ja");
+		renderEntriesRoute({ spaceId: "empty-ja" });
 
 		expect(await screen.findByRole("heading", { name: "エントリ" })).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "新しいエントリ" })).toBeInTheDocument();
+		expect(await screen.findByText("最初のフォームを作成して始めましょう。")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"エントリはフォームのテンプレートとフィールドをもとに作成します。先に1つフォームを作成してからエントリ作成に戻ってください。",
+			),
+		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "最初のフォームを作成" })).toBeInTheDocument();
 	});
 });

--- a/frontend/src/routes/spaces/[space_id]/entries/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.tsx
@@ -8,15 +8,16 @@ import {
 	Show,
 	onCleanup,
 } from "solid-js";
-import { CreateEntryDialog } from "~/components/create-dialogs";
+import { CreateEntryDialog, CreateFormDialog } from "~/components/create-dialogs";
 import { SpaceShell } from "~/components/SpaceShell";
 import { formatDateLabel } from "~/lib/date-format";
 import { buildEntryMarkdownByMode, type EntryInputMode } from "~/lib/entry-input";
 import { useEntriesRouteContext } from "~/lib/entries-route-context";
+import { formApi } from "~/lib/form-api";
 import { t } from "~/lib/i18n";
 import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { sqlSessionApi } from "~/lib/sql-session-api";
-import type { EntryRecord } from "~/lib/types";
+import type { EntryRecord, FormCreatePayload } from "~/lib/types";
 
 export default function SpaceEntriesIndexPane() {
 	const navigate = useNavigate();
@@ -24,7 +25,9 @@ export default function SpaceEntriesIndexPane() {
 	const ctx = useEntriesRouteContext();
 	const spaceId = () => ctx.spaceId();
 	const [showCreateEntryDialog, setShowCreateEntryDialog] = createSignal(false);
+	const [showCreateFormDialog, setShowCreateFormDialog] = createSignal(false);
 	const creatableForms = createMemo(() => filterCreatableEntryForms(ctx.forms()));
+	const hasCreatableForms = createMemo(() => creatableForms().length > 0);
 
 	const sessionId = createMemo(() => (searchParams.session ? String(searchParams.session) : ""));
 	const [page, setPage] = createSignal(1);
@@ -97,9 +100,28 @@ export default function SpaceEntriesIndexPane() {
 		if (!err) return null;
 		return err instanceof Error ? err.message : String(err);
 	});
+	const needsFirstFormGuidance = createMemo(
+		() =>
+			!sessionId().trim() &&
+			!isLoading() &&
+			!ctx.loadingForms() &&
+			displayEntries().length === 0 &&
+			!errorMessage() &&
+			!hasCreatableForms(),
+	);
 
 	const handleSelectEntry = (entryId: string) => {
 		navigate(`/spaces/${spaceId()}/entries/${encodeURIComponent(entryId)}`);
+	};
+
+	const handleCreateForm = async (payload: FormCreatePayload) => {
+		try {
+			await formApi.create(spaceId(), payload);
+			setShowCreateFormDialog(false);
+			void ctx.refetchForms();
+		} catch (e) {
+			alert(e instanceof Error ? e.message : t("dashboard.error.failedCreateForm"));
+		}
 	};
 
 	const handleCreateEntry = async (
@@ -157,7 +179,12 @@ export default function SpaceEntriesIndexPane() {
 						</Show>
 						<button
 							type="button"
-							class="ui-button ui-button-primary text-sm"
+							class="ui-button text-sm"
+							classList={{
+								"ui-button-primary": hasCreatableForms(),
+								"ui-button-secondary": !hasCreatableForms(),
+							}}
+							disabled={!hasCreatableForms()}
 							onClick={() => setShowCreateEntryDialog(true)}
 						>
 							{t("entriesPage.newButton")}
@@ -181,8 +208,32 @@ export default function SpaceEntriesIndexPane() {
 					<Show when={errorMessage()}>
 						<p class="text-sm ui-text-danger">{errorMessage()}</p>
 					</Show>
-					<Show when={!isLoading() && displayEntries().length === 0 && !errorMessage()}>
+					<Show
+						when={
+							!needsFirstFormGuidance() &&
+							!isLoading() &&
+							displayEntries().length === 0 &&
+							!errorMessage()
+						}
+					>
 						<p class="text-sm ui-muted">{t("entriesPage.noEntries")}</p>
+					</Show>
+					<Show when={needsFirstFormGuidance()}>
+						<div class="ui-alert ui-alert-warning mb-4 text-sm ui-stack-sm">
+							<div class="ui-stack-sm">
+								<p class="font-medium">{t("dashboard.section.createEntry.empty")}</p>
+								<p>{t("dashboard.section.createEntry.firstFormDescription")}</p>
+							</div>
+							<div>
+								<button
+									type="button"
+									class="ui-button ui-button-primary text-sm"
+									onClick={() => setShowCreateFormDialog(true)}
+								>
+									{t("dashboard.section.createEntry.createFirstForm")}
+								</button>
+							</div>
+						</div>
 					</Show>
 					<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 						<For each={displayEntries()}>
@@ -243,6 +294,13 @@ export default function SpaceEntriesIndexPane() {
 				defaultForm={creatableForms()[0]?.name}
 				onClose={() => setShowCreateEntryDialog(false)}
 				onSubmit={handleCreateEntry}
+			/>
+			<CreateFormDialog
+				open={showCreateFormDialog()}
+				columnTypes={ctx.columnTypes()}
+				formNames={ctx.forms().map((form) => form.name)}
+				onClose={() => setShowCreateFormDialog(false)}
+				onSubmit={handleCreateForm}
 			/>
 		</SpaceShell>
 	);


### PR DESCRIPTION
## Summary
- align the empty entries route with the dashboard by promoting first-form onboarding when no creatable forms exist
- disable the entries-page New entry action until a real entry form is available and surface the create-form dialog directly
- cover the behavior with route tests and the entries Playwright lane

## Related Issue
- Closes #1189

## Testing
- [x] `cd frontend && ./node_modules/.bin/biome ci src/routes/spaces/[space_id]/entries/index.tsx src/routes/spaces/[space_id]/entries/index.test.tsx`
- [x] `cd frontend && bun run test:run src/routes/spaces/[space_id]/entries/index.test.tsx`
- [x] `bash e2e/scripts/run-e2e.sh entries`
- [x] `mise run test`