### PR TITLE
docs: keep newcomer onboarding concepts-first

### DIFF
--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -112,10 +112,10 @@ find ./spaces -maxdepth 2 -type f | head
   bootstraps for you after login.
 - Try creating one plain Markdown entry in that space first. You do **not** need
   to define a Form before the first note.
+- If you skipped the primer earlier, read [Core Concepts](concepts.md) now
+  before exploring more of the UI or the deeper docs.
 - After that first browser-created note, inspect `./spaces` (or your overridden
   `UGOITE_SPACES_DIR`) to see where the data now lives on the host.
-- Read [Core Concepts](concepts.md) next if you want the mental model for
-  spaces, entries, forms, and search before exploring more of the UI.
 - Switch to the [CLI Guide](cli.md) when you want a lighter terminal-first
   workflow, or to the [Docker Compose Guide](docker-compose.md) when you want
   the full contributor stack from source.

--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -272,6 +272,7 @@ requirements:
       tests:
       - 'REQ-E2E-008: landing page explains what Ugoite is and points first-time users to getting started'
       - 'REQ-E2E-008: landing page labels the application overview CTA as documentation'
+      - 'REQ-E2E-008: landing and getting-started pages keep the concepts primer ahead of path selection'
       - 'REQ-E2E-008: desktop navigation prioritizes getting-started content before design docs'
       - 'REQ-E2E-008: run from source card opens the canonical host-dev workflow'
       - 'REQ-E2E-008: mobile navigation keeps getting-started links ahead of design content'
@@ -289,6 +290,7 @@ requirements:
       - test_docs_req_e2e_008_readme_start_here_surfaces_browser_caveat
       - test_docs_req_e2e_008_readme_doc_map_focuses_on_deeper_refs
       - test_docs_req_e2e_008_source_contributor_path_stays_canonical_across_docs
+      - test_docs_req_e2e_008_concepts_primer_order_stays_consistent
 - set_id: REQCAT-E2E
   source_file: requirements/e2e.yaml
   scope: End-to-end confidence and cross-layer behavior requirements.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -1324,6 +1324,46 @@ def test_docs_req_e2e_008_source_contributor_path_stays_canonical_across_docs() 
         raise AssertionError("; ".join(details))
 
 
+def test_docs_req_e2e_008_concepts_primer_order_stays_consistent() -> None:
+    """REQ-E2E-008: concepts primer guidance stays consistent across newcomer docs."""
+    quick_start = (GUIDE_DIR / "container-quickstart.md").read_text(encoding="utf-8")
+
+    details = [
+        detail
+        for detail in [
+            _require_file_contains(
+                GUIDE_DIR / "container-quickstart.md",
+                [
+                    "If you skipped the primer earlier",
+                    "[Core Concepts](concepts.md)",
+                    "before exploring more of the UI or the deeper docs",
+                ],
+                (
+                    "container-quickstart.md must keep concepts ahead of "
+                    "deeper exploration"
+                ),
+            ),
+            _require_file_contains(
+                GUIDE_DIR / "concepts.md",
+                ["before choosing", "Once the concepts make sense, choose the surface"],
+                "concepts.md must keep the concepts-first route into surface guides",
+            ),
+        ]
+        if detail
+    ]
+
+    if "Read [Core Concepts](concepts.md) next" in quick_start:
+        details.append(
+            (
+                "container-quickstart.md must not tell newcomers to defer "
+                "concepts until after deeper UI exploration"
+            ),
+        )
+
+    if details:
+        raise AssertionError("; ".join(details))
+
+
 def test_docs_req_ops_001_env_matrix_matches_runtime_usage() -> None:
     """REQ-OPS-001: Environment matrix must track runtime variables used by tooling."""
     matrix_text = ENV_MATRIX_PATH.read_text(encoding="utf-8")

