### PR TITLE
fix: auto-install package vitest deps in worktrees

### DIFF
--- a/docsite/mise.toml
+++ b/docsite/mise.toml
@@ -17,11 +17,11 @@ run = "bun run typecheck"
 depends = ["lint", "format:check", "typecheck"]
 
 [tasks.test]
-run = "bun run test:run"
+run = "bash ../scripts/ensure-bun-package-install.sh && bun run test:run"
 description = "Run docsite unit tests with Vitest"
 
 [tasks."test:coverage"]
-run = "node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
+run = "bash ../scripts/ensure-bun-package-install.sh && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
 description = "Run docsite unit tests with 100% coverage enforcement"
 
 [tasks.build]

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -7,9 +7,9 @@ run = "bun install --frozen-lockfile"
 run = "eval \"$(bash ../scripts/dev-auth-env.sh)\" && bash ../scripts/wait-for-http.sh http://localhost:8000/health 30 && BACKEND_URL=http://localhost:8000 bun run dev"
 
 [tasks.test]
-run = "bun run test:run"
+run = "bash ../scripts/ensure-bun-package-install.sh && bun run test:run"
 description = "Run frontend unit/component tests with Vitest"
 
 [tasks."test:coverage"]
-run = "node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
+run = "bash ../scripts/ensure-bun-package-install.sh && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
 description = "Run frontend unit/component tests with 100% coverage enforcement"

--- a/scripts/ensure-bun-package-install.sh
+++ b/scripts/ensure-bun-package-install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -f ./node_modules/vitest/vitest.mjs ]; then
+  exit 0
+fi
+
+echo "Missing package-local Vitest install in $(pwd); running bun install --frozen-lockfile --ignore-scripts..."
+bun install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary
- add a shared helper that restores package-local Vitest installs with bun install --frozen-lockfile --ignore-scripts when worktrees or repo copies do not have package-local node_modules
- route frontend and docsite test tasks through the helper so repo-root mise run test can recover missing package installs automatically
- keep the install logic scoped to package test flows instead of changing unrelated setup behavior

## Related Issue
- Closes #1168

## Testing
- mise run test
- confirmed //frontend:test:coverage recreated a missing package-local Vitest install during the repo-root test run