### PR TITLE
docs: clarify feature registry authoring modes

### DIFF
--- a/docs/spec/features/README.md
+++ b/docs/spec/features/README.md
@@ -23,6 +23,12 @@ must stay in sync with it.
 - [links.yaml](links.yaml) - Legacy link API registry kept for traceability after
   the product moved to `row_reference` fields instead of dedicated link APIs
 - [sql.md](sql.md) - Ugoite SQL dialect reference used by the saved SQL features
+- [Frontend–Backend Interface](../architecture/frontend-backend-interface.md) -
+  Canonical browser authoring-mode contract for Markdown, Web form, and Chat
+  Q&A submission behavior
+- [frontend.yaml](../requirements/frontend.yaml) - Frontend interaction
+  requirements, including REQ-FE-037 for create-entry modes and REQ-FE-057 for
+  the chat create-entry flow
 
 ## Purpose
 
@@ -35,6 +41,12 @@ The features registry serves multiple purposes:
 ## Registry Structure
 
 The registry is API-operation oriented.
+
+That means it is the canonical inventory for backend/frontend/API path surfaces,
+not the full catalog of browser authoring behaviors. Browser entry authoring
+modes such as Markdown, Web form, and Chat Q&A are intentionally tracked in the
+Frontend–Backend Interface contract plus the frontend requirements set instead
+of this API manifest.
 
 Each operation entry includes:
 

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -50,7 +50,7 @@ future work.
 - [Future-Proofing](architecture/future-proofing.md) - Experimental direction (BYOAI, multi-platform core)
 
 ### Features & Stories
-- [Features Registry](features/README.md) - API-level feature registry across modules
+- [Features Registry](features/README.md) - API-level feature registry across modules; browser authoring modes stay in interface/frontend specs
 - [Ugoite SQL](features/sql.md) - SQL dialect for structured queries
 - [Core Stories](stories/core.yaml) - Essential user scenarios
 - [Advanced Stories](stories/advanced.yaml) - Power user and experimental features

--- a/docs/tests/test_features.py
+++ b/docs/tests/test_features.py
@@ -279,6 +279,26 @@ def test_docs_req_api_004_feature_readme_inventory_matches_manifest() -> None:
         raise AssertionError(message)
 
 
+def test_docs_req_api_004_feature_readme_links_browser_modes_to_specs() -> None:
+    """REQ-API-004: Feature README must explain where browser authoring modes live."""
+    readme = _read_text(FEATURES_DIR / "README.md")
+    required_fragments = (
+        "../architecture/frontend-backend-interface.md",
+        "../requirements/frontend.yaml",
+        "Markdown, Web form, and Chat Q&A",
+        "REQ-FE-037",
+        "REQ-FE-057",
+        "API-operation oriented",
+    )
+    missing = [fragment for fragment in required_fragments if fragment not in readme]
+    if missing:
+        message = (
+            "docs/spec/features/README.md must point browser authoring modes to "
+            "their canonical frontend specs: " + ", ".join(missing)
+        )
+        raise AssertionError(message)
+
+
 def test_docs_req_api_004_docsite_feature_pages_use_manifest_loader() -> None:
     """REQ-API-004: Docsite feature pages must use the manifest-backed loader."""
     spec_data = _read_text(DOCSITE_SPEC_DATA)


### PR DESCRIPTION
## Summary

- clarify that the feature registry is the API-level inventory and does not own browser authoring mode behavior
- add direct breadcrumbs from the feature registry docs to the frontend interface and requirements specs for Markdown, Web form, and Chat Q&A flows
- add a REQ-API-004 regression test that keeps those breadcrumbs wired

## Related Issue (required)

closes #1338

## Testing

- [x] `mise run test`