### PR TITLE
docs: explain release compose remote networking

### DIFF
--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -7,6 +7,8 @@ services:
       - "${UGOITE_SPACES_DIR:-./spaces}:/data"
     environment:
       - UGOITE_ROOT=/data
+      # Required because the frontend container reaches the backend over the
+      # private Compose bridge network; host exposure still stays on 127.0.0.1.
       - UGOITE_ALLOW_REMOTE=true
       - UGOITE_BOOTSTRAP_DEFAULT_SPACE=true
       - UGOITE_DEV_AUTH_MODE=mock-oauth

--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -58,6 +58,25 @@ defaults to `mock-oauth` so first-time browser evaluators can reach `/spaces`
 with fewer steps, while source development keeps `passkey-totp` as the default
 so contributors exercise the explicit passkey + 2FA flow.
 
+## Why does release compose set `UGOITE_ALLOW_REMOTE=true`?
+
+The shipped `docker-compose.release.yaml` runs the frontend and backend as two
+separate containers. The frontend reaches the backend through the Compose
+network at `http://backend:8000`, so the backend must accept non-loopback
+traffic **inside that private container network**. That is why the published
+compose file sets `UGOITE_ALLOW_REMOTE=true`.
+
+This does **not** make the quick start publicly reachable by default. The
+published host ports still bind to `127.0.0.1`, so the browser UI and backend
+API remain localhost-only on the host unless you edit the compose file
+yourself.
+
+If you want stricter host exposure, remove the backend `ports:` mapping and use
+the browser only through the frontend container; it will still reach
+`http://backend:8000` over the Compose network. If you need a topology that
+keeps `UGOITE_ALLOW_REMOTE=false`, use the CLI in `core` mode or a non-Compose
+workflow where the client talks to a loopback-bound backend directly.
+
 ## Where browser-created data lives
 
 The browser path is still local-first in practice. When you create entries
@@ -135,6 +154,8 @@ Choose the release channel that matches your goal:
   space, and enables explicit `mock-oauth` browser login so `/login` works
   without editing the compose file.
 - The frontend container talks to the backend through the Compose network via
-  `http://backend:8000`.
+  `http://backend:8000`, which is why the shipped backend environment keeps
+  `UGOITE_ALLOW_REMOTE=true` inside the container network even though host
+  access still stays on `127.0.0.1`.
 - If you want source-mounted development containers instead, use
   `docker-compose.yaml` and build locally.

--- a/docs/spec/security/overview.md
+++ b/docs/spec/security/overview.md
@@ -37,6 +37,10 @@ targets an **Authenticated Access by Default** model.
 - Set `UGOITE_ALLOW_REMOTE=true` to allow remote connections
 - Required for dev containers or Codespaces
 - Automatically configured in `mise run dev`
+- Also required for the published two-container release Compose quick start,
+  because the frontend container reaches the backend over the private Compose
+  bridge network; host exposure still remains localhost-only there because the
+  published ports bind to `127.0.0.1`
 
 ### CORS
 - Restricted to explicit frontend origins from `ALLOW_ORIGIN`


### PR DESCRIPTION
## Summary
- explain why the published release compose topology needs UGOITE_ALLOW_REMOTE=true inside the private Compose network
- document why host exposure still stays localhost-only because the shipped ports bind to 127.0.0.1
- add the same rationale to the security overview and the compose file itself

## Related Issue (required)
close: #1239

## Testing
- [x] mise run test

