### PR TITLE
docs: unify the contributor onboarding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Start with the user-facing guides:
 - [Core Concepts](docs/guide/concepts.md) - Learn what spaces, entries, forms, and search mean before choosing a surface
 - [Container Quick Start](docs/guide/container-quickstart.md) - Run published GHCR release images
 - [CLI Guide](docs/guide/cli.md) - Install the released CLI or build it from source
-- [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) - Configure local bearer token auth
+- [Local Dev Auth/Login](docs/guide/local-dev-auth-login.md) - Canonical `mise run setup` -> `mise run dev` -> `/login` contributor path
 - [Backend Healthcheck](docs/guide/backend-healthcheck.md) - Quick backend readiness check
 
 Go deeper when you need architecture or implementation contracts:
@@ -446,7 +446,10 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE).
 
 ## Contributing
 
-Contributions welcome! See [AGENTS.md](AGENTS.md) for development guidelines.
+Contributions welcome! Start with [Run from source](docs/guide/local-dev-auth-login.md)
+for the canonical `mise run setup` -> `mise run dev` -> `/login` workflow. If
+you are using an AI coding agent in this repository, also read
+[AGENTS.md](AGENTS.md).
 
 1. Check [open issues](https://github.com/ugoite/ugoite/issues) and [pull requests](https://github.com/ugoite/ugoite/pulls) for current work items
 2. Open an issue to discuss larger changes

--- a/docs/guide/docker-compose.md
+++ b/docs/guide/docker-compose.md
@@ -1,9 +1,11 @@
 # Docker Compose Guide
 
-This guide describes how to run Ugoite with Docker Compose for local development
-from source.
-If you are working inside the devcontainer and Docker is not available, use the
-local dev workflow described in [README.md](../../README.md) instead.
+This guide describes an alternative way to run Ugoite from source when you
+specifically want Docker Compose instead of the canonical human contributor
+path.
+If you want the default contributor workflow, start with
+[Local Development Authentication and Login](local-dev-auth-login.md) and
+`mise run dev` instead.
 
 If you want pre-built release images from GHCR instead of local builds, use
 [Container Quick Start](container-quickstart.md).
@@ -64,5 +66,6 @@ rm -rf ./spaces
   reach it across the Compose network.
 - The configured `UGOITE_DEV_USER_ID` becomes the local `admin-space` admin for
   this source-based Compose stack.
-- If you prefer to run services directly on the host, use the `mise` tasks
-  instead of Docker Compose.
+- If you want the canonical contributor workflow, follow
+  [Local Development Authentication and Login](local-dev-auth-login.md) and use
+  `mise run dev` instead of Docker Compose.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -36,7 +36,7 @@ Ugoite is a knowledge management system built on three core principles:
 | --- | --- | --- |
 | [Container Quick Start](../guide/container-quickstart.md) | Fast visual evaluation of the shipped UI | Requires the backend/runtime stack plus explicit login before `/spaces` becomes useful |
 | [CLI Guide](../guide/cli.md) in `core` mode | Lowest-friction local-first workflow | Terminal-first only; skips the browser shell and server-backed behavior |
-| [Run from source](../guide/docker-compose.md) with `mise run dev` | Contributor work and full-surface debugging | Highest setup and auth overhead, but exercises backend, frontend, and docsite together |
+| [Run from source](../guide/local-dev-auth-login.md) with `mise run dev` | Contributor work and full-surface debugging | Highest setup and auth overhead, but exercises backend, frontend, and docsite together |
 
 ### Architecture & Design
 - [Architecture Overview](architecture/overview.md) - System design and component responsibilities
@@ -142,7 +142,7 @@ because the canonical data stays in the space itself.
 - [Machine-readable v0.1 tracker](../version/v0.1.yaml) - Current milestone/phase/task state for the v0.1 stream
 - [Machine-readable v0.2 tracker](../version/v0.2.yaml) - Planned milestone/phase/task state for the v0.2 stream
 - [Versions & Release Notes](versions/index.md) - Human-readable summary of what each version adds or changes
-- [Contributing](../../AGENTS.md) - Development guidelines
+- [Contributor onboarding](../guide/local-dev-auth-login.md) - Canonical `mise run setup` -> `mise run dev` -> `/login` workflow for human contributors
 
 ---
 

--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -287,6 +287,7 @@ requirements:
       tests:
       - test_docs_req_e2e_008_readme_start_here_mirrors_docsite_taxonomy
       - test_docs_req_e2e_008_readme_start_here_surfaces_browser_caveat
+      - test_docs_req_e2e_008_source_contributor_path_stays_canonical_across_docs
 - set_id: REQCAT-E2E
   source_file: requirements/e2e.yaml
   scope: End-to-end confidence and cross-layer behavior requirements.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -153,6 +153,7 @@ PUBLIC_PACKAGE_README_PATH = PUBLIC_PACKAGE_DIR / "README.md"
 PUBLIC_PACKAGE_LICENSE_PATH = PUBLIC_PACKAGE_DIR / "LICENSE"
 PUBLIC_PACKAGE_INSTALLER_PATH = PUBLIC_PACKAGE_DIR / "bin" / "ugoite-install"
 CI_CD_SPEC_PATH = REPO_ROOT / "docs" / "spec" / "testing" / "ci-cd.md"
+SPEC_INDEX_PATH = REPO_ROOT / "docs" / "spec" / "index.md"
 RELEASE_COMPOSE_PATH = REPO_ROOT / "docker-compose.release.yaml"
 BACKEND_DOCKERFILE_PATH = REPO_ROOT / "backend" / "Dockerfile"
 FRONTEND_DOCKERFILE_PATH = REPO_ROOT / "frontend" / "Dockerfile"
@@ -1191,6 +1192,70 @@ def test_docs_req_e2e_008_readme_start_here_surfaces_browser_caveat() -> None:
             + ", ".join(missing)
         )
         raise AssertionError(message)
