### PR TITLE
docs: add beginner storage settings guide

### DIFF
--- a/docs/guide/browser-first-entry.md
+++ b/docs/guide/browser-first-entry.md
@@ -92,7 +92,8 @@ space surfaces without guesswork:
 - Need the mental model behind spaces, entries, forms, and derived structure?
   Read [Core Concepts](concepts.md).
 - Need to inspect storage or other space configuration? Use the **Settings**
-  link from the spaces list or the dashboard storage summary card.
+  link from the spaces list or the dashboard storage summary card, then read
+  [Space Settings & Storage](space-settings-storage.md) before changing anything.
 - Need browser/CLI/API auth context after the first entry? Read
   [Authentication Overview](auth-overview.md).
 - Need integrations or server-backed automation next? Read the

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -19,6 +19,8 @@ stack healthy, diagnosable, and safe to evolve.
 
 ## Maintain storage safely
 
+- [Space Settings & Storage](space-settings-storage.md) for a beginner-friendly
+  explanation of the storage summary, connector metadata, and when to leave the defaults alone.
 - [Storage Cleanup](storage-cleanup.md) for reclaiming generated state without
   guessing which paths are safe to remove.
 - [Storage Migration](storage-migration.md) when you need to move or reshape a

--- a/docs/guide/space-settings-storage.md
+++ b/docs/guide/space-settings-storage.md
@@ -1,0 +1,58 @@
+# Space Settings & Storage
+
+Use this guide the first time the browser shows a space storage summary or a
+**Settings** link and you want to know whether you actually need to change
+anything.
+
+## What the storage summary is telling you
+
+The dashboard storage summary answers "where is this space writing right now?"
+It reflects the current storage topology reported by the backend for the active
+space before you edit any future targets.
+
+- The label tells you whether the current topology is local filesystem, remote
+  object storage, or another backend-managed target.
+- The URI shows the current root when the backend can report it.
+- The summary is there so you can review the active setup before opening
+  **Settings**.
+
+## What the Saved Storage URI means today
+
+In **Space Settings**, the **Saved Storage URI** field records connector
+metadata for a future migration target.
+
+- `file://` keeps the plan local-first and machine-owned.
+- `s3://` records a remote object storage target that adds credentials, network
+  reachability, and usage-cost questions.
+
+Today that field is metadata only: saving it does **not** move existing entries
+or assets, and it does **not** reroute live writes away from the storage summary
+shown above.
+
+## When to leave the defaults alone
+
+If the current space is already writing where you expect and you are just
+getting started, leave the defaults alone.
+
+Good reasons to keep the defaults:
+
+- you are creating the first space or first entry
+- local filesystem storage already matches the low-cost, local-first path you
+  want
+- you do not have a concrete migration plan yet
+
+## When to open Settings on purpose
+
+Open **Settings** when you want to:
+
+1. review the current storage summary before making an operational decision
+2. test a future connector target with **Test Connection**
+3. save connector metadata for a planned migration
+4. rename the space or inspect other space-level configuration
+
+## What to read next if you are changing storage
+
+If you are preparing an actual cutover, continue with the
+[Storage Migration Guide](storage-migration.md). If you are cleaning up old
+local state instead of moving it, use
+[Storage Cleanup](storage-cleanup.md).

--- a/docs/guide/storage-migration.md
+++ b/docs/guide/storage-migration.md
@@ -1,6 +1,8 @@
 # Storage Migration Guide
 
 Use this guide before you change the saved storage URI metadata for a space.
