### PR TITLE
fix: standardize entry markdown payloads

### DIFF
--- a/backend/src/app/api/endpoints/entry.py
+++ b/backend/src/app/api/endpoints/entry.py
@@ -24,6 +24,14 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+def _entry_response(entry: dict[str, Any]) -> dict[str, Any]:
+    response = dict(entry)
+    content = response.get("content")
+    if isinstance(content, str) and "markdown" not in response:
+        response["markdown"] = content
+    return response
+
+
 @router.post(
     "/spaces/{space_id}/entries",
     status_code=status.HTTP_201_CREATED,
@@ -48,19 +56,19 @@ async def create_entry_endpoint(
         await _validate_entry_markdown_against_form(
             storage_config,
             space_id,
-            payload.content,
+            payload.markdown,
         )
         await ugoite_core.require_markdown_write(
             storage_config,
             space_id,
             identity,
-            payload.content,
+            payload.markdown,
         )
         await ugoite_core.create_entry(
             storage_config,
             space_id,
             entry_id,
-            payload.content,
+            payload.markdown,
         )
         entry_data = await ugoite_core.get_entry(storage_config, space_id, entry_id)
     except ugoite_core.AuthorizationError as exc:
@@ -160,7 +168,7 @@ async def get_entry_endpoint(
             detail=str(e),
         ) from e
     else:
-        return entry
+        return _entry_response(entry)
 
 
 @router.put("/spaces/{space_id}/entries/{entry_id}")
@@ -228,7 +236,7 @@ async def update_entry_endpoint(
                     status_code=status.HTTP_409_CONFLICT,
                     detail={
                         "message": msg,
-                        "current_revision": current_entry,
+                        "current_revision": _entry_response(current_entry),
                     },
                 ) from e
             except RuntimeError:
@@ -369,11 +377,13 @@ async def get_entry_revision_endpoint(
             identity,
             current_entry,
         )
-        return await ugoite_core.get_entry_revision(
-            storage_config,
-            space_id,
-            entry_id,
-            revision_id,
+        return _entry_response(
+            await ugoite_core.get_entry_revision(
+                storage_config,
+                space_id,
+                entry_id,
+                revision_id,
+            ),
         )
     except ugoite_core.AuthorizationError as exc:
         raise_authorization_http_error(exc, space_id=space_id)
@@ -450,4 +460,4 @@ async def restore_entry_endpoint(
             detail=str(e),
         ) from e
 
-    return entry_data
+    return _entry_response(entry_data)

--- a/backend/src/app/models/payloads.py
+++ b/backend/src/app/models/payloads.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StringConstraints
 
 Identifier = Annotated[
     str,
@@ -39,8 +39,14 @@ class AuthLogin(BaseModel):
 class EntryCreate(BaseModel):
     """Entry creation payload."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: BoundedIdentifier | None = None
-    content: Annotated[str, StringConstraints(min_length=1, max_length=200_000)]
+    markdown: Annotated[
+        str,
+        StringConstraints(min_length=1, max_length=200_000),
+        Field(validation_alias=AliasChoices("markdown", "content")),
+    ]
 
 
 class EntryUpdate(BaseModel):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -385,7 +385,7 @@ def test_create_entry(test_client: TestClient, temp_space_root: Path) -> None:
     _create_form(test_client, "test-ws")
 
     entry_payload = {
-        "content": "---\nform: Entry\n---\n# My Entry\n\n## Body\nSome content",
+        "markdown": "---\nform: Entry\n---\n# My Entry\n\n## Body\nSome content",
     }
 
     response = test_client.post("/spaces/test-ws/entries", json=entry_payload)
@@ -398,6 +398,7 @@ def test_create_entry(test_client: TestClient, temp_space_root: Path) -> None:
     # Verify retrieval
     get_response = test_client.get(f"/spaces/test-ws/entries/{entry_id}")
     assert get_response.status_code == 200
+    assert get_response.json()["markdown"] == entry_payload["markdown"]
 
 
 def test_create_entry_conflict(
@@ -545,7 +546,7 @@ def test_get_entry(
     data = response.json()
     assert data["id"] == "test-entry"
     assert data["title"] == "Test Entry"
-    # Entry: get_entry returns "content" field (not "markdown")
+    assert "# Test Entry" in data["markdown"]
     assert "# Test Entry" in data["content"]
 
 
@@ -605,7 +606,7 @@ Original body""",
     get_response = test_client.get("/spaces/test-ws/entries/test-entry")
     updated_entry = get_response.json()
     assert updated_entry["title"] == "Updated Title"
-    # Entry: get_entry returns "content" field (not "markdown")
+    assert "New content" in updated_entry["markdown"]
     assert "New content" in updated_entry["content"]
 
 

--- a/backend/tests/test_api_memory.py
+++ b/backend/tests/test_api_memory.py
@@ -78,7 +78,7 @@ def test_create_entry_memory(memory_client: TestClient) -> None:
 
     # Create entry
     entry_payload = {
-        "content": "---\nform: Entry\n---\n# Memory Entry\n\n## Body\nStored in RAM.",
+        "markdown": "---\nform: Entry\n---\n# Memory Entry\n\n## Body\nStored in RAM.",
     }
     response = memory_client.post(f"/spaces/{ws_id}/entries", json=entry_payload)
     assert response.status_code == 201
@@ -88,7 +88,8 @@ def test_create_entry_memory(memory_client: TestClient) -> None:
     # Get entry
     response = memory_client.get(f"/spaces/{ws_id}/entries/{entry_id}")
     assert response.status_code == 200
-    assert response.json()["content"] == entry_payload["content"]
+    assert response.json()["markdown"] == entry_payload["markdown"]
+    assert response.json()["content"] == entry_payload["markdown"]
 
 
 def test_update_entry_and_search_memory(memory_client: TestClient) -> None:

--- a/docs/spec/api/openapi.yaml
+++ b/docs/spec/api/openapi.yaml
@@ -236,17 +236,17 @@ paths:
             schema:
               type: object
               required:
-                - content
+                - markdown
               properties:
                 id:
                   type: string
                   maxLength: 128
-                content:
+                markdown:
                   type: string
                   minLength: 1
                   maxLength: 200000
             example:
-              content: |-
+              markdown: |-
                 ---
                 form: Entry
                 ---

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -200,7 +200,7 @@ POST /spaces/{space_id}/entries
 Content-Type: application/json
 
 {
-  "content": "---\nform: Entry\n---\n# My Entry\n\n## Body\nValue"
+  "markdown": "---\nform: Entry\n---\n# My Entry\n\n## Body\nValue"
 }
 ```
 
@@ -217,7 +217,7 @@ or extracted properties resolve a `form`, the adapter MUST enforce that Form's
 write ACL before mutating storage; otherwise it falls back to the space-level
 `entry_write` permission.
 
-Create request bodies submit entry Markdown via the `content` field.
+Create request bodies submit entry Markdown via the canonical `markdown` field.
 Create responses return only the generated `id` and `revision_id`; fetch the
 entry afterward if a client needs extracted title or properties.
 

--- a/docs/spec/requirements/entry.yaml
+++ b/docs/spec/requirements/entry.yaml
@@ -35,7 +35,7 @@ requirements:
       - test_create_entry_conflict
     - file: docs/tests/test_api_docs.py
       tests:
-      - test_docs_req_entry_001_create_entry_payload_uses_content_field
+      - test_docs_req_entry_001_create_entry_payload_uses_markdown_field
       - test_docs_req_entry_001_create_entry_response_matches_backend_contract
     rust:
     - file: ugoite-core/tests/test_entry.rs

--- a/docs/tests/test_api_docs.py
+++ b/docs/tests/test_api_docs.py
@@ -61,14 +61,17 @@ def _extract_json_code_block(section: str, context: str) -> object:
     return json.loads(json_block)
 
 
-def test_docs_req_entry_001_create_entry_payload_uses_content_field() -> None:
-    """REQ-ENTRY-001: create-entry docs use the implemented `content` request field."""
+def test_docs_req_entry_001_create_entry_payload_uses_markdown_field() -> None:
+    """REQ-ENTRY-001: create-entry docs use the canonical `markdown` request field."""
     rest_text = _read_text(API_REST_PATH)
     details: list[str] = []
 
     rest_fragments = (
-        '"content": "---\\nform: Entry\\n---\\n# My Entry\\n\\n## Body\\nValue"',
-        "Create request bodies submit entry Markdown via the `content` field.",
+        '"markdown": "---\\nform: Entry\\n---\\n# My Entry\\n\\n## Body\\nValue"',
+        (
+            "Create request bodies submit entry Markdown via the canonical "
+            "`markdown` field."
+        ),
     )
     details.extend(
         f"api/rest.md missing fragment: {fragment!r}"
@@ -108,27 +111,27 @@ def test_docs_req_entry_001_create_entry_payload_uses_content_field() -> None:
     required = schema.get("required")
     example = _require_mapping(app_json.get("example"), "create-entry example")
 
-    if not isinstance(required, list) or "content" not in required:
+    if not isinstance(required, list) or "markdown" not in required:
         details.append(
-            "api/openapi.yaml create-entry schema must require the content field",
+            "api/openapi.yaml create-entry schema must require the markdown field",
         )
-    if "content" not in properties:
+    if "markdown" not in properties:
         details.append(
-            "api/openapi.yaml create-entry schema must define the content property",
+            "api/openapi.yaml create-entry schema must define the markdown property",
         )
-    if "markdown" in properties:
+    if "content" in properties:
         details.append(
-            "api/openapi.yaml create-entry schema must not advertise markdown",
+            "api/openapi.yaml create-entry schema must not advertise content",
         )
-    if "content" not in example:
+    if "markdown" not in example:
         details.append(
-            "api/openapi.yaml create-entry example must use the content field",
+            "api/openapi.yaml create-entry example must use the markdown field",
         )
-    if "markdown" in example:
+    if "content" in example:
         details.append(
-            "api/openapi.yaml create-entry example must not use markdown",
+            "api/openapi.yaml create-entry example must not use content",
         )
-    example_content = example.get("content")
+    example_content = example.get("markdown")
     if not isinstance(example_content, str) or "form: Entry" not in example_content:
         details.append(
             "api/openapi.yaml create-entry example must include form frontmatter",

--- a/e2e/entries.test.ts
+++ b/e2e/entries.test.ts
@@ -32,7 +32,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content: `---\nform: Entry\n---\n# E2E Test Entry ${timestamp}\n\n## Body\nCreated at ${new Date().toISOString()}`,
+					markdown: `---\nform: Entry\n---\n# E2E Test Entry ${timestamp}\n\n## Body\nCreated at ${new Date().toISOString()}`,
 				},
 			},
 		);
@@ -59,7 +59,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content:
+					markdown:
 						"---\nform: Entry\n---\n# Initial Content\n\n## Body\nThis is the first version.",
 				},
 			},
