### PR TITLE
Lead the CLI guide with a verify-first release install path

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -28,6 +28,7 @@ sha256sum -c "ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"
 shasum -a 256 -c "ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"
 
 tar -xzf "ugoite-v${VERSION}-${TARGET}.tar.gz"
+mkdir -p "$HOME/.local/bin"
 install -m 0755 ugoite "$HOME/.local/bin/ugoite"
 ugoite --help
 ```

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -9,6 +9,39 @@ Docker stack, frontend process, or browser login flow.
 
 ## Install the released CLI (recommended)
 
+### Verify-first archive install
+
+If you want the most auditable published path, install from an exact release
+archive and verify its checksum before you extract or run anything:
+
+```bash
+VERSION=0.1.0
+TARGET=x86_64-unknown-linux-gnu
+BASE_URL="https://github.com/ugoite/ugoite/releases/download/v${VERSION}"
+
+curl -fsSLO "${BASE_URL}/ugoite-v${VERSION}-${TARGET}.tar.gz"
+curl -fsSLO "${BASE_URL}/ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"
+
+# Linux
+sha256sum -c "ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"
+# macOS
+shasum -a 256 -c "ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"
+
+tar -xzf "ugoite-v${VERSION}-${TARGET}.tar.gz"
+install -m 0755 ugoite "$HOME/.local/bin/ugoite"
+ugoite --help
+```
+
+Swap `TARGET` for one of the published release targets listed below. This path
+keeps checksum verification ahead of extraction and ahead of any installer
+script execution.
+
+### Bootstrap helpers (secondary)
+
+If you want fewer manual steps and you already trust the bootstrap helper
+itself, use one of these shortcuts after considering the verify-first archive
+path above.
+
 Install the public `ugoite` npm bootstrap package:
 
 ```bash
@@ -27,10 +60,11 @@ ugoite --help
 
 The published package metadata lives in `packages/ugoite/package.json`, while
 the repository root `package.json` stays private tooling for Husky/commitlint
-and release automation.
+and release automation. The shared helper script behind the npm bootstrap and
+rendered release installers lives at `scripts/install-ugoite-cli.sh`.
 
-If you prefer the direct shell bootstrap, install the latest stable release with
-a one-liner:
+If you still prefer the direct shell bootstrap, keep it as an explicit
+trust-the-script shortcut rather than the default recommendation:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ugoite/ugoite/main/scripts/install-ugoite-cli.sh | bash

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -870,6 +870,9 @@ requirements:
       - test_docs_req_ops_018_platform_installer_asset_validates_prerelease
       - test_docs_req_ops_018_release_publish_draft_job_checks_out_requested_target
       - test_docs_req_ops_018_release_publish_finalize_job_checks_out_target
+    - file: docs/tests/test_cli_verify_first_install.py
+      tests:
+      - test_docs_req_ops_018_cli_guide_leads_with_verify_first_release_install
     rust:
     - file: ugoite-cli/tests/integration_test.rs
       tests:

--- a/docs/tests/test_cli_verify_first_install.py
+++ b/docs/tests/test_cli_verify_first_install.py
@@ -1,0 +1,67 @@
+"""REQ-OPS-018 regression coverage for verify-first CLI install guidance."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_GUIDE = REPO_ROOT / "docs" / "guide" / "cli.md"
+
+
+def test_docs_req_ops_018_cli_guide_leads_with_verify_first_release_install() -> None:
+    """REQ-OPS-018: CLI guide leads with a verify-first released install path."""
+    guide_text = CLI_GUIDE.read_text(encoding="utf-8")
+
+    verify_first_heading = "### Verify-first archive install"
+    raw_bootstrap_command = (
+        "curl -fsSL https://raw.githubusercontent.com/ugoite/ugoite/main/"
+        "scripts/install-ugoite-cli.sh | bash"
+    )
+
+    details = [
+        message
+        for condition, message in (
+            (
+                verify_first_heading not in guide_text,
+                "cli.md is missing the verify-first archive install heading",
+            ),
+            (
+                'curl -fsSLO "${BASE_URL}/ugoite-v${VERSION}-${TARGET}.tar.gz"'
+                not in guide_text,
+                "cli.md is missing the exact-release archive download command",
+            ),
+            (
+                'curl -fsSLO "${BASE_URL}/ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"'
+                not in guide_text,
+                "cli.md is missing the exact-release checksum download command",
+            ),
+            (
+                'sha256sum -c "ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"'
+                not in guide_text,
+                "cli.md is missing the Linux checksum verification command",
+            ),
+            (
+                'shasum -a 256 -c "ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"'
+                not in guide_text,
+                "cli.md is missing the macOS checksum verification command",
+            ),
+            (
+                raw_bootstrap_command not in guide_text,
+                "cli.md must still document the direct shell bootstrap shortcut",
+            ),
+            (
+                "trust-the-script shortcut rather than the default recommendation"
+                not in guide_text,
+                "cli.md must mark the raw bootstrap path as a secondary shortcut",
+            ),
+            (
+                verify_first_heading in guide_text
+                and raw_bootstrap_command in guide_text
+                and guide_text.index(verify_first_heading)
+                > guide_text.index(raw_bootstrap_command),
+                "cli.md must place the verify-first archive flow before raw piping",
+            ),
+        )
+        if condition
+    ]
+
+    if details:
+        raise AssertionError("; ".join(details))

--- a/docs/tests/test_cli_verify_first_install.py
+++ b/docs/tests/test_cli_verify_first_install.py
@@ -44,6 +44,10 @@ def test_docs_req_ops_018_cli_guide_leads_with_verify_first_release_install() ->
                 "cli.md is missing the macOS checksum verification command",
             ),
             (
+                'mkdir -p "$HOME/.local/bin"' not in guide_text,
+                "cli.md must create ~/.local/bin before installing the binary",
+            ),
+            (
                 raw_bootstrap_command not in guide_text,
                 "cli.md must still document the direct shell bootstrap shortcut",
             ),


### PR DESCRIPTION
## Summary
- move the CLI guide to a verify-first exact-release archive install path before any bootstrap shortcuts
- keep npm and raw helper flows available, but explicitly mark raw piping as a secondary trust-the-script shortcut
- add REQ-OPS-018 regression coverage for the verify-first ordering and checksum commands

## Related Issue (required)
closes #1359

## Testing
- uvx pre-commit run --files docs/spec/requirements/ops.yaml docs/guide/cli.md docs/tests/test_cli_verify_first_install.py --show-diff-on-failure
- uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_cli_verify_first_install.py -q
- [x] Tests added or updated