### PR TITLE
fix(frontend): route Learn More CTA to the getting-started docsite

### DIFF
--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -1,0 +1,24 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import HomeRoute from "./index";
+
+vi.mock("@solidjs/router", () => ({
+	A: (props: { href: string; class?: string; children: unknown }) => (
+		<a href={props.href} class={props.class}>
+			{props.children}
+		</a>
+	),
+}));
+
+describe("home route", () => {
+	it("REQ-E2E-008: public home page routes Learn More to the canonical getting-started docsite flow", () => {
+		render(() => <HomeRoute />);
+
+		expect(screen.getByRole("heading", { name: "Ugoite" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Learn More" })).toHaveAttribute(
+			"href",
+			"https://ugoite.github.io/ugoite/getting-started",
+		);
+	});
+});

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,5 +1,10 @@
 import { A } from "@solidjs/router";
 
+const learnMoreHref =
+	process.env.NODE_ENV === "development"
+		? "http://localhost:4321/getting-started"
+		: "https://ugoite.github.io/ugoite/getting-started";
+
 export default function Home() {
 	return (
 		<main class="ui-page text-center mx-auto">
@@ -14,9 +19,9 @@ export default function Home() {
 				<A href="/spaces" class="ui-button ui-button-primary">
 					Open Spaces
 				</A>
-				<A href="/about" class="ui-button ui-button-secondary">
+				<a href={learnMoreHref} class="ui-button ui-button-secondary">
 					Learn More
-				</A>
+				</a>
 			</div>
 			<div class="mt-12 sm:mt-16 grid grid-cols-1 md:grid-cols-3 gap-6 sm:gap-8 max-w-4xl mx-auto text-left">
 				<div class="ui-card">


### PR DESCRIPTION
## Summary

- send the public home-page Learn More CTA to the canonical docsite getting-started flow
- keep local development on the local docsite while using the published GitHub Pages docsite outside development
- cover the CTA target in a frontend route test and verify the browser-to-docsite handoff with Playwright

## Related Issue (required)

closes #1076

## Testing

- [x] cd frontend && bun run test:run src/routes/index.test.tsx
- [x] Playwright check against `UGOITE_DEV_AUTH_MODE=mock-oauth PORT=3100 mise run dev`
- [x] mise run test