@@ -104,7 +104,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content:
+					markdown:
 						"---\nform: Entry\n---\n# Conflict Test\n\n## Body\nTesting revision conflicts.",
 				},
 			},
@@ -146,7 +146,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content:
+					markdown:
 						"---\nform: Entry\n---\n# Persistence Test\n\n## Body\nOriginal content.",
 				},
 			},
@@ -213,7 +213,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content:
+					markdown:
 						"---\nform: Entry\n---\n# Detail Route Test\n\n## Body\nRoute render check.",
 				},
 			},
@@ -273,7 +273,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content: `---\nform: Entry\n---\n# ${title}\n\n## Body\nTesting special chars in title.`,
+					markdown: `---\nform: Entry\n---\n# ${title}\n\n## Body\nTesting special chars in title.`,
 				},
 			},
 		);
@@ -294,17 +294,17 @@ test.describe("Entries CRUD", () => {
 		const formEntries = await Promise.all([
 			request.post(getBackendUrl("/spaces/default/entries"), {
 				data: {
-					content: "---\nform: Entry\n---\n# Entry A\n\n## Body\nContent A",
+					markdown: "---\nform: Entry\n---\n# Entry A\n\n## Body\nContent A",
 				},
 			}),
 			request.post(getBackendUrl("/spaces/default/entries"), {
 				data: {
-					content: "---\nform: Entry\n---\n# Entry B\n\n## Body\nContent B",
+					markdown: "---\nform: Entry\n---\n# Entry B\n\n## Body\nContent B",
 				},
 			}),
 			request.post(getBackendUrl("/spaces/default/entries"), {
 				data: {
-					content: "---\nform: Entry\n---\n# Entry C\n\n## Body\nContent C",
+					markdown: "---\nform: Entry\n---\n# Entry C\n\n## Body\nContent C",
 				},
 			}),
 		]);
@@ -343,7 +343,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content:
+					markdown:
 						"---\nform: Entry\n---\n# Timeout Recovery Test\n\n## Body\nEnsure navigation resolves.",
 				},
 			},
