### PR TITLE
docs: add CLI routing mode guide

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -200,9 +200,16 @@ Backend and API modes still accept bare space IDs such as `demo`.
 
 CLI can run in three modes, and stores the selection in `~/.ugoite/cli-endpoints.json`.
 
-- `core`: call `ugoite-core` directly (default)
-- `backend`: call backend REST endpoints directly (e.g. `http://localhost:8000`)
-- `api`: call the frontend-proxied API base (e.g. `http://localhost:3000/api`)
+If you are choosing for the first time, use this rule of thumb:
+
+| Mode | Choose it when | Practical trade-off |
+| --- | --- | --- |
+| `core` | You are working directly with a local checkout or local `spaces/` directory on this machine | Reads and writes your filesystem directly with no backend required. This is the default because it is the shortest local-first path. |
+| `backend` | You want the CLI to talk to a backend server directly | Uses backend REST endpoints and the server's storage/auth behavior instead of your local filesystem. |
+| `api` | You want the CLI to use the same proxied `/api` surface as the frontend | Follows the frontend-facing API path and its proxy/auth behavior instead of direct local access. |
+
+Switch away from `core` only when you specifically want server-backed behavior
+or the same frontend proxy path the browser uses.
 
 When mode is `backend` or `api`, remote commands accept a `SPACE_ID` (or the
 shared `SPACE_ID_OR_PATH` argument for commands that also work in `core` mode)