--- a/docsite/src/pages/index.astro
+++ b/docsite/src/pages/index.astro
@@ -49,6 +49,28 @@ import {
       </div>
     </section>
 
+    <section id="concept-primer" class="doc-card doc-section-stack">
+      <div class="doc-section-copy">
+        <p class="doc-pill doc-kicker">Learn First</p>
+        <h2 class="doc-section-title">Understand spaces, entries, and forms before going deeper</h2>
+        <p class="doc-lead">
+          Ugoite stays easier to adopt when you start with the mental model, then choose the browser, CLI, or specifications that fit your task.
+        </p>
+      </div>
+
+      <div class="doc-grid doc-card-list">
+        <a href={withBasePath(conceptPrimerCard.href)} class="doc-card doc-card-hover doc-link-card">
+          <div class="doc-link-card__icon" aria-hidden="true">{conceptPrimerCard.icon}</div>
+          <div class="doc-link-card__eyebrow">
+            <span class="doc-pill">{conceptPrimerCard.badge}</span>
+          </div>
+          <h3 class="doc-link-card__title">{conceptPrimerCard.title}</h3>
+          <p class="doc-link-card__body">{conceptPrimerCard.description}</p>
+          <div class="doc-link-card__footer">Open primer</div>
+        </a>
+      </div>
+    </section>
+
     <section id="start-paths" class="doc-card doc-section-stack">
       <div class="doc-section-header">
         <div class="doc-section-copy">
@@ -70,28 +92,6 @@ import {
             <div class="doc-link-card__footer">Open guide</div>
           </a>
         ))}
-      </div>
-    </section>
-
-    <section id="concept-primer" class="doc-card doc-section-stack">
-      <div class="doc-section-copy">
-        <p class="doc-pill doc-kicker">Learn First</p>
-        <h2 class="doc-section-title">Understand spaces, entries, and forms before going deeper</h2>
-        <p class="doc-lead">
-          Ugoite stays easier to adopt when you start with the mental model, then choose the browser, CLI, or specifications that fit your task.
-        </p>
-      </div>
-
-      <div class="doc-grid doc-card-list">
-        <a href={withBasePath(conceptPrimerCard.href)} class="doc-card doc-card-hover doc-link-card">
-          <div class="doc-link-card__icon" aria-hidden="true">{conceptPrimerCard.icon}</div>
-          <div class="doc-link-card__eyebrow">
-            <span class="doc-pill">{conceptPrimerCard.badge}</span>
-          </div>
-          <h3 class="doc-link-card__title">{conceptPrimerCard.title}</h3>
-          <p class="doc-link-card__body">{conceptPrimerCard.description}</p>
-          <div class="doc-link-card__footer">Open primer</div>
-        </a>
       </div>
     </section>
 

--- a/e2e/docsite-onboarding.test.ts
+++ b/e2e/docsite-onboarding.test.ts
@@ -98,6 +98,30 @@ test.describe("Docsite onboarding-first navigation", () => {
 		await expect(page.getByText("Application Docs")).toBeVisible();
 	});
 
+	test("REQ-E2E-008: landing and getting-started pages keep the concepts primer ahead of path selection", async ({
+		page,
+	}) => {
+		await page.goto(buildDocsiteUrl("/"), { waitUntil: "networkidle" });
+
+		const homeSectionOrder = await page
+			.locator(".doc-page-stack > section[id]")
+			.evaluateAll((sections) => sections.map((section) => section.id));
+		expect(homeSectionOrder.indexOf("concept-primer")).toBeLessThan(
+			homeSectionOrder.indexOf("start-paths"),
+		);
+
+		await page.goto(buildDocsiteUrl("/getting-started"), {
+			waitUntil: "networkidle",
+		});
+
+		const gettingStartedSectionOrder = await page
+			.locator(".doc-page-stack > section[id]")
+			.evaluateAll((sections) => sections.map((section) => section.id));
+		expect(gettingStartedSectionOrder.indexOf("concepts")).toBeLessThan(
+			gettingStartedSectionOrder.indexOf("first-steps"),
+		);
+	});
+
 	test("REQ-E2E-008: desktop navigation prioritizes getting-started content before design docs", async ({
 		page,
 	}) => {


### PR DESCRIPTION
## Summary
- keep the newcomer docs concepts-first so browser and source paths are chosen after the shared mental model is introduced
- preserve the newer README deeper-reference and contributor-path guardrails while adding a dedicated concepts-order regression guard
- update the REQ-E2E-008 docs test mapping to cover the new consistency check

## Related Issue (required)
closes #1203

## Testing
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -v -W error -k 'e2e_008'`
- [ ] `mise run test`