@@ -366,7 +366,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content:
+					markdown:
 						"---\nform: Entry\n---\n# Update Test Entry\n\n## Body\nOriginal content",
 				},
 			},
@@ -399,7 +399,7 @@ test.describe("Entries CRUD", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content:
+					markdown:
 						"---\nform: Entry\n---\n# Delete Test Entry\n\n## Body\nTo be deleted",
 				},
 			},

--- a/e2e/forms.test.ts
+++ b/e2e/forms.test.ts
@@ -93,7 +93,7 @@ Active
 `;
 		const entryRes = await request.post(
 			getBackendUrl(`/spaces/${spaceId}/entries`),
-			{ data: { content: entryContent } },
+			{ data: { markdown: entryContent } },
 		);
 		expect(entryRes.status()).toBe(201);
 		const entry = (await entryRes.json()) as { id: string };

--- a/e2e/navigation.test.ts
+++ b/e2e/navigation.test.ts
@@ -18,7 +18,7 @@ test.describe("Dynamic navigation traversal", () => {
 
 		const createdEntry = await request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
 			data: {
-				content: `---\nform: Entry\n---\n# E2E Dynamic Traversal ${Date.now()}\n\n## Body\nTraversal seed entry.`,
+				markdown: `---\nform: Entry\n---\n# E2E Dynamic Traversal ${Date.now()}\n\n## Body\nTraversal seed entry.`,
 			},
 		});
 		expect(createdEntry.status()).toBe(201);

