### PR TITLE
fix: escape raw HTML in markdown previews

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -169,7 +169,9 @@ requirements:
   - SPEC-ARCH-INTERFACE
   id: REQ-FE-005
   title: Markdown Editor
-  description: 'Editor with Markdown editing, preview, and save functionality.
+  description: 'Editor with Markdown editing, preview, and save functionality. Preview
+
+    MUST escape raw HTML before inserting rendered content into the DOM.
 
     '
   related_spec:
@@ -192,6 +194,14 @@ requirements:
       - should handle null content gracefully
       - should render preview with undefined content without crashing
       - should display placeholder when content is empty
+      - 'REQ-FE-005: split preview escapes raw HTML content'
+    - file: frontend/src/lib/markdown.test.ts
+      tests:
+      - 'REQ-FE-005: renderMarkdownPreview escapes raw HTML while keeping markdown formatting'
+    e2e:
+    - file: e2e/entries.test.ts
+      tests:
+      - 'REQ-FE-005: entry detail preview escapes raw HTML in markdown content'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.

--- a/e2e/entries.test.ts
+++ b/e2e/entries.test.ts
@@ -232,6 +232,40 @@ test.describe("Entries CRUD", () => {
 		);
 	});
 
+	test("REQ-FE-005: entry detail preview escapes raw HTML in markdown content", async ({ page, request }) => {
+		const createRes = await request.post(
+			getBackendUrl("/spaces/default/entries"),
+			{
+				data: {
+					content:
+						'---\nform: Entry\n---\n# Preview Safety\n\n## Body\n<img src=x onerror="window.__ugoiteXss=\'ran\'">\n\n**bold**',
+				},
+			},
+		);
+		expect(createRes.status()).toBe(201);
+		const created = (await createRes.json()) as { id: string };
+
+		await page.goto(`/spaces/default/entries/${created.id}`);
+		await page.waitForLoadState("networkidle");
+		await settleUiLoading(page);
+
+		const preview = page.locator(".preview").first();
+		await expect(preview).toBeVisible();
+		await expect(preview.locator("img")).toHaveCount(0);
+		await expect(preview).toContainText('<img src=x onerror="window.__ugoiteXss=\'ran\'">');
+		await expect(preview.locator("strong")).toHaveText("bold");
+
+		const marker = await page.evaluate(() => {
+			const target = globalThis as typeof globalThis & { __ugoiteXss?: string };
+			return target.__ugoiteXss ?? null;
+		});
+		expect(marker).toBeNull();
+
+		await request.delete(
+			getBackendUrl(`/spaces/default/entries/${created.id}`),
+		);
+	});
+
 	test("REQ-FE-033: Retrieve entry with special characters", async ({ page, request }) => {
 		const timestamp = Date.now();
 		const title = `Special Entry @ ${timestamp} % &`;

--- a/frontend/src/components/MarkdownEditor.test.tsx
+++ b/frontend/src/components/MarkdownEditor.test.tsx
@@ -124,6 +124,22 @@ describe("MarkdownEditor", () => {
 		expect(preview).toBeInTheDocument();
 	});
 
+	it("REQ-FE-005: split preview escapes raw HTML content", () => {
+		render(() => (
+			<MarkdownEditor
+				content={'# Preview\n\n<img src=x onerror="alert(1)">\n\n**bold**'}
+				onChange={() => {}}
+				mode="split"
+			/>
+		));
+
+		const preview = document.querySelector(".preview");
+		expect(preview).toBeInTheDocument();
+		expect(preview?.querySelector("img")).not.toBeInTheDocument();
+		expect(preview).toHaveTextContent('<img src=x onerror="alert(1)">');
+		expect(preview?.querySelector("strong")).toHaveTextContent("bold");
+	});
+
 	it("should render forced preview mode without edit toggle", () => {
 		render(() => <MarkdownEditor content="# Preview" onChange={() => {}} mode="preview" />);
 

--- a/frontend/src/components/MarkdownEditor.tsx
+++ b/frontend/src/components/MarkdownEditor.tsx
@@ -1,4 +1,5 @@
 import { createSignal, Show } from "solid-js";
+import { renderMarkdownPreview } from "~/lib/markdown";
 
 export interface MarkdownEditorProps {
 	content: string | undefined;
@@ -32,22 +33,6 @@ export function MarkdownEditor(props: MarkdownEditorProps) {
 				props.onSave();
 			}
 		}
-	};
-
-	const renderMarkdown = (content: string | undefined | null) => {
-		// Simple markdown rendering for preview
-		// In production, use a proper markdown parser
-		/* v8 ignore start */
-		const safeContent = content ?? "";
-		/* v8 ignore stop */
-		return safeContent
-			.replace(/^# (.+)$/gm, '<h1 class="text-2xl font-bold mb-2">$1</h1>')
-			.replace(/^## (.+)$/gm, '<h2 class="text-xl font-semibold mb-2 mt-4">$1</h2>')
-			.replace(/^### (.+)$/gm, '<h3 class="text-lg font-medium mb-1 mt-3">$1</h3>')
-			.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-			.replace(/\*(.+?)\*/g, "<em>$1</em>")
-			.replace(/`(.+?)`/g, '<code class="ui-code">$1</code>')
-			.replace(/\n/g, "<br>");
 	};
 
 	return (
@@ -122,7 +107,7 @@ export function MarkdownEditor(props: MarkdownEditorProps) {
 						/>
 						<div
 							class="preview ui-preview w-1/2 h-full"
-							innerHTML={renderMarkdown(props.content ?? "")}
+							innerHTML={renderMarkdownPreview(props.content)}
 						/>
 					</div>
 				</Show>
@@ -143,7 +128,7 @@ export function MarkdownEditor(props: MarkdownEditorProps) {
 					>
 						<div
 							class="preview ui-preview h-full"
-							innerHTML={renderMarkdown(props.content ?? "")}
+							innerHTML={renderMarkdownPreview(props.content)}
 						/>
 					</Show>
 				</Show>

--- a/frontend/src/lib/markdown.test.ts
+++ b/frontend/src/lib/markdown.test.ts
@@ -1,6 +1,11 @@
 // REQ-ENTRY-006: Structured data extraction from markdown
 import { describe, it, expect } from "vitest";
-import { replaceFirstH1, ensureFormFrontmatter, updateH2Section } from "./markdown";
+import {
+	replaceFirstH1,
+	ensureFormFrontmatter,
+	renderMarkdownPreview,
+	updateH2Section,
+} from "./markdown";
 
 describe("markdown utils", () => {
 	it("replaceFirstH1 replaces existing H1", () => {
@@ -49,6 +54,18 @@ describe("markdown utils", () => {
 		const md = "# Title\n\n## Section (Special) [Ref]\nOldValue";
 		const out = updateH2Section(md, "Section (Special) [Ref]", "NewValue");
 		expect(out).toContain("## Section (Special) [Ref]\nNewValue");
+	});
+
+	it("REQ-FE-005: renderMarkdownPreview escapes raw HTML while keeping markdown formatting", () => {
+		const preview = renderMarkdownPreview(
+			'# Preview\n\n<img src=x onerror="alert(1)">\n\n**bold** `code`',
+		);
+
+		expect(preview).toContain('<h1 class="text-2xl font-bold mb-2">Preview</h1>');
+		expect(preview).toContain("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+		expect(preview).not.toContain("<img");
+		expect(preview).toContain("<strong>bold</strong>");
+		expect(preview).toContain('<code class="ui-code">code</code>');
 	});
 
 	it("ensureFormFrontmatter handles unclosed frontmatter (no closing ---)", () => {

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -62,6 +62,27 @@ export function ensureFormFrontmatter(markdown: string, formName: string): strin
 	return `---\nform: ${formName}\n---\n\n${markdown}`;
 }
 
+function escapeHtml(text: string): string {
+	return text
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+export function renderMarkdownPreview(markdown: string | undefined | null): string {
+	const safeContent = escapeHtml(markdown ?? "");
+	return safeContent
+		.replace(/^# (.+)$/gm, '<h1 class="text-2xl font-bold mb-2">$1</h1>')
+		.replace(/^## (.+)$/gm, '<h2 class="text-xl font-semibold mb-2 mt-4">$1</h2>')
+		.replace(/^### (.+)$/gm, '<h3 class="text-lg font-medium mb-1 mt-3">$1</h3>')
+		.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+		.replace(/\*(.+?)\*/g, "<em>$1</em>")
+		.replace(/`(.+?)`/g, '<code class="ui-code">$1</code>')
+		.replace(/\n/g, "<br>");
+}
+
 /**
  * Helper to escape regex special characters.
  */


### PR DESCRIPTION
## Summary
- move markdown preview rendering into a shared helper that escapes raw HTML before inserting preview markup
- update the markdown editor to use the safe preview renderer so split and preview modes no longer create attacker-controlled DOM nodes
- add REQ-FE-005 unit, component, docs, and Playwright coverage for escaped raw HTML in entry preview flows

## Related Issue (required)
closes #1031

## Testing
- [x] TMPDIR=/workspace/tmp TMP=/workspace/tmp TEMP=/workspace/tmp mise run test
- [x] bash e2e/scripts/run-e2e.sh entries