### PR TITLE
docs: clarify data model authority layers

### DIFF
--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -85,9 +85,13 @@ source of truth.
 
 That design matters because it keeps the system easier to reason about:
 
-- entries and forms are the canonical data
+- entries and forms are the canonical domain data
 - indexes can be rebuilt when needed
 - automation can trust that search results come from local-first source data
+
+In other words: Markdown stays the authoring surface, entries plus Forms define
+the logical contract, and storage/index internals exist to persist or accelerate
+that contract rather than replace it.
 
 ## Which surface should you use?
 

--- a/docs/spec/architecture/decisions.md
+++ b/docs/spec/architecture/decisions.md
@@ -37,6 +37,8 @@ Extract core logic into a Rust crate (`ugoite-core`) with:
 
 **Decision**: 
 Use "Forms" to define entry types:
+- Markdown remains the primary authoring surface
+- Forms define the logical contract for typed fields and validation
 - Form definitions are stored through the Iceberg-managed `forms/` area; the
   logical contract matters, while the physical layout is intentionally not
   specified

--- a/docs/spec/data-model/overview.md
+++ b/docs/spec/data-model/overview.md
@@ -23,6 +23,22 @@ Ugoite's data model is built on these principles:
 | **Append-Only Integrity** | Revisions are appended in Iceberg; history is immutable |
 | **Table-Backed Storage** | Entries live in Apache Iceberg tables via OpenDAL |
 
+## Authority Layers
+
+Ugoite uses three related "source of truth" layers, each for a different job:
+
+- **User-facing authoring surface**: Markdown is the primary editing surface for
+  humans and agents.
+- **Logical/domain contract**: Entries plus their Form definitions are the
+  canonical meaning of the data model, including which typed fields exist and
+  how they should be interpreted.
+- **Physical persistence layer**: Iceberg-managed tables and metadata are the
+  authoritative on-disk representation that persists those entries and Forms.
+
+These layers should agree with each other, but they are not interchangeable:
+Markdown is for authoring, Forms define the logical contract, and Iceberg owns
+the storage layout.
+
 ## Directory Structure
 
 See [directory-structure.md](directory-structure.md) for the full space layout.
@@ -210,7 +226,9 @@ Conflicts return HTTP 409 with current revision.
 ## Indices
 
 Materialized indexes (search, embeddings, stats) are derived from Iceberg tables
-and can be regenerated. The Iceberg-managed layout is the only source of truth.
+and can be regenerated. They are never authoritative. The authoritative
+physical storage layer is the Iceberg-managed layout, while the logical/domain
+contract still comes from entries and their Form definitions.
 
 ## Integrity
 


### PR DESCRIPTION
## Summary

- define explicit authoring, logical, and physical authority layers for the data model
- align the concepts guide and architecture decisions wording with that layered model

## Related Issue (required)

closes #1246

## Testing

- [x] mise run test
