### PR TITLE
docs: align package readmes with root dev flow

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -103,9 +103,16 @@ uv sync --locked
 
 ### Development
 
+For the canonical auth-aware contributor workflow that starts backend,
+frontend, and docsite together, return to the repository root and run
+`mise run dev` as described in the main [README](../README.md#setup--development-mise).
+
+Use the command below only when you intentionally want backend-isolated
+iteration:
+
 ```bash
-# Start development server
-uv run uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
+# Start the backend-only dev server
+mise run //backend:dev
 ```
 
 ### Testing

--- a/docsite/README.md
+++ b/docsite/README.md
@@ -2,6 +2,11 @@
 
 Astro + Bun + Tailwind based documentation site.
 
+For the canonical auth-aware contributor workflow that starts backend,
+frontend, and docsite together, return to the repository root and run
+`mise run dev` as described in the main [README](../README.md#setup--development-mise).
+Use the commands below when you intentionally want docsite-only iteration.
+
 ## Commands
 
 ```bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -95,9 +95,16 @@ npm install
 
 ### Development
 
+For the canonical auth-aware contributor workflow that starts backend,
+frontend, and docsite together, return to the repository root and run
+`mise run dev` as described in the main [README](../README.md#setup--development-mise).
+
+Use the command below only when you intentionally want frontend-isolated
+iteration and already have a reachable local backend:
+
 ```bash
-# Set backend URL and start dev server
-BACKEND_URL=http://localhost:8000 npm run dev
+# Start the frontend-only dev server
+mise run //frontend:dev
 ```
 
 ### Testing


### PR DESCRIPTION
## Summary

- point backend, frontend, and docsite contributors back to the root `mise run dev` flow for auth-aware full-stack work
- relabel the package README commands as isolated workflows and use the package mise tasks directly

## Related Issue (required)

closes #1244

## Testing

- [x] mise run test