+If you are still deciding whether to touch those settings at all, start with
+[Space Settings & Storage](space-settings-storage.md) first.
 
 ## What changing the URI does today
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -1,5 +1,9 @@
 """Guide validation tests.
 
+REQ-FE-017: Space settings storage docs must explain metadata-only connector
+planning clearly.
+REQ-FE-060: Browser walkthrough docs must route storage-summary users to the
+beginner guide.
 REQ-SEC-001: Local-only container guides must keep loopback/default
 secret protections explicit.
 REQ-OPS-001: Developer guides must be present with valid bash snippets.
@@ -125,6 +129,7 @@ FRONTEND_MISE_PATH = REPO_ROOT / "frontend" / "mise.toml"
 DOCSITE_MISE_PATH = REPO_ROOT / "docsite" / "mise.toml"
 E2E_MISE_PATH = REPO_ROOT / "e2e" / "mise.toml"
 CLI_GUIDE_PATH = GUIDE_DIR / "cli.md"
+BROWSER_FIRST_ENTRY_GUIDE_PATH = GUIDE_DIR / "browser-first-entry.md"
 INSTALL_CLI_SCRIPT_PATH = REPO_ROOT / "scripts" / "install-ugoite-cli.sh"
 RELEASE_INSTALLER_RENDERER_PATH = (
     REPO_ROOT / "scripts" / "render-cli-release-installer.sh"
@@ -140,11 +145,14 @@ RELEASE_CHANGELOG_ENTRYPOINT_PATH = (
     REPO_ROOT / "docs" / "spec" / "versions" / "changelog.md"
 )
 CONTAINER_QUICKSTART_GUIDE_PATH = GUIDE_DIR / "container-quickstart.md"
+OPERATIONS_GUIDE_PATH = GUIDE_DIR / "operations.md"
 DEV_SEED_SCRIPT_PATH = REPO_ROOT / "scripts" / "dev-seed.sh"
 ENV_MATRIX_PATH = GUIDE_DIR / "env-matrix.md"
 LOCAL_DEV_AUTH_GUIDE_PATH = REPO_ROOT / "docs" / "guide" / "local-dev-auth-login.md"
 AUTH_OVERVIEW_GUIDE_PATH = REPO_ROOT / "docs" / "guide" / "auth-overview.md"
 CONCEPTS_GUIDE_PATH = GUIDE_DIR / "concepts.md"
+SPACE_SETTINGS_STORAGE_GUIDE_PATH = GUIDE_DIR / "space-settings-storage.md"
+STORAGE_MIGRATION_GUIDE_PATH = GUIDE_DIR / "storage-migration.md"
 DOCSITE_HOME_PAGE_PATH = REPO_ROOT / "docsite" / "src" / "pages" / "index.astro"
 DOCSITE_GETTING_STARTED_PAGE_PATH = (
     REPO_ROOT / "docsite" / "src" / "pages" / "getting-started" / "index.astro"
@@ -2553,6 +2561,78 @@ def test_docs_req_ops_015_auth_profile_docs_describe_mode_and_next_step() -> Non
         text=auth_overview_text,
         required_fragments=REQUIRED_AUTH_PROFILE_OVERVIEW_GUIDE_FRAGMENTS,
         prefix="auth-overview.md missing auth profile guidance fragments: ",
+    )
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_fe_017_space_settings_guide_explains_metadata_defaults() -> None:
+    """REQ-FE-017: Space settings guide must explain metadata defaults."""
+    guide_text = SPACE_SETTINGS_STORAGE_GUIDE_PATH.read_text(encoding="utf-8")
+    migration_text = STORAGE_MIGRATION_GUIDE_PATH.read_text(encoding="utf-8")
+
+    details: list[str] = []
+    _append_missing_fragment_detail(
+        details,
+        text=guide_text,
+        required_fragments={
+            "# Space Settings & Storage",
+            "storage summary",
+            "Saved Storage URI",
+            "connector metadata",
+            "leave the defaults alone",
+            "Test Connection",
+            "[Storage Migration Guide](storage-migration.md)",
+        },
+        prefix="space-settings-storage.md missing first-run storage guidance: ",
+    )
+    _append_missing_fragment_detail(
+        details,
+        text=migration_text,
+        required_fragments={"[Space Settings & Storage](space-settings-storage.md)"},
+        prefix=(
+            "storage-migration.md must point first-time settings users to the "
+            "intro guide: "
+        ),
+    )
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_fe_060_browser_walkthrough_points_storage_summary_to_intro() -> None:
+    """REQ-FE-060: Browser walkthrough must link storage summary to the intro."""
+    browser_text = BROWSER_FIRST_ENTRY_GUIDE_PATH.read_text(encoding="utf-8")
+    operations_text = OPERATIONS_GUIDE_PATH.read_text(encoding="utf-8")
+    nav_text = (REPO_ROOT / "docsite" / "src" / "lib" / "navigation.ts").read_text(
+        encoding="utf-8",
+    )
+
+    details: list[str] = []
+    _append_missing_fragment_detail(
+        details,
+        text=browser_text,
+        required_fragments={
+            "[Space Settings & Storage](space-settings-storage.md)",
+            "dashboard storage summary card",
+            "before changing anything",
+        },
+        prefix="browser-first-entry.md missing storage-settings breadcrumb: ",
+    )
+    _append_missing_fragment_detail(
+        details,
+        text=operations_text,
+        required_fragments={
+            "[Space Settings & Storage](space-settings-storage.md)",
+            "storage summary",
+            "leave the defaults alone",
+        },
+        prefix="operations.md missing beginner storage guide pointer: ",
+    )
+    _append_missing_fragment_detail(
+        details,
+        text=nav_text,
+        required_fragments={"/docs/guide/space-settings-storage"},
+        prefix="docsite navigation missing space-settings-storage route: ",
     )
     if details:
         raise AssertionError("; ".join(details))

--- a/docsite/src/lib/navigation.test.ts
+++ b/docsite/src/lib/navigation.test.ts
@@ -171,6 +171,10 @@ test("REQ-E2E-008: newcomer navigation limits deep sections to getting-started c
 							href: "/docs/guide/log-redaction",
 						},
 						{
+							title: "Space Settings & Storage",
+							href: "/docs/guide/space-settings-storage",
+						},
+						{
 							title: "Storage Cleanup",
 							href: "/docs/guide/storage-cleanup",
 						},

--- a/docsite/src/lib/navigation.ts
+++ b/docsite/src/lib/navigation.ts
@@ -62,6 +62,10 @@ export const navSections: NavSection[] = [
 						href: "/docs/guide/log-redaction",
 					},
 					{
+						title: "Space Settings & Storage",
+						href: "/docs/guide/space-settings-storage",
+					},
+					{
 						title: "Storage Cleanup",
 						href: "/docs/guide/storage-cleanup",
 					},


### PR DESCRIPTION
## Summary

- add a first-run guide that explains the dashboard storage summary, Saved Storage URI metadata, and when to leave defaults alone
- link that guide from the browser walkthrough, storage migration doc, operations hub, and docsite navigation so Settings users have a canonical next step
- add REQ-FE-017 and REQ-FE-060 docs coverage to keep the breadcrumb and wording aligned

## Related Issue (required)

closes #1328

## Testing

- [x] `mise run test`