@@ -225,10 +232,9 @@ cargo run -q -p ugoite-cli -- config set --mode api --api-url http://localhost:3
 cargo run -q -p ugoite-cli -- config set --mode core
 ```
 
-When you switch away from `core`, the CLI now prints a reminder that future
-commands will run against the configured server or API instead of your local
-filesystem. Use `ugoite config current` whenever you want a quick plain-language
-summary of the active topology and the command to return to `core`.
+Use `ugoite config current` whenever you want the same newcomer-facing summary
+in plain language, including when the current mode is a better fit than the
+other two and how to return to `core`.
 
 ## Auth profile commands
 

--- a/ugoite-cli/src/commands/config.rs
+++ b/ugoite-cli/src/commands/config.rs
@@ -16,12 +16,12 @@ pub enum ConfigSubCmd {
     Current,
     /// Save endpoint config (mode, backend URL, API URL)
     #[command(
-        long_about = "Save endpoint configuration.\n\nThree modes are supported:\n  core     - Direct local filesystem access (no backend needed)\n  backend  - Connect to a running ugoite backend server\n  api      - Connect to a remote API endpoint\n\nExamples:\n  # Core mode (default, uses local filesystem)\n  ugoite config set --mode core\n\n  # Backend mode (connect to local backend)\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\n  # API mode (connect to remote API)\n  ugoite config set --mode api --api-url https://api.example.com\n\n  # Update only the backend URL (keep current mode)\n  ugoite config set --backend-url http://localhost:9000"
+        long_about = "Save endpoint configuration.\n\nWhich mode should you use?\n  core     - Default. Use when you are working directly with a local checkout or local spaces/ directory.\n  backend  - Use when you want the CLI to talk to a backend server directly.\n  api      - Use when you want the CLI to use the same proxied /api surface as the frontend.\n\nWhy core is the default:\n  core keeps the CLI local-first. Commands read and write your filesystem directly, with no server required.\n\nExamples:\n  # Core mode (default, uses local filesystem)\n  ugoite config set --mode core\n\n  # Backend mode (connect to local backend)\n  ugoite config set --mode backend --backend-url http://localhost:8000\n\n  # API mode (same proxied /api surface as the frontend)\n  ugoite config set --mode api --api-url https://example.com/api\n\n  # Update only the backend URL (keep current mode)\n  ugoite config set --backend-url http://localhost:9000"
     )]
     Set {
         #[arg(
             long,
-            help = "Endpoint mode: core (local filesystem), backend (ugoite server), or api (remote API)"
+            help = "Endpoint mode: core (local spaces/ on this machine, default), backend (direct backend server), or api (same proxied /api surface as the frontend)"
         )]
         mode: Option<String>,
         #[arg(
@@ -82,6 +82,10 @@ fn print_current_config(config: &crate::config::EndpointConfig) {
         EndpointMode::Core => {
             println!("Current endpoint mode: core");
             println!("Topology: local filesystem via ugoite-core.");
+            println!(
+                "Best when: you are working directly with a local checkout or local spaces/ directory."
+            );
+            println!("Why it stays the default: it is the shortest local-first path and does not require a running server.");
             println!("Future commands read and write your local workspace directly.");
             println!("To switch to a server-backed mode:");
             println!("  ugoite config set --mode backend --backend-url http://localhost:8000");
@@ -89,6 +93,8 @@ fn print_current_config(config: &crate::config::EndpointConfig) {
         EndpointMode::Backend => {
             println!("Current endpoint mode: backend");
             println!("Topology: direct backend server at {}", config.backend_url);
+            println!("Best when: you want the CLI to talk to a backend server directly.");
+            println!("Trade-off: future commands use the server's storage and auth behavior instead of your local filesystem.");
             println!("Future commands use the server instead of your local filesystem.");
             println!("To return to local-first mode:");
             println!("  ugoite config set --mode core");
@@ -96,6 +102,10 @@ fn print_current_config(config: &crate::config::EndpointConfig) {
         EndpointMode::Api => {
             println!("Current endpoint mode: api");
             println!("Topology: API endpoint at {}", config.api_url);
+            println!(
+                "Best when: you want the CLI to use the same proxied /api surface as the frontend."
+            );
+            println!("Trade-off: future commands follow the frontend-facing API path instead of direct local filesystem access.");
             println!("Future commands use the remote API instead of your local filesystem.");
             println!("To return to local-first mode:");
             println!("  ugoite config set --mode core");

--- a/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
+++ b/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
@@ -131,6 +131,25 @@ fn test_cli_req_ops_006_main_auth_and_config_error_paths() {
         Some("http://backend.example.test")
     );
 
+    let config_set_help = cli_command(&config_path)
+        .args(["config", "set", "--help"])
+        .output()
+        .expect("config set help");
+    assert_success(&config_set_help, "config set help");
+    let config_set_help_stdout = String::from_utf8_lossy(&config_set_help.stdout);
+    for needle in [
+        "Which mode should you use?",
+        "local checkout or local spaces/ directory",
+        "talk to a backend server directly",
+        "same proxied /api surface as the frontend",
+        "Why core is the default:",
+    ] {
+        assert!(
+            config_set_help_stdout.contains(needle),
+            "{config_set_help_stdout}"
+        );
+    }
+
     let current_core = cli_command(&config_path)
         .args(["config", "current"])
         .output()
@@ -139,6 +158,8 @@ fn test_cli_req_ops_006_main_auth_and_config_error_paths() {
     let current_core_stdout = String::from_utf8_lossy(&current_core.stdout);
     assert!(current_core_stdout.contains("Current endpoint mode: core"));
     assert!(current_core_stdout.contains("local filesystem"));
+    assert!(current_core_stdout.contains("local checkout or local spaces/ directory"));
+    assert!(current_core_stdout.contains("shortest local-first path"));
 
     let switch_to_api_from_core = cli_command(&config_path)
         .args([
@@ -164,6 +185,7 @@ fn test_cli_req_ops_006_main_auth_and_config_error_paths() {
     let current_api_stdout = String::from_utf8_lossy(&current_api.stdout);
     assert!(current_api_stdout.contains("Current endpoint mode: api"));
     assert!(current_api_stdout.contains("http://api.example.test/api"));
+    assert!(current_api_stdout.contains("same proxied /api surface as the frontend"));
     assert!(current_api_stdout.contains("remote API instead of your local filesystem"));
 
     let switch_to_core_from_api = cli_command(&config_path)
@@ -201,6 +223,7 @@ fn test_cli_req_ops_006_main_auth_and_config_error_paths() {
     let current_backend_stdout = String::from_utf8_lossy(&current_backend.stdout);
     assert!(current_backend_stdout.contains("Current endpoint mode: backend"));
     assert!(current_backend_stdout.contains("http://backend.example.test"));
+    assert!(current_backend_stdout.contains("talk to a backend server directly"));
     assert!(current_backend_stdout.contains("server instead of your local filesystem"));
 
     let switch_to_api_from_backend = cli_command(&config_path)


### PR DESCRIPTION
## Summary
- add a newcomer-friendly decision table to the CLI guide for core, backend, and api routing modes
- surface the same rule-of-thumb in `ugoite config set --help` and `ugoite config current`
- extend the existing REQ-OPS-006 CLI coverage test so the routing guidance stays shipped

## Related Issue (required)
close: #1054

## Testing
- [x] cargo test --test test_cli_req_ops_006_coverage test_cli_req_ops_006_main_auth_and_config_error_paths -- --nocapture
- [x] cargo run -q -- config set --help
- [x] cargo run -q -- config current
- [x] mise run test

