### PR TITLE
docs: add compose startup troubleshooting guide

### DIFF
--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -38,6 +38,11 @@ docker compose -f docker-compose.release.yaml pull
 docker compose -f docker-compose.release.yaml up -d
 ```
 
+If the stack does not start cleanly, ports are already occupied, or the browser
+cannot reach the backend, follow
+[Compose Startup and Connectivity Troubleshooting](troubleshooting-compose-startup.md)
+before debugging login/auth behavior.
+
 The compose file pulls these canonical published images:
 
 - `ghcr.io/ugoite/ugoite/backend:${UGOITE_VERSION}`
@@ -69,6 +74,8 @@ so contributors exercise the explicit passkey + 2FA flow.
 - Switch to the [CLI Guide](cli.md) when you want a lighter terminal-first
   workflow, or to the [Docker Compose Guide](docker-compose.md) when you want
   the full contributor stack from source.
+- If the published stack starts in a confusing partial state, use
+  [Compose Startup and Connectivity Troubleshooting](troubleshooting-compose-startup.md).
 
 To stop the stack:
 

--- a/docs/guide/docker-compose.md
+++ b/docs/guide/docker-compose.md
@@ -46,6 +46,10 @@ docker compose logs -f backend
 docker compose logs -f frontend
 ```
 
+If the stack fails before login, the browser stays blank, or the frontend and
+backend cannot reach each other, continue with
+[Compose Startup and Connectivity Troubleshooting](troubleshooting-compose-startup.md).
+
 ## Stop the stack
 
 ```bash

--- a/docs/guide/troubleshooting-compose-startup.md
+++ b/docs/guide/troubleshooting-compose-startup.md
@@ -1,0 +1,113 @@
+# Compose Startup and Connectivity Troubleshooting
+
+Use this guide when the container stack does not start cleanly enough to reach
+the normal login flow. It covers the earlier failure modes that happen before
+[Troubleshooting Unauthorized Spaces Page](troubleshooting-unauthorized-spaces.md)
+becomes relevant.
+
+Use the same Compose command prefix that you used to start the stack:
+
+- Source checkout: `docker compose`
+- Published release quick start: `docker compose -f docker-compose.release.yaml`
+
+## 1. Check whether ports 3000 and 8000 are already occupied
+
+```bash
+ss -ltnp | grep -E ':(3000|8000)\s'
+```
+
+- If another local process already owns one of these ports, stop that process
+  before retrying Ugoite.
+- For the published quick start you can also change `UGOITE_FRONTEND_PORT` and
+  `UGOITE_BACKEND_PORT` in `.env`, then run the same release compose commands
+  again.
+
+## 2. Confirm backend readiness before debugging the frontend
+
+```bash
+curl -sS http://localhost:8000/health
+```
+
+Expected output:
+
+```json
+{"status":"ok"}
+```
+
+If this health check fails, continue with the backend log checks below. For the
+health endpoint contract, see [Backend Healthcheck](backend-healthcheck.md).
+
+## 3. Inspect frontend and backend logs together
+
+Check the current service state first:
+
+```bash
+docker compose ps
+```
+
+Then inspect both services:
+
+```bash
+docker compose logs --tail=100 backend
+docker compose logs --tail=100 frontend
+```
+
+If you are using the published release quick start, replace those commands with
+`docker compose -f docker-compose.release.yaml ...`.
+
+Focus on these two checks:
+
+- The backend should bind successfully and answer `GET /health`.
+- The frontend container must reach the backend through the Compose network at
+  `http://backend:8000`, not through `http://localhost:8000`.
+
+If the browser shows a blank page or repeated API failures, inspect the
+frontend logs for proxy errors and the backend logs for startup exceptions at
+the same time.
+
+## 4. Validate that the local spaces directory is writable
+
+The Compose stack keeps local-first data on the host through the spaces mount.
+Use the same host path that your stack is configured to mount:
+
+- Source checkout: `./spaces`
+- Published release quick start: `${UGOITE_SPACES_DIR:-./spaces}`
+
+One quick write test:
+
+```bash
+SPACE_PATH="${UGOITE_SPACES_DIR:-./spaces}"
+mkdir -p "$SPACE_PATH"
+touch "$SPACE_PATH/.ugoite-write-test" && rm "$SPACE_PATH/.ugoite-write-test"
+```
+
+If that write test fails, fix the directory ownership or permissions on the
+host before retrying the stack.
+
+## 5. Reset stale services, networks, and partial startup state
+
+Repeated interrupted runs can leave orphaned containers or a half-started
+network behind. Reset the stack and start it again from a clean Compose state:
+
+```bash
+docker compose down --remove-orphans
+docker compose up --build
+```
+
+For the published release quick start:
+
+```bash
+docker compose -f docker-compose.release.yaml down --remove-orphans
+docker compose -f docker-compose.release.yaml pull
+docker compose -f docker-compose.release.yaml up -d
+```
+
+If you intentionally want a full local data reset for the source checkout, you
+can remove `./spaces` after the stack is down and then start again.
+
+## 6. Continue to auth-specific troubleshooting only after startup is healthy
+
+Once the backend health check succeeds, the frontend loads, and the services can
+reach each other, continue with
+[Troubleshooting Unauthorized Spaces Page](troubleshooting-unauthorized-spaces.md)
+if `/spaces` still fails after login.

--- a/docs/guide/troubleshooting-unauthorized-spaces.md
+++ b/docs/guide/troubleshooting-unauthorized-spaces.md
@@ -1,6 +1,10 @@
 # Troubleshooting Unauthorized Spaces Page
 
-When the spaces page returns `Unauthorized`, validate these items in order:
+When the spaces page returns `Unauthorized`, validate these items in order.
+If the container stack is not healthy enough to reach `/login` or `/spaces` at
+all, start with
+[Compose Startup and Connectivity Troubleshooting](troubleshooting-compose-startup.md)
+instead:
 
 1. Confirm backend is running and reachable.
    - `curl -sS http://localhost:8000/health`


### PR DESCRIPTION
## Summary
- add a dedicated guide for Docker Compose startup and connectivity failures before auth becomes relevant
- link the new guide from the release quick start, source Docker Compose guide, and auth troubleshooting path

## Related Issue (required)
close: #1248

## Testing
- [x] mise run test

