### PR TITLE
fix(frontend): reject placeholder UI specs

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1101,7 +1101,9 @@ requirements:
   title: UI Spec YAML Registry Validation
   description: 'Frontend tests MUST load all UI page YAML specs under docs/spec/ui/pages
 
-    and validate page links, shared chrome, and component type registry.
+    and validate page links, shared chrome, component type registry, and that
+
+    pages marked `implemented` do not still render obvious placeholder route copy.
 
     '
   related_spec:
@@ -1115,6 +1117,9 @@ requirements:
       - 'REQ-FE-040: loads UI page specs'
       - 'REQ-FE-040: validates page links'
       - 'REQ-FE-040: validates component types'
+      - 'REQ-FE-040: validates docs pages map to implemented routes'
+      - 'REQ-FE-040: validates implemented routes are documented'
+      - 'REQ-FE-040: implemented page specs reject placeholder route content'
       - 'REQ-FE-040: validates shared space chrome'
       - 'REQ-FE-040: validates entries/forms bottom tabs use product labels'
     - file: frontend/src/components/SpaceShell.test.tsx

--- a/docs/spec/ui/pages/space-sql-detail.yaml
+++ b/docs/spec/ui/pages/space-sql-detail.yaml
@@ -4,7 +4,7 @@ page:
   id: space-sql-detail
   title: Space SQL Detail
   route: /spaces/{space_id}/sql/{sql_id}
-  implementation: implemented
+  implementation: in-progress
 components:
   shared:
     - id: top-tabs

--- a/frontend/src/spec/ui-pages.test.ts
+++ b/frontend/src/spec/ui-pages.test.ts
@@ -95,6 +95,13 @@ const collectRouteFiles = (dir: string): string[] => {
 	return files;
 };
 
+const placeholderStubPatterns = [
+	/\bis not yet available\b/i,
+	/\bcoming soon\b/i,
+	/\bnot implemented\b/i,
+	/\bplaceholder (?:screen|ui|route)\b/i,
+];
+
 const segmentFromFile = (segment: string) => {
 	if (segment === "index") return "";
 	if (segment.startsWith("[") && segment.endsWith("]")) {
@@ -109,6 +116,13 @@ const routeFromFilePath = (filePath: string) => {
 	const segments = withoutExt.split("/").map(segmentFromFile).filter(Boolean);
 	return `/spaces/{space_id}${segments.length ? `/${segments.join("/")}` : ""}`;
 };
+
+const loadRoutes = () =>
+	collectRouteFiles(routesDir).map((filePath) => ({
+		filePath,
+		route: routeFromFilePath(filePath),
+		source: readFileSync(filePath, "utf8"),
+	}));
 
 const collectTargets = (value: unknown, targets: string[]) => {
 	if (Array.isArray(value)) {
@@ -183,7 +197,7 @@ describe("UI spec YAML registry", () => {
 
 	it("REQ-FE-040: validates docs pages map to implemented routes", () => {
 		const pages = loadPages();
-		const routes = new Set(collectRouteFiles(routesDir).map(routeFromFilePath));
+		const routes = new Set(loadRoutes().map(({ route }) => route));
 		for (const { spec, filePath } of pages) {
 			const route = spec.page?.route;
 			expect(route, `${filePath} missing route`).toBeTruthy();
@@ -198,11 +212,35 @@ describe("UI spec YAML registry", () => {
 		const documented = new Set(
 			pages.map(({ spec }) => spec.page?.route).filter((route): route is string => Boolean(route)),
 		);
-		const routes = new Set(collectRouteFiles(routesDir).map(routeFromFilePath));
+		const routes = new Set(loadRoutes().map(({ route }) => route));
 		for (const route of routes) {
 			expect(documented.has(route), `missing docs/spec/ui/pages entry for route: ${route}`).toBe(
 				true,
 			);
+		}
+	});
+
+	it("REQ-FE-040: implemented page specs reject placeholder route content", () => {
+		const pages = loadPages();
+		const routesByPath = new Map(loadRoutes().map((route) => [route.route, route]));
+		for (const { spec, filePath } of pages) {
+			if (spec.page?.implementation !== "implemented") {
+				continue;
+			}
+			const route = spec.page?.route;
+			expect(route, `${filePath} missing route`).toBeTruthy();
+			const routeRecord = routesByPath.get(String(route));
+			expect(routeRecord, `${filePath} route not implemented: ${String(route)}`).toBeTruthy();
+			if (!routeRecord) {
+				continue;
+			}
+			const matchedPattern = placeholderStubPatterns.find((pattern) =>
+				pattern.test(routeRecord.source),
+			);
+			expect(
+				matchedPattern,
+				`${filePath} marks ${String(route)} implemented but ${routeRecord.filePath} still contains placeholder copy`,
+			).toBeUndefined();
 		}
 	});
 


### PR DESCRIPTION
## Summary
- tighten the UI page spec guard so placeholder route files do not count as implemented pages
- update the shipped UI spec status alongside the regression coverage so the docs stay honest about current frontend behavior
- keep the placeholder detection covered in frontend tests

## Related Issue (required)
closes #1197

## Testing
- [ ] `mise run test`
- [ ] `cd frontend && bun run test:run src/spec/ui-pages.test.ts`
