### PR TITLE
fix: sanitize asset upload filenames before storage

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1118,6 +1118,36 @@ def test_upload_asset_strips_traversal_segments_from_filename(
     assert victim_meta_path.read_text(encoding="utf-8") == victim_meta_before
 
 
+def test_upload_asset_req_asset_001_normalizes_markdown_heading_filename(
+    test_client: TestClient,
+) -> None:
+    """REQ-ASSET-001: asset upload normalizes metadata-spoofing filenames."""
+    test_client.post("/spaces", json={"name": "test-ws"})
+
+    response = test_client.post(
+        "/spaces/test-ws/assets",
+        files={
+            "file": (
+                "## uploaded_at.txt",
+                io.BytesIO(b"hello"),
+                "text/plain",
+            ),
+        },
+    )
+    assert response.status_code == 201
+
+    asset = response.json()
+    assert asset["name"] == "uploaded_at.txt"
+    assert asset["path"] == f"assets/{asset['id']}_uploaded_at.txt"
+
+    entry_response = test_client.get(f"/spaces/test-ws/entries/{asset['id']}")
+    assert entry_response.status_code == 200
+    content = entry_response.json()["content"]
+    assert "## name\nuploaded_at.txt" in content
+    assert f"## link\nugoite://asset/{asset['id']}" in content
+    assert "## name\n## uploaded_at.txt" not in content
+
+
 def test_delete_asset_referenced_fails(
     test_client: TestClient,
     temp_space_root: Path,

--- a/docs/spec/requirements/asset.yaml
+++ b/docs/spec/requirements/asset.yaml
@@ -13,6 +13,16 @@ requirements:
   title: Asset Creation
   description: 'Store binary files (images, PDF, etc.) in the assets/ folder.
 
+    Upload filenames MUST resolve to a single metadata-safe basename inside the
+
+    target space''s
+
+    `assets/` directory; path separators, traversal segments, control characters,
+
+    and Markdown heading prefixes MUST NOT escape that directory or spoof stored
+
+    asset metadata.
+
     '
   related_spec:
   - api/rest.md#upload-asset
@@ -21,9 +31,14 @@ requirements:
   status: implemented
   tests:
     pytest:
+    - file: backend/tests/test_api.py
+      tests:
+      - test_upload_asset_req_asset_001_normalizes_markdown_heading_filename
     - file: ugoite-cli/tests/test_assets.rs
       tests:
       - test_asset_lifecycle
+      - test_asset_req_asset_001_upload_strips_filename_traversal
+      - test_asset_req_asset_001_upload_normalizes_markdown_heading_filename
     rust:
     - file: ugoite-core/tests/test_asset.rs
       tests:

--- a/docs/spec/security/overview.md
+++ b/docs/spec/security/overview.md
@@ -71,6 +71,9 @@ targets an **Authenticated Access by Default** model.
 ### Input Sanitization
 - All inputs validated via Pydantic models
 - Path traversal prevention in file operations
+- Asset upload filenames are reduced to a single metadata-safe basename before
+  storage writes so traversal segments, control characters, and Markdown heading
+  prefixes cannot escape or spoof a space's `assets/` directory metadata
 - SQL injection not applicable (no SQL database)
 
 ## Software Supply Chain Security

--- a/ugoite-cli/tests/test_assets.rs
+++ b/ugoite-cli/tests/test_assets.rs
@@ -1,6 +1,7 @@
 //! Integration tests for asset lifecycle management.
 //! REQ-ASSET-001
 
+use std::path::Path;
 use std::process::Command;
 
 fn ugoite_bin() -> String {
@@ -61,4 +62,99 @@ fn test_asset_lifecycle() {
     let stdout = String::from_utf8_lossy(&list_output.stdout);
     let v: serde_json::Value = serde_json::from_str(&stdout).expect("JSON");
     assert!(v.as_array().map(|a| !a.is_empty()).unwrap_or(false));
+}
+
+/// REQ-ASSET-001: Asset upload strips traversal from explicit filenames.
+#[test]
+fn test_asset_req_asset_001_upload_strips_filename_traversal() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_string_lossy().to_string();
+    let config_path = dir.path().join("cli-config.json");
+
+    Command::new(ugoite_bin())
+        .args(["create-space", "--root", &root, "asset-space"])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+
+    let asset_file = dir.path().join("test-asset.txt");
+    std::fs::write(&asset_file, b"test asset content").unwrap();
+
+    let space_path = format!("{root}/spaces/asset-space");
+    let upload_output = Command::new(ugoite_bin())
+        .args([
+            "asset",
+            "upload",
+            &space_path,
+            asset_file.to_str().unwrap(),
+            "--filename",
+            "nested/../../outside.txt",
+        ])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        upload_output.status.success(),
+        "upload stderr: {}",
+        String::from_utf8_lossy(&upload_output.stderr)
+    );
+
+    let asset: serde_json::Value =
+        serde_json::from_slice(&upload_output.stdout).expect("asset upload JSON");
+    let asset_name = asset["name"].as_str().expect("asset name");
+    let asset_path = asset["path"].as_str().expect("asset path");
+
+    assert_eq!(asset_name, "outside.txt");
+    assert!(asset_path.ends_with("_outside.txt"));
+    assert!(Path::new(&space_path).join(asset_path).exists());
+    assert!(!Path::new(&space_path).join("outside.txt").exists());
+}
+
+/// REQ-ASSET-001: Asset upload normalizes metadata-spoofing explicit filenames.
+#[test]
+fn test_asset_req_asset_001_upload_normalizes_markdown_heading_filename() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_string_lossy().to_string();
+    let config_path = dir.path().join("cli-config.json");
+
+    Command::new(ugoite_bin())
+        .args(["create-space", "--root", &root, "asset-space"])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+
+    let asset_file = dir.path().join("test-asset.txt");
+    std::fs::write(&asset_file, b"test asset content").unwrap();
+
+    let space_path = format!("{root}/spaces/asset-space");
+    let upload_output = Command::new(ugoite_bin())
+        .args([
+            "asset",
+            "upload",
+            &space_path,
+            asset_file.to_str().unwrap(),
+            "--filename",
+            "## uploaded_at\nspoofed.txt",
+        ])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("failed to execute");
+
+    assert!(
+        upload_output.status.success(),
+        "upload stderr: {}",
+        String::from_utf8_lossy(&upload_output.stderr)
+    );
+
+    let asset: serde_json::Value =
+        serde_json::from_slice(&upload_output.stdout).expect("asset upload JSON");
+    let asset_name = asset["name"].as_str().expect("asset name");
+    let asset_path = asset["path"].as_str().expect("asset path");
+
+    assert_eq!(asset_name, "uploaded_at spoofed.txt");
+    assert!(asset_path.ends_with("_uploaded_at spoofed.txt"));
+    assert!(!asset_name.contains('\n'));
+    assert!(!asset_name.starts_with('#'));
+    assert!(Path::new(&space_path).join(asset_path).exists());
 }

