### PR TITLE
fix: add auth overview provenance fields

### DIFF
--- a/ugoite-cli/tests/test_auth.rs
+++ b/ugoite-cli/tests/test_auth.rs
@@ -549,7 +549,7 @@ fn test_cli_auth_login_req_ops_015_help_scopes_mock_oauth_proxy_token_requiremen
     );
 }
 
-/// REQ-SEC-003: auth overview includes the canonical channels field.
+/// REQ-SEC-003: auth overview includes canonical channels and provider provenance fields.
 #[test]
 fn test_cli_auth_overview_req_sec_003_includes_channels() {
     let output = Command::new(ugoite_bin())
@@ -577,5 +577,27 @@ fn test_cli_auth_overview_req_sec_003_includes_channels() {
             "cli(via backend)",
             "frontend(via backend)",
         ],
+    );
+
+    let providers = payload
+        .get("providers")
+        .and_then(Value::as_object)
+        .expect("providers object");
+    let bearer = providers
+        .get("bearer")
+        .and_then(Value::as_object)
+        .expect("bearer provider");
+    let api_key = providers
+        .get("api_key")
+        .and_then(Value::as_object)
+        .expect("api_key provider");
+
+    assert_eq!(
+        bearer.get("active_kids_source").and_then(Value::as_str),
+        Some("UGOITE_AUTH_BEARER_ACTIVE_KIDS"),
+    );
+    assert_eq!(
+        api_key.get("revocation_source").and_then(Value::as_str),
+        Some("UGOITE_AUTH_REVOKED_KEY_IDS"),
     );
 }

--- a/ugoite-core/src/auth.rs
+++ b/ugoite-core/src/auth.rs
@@ -467,13 +467,15 @@ pub fn auth_capabilities_snapshot(
                 "supports_signed_tokens": true,
                 "configured_static_token_count": bearer_tokens.len(),
                 "configured_signing_kid_count": signing_secrets.len(),
-                "active_kids": active_kids
+                "active_kids": active_kids,
+                "active_kids_source": "UGOITE_AUTH_BEARER_ACTIVE_KIDS"
             },
             "api_key": {
                 "supports_static_api_keys": true,
                 "supports_space_service_account_keys": true,
                 "configured_static_api_key_count": api_keys.len(),
-                "revoked_key_ids": revoked_key_ids
+                "revoked_key_ids": revoked_key_ids,
+                "revocation_source": "UGOITE_AUTH_REVOKED_KEY_IDS"
             }
         },
         "identity_model": {

--- a/ugoite-core/tests/test_auth_overview_consistency.py
+++ b/ugoite-core/tests/test_auth_overview_consistency.py
@@ -11,8 +11,6 @@ from typing import cast
 
 from ugoite_core.auth import export_authentication_overview
 
-DOC_ONLY_PROVIDER_FIELDS = {"active_kids_source", "revocation_source"}
-
 
 def _as_map(value: object) -> dict[str, object]:
     assert isinstance(value, dict)
@@ -23,16 +21,12 @@ def _assert_provider_contract(
     expected_provider: dict[str, object],
     actual_provider: dict[str, object],
 ) -> None:
-    expected_keys = set(expected_provider.keys()) - DOC_ONLY_PROVIDER_FIELDS
+    expected_keys = set(expected_provider.keys())
     actual_keys = set(actual_provider.keys())
     assert actual_keys == expected_keys
 
     for key in expected_keys:
         assert actual_provider[key] == expected_provider[key]
-
-    for key in DOC_ONLY_PROVIDER_FIELDS:
-        if key in expected_provider:
-            assert key not in actual_provider
 
 
 def test_auth_overview_matches_security_yaml_contract() -> None:


### PR DESCRIPTION
## Summary

- add the missing bearer/API-key provenance fields to the rust-core auth capabilities snapshot
- make the core auth overview consistency test require the full documented provider contract
- extend the CLI auth overview test to assert the exported source fields are present in live JSON

## Related Issue (required)

closes #1190

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo run -q -p ugoite-cli -- auth overview`
- [x] `cd ugoite-core && uv run pytest tests/test_auth_overview_consistency.py -q`
- [x] `cd ugoite-cli && cargo test --no-default-features --test test_auth test_cli_auth_overview_req_sec_003_includes_channels -- --exact`
- [x] `mise run test`