### PR TITLE
fix(frontend): explain legacy /query route recovery

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1751,3 +1751,35 @@ requirements:
       tests:
       - 'REQ-FE-062: saved SQL detail renders a read-only query summary and supported actions'
       - 'REQ-FE-062: saved SQL detail runs variable-free queries through SQL sessions'
+- set_id: REQCAT-FRONTEND
+  source_file: requirements/frontend.yaml
+  scope: Frontend route, component, and interaction requirements.
+  linked_policies:
+  - POL-006
+  - POL-009
+  - POL-013
+  - POL-014
+  linked_specifications:
+  - SPEC-UI-OVERVIEW
+  - SPEC-UI-PAGES
+  - SPEC-ARCH-INTERFACE
+  id: REQ-FE-063
+  title: Legacy Query Route Recovery Guidance
+  description: 'The `/spaces/{space_id}/query` route MUST not silently rewrite users
+
+    to `/search`. It MUST explain that Search is the supported query surface,
+
+    preserve a clear recovery path into `/search`, and offer a direct route back
+
+    to the current space context.
+
+    '
+  related_spec:
+  - ui/pages/space-search.yaml
+  priority: medium
+  status: implemented
+  tests:
+    vitest:
+    - file: frontend/src/routes/spaces/[space_id]/query.test.tsx
+      tests:
+      - 'REQ-FE-063: legacy query route explains the supported search path'

--- a/frontend/src/routes/spaces/[space_id]/query.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/query.test.tsx
@@ -1,0 +1,48 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import SpaceQueryRoute from "./query";
+
+vi.mock("@solidjs/router", () => ({
+	A: (props: { href: string; class?: string; children: unknown }) => (
+		<a href={props.href} class={props.class}>
+			{props.children}
+		</a>
+	),
+	useParams: () => ({ space_id: "default" }),
+}));
+
+vi.mock("~/components/SpaceShell", () => ({
+	SpaceShell: (props: { children: unknown; spaceId: string; activeTopTab?: string }) => (
+		<div data-space-id={props.spaceId} data-active-top-tab={props.activeTopTab}>
+			{props.children}
+		</div>
+	),
+}));
+
+describe("/spaces/:space_id/query", () => {
+	it("REQ-FE-063: legacy query route explains the supported search path", () => {
+		const { container } = render(() => <SpaceQueryRoute />);
+		const subtitle = container.querySelector(".ui-page-subtitle");
+
+		expect(screen.getByRole("heading", { name: "Query moved to Search" })).toBeInTheDocument();
+		expect(subtitle).not.toBeNull();
+		expect(subtitle).toHaveTextContent(
+			"This legacy /query URL is kept only so older bookmarks and stale links do not fail.",
+		);
+		expect(subtitle).toHaveTextContent("/search");
+		expect(
+			screen.getByText(/keyword search, advanced filters, and query history/i),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Open Search" })).toHaveAttribute(
+			"href",
+			"/spaces/default/search",
+		);
+		expect(screen.getByRole("link", { name: "Back to Dashboard" })).toHaveAttribute(
+			"href",
+			"/spaces/default/dashboard",
+		);
+		expect(container.firstElementChild).toHaveAttribute("data-space-id", "default");
+		expect(container.firstElementChild).toHaveAttribute("data-active-top-tab", "search");
+	});
+});

--- a/frontend/src/routes/spaces/[space_id]/query.tsx
+++ b/frontend/src/routes/spaces/[space_id]/query.tsx
@@ -1,13 +1,46 @@
-import { useNavigate, useParams } from "@solidjs/router";
-import { onMount } from "solid-js";
+import { A, useParams } from "@solidjs/router";
+import { SpaceShell } from "~/components/SpaceShell";
 
 export default function SpaceQueryRoute() {
 	const params = useParams<{ space_id: string }>();
-	const navigate = useNavigate();
+	const spaceId = () => params.space_id;
 
-	onMount(() => {
-		navigate(`/spaces/${params.space_id}/search`, { replace: true });
-	});
+	return (
+		<SpaceShell spaceId={spaceId()} activeTopTab="search">
+			<div class="mx-auto max-w-4xl ui-stack">
+				<section class="ui-card ui-stack">
+					<div class="ui-stack-sm">
+						<p class="text-sm ui-muted">Space: {spaceId()}</p>
+						<h1 class="ui-page-title">Query moved to Search</h1>
+						<p class="ui-page-subtitle max-w-2xl">
+							This legacy <code>/query</code> URL is kept only so older bookmarks and stale links do
+							not fail. Ugoite&apos;s supported query and search flow now lives under{" "}
+							<code>/search</code>, where keyword search, advanced filters, and query history are
+							available together.
+						</p>
+					</div>
 
-	return null;
+					<div class="ui-stack-sm">
+						<h2 class="text-lg font-semibold">What to do next</h2>
+						<ul class="list-disc space-y-2 pl-5 text-sm ui-muted">
+							<li>Open Search to continue with the supported query experience.</li>
+							<li>
+								Update old bookmarks or shared links that still point to <code>/query</code>.
+							</li>
+							<li>Return to the dashboard if you were only trying to get back into this space.</li>
+						</ul>
+					</div>
+
+					<div class="flex flex-wrap gap-3">
+						<A href={`/spaces/${spaceId()}/search`} class="ui-button ui-button-primary">
+							Open Search
+						</A>
+						<A href={`/spaces/${spaceId()}/dashboard`} class="ui-button ui-button-secondary">
+							Back to Dashboard
+						</A>
+					</div>
+				</section>
+			</div>
+		</SpaceShell>
+	);
 }


### PR DESCRIPTION
## Summary
- replace the silent `/spaces/:space_id/query` rewrite with an explanatory recovery page
- keep direct links to Search and Dashboard for legacy bookmarks and stale links
- renumber the frontend requirement and test traceability to `REQ-FE-063` after rebasing onto `main`

## Related Issue (required)
closes #1053

## Testing
- [x] `cd frontend && bun run test:run 'src/routes/spaces/[space_id]/query.test.tsx' --maxWorkers=1 --pool=forks`
- [x] `cd frontend && bunx biome ci 'src/routes/spaces/[space_id]/query.tsx' 'src/routes/spaces/[space_id]/query.test.tsx'`
- [x] `uvx pre-commit run yamllint --files docs/spec/requirements/frontend.yaml`
