### PR TITLE
docs: make CLI local workflow reset to core mode

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -97,10 +97,18 @@ cargo run -q -p ugoite-cli -- --help
 If you installed a released binary, use `ugoite` directly:
 
 ```bash
+ugoite config current
+ugoite config set --mode core
+
 mkdir -p ./spaces
 ugoite space list ./spaces
 ugoite space create ./spaces/demo
 ```
+
+The local filesystem examples in this section assume `core` mode. If you
+previously pointed the CLI at a backend or API endpoint, `ugoite config current`
+shows the saved routing state and `ugoite config set --mode core` switches back
+to the local-first filesystem path before you create `./spaces/demo`.
 
 If you are actively developing inside the repository, you can swap those for
 `cargo run -q -p ugoite-cli -- ...` instead.
@@ -163,6 +171,10 @@ CARGO_TARGET_DIR=target/rust cargo run -q -p ugoite-cli -- space sample-scenario
 
 ## Notes
 
+- The quick-start filesystem examples above assume `core` mode. Run
+  `ugoite config current` to inspect the saved routing state and
+  `ugoite config set --mode core` when you need to switch back from
+  backend/api mode before using local paths such as `./spaces/demo`.
 - In `core` mode, commands that target a specific space now take a positional
   `SPACE_ID_OR_PATH`. Pass the full local path such as
   `./spaces/dev-seed` or `/root/spaces/dev-seed`.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -665,6 +665,8 @@ REQUIRED_AUTH_PROFILE_CLI_GUIDE_FRAGMENTS = {
     "`ugoite auth login`",
     "`ugoite auth token-clear`",
     '`eval "$(ugoite auth token-clear)"`',
+    "`ugoite config set --mode core`",
+    "The local filesystem examples in this section assume `core` mode",
 }
 REQUIRED_AUTH_PROFILE_OVERVIEW_GUIDE_FRAGMENTS = {
     "`ugoite config current`",


### PR DESCRIPTION
## Summary
- make the first CLI local-filesystem workflow explicitly inspect and reset the saved endpoint mode before using `./spaces/...` paths
- explain why the quick-start space examples assume `core` mode when contributors previously routed the CLI to backend/api
- extend the REQ-OPS-015 docs consistency guard so the CLI guide keeps that reset step discoverable

## Related Issue
- Closes #1195

## Testing
- [x] `tmpdir=$(mktemp -d) && mkdir -p "$tmpdir/home" "$tmpdir/work/spaces" && HOME="$tmpdir/home" cargo run -q -p ugoite-cli -- config set --mode backend --backend-url https://prod.example.com && HOME="$tmpdir/home" cargo run -q -p ugoite-cli -- config set --mode core && HOME="$tmpdir/home" cargo run -q -p ugoite-cli -- space list "$tmpdir/work/spaces" && HOME="$tmpdir/home" cargo run -q -p ugoite-cli -- space create "$tmpdir/work/spaces/demo"`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py::test_docs_req_ops_015_auth_profile_docs_describe_mode_and_next_step -v -W error`
- [x] `uvx ruff check --select ALL --ignore-noqa docs/tests/test_guides.py && uvx ruff format --check docs/tests/test_guides.py`
- [x] `mise run test`