### PR TITLE
docs: clarify auth overview next step

### DIFF
--- a/docs/guide/auth-overview.md
+++ b/docs/guide/auth-overview.md
@@ -3,9 +3,11 @@
 Use this guide when you want the human-facing explanation of how authentication
 works across the browser, CLI, and backend today.
 
-If you are actively running the local development stack, read
-[Local Development Authentication and Login](local-dev-auth-login.md) next. That
-guide is the step-by-step workflow for `mise run dev`, `/login`, and
+This guide explains the current auth model. If you want the practical
+step-by-step setup flow, continue to
+[Local Development Authentication and Login](local-dev-auth-login.md) next,
+whether you have already started the stack or are still deciding how to do it.
+That guide is the hands-on workflow for `mise run dev`, `/login`, and
 `ugoite auth login`.
 
 If you need the machine-readable snapshot of the current auth contract, run:


### PR DESCRIPTION
## Summary

- make the auth overview handoff to the local dev auth/login guide explicit for both theory-first and hands-on readers
- describe auth-overview as the model guide and local-dev-auth-login as the practical setup workflow

## Related Issue (required)

closes #1241

## Testing

- [x] mise run test
