### PR TITLE
docs: clarify docsite local-first landing copy

### DIFF
--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -4,6 +4,7 @@ import {
 	browserPathCaveat,
 	conceptPrimerCard,
 	coreConceptSummaries,
+	landingLead,
 	nextStepCards,
 	primaryStartCards,
 } from "./onboarding";
@@ -48,6 +49,10 @@ test("REQ-E2E-008: onboarding content keeps browser, auth, and deeper reference 
 });
 
 test("REQ-E2E-008: onboarding content keeps browser caveats explicit on browser-first paths", () => {
+	expect(landingLead).toContain(
+		"CLI `core` mode is the lowest-setup local-first path today",
+	);
+	expect(landingLead).toContain("backend + frontend stack");
 	expect(browserPathCaveat).toEqual({
 		badge: "Browser caveat today",
 		description:

--- a/docsite/src/lib/onboarding.ts
+++ b/docsite/src/lib/onboarding.ts
@@ -11,6 +11,9 @@ export type ConceptSummary = {
 	title: string;
 };
 
+export const landingLead =
+	"A private, portable knowledge space you can keep on infrastructure you control: CLI `core` mode is the lowest-setup local-first path today, while the current browser route still runs on the backend + frontend stack you launch with Docker or `mise run dev`.";
+
 export const browserPathCaveat = {
 	badge: "Browser caveat today",
 	description:

--- a/docsite/src/lib/onboarding.ts
+++ b/docsite/src/lib/onboarding.ts
@@ -12,7 +12,7 @@ export type ConceptSummary = {
 };
 
 export const landingLead =
-	"A private, portable knowledge space you can keep on infrastructure you control: CLI `core` mode is the lowest-setup local-first path today, while the current browser route still runs on the backend + frontend stack you launch with Docker or `mise run dev`.";
+	"A private, portable knowledge space you can run with Docker: CLI `core` mode is the lowest-setup local-first path today, while the current browser route still runs on the backend + frontend stack you launch with Docker or `mise run dev`.";
 
 export const browserPathCaveat = {
 	badge: "Browser caveat today",

--- a/docsite/src/pages/index.astro
+++ b/docsite/src/pages/index.astro
@@ -4,6 +4,7 @@ import { withBasePath } from "../lib/base-path";
 import {
   browserPathCaveat,
   conceptPrimerCard,
+  landingLead,
   nextStepCards,
   primaryStartCards,
 } from "../lib/onboarding";
@@ -20,7 +21,7 @@ import {
         </h1>
 
         <p class="doc-lead">
-          A private, portable knowledge space you can run with Docker, automate from the CLI, and keep on infrastructure you control.
+          {landingLead}
         </p>
 
         <div class="doc-pill-row">


### PR DESCRIPTION
## Summary
- make the docsite landing lead explicitly contrast CLI `core` mode with the current browser stack
- route the landing lead through shared onboarding copy so the landing page and onboarding tests stay aligned
- extend the REQ-E2E-008 onboarding test to keep the local-first/browser-stack distinction explicit

## Related Issue (required)
closes #1340

## Testing
- [x] ./node_modules/.bin/biome check src/lib/onboarding.ts src/lib/onboarding.test.ts
- [x] node ./node_modules/vitest/vitest.mjs run src/lib/onboarding.test.ts
- [x] bun run build