### PR TITLE
Fix the docsite API verification example to use /health

### DIFF
--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -398,6 +398,10 @@ requirements:
     - file: docs/tests/test_guides.py
       tests:
       - test_docs_req_ops_010_frontend_dev_proxy_readiness_declared
+    vitest:
+    - file: docsite/src/lib/app-api-storage-healthcheck.test.ts
+      tests:
+      - 'REQ-OPS-010: app API & Storage page verifies readiness with the health endpoint first'
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/docsite/src/lib/app-api-storage-healthcheck.test.ts
+++ b/docsite/src/lib/app-api-storage-healthcheck.test.ts
@@ -8,9 +8,12 @@ const apiStoragePage = readFileSync(
 );
 
 test("REQ-OPS-010: app API & Storage page verifies readiness with the health endpoint first", () => {
-	expect(apiStoragePage).toContain("curl -sS http://localhost:8000/health");
-	expect(apiStoragePage).not.toContain(
-		'TerminalCommand command="curl http://localhost:8000/spaces"',
+	const readinessCommand =
+		'<TerminalCommand command="curl -sS http://localhost:8000/health" />';
+
+	expect(apiStoragePage).toContain(readinessCommand);
+	expect(apiStoragePage).not.toMatch(
+		/<TerminalCommand command="curl[^"]*http:\/\/localhost:8000\/(?!health)[^"]*"/,
 	);
 	expect(apiStoragePage).toContain(
 		"Authenticated routes such as <code>/spaces</code> require",

--- a/docsite/src/lib/app-api-storage-healthcheck.test.ts
+++ b/docsite/src/lib/app-api-storage-healthcheck.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+const apiStoragePage = readFileSync(
+	path.resolve(process.cwd(), "src/pages/app/api-storage/index.astro"),
+	"utf-8",
+);
+
+test("REQ-OPS-010: app API & Storage page verifies readiness with the health endpoint first", () => {
+	expect(apiStoragePage).toContain("curl -sS http://localhost:8000/health");
+	expect(apiStoragePage).not.toContain(
+		'TerminalCommand command="curl http://localhost:8000/spaces"',
+	);
+	expect(apiStoragePage).toContain(
+		"Authenticated routes such as <code>/spaces</code> require",
+	);
+});

--- a/docsite/src/pages/app/api-storage/index.astro
+++ b/docsite/src/pages/app/api-storage/index.astro
@@ -118,7 +118,11 @@ const toc = [
       </div>
       <div>
         <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">4. Verify the API</p>
-        <TerminalCommand command="curl http://localhost:8000/spaces" />
+        <TerminalCommand command="curl -sS http://localhost:8000/health" />
+        <p style="font-size: 0.75rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">
+          Use the health endpoint for the unauthenticated readiness check. Authenticated routes such as <code>/spaces</code> require the browser or CLI login flow from{" "}
+          <a href={localDevAuthGuideHref} target="_blank" rel="noreferrer">Local Dev Auth/Login</a>.
+        </p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- switch the `/app/api-storage` readiness example from the auth-gated `/spaces` route to `/health`
- explain that `/spaces` requires the normal browser or CLI login flow
- add REQ-OPS-010 docsite regression coverage for the health-first verification step

## Related Issue (required)
closes #1361

## Testing
- uvx pre-commit run --files docs/spec/requirements/ops.yaml docsite/src/pages/app/api-storage/index.astro docsite/src/lib/app-api-storage-healthcheck.test.ts --show-diff-on-failure
- cd docsite && npx vitest run src/lib/app-api-storage-healthcheck.test.ts
- [x] Tests added or updated