### PR TITLE
Add published CLI quick start to the docsite CLI page

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -880,6 +880,10 @@ requirements:
     - file: docs/tests/test_cli_verify_first_install.py
       tests:
       - test_docs_req_ops_018_cli_guide_leads_with_verify_first_release_install
+    vitest:
+    - file: docsite/src/lib/app-cli-published-install.test.ts
+      tests:
+      - 'REQ-OPS-018: app CLI landing page exposes the released install path before source builds'
     rust:
     - file: ugoite-cli/tests/integration_test.rs
       tests:

--- a/docsite/src/lib/app-cli-published-install.test.ts
+++ b/docsite/src/lib/app-cli-published-install.test.ts
@@ -8,10 +8,16 @@ const cliPage = readFileSync(
 );
 
 test("REQ-OPS-018: app CLI landing page exposes the released install path before source builds", () => {
-	expect(cliPage).toContain("Published install (recommended)");
+	const publishedHeading = "Published install (recommended)";
+	const sourceHeading = "Build from source (contributors)";
+
+	expect(cliPage).toContain(publishedHeading);
 	expect(cliPage).toContain(
 		"npm install -g ugoite && ugoite-install && ugoite --help",
 	);
-	expect(cliPage).toContain("Build from source (contributors)");
+	expect(cliPage).toContain(sourceHeading);
 	expect(cliPage).toContain('href={withBasePath("/docs/guide/cli")}');
+	expect(cliPage.indexOf(publishedHeading)).toBeLessThan(
+		cliPage.indexOf(sourceHeading),
+	);
 });

--- a/docsite/src/lib/app-cli-published-install.test.ts
+++ b/docsite/src/lib/app-cli-published-install.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+const cliPage = readFileSync(
+	path.resolve(process.cwd(), "src/pages/app/cli/index.astro"),
+	"utf-8",
+);
+
+test("REQ-OPS-018: app CLI landing page exposes the released install path before source builds", () => {
+	expect(cliPage).toContain("Published install (recommended)");
+	expect(cliPage).toContain(
+		"npm install -g ugoite && ugoite-install && ugoite --help",
+	);
+	expect(cliPage).toContain("Build from source (contributors)");
+	expect(cliPage).toContain('href={withBasePath("/docs/guide/cli")}');
+});

--- a/docsite/src/pages/app/cli/index.astro
+++ b/docsite/src/pages/app/cli/index.astro
@@ -7,7 +7,7 @@ import path from "node:path";
 
 const toc = [
   { id: "overview", title: "Overview" },
-  { id: "setup", title: "Setup" },
+  { id: "setup", title: "Quick Start" },
   { id: "examples", title: "Command Outputs" },
   { id: "commands", title: "Commands" },
 ];
@@ -35,21 +35,28 @@ const commandOutputs = await fs
   </section>
 
   <section id="setup" class="doc-card">
-    <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Setup</h2>
-    <div style="display: grid; gap: 0.75rem;">
-      <div>
-        <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">1. Install dependencies</p>
-        <TerminalCommand command="mise run setup" />
+      <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Quick Start</h2>
+      <div style="display: grid; gap: 0.75rem;">
+        <div>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">1. Published install (recommended)</p>
+          <TerminalCommand command="npm install -g ugoite && ugoite-install && ugoite --help" />
+          <p style="font-size: 0.75rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">
+            Use this when you want the released CLI without cloning the repository. For the full installer and archive options, continue to the canonical <a href={withBasePath("/docs/guide/cli")}>CLI Guide</a>.
+          </p>
+        </div>
+        <div>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">2. Build from source (contributors)</p>
+          <TerminalCommand command="mise run setup" />
+        </div>
+        <div>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">3. Check the CLI from source</p>
+          <TerminalCommand command="cargo run -q -p ugoite-cli -- --help" />
+        </div>
+        <div>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">4. List spaces from source</p>
+          <TerminalCommand command="mkdir -p ./spaces && cargo run -q -p ugoite-cli -- space list ./spaces" />
+        </div>
       </div>
-      <div>
-        <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">2. Check the CLI is available</p>
-        <TerminalCommand command="cargo run -q -p ugoite-cli -- --help" />
-      </div>
-      <div>
-        <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">3. List spaces</p>
-        <TerminalCommand command="mkdir -p ./spaces && cargo run -q -p ugoite-cli -- space list ./spaces" />
-      </div>
-    </div>
   </section>
 
   {commandOutputs.length > 0 && (


### PR DESCRIPTION
## Summary
- add a published CLI install path to `/app/cli` ahead of the source build workflow
- keep the released install path explicitly separated from contributor-only source steps
- add REQ-OPS-018 docsite regression coverage for the new landing-page quick start

## Related Issue (required)
closes #1363

## Testing
- uvx pre-commit run --files docs/spec/requirements/ops.yaml docsite/src/pages/app/cli/index.astro docsite/src/lib/app-cli-published-install.test.ts --show-diff-on-failure
- cd docsite && npx vitest run src/lib/app-cli-published-install.test.ts
- [x] Tests added or updated