### PR TITLE
Keep README documentation map focused on deeper references

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,21 @@ e2e/                # End-to-end tests (Bun)
 
 ## Documentation Map
 
-The Start Here section above is the canonical newcomer map. Use the deeper
-references below once you want implementation details, contributor diagnostics,
-or release planning:
+Use **Start Here** above for the newcomer path. This section only lists the
+additional references you usually open after that first choice.
+
+### Operational guides
+
 - [Backend Healthcheck](docs/guide/backend-healthcheck.md) - Quick backend readiness check
-- [Specification Index](docs/spec/index.md) - Technical specifications
+- [Environment Matrix](docs/guide/env-matrix.md) - Runtime variables and which surface consumes them
+
+### Design and implementation references
+
 - [Architecture Overview](docs/spec/architecture/overview.md) - System design
-- [API Reference](docs/spec/api/rest.md) - REST API documentation
+- [REST API Reference](docs/spec/api/rest.md) - Backend HTTP contract
+- [MCP Reference](docs/spec/api/mcp.md) - Current resource-first MCP surface
+
+### Release planning
 - [Versions Overview](docs/spec/versions/index.md) - Human-readable release streams
   and planned milestones
 - [Machine-readable roadmap](docs/version/unknown/roadmap.yaml) - YAML milestone

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -1229,11 +1229,12 @@ def test_docs_req_e2e_008_readme_doc_map_focuses_on_deeper_refs() -> None:
 
     section = match.group("section")
     required_fragments = [
-        "Start Here section above is the canonical newcomer map",
+        "Use **Start Here** above for the newcomer path.",
         "Backend Healthcheck",
-        "Specification Index",
+        "Environment Matrix",
         "Architecture Overview",
-        "API Reference",
+        "REST API Reference",
+        "MCP Reference",
         "Versions Overview",
         "Machine-readable roadmap",
     ]
@@ -1245,17 +1246,20 @@ def test_docs_req_e2e_008_readme_doc_map_focuses_on_deeper_refs() -> None:
         )
         raise AssertionError(message)
 
-    forbidden_fragments = [
-        "[Core Concepts](docs/guide/concepts.md)",
-        "[Container Quick Start](docs/guide/container-quickstart.md)",
-        "[CLI Guide](docs/guide/cli.md)",
-        "[Local Dev Auth/Login](docs/guide/local-dev-auth-login.md)",
+    duplicated_start_here_references = [
+        "Core Concepts",
+        "Container Quick Start",
+        "CLI Guide",
+        "Local Dev Auth/Login",
+        "Specification Index",
     ]
-    duplicated = [fragment for fragment in forbidden_fragments if fragment in section]
-    if duplicated:
+    duplicates = [
+        fragment for fragment in duplicated_start_here_references if fragment in section
+    ]
+    if duplicates:
         message = (
-            "README Documentation Map must not duplicate Start Here newcomer links: "
-            + ", ".join(duplicated)
+            "README Documentation Map must not repeat Start Here references: "
+            + ", ".join(duplicates)
         )
         raise AssertionError(message)
 


### PR DESCRIPTION
## Summary
- keep `README.md` focused on a single newcomer path by reserving `Documentation Map` for post-onboarding references
- surface Environment Matrix, REST API, and MCP links where readers need deeper operational or implementation context
- keep the REQ-E2E-008 docs test aligned with the tighter README documentation-map wording after rebasing onto `main`

## Related Issue (required)
closes #1200

## Testing
- [x] uvx ruff check --select ALL --ignore-noqa docs/tests/test_guides.py
- [x] uvx ruff format --check docs/tests/test_guides.py
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -k 'readme_start_here or doc_map or source_contributor_path' -v -W error
- [x] uvx pre-commit run --files README.md docs/spec/requirements/e2e.yaml docs/tests/test_guides.py