### PR TITLE
fix: keep admin-space separate in newcomer flows

### DIFF
--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -139,6 +139,26 @@ def _reserved_admin_space_error(space_id: str) -> HTTPException:
     )
 
 
+def _is_admin_space(space_id: str) -> bool:
+    """Return whether a space id refers to the reserved admin space."""
+    return space_id == ugoite_core.admin_space_id()
+
+
+def _space_sort_key(space_meta: dict[str, Any]) -> tuple[int, str, str]:
+    """Sort user-facing spaces with default first and admin-space last."""
+    raw_space_id = space_meta.get("id")
+    space_id = raw_space_id if isinstance(raw_space_id, str) else ""
+    raw_name = space_meta.get("name")
+    name = raw_name if isinstance(raw_name, str) else space_id
+    if space_id == "default":
+        priority = 0
+    elif _is_admin_space(space_id):
+        priority = 2
+    else:
+        priority = 1
+    return (priority, name.casefold(), space_id.casefold())
+
+
 def _space_exists_conflict_error(space_id: str) -> HTTPException:
     """Return a stable create-space conflict error without storage internals."""
     return HTTPException(
@@ -152,14 +172,16 @@ def _sanitize_space_meta(space_meta: dict[str, Any]) -> dict[str, Any]:
     sanitized = dict(space_meta)
     sanitized.pop("hmac_key", None)
     settings_obj = sanitized.get("settings")
-    if not isinstance(settings_obj, dict):
-        return sanitized
-
-    settings = dict(settings_obj)
-    settings.pop("hmac_key", None)
-    if "invitations" in settings:
-        settings["invitations"] = {}
-    sanitized["settings"] = settings
+    if isinstance(settings_obj, dict):
+        settings = dict(settings_obj)
+        settings.pop("hmac_key", None)
+        if "invitations" in settings:
+            settings["invitations"] = {}
+        sanitized["settings"] = settings
+    space_id = sanitized.get("id")
+    sanitized["is_admin_space"] = isinstance(space_id, str) and _is_admin_space(
+        space_id,
+    )
     return sanitized
 
 
@@ -203,7 +225,7 @@ async def list_spaces_endpoint(request: Request) -> list[dict[str, Any]]:
                 detail="Failed to read space metadata",
             ) from exc
 
-    return results
+    return sorted(results, key=_space_sort_key)
 
 
 @router.post("/spaces", status_code=status.HTTP_201_CREATED)

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -89,6 +89,8 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         os.environ.get("UGOITE_BOOTSTRAP_DEFAULT_SPACE", "false").lower() == "true"
     )
     if should_bootstrap_default_space:
