### PR TITLE
docs: align contributor prereq tooling guidance

### DIFF
--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -48,7 +48,7 @@ jobs:
           check-compliance: true
           compliance-fail-level: "ERROR"
           compliance-fail-on-vulnerabilities: true
-          python-version: "3.12.13"
+          python-version: "3.13.12"
         env:
           VULNERABLECODE_URL: "https://public.vulnerablecode.io/"
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ For contributor-oriented Cargo workflows, see [CLI Guide](docs/guide/cli.md).
 
 Install dependencies and repository pre-commit hooks:
 
+The repository root `mise.toml` is the contributor-facing source of truth for
+managed tool versions. Use that shared toolchain story first, then treat
+package README prerequisites as workflow notes on top of the same managed
+environment.
+
 ```bash
 mise run setup
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -92,7 +92,9 @@ async def update_entry_endpoint(payload: EntryUpdate):
 ### Prerequisites
 
 - Python 3.13+
-- uv (package manager)
+- For contributor-managed tool versions, use the repository root `mise.toml`
+  via `mise run setup`; backend-local commands below assume that shared Python
+  + `uv` toolchain.
 
 ### Installation
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -84,13 +84,15 @@ const store = createEntryStore(...);  // NO! Violates responsibility
 
 ### Prerequisites
 
-- Node.js >= 22
-- Backend service running (see backend README)
+- For contributor-managed tool versions, use the repository root `mise.toml`
+  via `mise run setup`.
+- Backend service running (see backend README) if you are not using the root
+  `mise run dev` workflow.
 
 ### Installation
 
 ```bash
-npm install
+mise run //frontend:install
 ```
 
 ### Development

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,7 @@ BROWSERSLIST_IGNORE_OLD_DATA = "true"
 biome = "2.3.15"
 bun = "1.3.8"
 node = "22.12.0"
-python = "3.12.13"
+python = "3.13.12"
 rust = "1.93.0"
 uv = "0.10.10"
 


### PR DESCRIPTION
## Summary

- make the root README explicitly point contributors at `mise.toml` as the managed toolchain source of truth
- keep backend/frontend package READMEs aligned with that shared toolchain story while preserving their package-local setup notes
- align the repo-managed Python pin with the backend requirement and CI ScanCode runtime

## Related Issue (required)

closes #1243

## Testing

- [x] mise run test
