### PR TITLE
fix: keep auth config read-only

### DIFF
--- a/backend/src/app/api/endpoints/auth.py
+++ b/backend/src/app/api/endpoints/auth.py
@@ -187,7 +187,6 @@ async def auth_config_endpoint(request: Request) -> dict[str, object]:
     """Expose the current passwordless login mode to browser/CLI clients."""
     _ensure_local_dev_auth_request(request)
     mode = _resolve_dev_auth_mode()
-    await ugoite_core.ensure_admin_space(_storage_config(), _dev_user_id())
     return {
         "mode": mode,
         "username_hint": _dev_user_id(),

--- a/backend/tests/test_dev_auth.py
+++ b/backend/tests/test_dev_auth.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import hmac
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -256,6 +257,32 @@ def test_dev_auth_req_ops_015_startup_bootstraps_admin_space(
     assert admin_space_response.status_code == 200
     admin_settings = admin_space_response.json()["settings"]
     assert admin_settings["members"]["dev-startup-user"]["state"] == "active"
+
+
+def test_dev_auth_req_ops_015_auth_config_remains_read_only(
+    monkeypatch: pytest.MonkeyPatch,
+    temp_space_root: Path,
+) -> None:
+    """REQ-OPS-015: auth config discovery must not recreate admin-space."""
+    _configure_dev_auth_env(
+        monkeypatch,
+        temp_space_root,
+        mode="mock-oauth",
+        overrides={"UGOITE_DEV_USER_ID": "dev-config-user"},
+    )
+    clear_auth_manager_cache()
+
+    admin_space_dir = temp_space_root / "spaces" / ugoite_core.admin_space_id()
+
+    with TestClient(app) as client:
+        assert admin_space_dir.is_dir()
+        shutil.rmtree(admin_space_dir)
+
+        response = client.get("/auth/config")
+
+    assert response.status_code == 200
+    assert response.json()["mode"] == "mock-oauth"
+    assert not admin_space_dir.exists()
 
 
 def test_dev_seed_req_ops_016_seeded_space_is_visible_to_local_dev_stack(

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -43,6 +43,8 @@ Planned endpoint surface (exact payloads may evolve during implementation):
 
 These endpoints expose the current explicit passwordless login flow and stay
 unauthenticated so the browser and CLI can complete sign-in after startup.
+`GET /auth/config` is read-only discovery: it must not create admin-space or
+patch storage as a side effect.
 
 - `GET /auth/config`
 - `POST /auth/login`

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -564,7 +564,11 @@ requirements:
 
     login context with owner-only permissions, require a passkey-bound local
 
-    context in addition to the 2FA code during explicit browser/CLI login, and
+    context in addition to the 2FA code during explicit browser/CLI login,
+
+    keep `GET /auth/config` read-only so login discovery cannot recreate
+
+    admin-space or other storage state, and
 
     complete an explicit login step before a bearer token is issued. `mock-oauth`
 
@@ -600,6 +604,7 @@ requirements:
     - file: backend/tests/test_dev_auth.py
       tests:
       - test_dev_auth_req_ops_015_config_exposes_passkey_totp_mode
+      - test_dev_auth_req_ops_015_auth_config_remains_read_only
       - test_dev_auth_req_ops_015_passkey_totp_login_issues_signed_token
       - test_dev_auth_req_ops_015_passkey_totp_login_rejects_replayed_code
       - test_dev_auth_req_ops_015_mock_oauth_login_issues_signed_token


### PR DESCRIPTION
## Summary

- keep GET /auth/config read-only by removing the admin-space bootstrap side effect
- add a regression test proving auth config does not recreate deleted admin-space after startup
- document the read-only auth config contract in REQ-OPS-015 and the REST auth docs

## Related Issue (required)

closes #1057

## Testing

- [x] `mise run test`
- [x] `uv run pytest -W error --no-cov tests/test_dev_auth.py`
