### PR TITLE
docs: clarify frontend boundary responsibilities

### DIFF
--- a/docs/spec/architecture/overview.md
+++ b/docs/spec/architecture/overview.md
@@ -99,11 +99,12 @@ API layer providing access to frontend and AI agents:
 
 ### Frontend (TypeScript/SolidStart)
 
-UI layer with NO data logic:
+UI/client layer with client-side state and cache responsibilities, but no
+business-rule or persistence logic:
 
 | Component | Responsibility |
 |-----------|----------------|
-| `lib/*-store.ts` | State management, optimistic updates |
+| `lib/*-store.ts` | Client-side state, local cache, optimistic updates |
 | `lib/*-api.ts` | Feature API clients (REST calls only) |
 | `routes/` | Page components |
 | `components/` | Reusable UI components |

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -95,7 +95,7 @@ Ugoite is a knowledge management system built on three core principles:
 | `ugoite-core` | OpenDAL/Iceberg adapter layer, persistence, Python bindings | Rust |
 | `ugoite-cli` | Command-line interface for direct user interaction | Rust |
 | `backend` | REST API, MCP server (delegates to ugoite-core) | Python (FastAPI) |
-| `frontend` | UI rendering, optimistic updates (no data logic) | TypeScript (SolidStart) |
+| `frontend` | UI rendering, client-side state, optimistic updates (no business or persistence logic) | TypeScript (SolidStart) |
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the contradictory “no data logic” wording with an explicit client-state vs. business/persistence boundary
- align the architecture overview and top-level module matrix with the frontend-backend interface spec

## Related Issue (required)
closes #1245

## Testing
- [x] mise run test
