### PR TITLE
docs: add browser entry editing walkthrough

### DIFF
--- a/docs/guide/browser-first-entry.md
+++ b/docs/guide/browser-first-entry.md
@@ -37,16 +37,32 @@ need to design a custom form before the first note.
 4. Add the first body content you actually want to keep.
 5. Submit the dialog to create the entry.
 
-The browser should open the new entry detail page. From there you can keep
-editing Markdown content, save revisions, and confirm that the starter entry is
-now part of the space.
+The browser should open the new entry detail page. That page is the Markdown
+editor you will use for follow-up revisions on the same record.
 
 Before moving on, look for the confidence checks that prove the first-run path
 worked: the entry detail page is open, the new record can be reopened from
 **Entries**, and the space now has content that the derived **Search** surface
 can discover.
 
-## 3) Add a custom form when you want stricter structure
+## 3) Make one follow-up edit in the entry detail editor
+
+1. Stay on the new entry detail page, or reopen the same record from
+   **Entries**.
+2. Edit the left Markdown pane. The right preview pane updates from the same
+   content so you can confirm headings, lists, and emphasis before saving.
+3. After you type, look for the **Unsaved changes** indicator in the editor
+   toolbar.
+4. Click **Save** or press `Cmd/Ctrl+S`.
+5. Confirm the **Unsaved changes** indicator disappears and the editor stays on
+   the same entry detail page.
+6. Open **Entries** again and reopen the record to verify the updated text is still there.
+
+Why this matters: the browser keeps the Markdown editor and preview together, so
+the next edit after first-entry creation is the fastest way to confirm that
+future revisions are working end to end.
+
+## 4) Add a custom form when you want stricter structure
 
 Once the first note exists, add a custom form if you want queryable fields or a
 repeatable template for a specific entry type.
@@ -73,7 +89,7 @@ The example field types are intentionally different: `summary` works well as a
 `string` when you want short list-friendly text, while `next_steps` as
 `markdown` leaves room for longer formatted follow-up notes.
 
-## 4) Confirm the browser workflow is now unlocked
+## 5) Confirm the browser workflow is now unlocked
 
 After that first successful entry, you should be able to move through the main
 space surfaces without guesswork:
@@ -87,7 +103,7 @@ space surfaces without guesswork:
 - **Search**: the derived search surface built from entries and Forms when you
   want to confirm that the space is now discoverable beyond a single page.
 
-## 5) Where to go next
+## 6) Where to go next
 
 - Need the mental model behind spaces, entries, forms, and derived structure?
   Read [Core Concepts](concepts.md).

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -1,7 +1,11 @@
 """Guide validation tests.
 
+REQ-FE-005: Browser walkthrough docs must explain the Markdown editor follow-up
+flow.
 REQ-FE-017: Space settings storage docs must explain metadata-only connector
 planning clearly.
+REQ-FE-033: Browser walkthrough docs must explain reopening saved entries from
+the list.
 REQ-FE-060: Browser walkthrough docs must route storage-summary users to the
 beginner guide.
 REQ-SEC-001: Local-only container guides must keep loopback/default
@@ -2668,6 +2672,47 @@ def test_docs_req_fe_060_browser_walkthrough_points_storage_summary_to_intro() -
         text=nav_text,
         required_fragments={"/docs/guide/space-settings-storage"},
         prefix="docsite navigation missing space-settings-storage route: ",
+    )
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_fe_005_browser_walkthrough_explains_follow_up_editor_flow() -> None:
+    """REQ-FE-005: Browser walkthrough must explain the follow-up editor flow."""
+    browser_text = BROWSER_FIRST_ENTRY_GUIDE_PATH.read_text(encoding="utf-8")
+
+    details: list[str] = []
+    _append_missing_fragment_detail(
+        details,
+        text=browser_text,
+        required_fragments={
+            "left Markdown pane",
+            "right preview pane",
+            "**Unsaved changes**",
+            "**Save**",
+            "`Cmd/Ctrl+S`",
+        },
+        prefix="browser-first-entry.md missing Markdown editor follow-up guidance: ",
+    )
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_fe_033_browser_walkthrough_explains_reopening_saved_entries() -> None:
+    """REQ-FE-033: Browser walkthrough must explain reopening saved entries."""
+    browser_text = BROWSER_FIRST_ENTRY_GUIDE_PATH.read_text(encoding="utf-8")
+
+    details: list[str] = []
+    _append_missing_fragment_detail(
+        details,
+        text=browser_text,
+        required_fragments={
+            "reopen the same record from",
+            "**Entries**",
+            "same entry detail page",
+            "verify the updated text is still there",
+        },
+        prefix="browser-first-entry.md missing reopen-and-verify guidance: ",
     )
     if details:
         raise AssertionError("; ".join(details))


### PR DESCRIPTION
## Summary
- add a follow-up browser editing section to the post-login walkthrough
- explain the Markdown/preview panes, Unsaved changes indicator, save action, and reopen flow
- add REQ-FE-005 and REQ-FE-033 docs coverage for the new walkthrough details

## Related Issue (required)
closes #1327

## Testing
- [x] `mise run test`