--- a/e2e/search-ui.test.ts
+++ b/e2e/search-ui.test.ts
@@ -108,9 +108,9 @@ async function ensureSearchForm(request: APIRequestContext, formName: string): P
 	}
 }
 
-async function createEntry(request: APIRequestContext, content: string): Promise<string> {
+async function createEntry(request: APIRequestContext, markdown: string): Promise<string> {
 	const response = await request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
-		data: { content },
+		data: { markdown },
 	});
 	expect(response.status()).toBe(201);
 	const entry = (await response.json()) as { id: string };

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -41,7 +41,7 @@ test.describe("Smoke Tests", () => {
 			getBackendUrl("/spaces/default/entries"),
 			{
 				data: {
-					content: `---\nform: Entry\n---\n# E2E Detail Route Entry\n\n## Body\nCreated at ${new Date().toISOString()}`,
+					markdown: `---\nform: Entry\n---\n# E2E Detail Route Entry\n\n## Body\nCreated at ${new Date().toISOString()}`,
 				},
 			},
 		);

--- a/e2e/ui-pages-screenshots.test.ts
+++ b/e2e/ui-pages-screenshots.test.ts
@@ -23,7 +23,7 @@ test.describe("UI page screenshot export @screenshot", () => {
 		const entryTitle = `E2E Screenshot Entry ${Date.now()}`;
 		const entryRes = await request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
 			data: {
-				content: `---\nform: Entry\n---\n# ${entryTitle}\n\n## Body\nScreenshot seed entry.`,
+				markdown: `---\nform: Entry\n---\n# ${entryTitle}\n\n## Body\nScreenshot seed entry.`,
 			},
 		});
 		expect(entryRes.status()).toBe(201);

--- a/e2e/ui-themes.test.ts
+++ b/e2e/ui-themes.test.ts
@@ -30,7 +30,7 @@ test.describe("UI theme flows", () => {
 			try {
 				const entryRes = await request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
 					data: {
-						content: `---\nform: Entry\n---\n# ${entryTitle}\n\n## Body\nTheme flow test.`,
+						markdown: `---\nform: Entry\n---\n# ${entryTitle}\n\n## Body\nTheme flow test.`,
 					},
 				});
 				expect(entryRes.status()).toBe(201);

--- a/frontend/src/lib/client.test.ts
+++ b/frontend/src/lib/client.test.ts
@@ -163,7 +163,7 @@ describe("entryApi", () => {
 	describe("create", () => {
 		it("should create a entry and extract title from markdown", async () => {
 			const result = await entryApi.create("test-ws", {
-				content: "# My Meeting Entries\n\n## Date\n2025-01-15\n\n## Attendees\nAlice, Bob",
+				markdown: "# My Meeting Entries\n\n## Date\n2025-01-15\n\n## Attendees\nAlice, Bob",
 			});
 
 			expect(result.id).toBeDefined();
@@ -179,7 +179,7 @@ describe("entryApi", () => {
 
 		it("should extract H2 headers as properties", async () => {
 			const result = await entryApi.create("test-ws", {
-				content: "# Task\n\n## Status\nPending\n\n## Priority\nHigh",
+				markdown: "# Task\n\n## Status\nPending\n\n## Priority\nHigh",
 			});
 
 			const entries = await entryApi.list("test-ws");
@@ -192,26 +192,33 @@ describe("entryApi", () => {
 	describe("get", () => {
 		it("should return full entry content", async () => {
 			const content = "# Full Entry\n\nWith body content";
-			const entry: Entry = {
-				id: "entry-get",
-				content,
-				revision_id: "rev-get",
-				created_at: "2025-01-01T00:00:00Z",
-				updated_at: "2025-01-01T00:00:00Z",
-			};
-			const record: EntryRecord = {
-				id: "entry-get",
-				title: "Full Entry",
-				updated_at: "2025-01-01T00:00:00Z",
-				properties: {},
-				tags: [],
-				links: [],
-			};
-			seedEntry("test-ws", entry, record);
+			server.use(
+				http.get(testApiUrl("/spaces/test-ws/entries/entry-get"), () =>
+					HttpResponse.json({
+						id: "entry-get",
+						markdown: content,
+						revision_id: "rev-get",
+						created_at: "2025-01-01T00:00:00Z",
+						updated_at: "2025-01-01T00:00:00Z",
+					}),
+				),
+				http.get(testApiUrl("/spaces/test-ws/entries/entry-empty"), () =>
+					HttpResponse.json({
+						id: "entry-empty",
+						revision_id: "rev-empty",
+						created_at: "2025-01-01T00:00:00Z",
+						updated_at: "2025-01-01T00:00:00Z",
+					}),
+				),
+			);
 
 			const fetched = await entryApi.get("test-ws", "entry-get");
 			expect(fetched.content).toBe(content);
+			expect(fetched.markdown).toBe(content);
 			expect(fetched.revision_id).toBe("rev-get");
+
+			const emptyFetched = await entryApi.get("test-ws", "entry-empty");
+			expect(emptyFetched.content).toBe("");
 		});
 
 		it("should throw error for non-existent entry", async () => {
@@ -222,7 +229,7 @@ describe("entryApi", () => {
 	describe("update", () => {
 		it("should update entry with correct parent_revision_id", async () => {
 			const createResult = await entryApi.create("test-ws", {
-				content: "# Original\n\n## Status\nDraft",
+				markdown: "# Original\n\n## Status\nDraft",
 			});
 
 			const updateResult = await entryApi.update("test-ws", createResult.id, {
@@ -241,7 +248,7 @@ describe("entryApi", () => {
 
 		it("should throw RevisionConflictError (409) on revision mismatch", async () => {
 			const createResult = await entryApi.create("test-ws", {
-				content: "# Original",
+				markdown: "# Original",
 			});
 
 			// First update succeeds
@@ -263,7 +270,7 @@ describe("entryApi", () => {
 	describe("delete", () => {
 		it("should remove entry from list", async () => {
 			const result = await entryApi.create("test-ws", {
-				content: "# To Delete",
+				markdown: "# To Delete",
 			});
 
 			let entries = await entryApi.list("test-ws");
@@ -279,7 +286,7 @@ describe("entryApi", () => {
 	describe("search, assets, and links", () => {
 		it("searches entries by keyword", async () => {
 			const created = await entryApi.create("test-ws", {
-				content: "# Rocket Project\nEntries about propulsion",
+				markdown: "# Rocket Project\nEntries about propulsion",
 			});
 
 			const matches = await searchApi.keyword("test-ws", "rocket");
@@ -288,7 +295,7 @@ describe("entryApi", () => {
 
 		it("uploads asset and blocks deletion when referenced", async () => {
 			const { id, revision_id } = await entryApi.create("test-ws", {
-				content: "# Audio Entry",
+				markdown: "# Audio Entry",
 			});
 
 			const file = new File(["data"], "voice.m4a", { type: "audio/m4a" });
@@ -494,7 +501,7 @@ describe("error paths", () => {
 	it("entryApi.history returns revisions", async () => {
 		resetMockData();
 		seedSpace({ id: "ws-history", name: "H", created_at: "2025-01-01T00:00:00Z" });
-		const created = await entryApi.create("ws-history", { content: "# Entry" });
+		const created = await entryApi.create("ws-history", { markdown: "# Entry" });
 		const history = await entryApi.history("ws-history", created.id);
 		expect(history.revisions).toBeDefined();
 	});
@@ -502,7 +509,7 @@ describe("error paths", () => {
 	it("entryApi.getRevision returns a revision", async () => {
 		resetMockData();
 		seedSpace({ id: "ws-rev", name: "R", created_at: "2025-01-01T00:00:00Z" });
-		const created = await entryApi.create("ws-rev", { content: "# Entry" });
+		const created = await entryApi.create("ws-rev", { markdown: "# Entry" });
 		const entry = await entryApi.get("ws-rev", created.id);
 		const revision = await entryApi.getRevision("ws-rev", created.id, entry.revision_id);
 		expect(revision.revision_id).toBe(entry.revision_id);
@@ -511,7 +518,7 @@ describe("error paths", () => {
 	it("entryApi.restore succeeds", async () => {
 		resetMockData();
 		seedSpace({ id: "ws-restore", name: "RR", created_at: "2025-01-01T00:00:00Z" });
-		const created = await entryApi.create("ws-restore", { content: "# Entry" });
+		const created = await entryApi.create("ws-restore", { markdown: "# Entry" });
 		const entry = await entryApi.get("ws-restore", created.id);
 		const restored = await entryApi.restore("ws-restore", created.id, entry.revision_id);
 		expect(restored).toBeDefined();

--- a/frontend/src/lib/entry-api.ts
+++ b/frontend/src/lib/entry-api.ts
@@ -10,13 +10,19 @@ import { apiFetch } from "./api";
 import { normalizeTimestamp } from "./date-format";
 import { buildEntryMarkdownByMode } from "./entry-input";
 
+type EntryResponse = Omit<Entry, "content"> & {
+	content?: string;
+	markdown?: string;
+};
+
 const normalizeEntryRecord = (entry: EntryRecord): EntryRecord => ({
 	...entry,
 	updated_at: normalizeTimestamp(entry.updated_at),
 });
 
-const normalizeEntry = (entry: Entry): Entry => ({
+const normalizeEntry = (entry: EntryResponse): Entry => ({
 	...entry,
+	content: entry.content ?? entry.markdown ?? "",
 	created_at: normalizeTimestamp(entry.created_at),
 	updated_at: normalizeTimestamp(entry.updated_at),
 });
@@ -51,7 +57,7 @@ export const entryApi = {
 			}
 			throw new Error(`Failed to get entry: ${detail}`);
 		}
-		return normalizeEntry((await res.json()) as Entry);
+		return normalizeEntry((await res.json()) as EntryResponse);
 	},
 
 	/** Create a new entry */
@@ -79,7 +85,7 @@ export const entryApi = {
 		markdown: string,
 		id?: string,
 	): Promise<{ id: string; revision_id: string }> {
-		return await this.create(spaceId, { id, content: markdown });
+		return await this.create(spaceId, { id, markdown });
 	},
 
 	/** Create a new entry from webform field input */
@@ -91,7 +97,7 @@ export const entryApi = {
 		id?: string,
 	): Promise<{ id: string; revision_id: string }> {
 		const markdown = buildEntryMarkdownByMode(formDef, title, fieldValues, "webform");
-		return await this.create(spaceId, { id, content: markdown });
+		return await this.create(spaceId, { id, markdown });
 	},
 
 	/** Create a new entry from chat-style Q&A input */
@@ -103,7 +109,7 @@ export const entryApi = {
 		id?: string,
 	): Promise<{ id: string; revision_id: string }> {
 		const markdown = buildEntryMarkdownByMode(formDef, title, answers, "chat");
-		return await this.create(spaceId, { id, content: markdown });
+		return await this.create(spaceId, { id, markdown });
 	},
 
 	/** Update a entry (requires parent_revision_id for optimistic locking) */
@@ -170,7 +176,7 @@ export const entryApi = {
 		if (!res.ok) {
 			throw new Error(`Failed to get entry revision: ${res.statusText}`);
 		}
-		return normalizeEntry((await res.json()) as Entry);
+		return normalizeEntry((await res.json()) as EntryResponse);
 	},
 
 	/** Restore entry to a previous revision */
@@ -189,7 +195,7 @@ export const entryApi = {
 			throw new Error(error.detail || `Failed to restore entry: ${res.statusText}`);
 			/* v8 ignore stop */
 		}
-		return normalizeEntry((await res.json()) as Entry);
+		return normalizeEntry((await res.json()) as EntryResponse);
 	},
 };
 

--- a/frontend/src/lib/entry-store.ts
+++ b/frontend/src/lib/entry-store.ts
@@ -66,7 +66,7 @@ export function createEntryStore(spaceId: () => string) {
 	async function createEntry(content: string, id?: string) {
 		setError(null);
 		try {
-			const result = await entryApi.create(spaceId(), { content, id });
+			const result = await entryApi.create(spaceId(), { markdown: content, id });
 			// Reload to get the indexed version
 			await loadEntries();
 			return result;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -123,6 +123,7 @@ export interface Entry {
 	tags?: string[];
 	canvas_position?: CanvasPosition;
 	content: string;
+	markdown?: string;
 	revision_id: string;
 	created_at: string;
 	updated_at: string;
@@ -138,7 +139,7 @@ export interface EntryRevision {
 /** Create entry payload */
 export interface EntryCreatePayload {
 	id?: string;
-	content: string;
+	markdown: string;
 }
 
 /** Update entry payload */

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -45,6 +45,12 @@ let revisionCounter = 0;
 
 const generateRevisionId = () => `rev-${++revisionCounter}`;
 
+const normalizeMockEntry = (entry: Entry): Entry => ({
+	...entry,
+	content: entry.content ?? entry.markdown ?? "",
+	markdown: entry.markdown ?? entry.content,
+});
+
 const createTestApiPredicate = <Params extends PathParams = PathParams>(path: string) => {
 	const testApiPathname = testApiPath(path);
 	return ({ request }: { request: Request }) => {
@@ -118,7 +124,7 @@ export const seedSpace = (space: Space) => {
 };
 
 export const seedEntry = (spaceId: string, entry: Entry, record: EntryRecord) => {
-	mockEntries.get(spaceId)?.set(entry.id, entry);
+	mockEntries.get(spaceId)?.set(entry.id, normalizeMockEntry(entry));
 	mockEntryIndex.get(spaceId)?.set(entry.id, record);
 };
 
@@ -354,27 +360,28 @@ export const handlers = [
 		const now = new Date().toISOString();
 
 		// Extract title from markdown (first H1 or first line)
-		const titleMatch = body.content.match(/^#\s+(.+)$/m);
-		const title = titleMatch ? titleMatch[1] : body.content.split("\n")[0] || "Untitled";
+		const titleMatch = body.markdown.match(/^#\s+(.+)$/m);
+		const title = titleMatch ? titleMatch[1] : body.markdown.split("\n")[0] || "Untitled";
 
 		// Extract properties from H2 headers
 		const properties: Record<string, string> = {};
 		const h2Regex = /^##\s+(.+)\n([\s\S]*?)(?=^##\s|$(?![\r\n]))/gm;
-		for (const match of body.content.matchAll(h2Regex)) {
+		for (const match of body.markdown.matchAll(h2Regex)) {
 			const key = match[1].trim();
 			const value = match[2].trim();
 			properties[key] = value;
 		}
 
-		const entry: Entry = {
+		const entry: Entry = normalizeMockEntry({
 			id: entryId,
-			content: body.content,
+			content: body.markdown,
+			markdown: body.markdown,
 			revision_id: revisionId,
 			created_at: now,
 			updated_at: now,
 			assets: [],
 			links: [],
-		};
+		});
 
 		const record: EntryRecord = {
 			id: entryId,
@@ -401,7 +408,7 @@ export const handlers = [
 		if (!entry) {
 			return HttpResponse.json({ detail: "Entry not found" }, { status: 404 });
 		}
-		return HttpResponse.json(entry);
+		return HttpResponse.json(normalizeMockEntry(entry));
 	}),
 
 	// Update entry
@@ -445,6 +452,7 @@ export const handlers = [
 
 		// Update entry
 		entry.content = body.markdown;
+		entry.markdown = body.markdown;
 		entry.revision_id = newRevisionId;
 		entry.updated_at = now;
 		entry.assets = body.assets ?? entry.assets ?? [];
@@ -517,7 +525,10 @@ export const handlers = [
 		const entries = Array.from(mockEntries.get(spaceId)?.values() || []);
 		const index = Array.from(mockEntryIndex.get(spaceId)?.values() || []);
 		const matches = index.filter((record) => {
-			const entryContent = entries.find((n) => n.id === record.id)?.content ?? "";
+			const entryContent =
+				entries.find((n) => n.id === record.id)?.markdown ??
+				entries.find((n) => n.id === record.id)?.content ??
+				"";
 			const haystack =
 				`${record.title}\n${JSON.stringify(record.properties)}\n${entryContent}`.toLowerCase();
 			return haystack.includes(q);
@@ -546,7 +557,7 @@ export const handlers = [
 		const spaceId = params.spaceId as string;
 		const assetId = params.assetId as string;
 		const store = mockAssets.get(spaceId);
-		if (!store || !store.has(assetId)) {
+		if (!store?.has(assetId)) {
 			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
 		}
 
@@ -594,7 +605,7 @@ export const handlers = [
 		if (!entry || entry.revision_id !== revisionId) {
 			return HttpResponse.json({ detail: "Revision not found" }, { status: 404 });
 		}
-		return HttpResponse.json(entry);
+		return HttpResponse.json(normalizeMockEntry(entry));
 	}),
 
 	// Restore entry
@@ -608,7 +619,7 @@ export const handlers = [
 		const _body = (await request.json()) as { revision_id: string };
 		const newRevisionId = generateRevisionId();
 		entry.revision_id = newRevisionId;
-		return HttpResponse.json({ ...entry, revision_id: newRevisionId });
+		return HttpResponse.json(normalizeMockEntry({ ...entry, revision_id: newRevisionId }));
 	}),
 
 	// SQL CRUD
@@ -654,8 +665,7 @@ export const handlers = [
 		const spaceId = params.spaceId as string;
 		const sqlId = params.sqlId as string;
 		const store = mockSqlEntries.get(spaceId);
-		if (!store || !store.has(sqlId))
-			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
+		if (!store?.has(sqlId)) return HttpResponse.json({ detail: "Not found" }, { status: 404 });
 		store.delete(sqlId);
 		return HttpResponse.json({ status: "deleted" });
 	}),

--- a/ugoite-cli/src/commands/entry.rs
+++ b/ugoite-cli/src/commands/entry.rs
@@ -216,7 +216,7 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 }
                 let result = http::http_post(
                     &format!("{base}/spaces/{space_id}/entries"),
-                    &serde_json::json!({"id": entry_id, "content": content}),
+                    &serde_json::json!({"id": entry_id, "markdown": content}),
                 )
                 .await?;
                 print_json(&result);

--- a/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -360,7 +360,7 @@ fn test_entry_create_req_api_002_routes_to_backend_post_entries() {
     );
     assert!(request.contains(r#""id":"entry-1""#), "{request}");
     assert!(
-        request.contains("\"content\":\"# Remote Entry\""),
+        request.contains("\"markdown\":\"# Remote Entry\""),
         "{request}"
     );
     assert!(!request.contains(r#""author":"#), "{request}");

--- a/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
+++ b/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
@@ -1508,7 +1508,7 @@ fn test_cli_req_ops_006_entry_local_and_remote_paths() {
     handle.join().expect("join remote entry create server");
     assert!(remote_create_request.starts_with("POST /spaces/remote-space/entries HTTP/1.1"));
     assert!(remote_create_request.contains(r#""id":"entry-1""#));
-    assert!(remote_create_request.contains("\"content\":\"# Remote Entry\""));
+    assert!(remote_create_request.contains("\"markdown\":\"# Remote Entry\""));
     assert!(!remote_create_request.contains(r#""author":"#));
 
     let (base, requests, handle) = spawn_recording_server("HTTP/1.1 200 OK", r#"{"updated":true}"#);


### PR DESCRIPTION
## Summary
- standardize first-party entry create payloads on `markdown` across the backend, frontend, CLI, docs, and e2e fixtures
- keep backend compatibility for legacy `content` callers and mirror `markdown` in entry API responses
- update frontend normalization and tests so existing internal `content` usage keeps working while the API contract becomes explicit

## Related Issue (required)
closes #1081

## Testing
- [x] `TMPDIR=/workspace/tmp TMP=/workspace/tmp TEMP=/workspace/tmp mise run test`
- [x] `TMPDIR=/workspace/tmp TMP=/workspace/tmp TEMP=/workspace/tmp bash e2e/scripts/run-e2e.sh entries`