--- a/ugoite-core/src/asset.rs
+++ b/ugoite-core/src/asset.rs
@@ -52,15 +52,32 @@ fn build_asset_entry_content(name: &str, link: &str, uploaded_at: &str) -> Strin
     )
 }
 
+fn normalize_asset_basename(segment: &str) -> Option<String> {
+    let trimmed = segment.trim();
+    if trimmed.is_empty() || matches!(trimmed, "." | "..") {
+        return None;
+    }
+
+    let flattened = trimmed
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect::<String>();
+    let single_line = flattened.split_whitespace().collect::<Vec<_>>().join(" ");
+    let metadata_safe = single_line.trim_start_matches('#').trim_start();
+
+    if metadata_safe.is_empty() {
+        None
+    } else {
+        Some(metadata_safe.to_string())
+    }
+}
+
 fn normalize_asset_filename(filename: &str, fallback_name: &str) -> String {
     let basename = filename
         .rsplit(['/', '\\'])
         .find(|segment| !segment.is_empty())
         .unwrap_or("");
-    if basename.is_empty() || matches!(basename, "." | "..") {
-        return fallback_name.to_string();
-    }
-    basename.to_string()
+    normalize_asset_basename(basename).unwrap_or_else(|| fallback_name.to_string())
 }
 
 pub async fn save_asset(

--- a/ugoite-core/tests/test_asset.rs
+++ b/ugoite-core/tests/test_asset.rs
@@ -1,5 +1,6 @@
 mod common;
 use _ugoite_core::asset;
+use _ugoite_core::entry;
 use _ugoite_core::space;
 use common::setup_operator;
 #[cfg(unix)]
@@ -98,6 +99,42 @@ async fn test_asset_req_asset_001_normalizes_uploaded_filename() -> anyhow::Resu
     assert!(
         op.exists(&format!("spaces/source-space/{}", dot_info.path))
             .await?
+    );
+
+    let metadata_safe_info = asset::save_asset(
+        &op,
+        "spaces/source-space",
+        "## uploaded_at\nspoofed.txt",
+        b"metadata payload",
+    )
+    .await?;
+    let metadata_entry =
+        entry::get_entry_content(&op, "spaces/source-space", &metadata_safe_info.id).await?;
+
+    assert_eq!(metadata_safe_info.name, "uploaded_at spoofed.txt");
+    assert_eq!(
+        metadata_safe_info.path,
+        format!("assets/{}_uploaded_at spoofed.txt", metadata_safe_info.id)
+    );
+    assert_eq!(metadata_entry.sections["name"], "uploaded_at spoofed.txt");
+    assert_eq!(
+        metadata_entry.sections["link"],
+        format!("ugoite://asset/{}", metadata_safe_info.id)
+    );
+    assert!(metadata_entry.sections["uploaded_at"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+    assert!(
+        metadata_entry
+            .markdown
+            .contains("## name\nuploaded_at spoofed.txt"),
+        "markdown was {}",
+        metadata_entry.markdown
+    );
+    assert!(
+        !metadata_entry.markdown.contains("## name\n## uploaded_at"),
+        "markdown was {}",
+        metadata_entry.markdown
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- sanitize uploaded asset filenames down to a single safe basename before saving
- cover the confinement behavior in core, backend, and CLI regression tests
- document the REQ-ASSET-001 confinement rule and security expectation

## Related Issue (required)
closes #1030

## Testing
- [x] TMPDIR=/workspace/tmp TMP=/workspace/tmp TEMP=/workspace/tmp mise run test
- [x] RUSTFLAGS="-C debuginfo=0" CARGO_BUILD_JOBS=1 cargo test -p ugoite-core test_asset_req_asset_001_strips_filename_traversal -- --exact
- [x] RUSTFLAGS="-C debuginfo=0" CARGO_BUILD_JOBS=1 cargo test -p ugoite-cli test_asset_req_asset_001_upload_strips_filename_traversal -- --exact