+
+
+def test_docs_req_e2e_008_source_contributor_path_stays_canonical_across_docs() -> None:
+    """REQ-E2E-008: source contributor docs keep one canonical onboarding path."""
+    readme = README_PATH.read_text(encoding="utf-8")
+    spec_index = SPEC_INDEX_PATH.read_text(encoding="utf-8")
+
+    details = [
+        detail
+        for detail in [
+            _require_file_contains(
+                README_PATH,
+                ["Start with [Run from source](docs/guide/local-dev-auth-login.md)"],
+                "README Contributing section must route humans through Run from source",
+            ),
+            _require_file_contains(
+                SPEC_INDEX_PATH,
+                [
+                    "[Run from source](../guide/local-dev-auth-login.md)",
+                    "[Contributor onboarding](../guide/local-dev-auth-login.md)",
+                ],
+                (
+                    "spec index must point human contributor guidance at "
+                    "local-dev-auth-login"
+                ),
+            ),
+            _require_file_contains(
+                GUIDE_DIR / "docker-compose.md",
+                [
+                    "alternative way to run Ugoite from source",
+                    (
+                        "[Local Development Authentication and Login]"
+                        "(local-dev-auth-login.md)"
+                    ),
+                ],
+                (
+                    "docker-compose guide must position itself as the "
+                    "alternative source workflow"
+                ),
+            ),
+        ]
+        if detail
+    ]
+
+    if (
+        "Contributions welcome! See [AGENTS.md](AGENTS.md) for development "
+        "guidelines." in readme
+    ):
+        details.append(
+            "README Contributing section must not send human contributors to AGENTS.md",
+        )
+
+    if "[Run from source](../guide/docker-compose.md)" in spec_index:
+        details.append(
+            "spec index must not keep docker-compose as the Run from source path",
+        )
+
+    if "[Contributing](../../AGENTS.md)" in spec_index:
+        details.append(
+            "spec index must not label AGENTS.md as human contributing guidance",
+        )
+
+    if details:
+        raise AssertionError("; ".join(details))
 
 
 def test_docs_req_ops_001_env_matrix_matches_runtime_usage() -> None:

--- a/docsite/src/lib/navigation.test.ts
+++ b/docsite/src/lib/navigation.test.ts
@@ -142,9 +142,9 @@ test("REQ-E2E-008: newcomer navigation limits deep sections to getting-started c
 					title: "Container Quickstart",
 					href: "/docs/guide/container-quickstart",
 				},
-				{ title: "Docker Compose", href: "/docs/guide/docker-compose" },
-				{ title: "Auth Overview", href: "/docs/guide/auth-overview" },
+				{ title: "Run from source", href: "/docs/guide/local-dev-auth-login" },
 				{ title: "CLI Guide", href: "/docs/guide/cli" },
+				{ title: "Auth Overview", href: "/docs/guide/auth-overview" },
 			],
 		},
 	]);

--- a/docsite/src/lib/navigation.ts
+++ b/docsite/src/lib/navigation.ts
@@ -34,9 +34,9 @@ export const navSections: NavSection[] = [
 				title: "Container Quickstart",
 				href: "/docs/guide/container-quickstart",
 			},
-			{ title: "Docker Compose", href: "/docs/guide/docker-compose" },
-			{ title: "Auth Overview", href: "/docs/guide/auth-overview" },
+			{ title: "Run from source", href: "/docs/guide/local-dev-auth-login" },
 			{ title: "CLI Guide", href: "/docs/guide/cli" },
+			{ title: "Auth Overview", href: "/docs/guide/auth-overview" },
 		],
 	},
 	{

--- a/e2e/docsite-onboarding.test.ts
+++ b/e2e/docsite-onboarding.test.ts
@@ -116,9 +116,9 @@ test.describe("Docsite onboarding-first navigation", () => {
 		).toHaveText([
 			"Core Concepts",
 			"Container Quickstart",
-			"Docker Compose",
-			"Auth Overview",
+			"Run from source",
 			"CLI Guide",
+			"Auth Overview",
 		]);
 		await expect(
 			page.locator(".site-nav-menu").nth(2).locator(".site-nav-submenu a"),


### PR DESCRIPTION
## Summary
- point README, the spec index, and docsite newcomer navigation at one canonical human contributor path: `Run from source` via `local-dev-auth-login.md`
- reposition the Docker Compose guide as an alternative source workflow instead of the default onboarding route
- add a REQ-E2E-008 docs consistency guard so contributor-facing docs do not drift back to AGENTS.md or Docker Compose as the primary human path

## Related Issue
- Closes #1169

## Testing
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py::test_docs_req_e2e_008_source_contributor_path_stays_canonical_across_docs -v -W error`
- [x] `cd docsite && bun run test:run src/lib/navigation.test.ts`
- [x] `cd e2e && E2E_AUTH_BEARER_TOKEN=docsite-only bun x playwright test docsite-onboarding.test.ts`
- [x] `cd docsite && bun run lint && bun run format:check && bun run typecheck && bun run test:validation`
- [x] `uvx ruff check --select ALL --ignore-noqa docs/tests/test_guides.py && uvx ruff format --check docs/tests/test_guides.py`
- [x] `mise run test`
- [x] `mise run test:docs`