### PR TITLE
Surface MCP as a first-class application path in the docsite

### DIFF
--- a/docs/spec/requirements/api.yaml
+++ b/docs/spec/requirements/api.yaml
@@ -651,3 +651,7 @@ requirements:
     - file: docs/tests/test_mcp_docs.py
       tests:
       - test_docs_req_api_013_current_mcp_surface_stays_resource_first
+    vitest:
+    - file: docsite/src/lib/app-mcp-page.test.ts
+      tests:
+      - 'REQ-API-013: app MCP page keeps the shipped surface resource-first and clearly scoped'

--- a/docs/spec/requirements/e2e.yaml
+++ b/docs/spec/requirements/e2e.yaml
@@ -211,6 +211,7 @@ requirements:
       tests:
       - 'REQ-E2E-006: navigation helpers build child docsite links from spec data'
       - 'REQ-E2E-006: navigation helpers tolerate missing child anchors without mutating shared nav state'
+      - 'REQ-E2E-006: application navigation keeps MCP as a first-class docsite route'
 - set_id: REQCAT-E2E
   source_file: requirements/e2e.yaml
   scope: End-to-end confidence and cross-layer behavior requirements.

--- a/docsite/src/lib/app-mcp-page.test.ts
+++ b/docsite/src/lib/app-mcp-page.test.ts
@@ -14,7 +14,7 @@ const appMcpPage = readFileSync(
 test("REQ-API-013: app MCP page keeps the shipped surface resource-first and clearly scoped", () => {
 	expect(appOverviewPage).toContain('href={withBasePath("/app/mcp")}');
 	expect(appMcpPage).toContain("resource-first baseline");
-	expect(appMcpPage).toContain('ugoite://{"{space_id}"}/entries/list');
+	expect(appMcpPage).toContain("ugoite://&#123;space_id&#125;/entries/list");
 	expect(appMcpPage).toContain("no MCP tools or prompts yet");
 	expect(appMcpPage).toContain("planned as v0.2 work");
 	expect(appMcpPage).toContain('href={withBasePath("/docs/spec/api/mcp")}');

--- a/docsite/src/lib/app-mcp-page.test.ts
+++ b/docsite/src/lib/app-mcp-page.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+const appOverviewPage = readFileSync(
+	path.resolve(process.cwd(), "src/pages/app/index.astro"),
+	"utf-8",
+);
+const appMcpPage = readFileSync(
+	path.resolve(process.cwd(), "src/pages/app/mcp/index.astro"),
+	"utf-8",
+);
+
+test("REQ-API-013: app MCP page keeps the shipped surface resource-first and clearly scoped", () => {
+	expect(appOverviewPage).toContain('href={withBasePath("/app/mcp")}');
+	expect(appMcpPage).toContain("resource-first baseline");
+	expect(appMcpPage).toContain('ugoite://{"{space_id}"}/entries/list');
+	expect(appMcpPage).toContain("no MCP tools or prompts yet");
+	expect(appMcpPage).toContain("planned as v0.2 work");
+	expect(appMcpPage).toContain('href={withBasePath("/docs/spec/api/mcp")}');
+});

--- a/docsite/src/lib/navigation.test.ts
+++ b/docsite/src/lib/navigation.test.ts
@@ -127,6 +127,17 @@ test("REQ-E2E-006: navigation helpers tolerate missing child anchors without mut
 	expect(specDataMocks.getUiPages).toHaveBeenCalledTimes(1);
 });
 
+test("REQ-E2E-006: application navigation keeps MCP as a first-class docsite route", () => {
+	const applicationSection = navSections.find(
+		(section) => section.title === "Application",
+	);
+
+	expect(applicationSection?.items.map((item) => item.href)).toContain(
+		"/app/mcp",
+	);
+	expect(applicationSection?.items.map((item) => item.title)).toContain("MCP");
+});
+
 test("REQ-E2E-008: newcomer navigation limits deep sections to getting-started content", () => {
 	expect(getNewcomerNavSections()).toEqual([
 		{

--- a/docsite/src/lib/navigation.ts
+++ b/docsite/src/lib/navigation.ts
@@ -86,6 +86,7 @@ export const navSections: NavSection[] = [
 			{ title: "UI Pages", href: "/app/frontend/pages", items: [] },
 			{ title: "API & Storage", href: "/app/api-storage" },
 			{ title: "CLI", href: "/app/cli" },
+			{ title: "MCP", href: "/app/mcp" },
 			{ title: "CLI Commands", href: "/app/cli/commands" },
 			{ title: "Data Model", href: "/app/api-storage/data-model" },
 			{ title: "API Catalog", href: "/app/api-storage/apis" },

--- a/docsite/src/pages/app/index.astro
+++ b/docsite/src/pages/app/index.astro
@@ -104,6 +104,12 @@ const toc = [
         <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.375rem;">Scriptable terminal interface for space management, entries, search, and SQL operations.</p>
       </a>
 
+      <a href={withBasePath("/app/mcp")} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
+        <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🤖</div>
+        <h3 style="font-size: 1rem; font-weight: 700;">MCP</h3>
+        <p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.375rem;">Resource-first AI client surface for browsing entries through the shipped MCP contract and roadmap.</p>
+      </a>
+
       <a href={withBasePath("/app/frontend")} class="doc-card doc-card-hover" style="text-decoration: none; color: inherit;">
         <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🖥️</div>
         <h3 style="font-size: 1rem; font-weight: 700;">Frontend</h3>

--- a/docsite/src/pages/app/mcp/index.astro
+++ b/docsite/src/pages/app/mcp/index.astro
@@ -80,7 +80,7 @@ const toc = [
 		</p>
 		<pre
 			style="margin-top: 1rem; font-size: 0.8125rem; padding: 0.75rem; border-radius: var(--doc-radius-md); background: var(--doc-bg-subtle); overflow-x: auto;"
-		><code>ugoite://{"{space_id}"}/entries/list</code></pre>
+		><code>ugoite://&#123;space_id&#125;/entries/list</code></pre>
 		<ul style="margin-top: 1rem; color: var(--doc-muted); line-height: 1.7; padding-left: 1.25rem;">
 			<li>The current contract exposes entry-list resources only.</li>
 			<li>The shipped build includes no MCP tools or prompts yet.</li>

--- a/docsite/src/pages/app/mcp/index.astro
+++ b/docsite/src/pages/app/mcp/index.astro
@@ -1,0 +1,122 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import { withBasePath } from "../../../lib/base-path";
+
+const toc = [
+	{ id: "overview", title: "Overview" },
+	{ id: "choose", title: "When to Choose MCP" },
+	{ id: "surface", title: "Current Surface" },
+	{ id: "next-steps", title: "Next Steps" },
+];
+---
+
+<BaseLayout
+	title="MCP | Ugoite"
+	description="Resource-first MCP surface for AI clients that need the current shipped contract."
+	toc={toc}
+	related={[
+		{ href: "/app", label: "App Overview" },
+		{ href: "/docs/spec/api/mcp", label: "MCP API Spec" },
+		{ href: "/app/api-storage", label: "API & Storage" },
+	]}
+>
+	<section id="overview" class="doc-card-hero">
+		<div style="position: relative; z-index: 1;">
+			<span class="doc-pill">MCP</span>
+			<h1
+				style="font-size: 2rem; font-weight: 800; margin-top: 0.75rem; letter-spacing: -0.02em;"
+			>
+				Resource-First AI Client Access
+			</h1>
+			<p
+				style="color: var(--doc-muted); margin-top: 0.5rem; max-width: 42rem; line-height: 1.6;"
+			>
+				Choose MCP when an AI client should browse Ugoite through a stable
+				resource contract instead of hand-rolled REST glue or local CLI process
+				invocation. The shipped surface stays intentionally small and
+				resource-first.
+			</p>
+		</div>
+	</section>
+
+	<section id="choose" class="doc-card">
+		<h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">
+			When to Choose MCP
+		</h2>
+		<div class="doc-grid">
+			<div class="doc-card">
+				<h3 style="font-size: 1rem; font-weight: 700;">Use MCP when</h3>
+				<p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.375rem;">
+					An AI client needs authenticated resource browsing with the same
+					server-managed data model, but you do not want to build a custom REST
+					integration first.
+				</p>
+			</div>
+			<div class="doc-card">
+				<h3 style="font-size: 1rem; font-weight: 700;">Use REST when</h3>
+				<p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.375rem;">
+					You need explicit endpoint-by-endpoint control, broader HTTP tooling,
+					or non-MCP automation against the backend surface.
+				</p>
+			</div>
+			<div class="doc-card">
+				<h3 style="font-size: 1rem; font-weight: 700;">Use CLI when</h3>
+				<p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.375rem;">
+					You want terminal-native workflows, local core-mode filesystem access,
+					or scripted commands inside shells and CI jobs.
+				</p>
+			</div>
+		</div>
+	</section>
+
+	<section id="surface" class="doc-card">
+		<h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">
+			Current Surface
+		</h2>
+		<p style="font-size: 0.875rem; color: var(--doc-muted); line-height: 1.7;">
+			The shipped MCP surface is a resource-first baseline: one registered
+			resource, no MCP tools, and no prompts. That keeps the current contract easy
+			to reason about while the broader AI surface is still being shaped.
+		</p>
+		<pre
+			style="margin-top: 1rem; font-size: 0.8125rem; padding: 0.75rem; border-radius: var(--doc-radius-md); background: var(--doc-bg-subtle); overflow-x: auto;"
+		><code>ugoite://{"{space_id}"}/entries/list</code></pre>
+		<ul style="margin-top: 1rem; color: var(--doc-muted); line-height: 1.7; padding-left: 1.25rem;">
+			<li>The current contract exposes entry-list resources only.</li>
+			<li>The shipped build includes no MCP tools or prompts yet.</li>
+			<li>Broader MCP resource and tool coverage is planned as v0.2 work, not current behavior.</li>
+		</ul>
+	</section>
+
+	<section id="next-steps" class="doc-card">
+		<h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">
+			Next Steps
+		</h2>
+		<div class="doc-grid">
+			<a
+				href={withBasePath("/docs/spec/api/mcp")}
+				class="doc-card doc-card-hover"
+				style="text-decoration: none; color: inherit;"
+			>
+				<div style="font-size: 1.5rem; margin-bottom: 0.5rem;">📘</div>
+				<h3 style="font-size: 1rem; font-weight: 700;">Read the MCP spec</h3>
+				<p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.375rem;">
+					Current-state protocol details, naming, and framing rules for the shipped
+					resource-first surface.
+				</p>
+			</a>
+			<a
+				href={withBasePath("/app/api-storage")}
+				class="doc-card doc-card-hover"
+				style="text-decoration: none; color: inherit;"
+			>
+				<div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🔌</div>
+				<h3 style="font-size: 1rem; font-weight: 700;">Compare with REST</h3>
+				<p style="font-size: 0.8125rem; color: var(--doc-muted); margin-top: 0.375rem;">
+					See when the broader backend/API surface is a better fit than the
+					resource-scoped MCP contract.
+				</p>
+			</a>
+		</div>
+	</section>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add a dedicated `/app/mcp` page that explains when to choose MCP and what the shipped resource-first contract currently includes
- surface MCP from the Application overview cards and the Application navigation section
- add REQ-API-013 and REQ-E2E-006 regression coverage for the current MCP page content and docsite navigation

## Related Issue (required)
closes #1366

## Testing
- uvx pre-commit run --files docs/spec/requirements/api.yaml docs/spec/requirements/e2e.yaml docsite/src/lib/navigation.ts docsite/src/pages/app/index.astro docsite/src/pages/app/mcp/index.astro docsite/src/lib/app-mcp-page.test.ts docsite/src/lib/navigation.test.ts --show-diff-on-failure
- cd docsite && npx vitest run src/lib/app-mcp-page.test.ts src/lib/navigation.test.ts
- [x] Tests added or updated