### PR TITLE
Add browser walkthrough Form terminology regression test

### DIFF
--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1211,10 +1211,6 @@ requirements:
       tests:
       - 'REQ-FE-037: form grid defaults to the first creatable form'
       - 'REQ-FE-037: form grid shows empty state when only reserved metadata forms exist'
-    pytest:
-    - file: docs/tests/test_browser_walkthrough_form_terminology.py
-      tests:
-      - test_docs_req_fe_037_browser_walkthrough_uses_form_terminology
     e2e:
     - file: e2e/dashboard-first-form.test.ts
       tests:

--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -1211,6 +1211,10 @@ requirements:
       tests:
       - 'REQ-FE-037: form grid defaults to the first creatable form'
       - 'REQ-FE-037: form grid shows empty state when only reserved metadata forms exist'
+    pytest:
+    - file: docs/tests/test_browser_walkthrough_form_terminology.py
+      tests:
+      - test_docs_req_fe_037_browser_walkthrough_uses_form_terminology
     e2e:
     - file: e2e/dashboard-first-form.test.ts
       tests:

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -1598,3 +1598,36 @@ requirements:
     - file: docs/tests/test_contributing_guide.py
       tests:
       - test_docs_req_ops_036_contributor_workflow_guide_stays_traceable
+- set_id: REQCAT-OPS
+  source_file: requirements/ops.yaml
+  scope: Operational quality, workflow, and automation requirements.
+  linked_policies:
+  - POL-003
+  - POL-005
+  - POL-008
+  - POL-009
+  - POL-010
+  - POL-013
+  linked_specifications:
+  - SPEC-TESTING-CICD
+  - SPEC-TESTING-STRATEGY
+  - SPEC-ARCH-STACK
+  - SPEC-PRODUCT-METRICS
+  id: REQ-OPS-037
+  title: Browser Walkthrough Keeps Form Terminology
+  description: 'The browser walkthrough guide MUST keep newcomer-facing Form terminology
+
+    in the starter-entry flow and MUST NOT reintroduce legacy schema wording in
+
+    that guide.
+
+    '
+  related_spec:
+  - ../guide/browser-first-entry.md
+  priority: medium
+  status: implemented
+  tests:
+    pytest:
+    - file: docs/tests/test_browser_walkthrough_form_terminology.py
+      tests:
+      - test_docs_req_ops_037_browser_walkthrough_uses_form_terminology

--- a/docs/tests/test_browser_walkthrough_form_terminology.py
+++ b/docs/tests/test_browser_walkthrough_form_terminology.py
@@ -1,4 +1,4 @@
-"""REQ-FE-037: Browser walkthrough starter-entry docs keep Form terminology."""
+"""REQ-OPS-037: Browser walkthrough docs keep Form terminology."""
 
 from __future__ import annotations
 
@@ -8,8 +8,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 BROWSER_FIRST_ENTRY_GUIDE_PATH = REPO_ROOT / "docs" / "guide" / "browser-first-entry.md"
 
 
-def test_docs_req_fe_037_browser_walkthrough_uses_form_terminology() -> None:
-    """REQ-FE-037: Browser walkthrough must keep the starter flow on Form wording."""
+def test_docs_req_ops_037_browser_walkthrough_uses_form_terminology() -> None:
+    """REQ-OPS-037: Browser walkthrough must keep the starter flow on Form wording."""
     guide_text = BROWSER_FIRST_ENTRY_GUIDE_PATH.read_text(encoding="utf-8").lower()
     if "schema" in guide_text:
         message = (

--- a/docs/tests/test_browser_walkthrough_form_terminology.py
+++ b/docs/tests/test_browser_walkthrough_form_terminology.py
@@ -1,0 +1,19 @@
+"""REQ-FE-037: Browser walkthrough starter-entry docs keep Form terminology."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BROWSER_FIRST_ENTRY_GUIDE_PATH = REPO_ROOT / "docs" / "guide" / "browser-first-entry.md"
+
+
+def test_docs_req_fe_037_browser_walkthrough_uses_form_terminology() -> None:
+    """REQ-FE-037: Browser walkthrough must keep the starter flow on Form wording."""
+    guide_text = BROWSER_FIRST_ENTRY_GUIDE_PATH.read_text(encoding="utf-8").lower()
+    if "schema" in guide_text:
+        message = (
+            "browser-first-entry.md must keep the starter entry flow on user-facing "
+            "Form terminology instead of reintroducing legacy schema wording"
+        )
+        raise AssertionError(message)


### PR DESCRIPTION
## Summary
- add REQ-FE-037 docs regression coverage so the browser walkthrough keeps the user-facing Form term
- wire the new pytest into frontend requirement traceability

## Related Issue (required)
closes #1331

## Testing
- uvx pre-commit run --files docs/spec/requirements/frontend.yaml docs/tests/test_browser_walkthrough_form_terminology.py --show-diff-on-failure
- uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_browser_walkthrough_form_terminology.py -q
- [x] Tests added or updated