+        # Dev auth still bootstraps admin-space for creation permissions, while
+        # newcomer browser flows rely on a separate user-facing default space.
         try:
             await ugoite_core.create_space(storage_config, "default")
             logger.info("Created default space at startup")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -219,6 +219,31 @@ def test_list_spaces_req_api_001_admin_sees_admin_space(
     assert ugoite_core.admin_space_id() in space_ids
 
 
+def test_list_spaces_req_api_001_flags_reserved_admin_space_and_keeps_default_first(
+    test_client: TestClient,
+    temp_space_root: Path,
+) -> None:
+    """REQ-API-001: /spaces flags reserved admin-space and keeps it behind default."""
+    default_response = test_client.post("/spaces", json={"name": "default"})
+    assert default_response.status_code == 201
+    workspace_response = test_client.post("/spaces", json={"name": "workspace-a"})
+    assert workspace_response.status_code == 201
+
+    response = test_client.get("/spaces")
+
+    assert response.status_code == 200
+    spaces = response.json()
+    assert [space["id"] for space in spaces] == [
+        "default",
+        "workspace-a",
+        ugoite_core.admin_space_id(),
+    ]
+    flags = {space["id"]: space["is_admin_space"] for space in spaces}
+    assert flags["default"] is False
+    assert flags["workspace-a"] is False
+    assert flags[ugoite_core.admin_space_id()] is True
+
+
 def test_list_spaces_req_api_001_non_admin_cannot_see_admin_space(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -10,6 +10,8 @@ services:
       # Required because the frontend container reaches the backend over the
       # private Compose bridge network; host exposure still stays on 127.0.0.1.
       - UGOITE_ALLOW_REMOTE=true
+      # Keep a newcomer-facing workspace ready; admin-space stays separate in
+      # the browser UI after mock-oauth login.
       - UGOITE_BOOTSTRAP_DEFAULT_SPACE=true
       - UGOITE_DEV_AUTH_MODE=mock-oauth
       - UGOITE_DEV_USER_ID=${UGOITE_DEV_USER_ID:-dev-local-user}

--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -61,8 +61,10 @@ Then open:
 Click **Continue with Local Demo Login** to reach `/spaces`. That button starts
 the local demo login path (`mock-oauth`), so no external OAuth provider is
 involved. The shipped compose file bootstraps the `default` space at startup so
-the first browser and CLI session both have a ready workspace. For more detail
-on the explicit browser login flow, see
+the first browser and CLI session both have a ready workspace. The reserved
+`admin-space` still exists for admin-only workflows, but `/spaces` keeps it in a
+separate admin section so the first visible workspace path stays newcomer-friendly.
+For more detail on the explicit browser login flow, see
 [Local Dev Auth Login](local-dev-auth-login.md).
 
 This published quick start intentionally differs from `mise run dev`: it
@@ -112,7 +114,8 @@ find ./spaces -maxdepth 2 -type f | head
 ## Next steps
 
 - The `default` space is the starter workspace that the published quick start
-  bootstraps for you after login.
+  bootstraps for you after login. The reserved `admin-space` stays separate in
+  the UI for admin tasks.
 - Try creating one plain Markdown entry in that space first. You do **not** need
   to define a Form before the first note.
 - Read [Core Concepts](concepts.md) once you want the mental model for spaces,

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -107,12 +107,19 @@ GET /spaces
 ```json
 [
   {
-    "id": "ws-main",
-    "name": "Personal Knowledge",
-    "created_at": "2025-08-12T12:00:00Z"
+    "id": "default",
+    "name": "default",
+    "created_at": "2025-08-12T12:00:00Z",
+    "is_admin_space": false
   }
 ]
 ```
+
+Notes:
+
+- `default` stays ahead of reserved bootstrap spaces in list responses.
+- Reserved bootstrap spaces include `is_admin_space: true` so browser clients can
+  keep newcomer-facing workspace lists separate from internal admin workflows.
 
 #### Create Space
 ```http

--- a/docs/spec/requirements/api.yaml
+++ b/docs/spec/requirements/api.yaml
@@ -25,7 +25,11 @@ requirements:
   - SPEC-STORIES-EXPERIMENTAL
   id: REQ-API-001
   title: Space CRUD
-  description: 'Create, retrieve, and list spaces.
+  description: 'Create, retrieve, and list spaces. `/spaces` MUST keep the default
+
+    user workspace ahead of the reserved admin-space and identify the reserved
+
+    admin-space explicitly for clients.
 
     '
   related_spec:
@@ -42,6 +46,7 @@ requirements:
       - test_create_space_req_api_001_propagates_http_exception
       - test_list_spaces
       - test_list_spaces_req_api_001_admin_sees_admin_space
+      - test_list_spaces_req_api_001_flags_reserved_admin_space_and_keeps_default_first
       - test_list_spaces_req_api_001_non_admin_cannot_see_admin_space
       - test_get_space
       - test_get_space_not_found

--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -17,6 +17,10 @@ requirements:
   title: Space Selector
   description: 'Select and switch spaces.
 
+    Newcomer-facing lists and automatic selection MUST keep user workspaces
+
+    primary and avoid preferring the reserved admin-space by default.
+
     '
   related_spec:
   - stories/core.yaml#STORY-003
@@ -34,9 +38,14 @@ requirements:
       tests:
       - should keep selection empty when no spaces exist
       - should select existing default space
+      - 'REQ-FE-001: should skip reserved admin-space when choosing the first user space'
+      - 'REQ-FE-001: should sort blank space names by fallback id'
       - should restore persisted space selection
       - should select space and persist choice
       - should not select non-existent space
+    - file: frontend/src/routes/spaces/index.test.tsx
+      tests:
+      - 'REQ-FE-001: keeps reserved admin-space out of the primary newcomer list'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.
@@ -67,12 +76,14 @@ requirements:
     - file: frontend/src/lib/space-store.test.ts
       tests:
       - should keep selection empty when no spaces exist
+      - 'REQ-FE-002: should keep selection empty when only reserved admin spaces exist'
     - file: frontend/src/routes/spaces/index.test.tsx
       tests:
       - 'REQ-FE-002: shows a create-space action when no spaces exist'
       - 'REQ-FE-002: creates a space only after explicit user submission'
       - 'REQ-FE-002: labels the create-space field as a space ID and explains allowed characters'
       - 'REQ-FE-002: rewrites invalid space_id backend errors into user-facing guidance'
+      - 'REQ-FE-002: treats reserved admin-space-only responses as an empty user-space state'
 - set_id: REQCAT-FRONTEND
   source_file: requirements/frontend.yaml
   scope: Frontend route, component, and interaction requirements.

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -676,6 +676,7 @@ requirements:
     e2e:
     - file: e2e/smoke.test.ts
       tests:
+      - 'REQ-OPS-015: browser mock-oauth login reaches /spaces with default ahead of reserved admin-space'
       - 'REQ-OPS-015: visiting login does not clear an existing browser auth cookie'
     - file: e2e/public-pages.test.ts
       tests:

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -65,7 +65,9 @@ test.describe("Smoke Tests", () => {
 		expect(body.toLowerCase()).toContain("<!doctype html>");
 	});
 
-	test("REQ-OPS-015: browser mock-oauth login reaches the spaces page", async ({ browser }) => {
+	test("REQ-OPS-015: browser mock-oauth login reaches /spaces with default ahead of reserved admin-space", async ({
+		browser,
+	}) => {
 		const context = await browser.newContext();
 		const page = await context.newPage();
 
@@ -74,6 +76,13 @@ test.describe("Smoke Tests", () => {
 			await page.getByRole("button", { name: "Continue with Local Demo Login" }).click();
 			await expect(page).toHaveURL(/\/spaces$/);
 			await expect(page.getByText("Available Spaces")).toBeVisible();
+			const userSpaces = page.getByRole("list", { name: "User spaces" });
+			await expect(userSpaces).toContainText("default");
+			await expect(userSpaces).not.toContainText("admin-space");
+			const adminSpaces = page.getByRole("list", { name: "Admin spaces" });
+			await expect(adminSpaces).toContainText("admin-space");
+			await userSpaces.getByRole("link", { name: "Open Space" }).first().click();
+			await expect(page).toHaveURL(/\/spaces\/default\/dashboard$/);
 		} finally {
 			await context.close();
 		}

--- a/frontend/src/lib/space-list.ts
+++ b/frontend/src/lib/space-list.ts
@@ -1,0 +1,37 @@
+import type { Space } from "./types";
+
+export const DEFAULT_SPACE_ID = "default";
+const RESERVED_ADMIN_SPACE_ID = "admin-space";
+
+export function isReservedAdminSpace(space: Pick<Space, "id" | "is_admin_space">): boolean {
+	return space.is_admin_space === true || space.id === RESERVED_ADMIN_SPACE_ID;
+}
+
+function compareSpaces(a: Space, b: Space): number {
+	const priority = (space: Space): number => {
+		if (space.id === DEFAULT_SPACE_ID) return 0;
+		if (isReservedAdminSpace(space)) return 2;
+		return 1;
+	};
+	const priorityDiff = priority(a) - priority(b);
+	if (priorityDiff !== 0) {
+		return priorityDiff;
+	}
+	const aLabel = (a.name || a.id).toLocaleLowerCase();
+	const bLabel = (b.name || b.id).toLocaleLowerCase();
+	return aLabel.localeCompare(bLabel);
+}
+
+export function sortSpaces(spaces: readonly Space[]): Space[] {
+	return [...spaces].sort(compareSpaces);
+}
+
+export function partitionSpaces(spaces: readonly Space[]): {
+	userSpaces: Space[];
+	adminSpaces: Space[];
+} {
+	const sortedSpaces = sortSpaces(spaces);
+	const userSpaces = sortedSpaces.filter((space) => !isReservedAdminSpace(space));
+	const adminSpaces = sortedSpaces.filter((space) => isReservedAdminSpace(space));
+	return { userSpaces, adminSpaces };
+}

--- a/frontend/src/lib/space-store.test.ts
+++ b/frontend/src/lib/space-store.test.ts
@@ -91,6 +91,94 @@ describe("createSpaceStore", () => {
 		});
 	});
 
+	it("REQ-FE-001: should skip reserved admin-space when choosing the first user space", async () => {
+		const adminSpace: Space = {
+			id: "admin-space",
+			name: "admin-space",
+			created_at: "2025-01-01T00:00:00Z",
+			is_admin_space: true,
+		};
+		const workspace: Space = {
+			id: "workspace-a",
+			name: "Workspace A",
+			created_at: "2025-01-01T00:00:00Z",
+		};
+		seedSpace(adminSpace);
+		seedSpace(workspace);
+
+		await createRoot(async (dispose) => {
+			const store = createSpaceStore();
+
+			const selectedId = await store.loadSpaces();
+
+			expect(selectedId).toBe("workspace-a");
+			expect(store.spaces().map((space) => space.id)).toEqual(["workspace-a", "admin-space"]);
+			expect(store.selectedSpaceId()).toBe("workspace-a");
+
+			dispose();
+		});
+	});
+
+	it("REQ-FE-001: should ignore a stale reserved admin-space local selection", async () => {
+		const adminSpace: Space = {
+			id: "admin-space",
+			name: "admin-space",
+			created_at: "2025-01-01T00:00:00Z",
+			is_admin_space: true,
+		};
+		const workspace: Space = {
+			id: "workspace-a",
+			name: "Workspace A",
+			created_at: "2025-01-01T00:00:00Z",
+		};
+		seedSpace(adminSpace);
+		seedSpace(workspace);
+		localStorageMock.setItem("ugoite-selected-space", "admin-space");
+
+		await createRoot(async (dispose) => {
+			const store = createSpaceStore();
+
+			const selectedId = await store.loadSpaces();
+
+			expect(selectedId).toBe("workspace-a");
+			expect(store.selectedSpaceId()).toBe("workspace-a");
+			expect(localStorageMock.setItem).toHaveBeenCalledWith("ugoite-selected-space", "workspace-a");
+			await waitFor(() => {
+				const expectedPatch = {} as import("./types").UserPreferencesPatchPayload;
+				expectedPatch.selected_space_id = "workspace-a";
+				expect(getPreferencePatches()).toContainEqual(expectedPatch);
+			});
+
+			dispose();
+		});
+	});
+
+	it("REQ-FE-001: should sort blank space names by fallback id", async () => {
+		const zetaSpace: Space = {
+			id: "zeta-space",
+			name: "",
+			created_at: "2025-01-01T00:00:00Z",
+		};
+		const alphaSpace: Space = {
+			id: "alpha-space",
+			name: "",
+			created_at: "2025-01-01T00:00:00Z",
+		};
+		seedSpace(zetaSpace);
+		seedSpace(alphaSpace);
+
+		await createRoot(async (dispose) => {
+			const store = createSpaceStore();
+
+			const selectedId = await store.loadSpaces();
+
+			expect(selectedId).toBe("alpha-space");
+			expect(store.spaces().map((space) => space.id)).toEqual(["alpha-space", "zeta-space"]);
+
+			dispose();
+		});
+	});
+
 	it("should restore persisted space selection", async () => {
 		const ws1: Space = {
 			id: "space-1",
@@ -147,6 +235,80 @@ describe("createSpaceStore", () => {
 
 			expect(selectedId).toBe("space-2");
 			expect(store.selectedSpaceId()).toBe("space-2");
+
+			dispose();
+		});
+	});
+
+	it("REQ-FE-003: should ignore a reserved admin-space portable preference", async () => {
+		const adminSpace: Space = {
+			id: "admin-space",
+			name: "admin-space",
+			created_at: "2025-01-01T00:00:00Z",
+			is_admin_space: true,
+		};
+		const defaultSpace: Space = {
+			id: "default",
+			name: "default",
+			created_at: "2025-01-01T00:00:00Z",
+		};
+		const workspace: Space = {
+			id: "workspace-a",
+			name: "Workspace A",
+			created_at: "2025-01-01T00:00:00Z",
+		};
+		seedSpace(adminSpace);
+		seedSpace(defaultSpace);
+		seedSpace(workspace);
+		const portableSelection = {} as import("./types").UserPreferencesPatchPayload;
+		portableSelection.selected_space_id = "admin-space";
+		seedPreferences(portableSelection);
+		localStorageMock.setItem("ugoite-selected-space", "workspace-a");
+
+		const { initializePortablePreferences } = await import("./preferences-store");
+		await initializePortablePreferences();
+
+		await createRoot(async (dispose) => {
+			const store = createSpaceStore();
+
+			const selectedId = await store.loadSpaces();
+
+			expect(selectedId).toBe("default");
+			expect(store.selectedSpaceId()).toBe("default");
+			expect(localStorageMock.setItem).toHaveBeenCalledWith("ugoite-selected-space", "default");
+			await waitFor(() => {
+				const expectedPatch = {} as import("./types").UserPreferencesPatchPayload;
+				expectedPatch.selected_space_id = "default";
+				expect(getPreferencePatches()).toContainEqual(expectedPatch);
+			});
+
+			dispose();
+		});
+	});
+
+	it("REQ-FE-002: should keep selection empty when only reserved admin spaces exist", async () => {
+		const adminSpace: Space = {
+			id: "admin-space",
+			name: "admin-space",
+			created_at: "2025-01-01T00:00:00Z",
+			is_admin_space: true,
+		};
+		seedSpace(adminSpace);
+		localStorageMock.setItem("ugoite-selected-space", "admin-space");
+
+		await createRoot(async (dispose) => {
+			const store = createSpaceStore();
+
+			const selectedId = await store.loadSpaces();
+
+			expect(selectedId).toBe("");
+			expect(store.selectedSpaceId()).toBeNull();
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith("ugoite-selected-space");
+			await waitFor(() => {
+				const expectedPatch = {} as import("./types").UserPreferencesPatchPayload;
+				expectedPatch.selected_space_id = null;
+				expect(getPreferencePatches()).toContainEqual(expectedPatch);
+			});
 
 			dispose();
 		});

--- a/frontend/src/lib/space-store.ts
+++ b/frontend/src/lib/space-store.ts
@@ -1,10 +1,9 @@
 import { createSignal } from "solid-js";
 import { readLocalPreferences, writeLocalPreferences } from "./preferences-local";
 import { portablePreferences, setSelectedSpacePreference } from "~/lib/preferences-store";
+import { DEFAULT_SPACE_ID, isReservedAdminSpace, sortSpaces } from "./space-list";
 import type { Space } from "./types";
 import { spaceApi } from "./space-api";
-
-const DEFAULT_SPACE_ID = "default";
 
 /**
  * Creates a reactive space store.
@@ -43,35 +42,38 @@ export function createSpaceStore() {
 		setLoading(true);
 		setError(null);
 		try {
-			const fetchedSpaces = await spaceApi.list();
+			const fetchedSpaces = sortSpaces(await spaceApi.list());
 			setSpaces(fetchedSpaces);
+			const selectableSpaces = fetchedSpaces.filter((space) => !isReservedAdminSpace(space));
 
 			// Try to restore persisted space selection
 			const persistedId = getPersistedSpaceId();
-			if (persistedId && fetchedSpaces.some((space) => space.id === persistedId)) {
+			const repairingPersistedSelection =
+				persistedId !== null && !selectableSpaces.some((space) => space.id === persistedId);
+			if (persistedId && selectableSpaces.some((space) => space.id === persistedId)) {
 				setSelectedSpaceId(persistedId, false);
 				setInitialized(true);
 				return persistedId;
 			}
 
 			// If default space exists, select it
-			const defaultSpace = fetchedSpaces.find((space) => space.id === DEFAULT_SPACE_ID);
+			const defaultSpace = selectableSpaces.find((space) => space.id === DEFAULT_SPACE_ID);
 			if (defaultSpace) {
-				setSelectedSpaceId(DEFAULT_SPACE_ID, false);
+				setSelectedSpaceId(DEFAULT_SPACE_ID, repairingPersistedSelection);
 				setInitialized(true);
 				return DEFAULT_SPACE_ID;
 			}
 
-			// No client-side space creation; remain unselected when list is empty
-			if (fetchedSpaces.length === 0) {
-				setSelectedSpaceIdInternal(null);
+			// No client-side space creation; remain unselected when no user-facing spaces exist
+			if (selectableSpaces.length === 0) {
+				setSelectedSpaceId(null, repairingPersistedSelection);
 				setInitialized(true);
 				return "";
 			}
 
-			// Otherwise, select the first available space
-			const firstSpace = fetchedSpaces[0];
-			setSelectedSpaceId(firstSpace.id, false);
+			// Otherwise, select the first available user-facing space
+			const firstSpace = selectableSpaces[0];
+			setSelectedSpaceId(firstSpace.id, repairingPersistedSelection);
 			setInitialized(true);
 			return firstSpace.id;
 		} catch (e) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -8,6 +8,7 @@ export interface Space {
 	id: string;
 	name: string;
 	created_at: string;
+	is_admin_space?: boolean;
 	storage_config?: Record<string, unknown>;
 	settings?: Record<string, unknown>;
 }

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
 import SpacesIndexRoute from "./index";
 import { spaceApi } from "~/lib/space-api";
 
@@ -124,6 +124,59 @@ describe("/spaces", () => {
 		expect(
 			screen.queryByText(/localhost and remote mode both require authentication/i),
 		).not.toBeInTheDocument();
+	});
+
+	it("REQ-FE-001: keeps reserved admin-space out of the primary newcomer list", async () => {
+		(spaceApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{
+				id: "admin-space",
+				name: "admin-space",
+				created_at: "2025-01-01T00:00:00Z",
+				is_admin_space: true,
+			},
+			{
+				id: "default",
+				name: "default",
+				created_at: "2025-01-01T00:00:00Z",
+			},
+		]);
+
+		render(() => <SpacesIndexRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("list", { name: "User spaces" })).toBeInTheDocument();
+		});
+
+		const userList = screen.getByRole("list", { name: "User spaces" });
+		expect(within(userList).getByText("default")).toBeInTheDocument();
+		expect(within(userList).queryByText("admin-space")).not.toBeInTheDocument();
+		expect(within(userList).getByRole("link", { name: "Open Space" })).toHaveAttribute(
+			"href",
+			"/spaces/default/dashboard",
+		);
+
+		const adminList = screen.getByRole("list", { name: "Admin spaces" });
+		expect(within(adminList).getByText("admin-space")).toBeInTheDocument();
+	});
+
+	it("REQ-FE-002: treats reserved admin-space-only responses as an empty user-space state", async () => {
+		(spaceApi.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+			{
+				id: "admin-space",
+				name: "admin-space",
+				created_at: "2025-01-01T00:00:00Z",
+				is_admin_space: true,
+			},
+		]);
+
+		render(() => <SpacesIndexRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByText("No user spaces available yet.")).toBeInTheDocument();
+		});
+
+		expect(screen.getByRole("button", { name: "Create space" })).toBeInTheDocument();
+		expect(screen.getByRole("list", { name: "Admin spaces" })).toBeInTheDocument();
 	});
 
 	it("REQ-FE-056: shows concise auth errors only when space loading fails", async () => {

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -2,6 +2,8 @@ import { A, useNavigate } from "@solidjs/router";
 import { createEffect, createMemo, createResource, createSignal, For, Show } from "solid-js";
 import { getDocsiteHref } from "~/lib/docsite-links";
 import { spaceApi } from "~/lib/space-api";
+import { partitionSpaces } from "~/lib/space-list";
+import type { Space } from "~/lib/types";
 
 const localDevAuthGuideUrl = getDocsiteHref(
 	"/docs/guide/local-dev-auth-login",
@@ -23,6 +25,34 @@ const normalizeCreateError = (value: unknown): string => {
 	return message || "Failed to create space.";
 };
 
+function SpaceCards(props: { label: string; spaces: readonly Space[] }) {
+	return (
+		<ul aria-label={props.label} class="ui-stack-sm">
+			<For each={props.spaces}>
+				{(space) => (
+					<li class="ui-card flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+						<div>
+							<h3 class="font-medium">{space.name || space.id}</h3>
+							<p class="text-xs ui-muted">ID: {space.id}</p>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<A
+								href={`/spaces/${space.id}/settings`}
+								class="ui-button ui-button-secondary text-sm"
+							>
+								Settings
+							</A>
+							<A href={`/spaces/${space.id}/dashboard`} class="ui-button ui-button-primary text-sm">
+								Open Space
+							</A>
+						</div>
+					</li>
+				)}
+			</For>
+		</ul>
+	);
+}
+
 export default function SpacesIndexRoute() {
 	const navigate = useNavigate();
 	const [spacesError, setSpacesError] = createSignal("");
@@ -40,6 +70,9 @@ export default function SpacesIndexRoute() {
 	const [newSpaceId, setNewSpaceId] = createSignal("");
 	const [createError, setCreateError] = createSignal<string | null>(null);
 	const [isCreating, setIsCreating] = createSignal(false);
+	const listedSpaces = createMemo(() => partitionSpaces(spaces() || []));
+	const userSpaces = createMemo(() => listedSpaces().userSpaces);
+	const adminSpaces = createMemo(() => listedSpaces().adminSpaces);
 
 	const authHint = createMemo((): { message: string; showGuide: boolean } | null => {
 		const message = spacesError().toLowerCase();
@@ -67,7 +100,10 @@ export default function SpacesIndexRoute() {
 	});
 
 	const hasNoSpaces = createMemo(
-		() => !spaces.loading && !spacesError() && (spaces()?.length ?? 0) === 0,
+		() => !spaces.loading && !spacesError() && userSpaces().length === 0,
+	);
+	const emptyStateMessage = createMemo(() =>
+		adminSpaces().length > 0 ? "No user spaces available yet." : "No spaces available.",
 	);
 
 	const openCreateForm = () => {
@@ -139,6 +175,12 @@ export default function SpacesIndexRoute() {
 
 			<section class="ui-card">
 				<h2 class="text-lg font-semibold mb-3">Available Spaces</h2>
+				<Show when={adminSpaces().length > 0}>
+					<p class="mb-3 text-sm ui-muted">
+						User-facing spaces stay primary here. Reserved admin spaces remain available in a
+						separate section below.
+					</p>
+				</Show>
 				<Show when={showCreateForm()}>
 					<form class="ui-card ui-stack-sm mb-4" onSubmit={handleCreateSpace}>
 						<div>
@@ -211,7 +253,7 @@ export default function SpacesIndexRoute() {
 				</Show>
 				<Show when={hasNoSpaces() && !showCreateForm()}>
 					<div class="ui-card ui-card-dashed ui-stack-sm">
-						<p class="text-sm ui-muted">No spaces available.</p>
+						<p class="text-sm ui-muted">{emptyStateMessage()}</p>
 						<div>
 							<button
 								type="button"
@@ -223,32 +265,20 @@ export default function SpacesIndexRoute() {
 						</div>
 					</div>
 				</Show>
-				<ul class="ui-stack-sm">
-					<For each={spaces() || []}>
-						{(space) => (
-							<li class="ui-card flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-								<div>
-									<h3 class="font-medium">{space.name || space.id}</h3>
-									<p class="text-xs ui-muted">ID: {space.id}</p>
-								</div>
-								<div class="flex flex-wrap gap-2">
-									<A
-										href={`/spaces/${space.id}/settings`}
-										class="ui-button ui-button-secondary text-sm"
-									>
-										Settings
-									</A>
-									<A
-										href={`/spaces/${space.id}/dashboard`}
-										class="ui-button ui-button-primary text-sm"
-									>
-										Open Space
-									</A>
-								</div>
-							</li>
-						)}
-					</For>
-				</ul>
+				<Show when={userSpaces().length > 0}>
+					<SpaceCards label="User spaces" spaces={userSpaces()} />
+				</Show>
+				<Show when={adminSpaces().length > 0}>
+					<div class="mt-4 ui-stack-sm">
+						<div>
+							<h3 class="text-base font-semibold">Admin Spaces</h3>
+							<p class="text-sm ui-muted">
+								Reserved workspaces for administration and setup tasks.
+							</p>
+						</div>
+						<SpaceCards label="Admin spaces" spaces={adminSpaces()} />
+					</div>
+				</Show>
 			</section>
 		</main>
 	);


### PR DESCRIPTION
## Summary
- mark reserved admin-space explicitly in the spaces API, keep `default` first, and separate admin spaces from the primary newcomer list
- avoid auto-selecting reserved admin-space in the frontend fallback selection flow and add REQ-linked coverage for ordering, empty-state, and blank-name sorting
- document the release/mock-oauth newcomer path and verify it with the Playwright smoke flow plus the full repo test suite

## Related Issue (required)
closes #1025

## Testing
- [x] `cd frontend && npm run test:run -- src/lib/client.test.ts src/lib/space-store.test.ts src/routes/spaces/index.test.tsx`
- [x] `bash e2e/scripts/run-e2e.sh smoke`
- [x] `TMPDIR=/workspace/tmp TMP=/workspace/tmp TEMP=/workspace/tmp mise run test`
