### PR TITLE
feat: simplify entry create help examples

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -242,6 +242,7 @@ requirements:
     rust:
     - file: ugoite-cli/tests/test_cli_endpoint_routing.rs
       tests:
+      - test_entry_create_req_ops_006_help_leads_with_plain_markdown_example
       - test_entry_update_req_ops_006_help_describes_required_inputs
       - test_form_and_search_req_ops_006_help_describes_required_inputs
 - set_id: REQCAT-OPS

--- a/ugoite-cli/src/commands/entry.rs
+++ b/ugoite-cli/src/commands/entry.rs
@@ -46,7 +46,7 @@ pub enum EntrySubCmd {
     },
     /// Create an entry
     #[command(
-        long_about = "Create an entry in a space.\n\nThe entry ID is a slug (alphanumeric + hyphens). Content is a Markdown string.\n\nExamples:\n  # Core mode - create a note\n  ugoite entry create /root/spaces/my-space my-note --content $'---\\nform: Note\\n---\\n# My Note\\n\\n## Body\\n\\nHello world.'\n\n  # Backend mode - minimal entry\n  ugoite entry create my-space task-01 --content '# Task 01'\n\n  # Core mode with custom author\n  ugoite entry create /root/spaces/my-space my-note --content '# Note' --author alice"
+        long_about = "Create an entry in a space.\n\nThe entry ID is a slug (alphanumeric + hyphens). Content is a Markdown string. Frontmatter is optional and only needed when you want form-backed metadata.\n\nExamples:\n  # Core mode - minimal note\n  ugoite entry create /root/spaces/my-space my-note --content '# My Note'\n\n  # Core mode - note with form frontmatter\n  ugoite entry create /root/spaces/my-space my-note --content $'---\\nform: Note\\n---\\n# My Note\\n\\n## Body\\n\\nHello world.'\n\n  # Backend mode - minimal entry\n  ugoite entry create my-space task-01 --content '# Task 01'\n\n  # Core mode with custom author\n  ugoite entry create /root/spaces/my-space my-note --content '# Note' --author alice"
     )]
     Create {
         #[arg(

--- a/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -588,6 +588,35 @@ fn test_entry_update_req_ops_006_help_describes_required_inputs() {
     }
 }
 
+/// REQ-OPS-006: entry create help must lead with the simplest Markdown-only example.
+#[test]
+fn test_entry_create_req_ops_006_help_leads_with_plain_markdown_example() {
+    let help = Command::new(ugoite_bin())
+        .args(["entry", "create", "--help"])
+        .output()
+        .expect("failed to execute");
+    assert!(help.status.success());
+    let stdout = String::from_utf8_lossy(&help.stdout);
+
+    let simple_example = "ugoite entry create /root/spaces/my-space my-note --content '# My Note'";
+    let structured_example = "form: Note";
+
+    for needle in [
+        "Frontmatter is optional",
+        simple_example,
+        structured_example,
+        "Backend mode - minimal entry",
+    ] {
+        assert!(stdout.contains(needle), "{stdout}");
+    }
+
+    let simple_index = stdout.find(simple_example).expect("simple example");
+    let structured_index = stdout
+        .find(structured_example)
+        .expect("frontmatter example");
+    assert!(simple_index < structured_index, "{stdout}");
+}
+
 /// REQ-OPS-006: form and search help must describe required positional inputs before execution.
 #[test]
 fn test_form_and_search_req_ops_006_help_describes_required_inputs() {


### PR DESCRIPTION
## Summary

- lead `ugoite entry create --help` with a plain Markdown core-mode example
- explain that frontmatter is optional and move the structured example after the minimal path
- add REQ-OPS-006 coverage for the new help wording and example order

## Related Issue (required)

closes #1055

## Testing

- [x] `cargo run -q -p ugoite-cli -- entry create --help`
- [x] `cargo test --no-default-features --test test_cli_endpoint_routing test_entry_create_req_ops_006_help_leads_with_plain_markdown_example -- --exact`
- [x] `mise run test`