### PR TITLE
Add docsite browser next-step regression test

### DIFF
--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -282,6 +282,7 @@ requirements:
       - 'REQ-E2E-008: onboarding content keeps try, source, and CLI paths as the first entry choices'
       - 'REQ-E2E-008: onboarding content keeps browser, auth, and deeper reference docs available after the first step'
       - 'REQ-E2E-008: onboarding content keeps browser caveats explicit on browser-first paths'
+      - 'REQ-E2E-008: onboarding content keeps the browser next step aligned to the walkthrough'
       - 'REQ-E2E-008: onboarding content offers a concepts primer before deeper guides and references'
       - 'REQ-E2E-008: onboarding content keeps core concepts ready for the follow-up primer'
     pytest:

--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -78,7 +78,10 @@ test("REQ-E2E-008: onboarding content keeps the browser next step aligned to the
 	});
 	expect(nextStepCards[0]?.description).toContain("starter entry");
 	expect(nextStepCards[0]?.description).toContain("After login");
-	expect(nextStepCards[0]?.description).not.toContain("create a form first");
+	expect(nextStepCards[0]?.description).toContain("forms/search path");
+	expect(nextStepCards[0]?.description).toContain(
+		"what each main browser surface is for",
+	);
 });
 
 test("REQ-E2E-008: onboarding content offers a concepts primer before deeper guides and references", () => {

--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -71,6 +71,16 @@ test("REQ-E2E-008: onboarding content keeps browser caveats explicit on browser-
 	expect(nextStepCards[0]?.description).toContain("browser surface");
 });
 
+test("REQ-E2E-008: onboarding content keeps the browser next step aligned to the walkthrough", () => {
+	expect(nextStepCards[0]).toMatchObject({
+		badge: "Browser walkthrough",
+		href: "/docs/guide/browser-first-entry",
+	});
+	expect(nextStepCards[0]?.description).toContain("starter entry");
+	expect(nextStepCards[0]?.description).toContain("After login");
+	expect(nextStepCards[0]?.description).not.toContain("create a form first");
+});
+
 test("REQ-E2E-008: onboarding content offers a concepts primer before deeper guides and references", () => {
 	expect(conceptPrimerCard).toEqual({
 		badge: "Concept primer",


### PR DESCRIPTION
## Summary
- add REQ-E2E-008 regression coverage so docsite onboarding keeps the browser next step on the Browser Walkthrough
- lock the card copy away from the stale "create a form first" guidance

## Related Issue (required)
closes #1362

## Testing
- uvx pre-commit run --files docs/spec/requirements/e2e.yaml docsite/src/lib/onboarding.test.ts --show-diff-on-failure
- cd docsite && npx vitest run src/lib/onboarding.test.ts
- [x] Tests added or updated