### PR TITLE
fix: remove looping login spaces CTA

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -619,6 +619,7 @@ requirements:
       - 'REQ-OPS-015: signs in with passkey-totp and stores a browser auth cookie'
       - 'REQ-OPS-015: uses explicit mock-oauth browser login without startup auth injection'
       - 'REQ-OPS-015: visiting login preserves an existing browser auth cookie until re-auth completes'
+      - 'REQ-OPS-015: keeps the /spaces shortcut out of signed-out login screens'
       - 'REQ-OPS-015: shows first-run passkey guidance with the canonical local auth guide'
       - 'REQ-OPS-015: keeps first-run passkey guidance out of mock-oauth login'
       - 'REQ-OPS-015: keeps auth-config recovery guidance compatible with source and published browser flows'

--- a/frontend/src/routes/login.test.tsx
+++ b/frontend/src/routes/login.test.tsx
@@ -91,6 +91,21 @@ describe("/login", () => {
 		expect(navigateMock).not.toHaveBeenCalled();
 	});
 
+	it("REQ-OPS-015: keeps the /spaces shortcut out of signed-out login screens", async () => {
+		seedDevAuthConfig({
+			mode: "mock-oauth",
+			username_hint: "dev-oauth-user",
+			supports_passkey_totp: false,
+			supports_mock_oauth: true,
+		});
+
+		render(() => <LoginRoute />);
+
+		await screen.findByRole("button", { name: "Continue with Mock OAuth" });
+		expect(screen.getByRole("link", { name: "Back to Home" })).toHaveAttribute("href", "/");
+		expect(screen.queryByRole("link", { name: "Go to Spaces" })).not.toBeInTheDocument();
+	});
+
 	it("REQ-OPS-015: shows first-run passkey guidance with the canonical local auth guide", async () => {
 		seedDevAuthConfig({
 			mode: "passkey-totp",

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -206,9 +206,6 @@ export default function LoginRoute() {
 					<A href="/" class="ui-button ui-button-secondary">
 						Back to Home
 					</A>
-					<A href="/spaces" class="ui-button ui-button-secondary">
-						Go to Spaces
-					</A>
 				</div>
 			</section>
 		</main>


### PR DESCRIPTION
## Summary

- remove the signed-out `Go to Spaces` CTA from `/login` so the page stops advertising a no-op redirect loop
- add a REQ-OPS-015 login-route regression test for the signed-out state and record it in the requirement manifest

## Related Issue (required)

closes #1072

## Testing

- [x] cd frontend && bun run test:run src/lib/auth-api.test.ts src/routes/login.test.tsx
- [x] Playwright smoke: signed-out `/login` shows `Back to Home` and does not show `Go to Spaces`
- [x] mise run test
