### PR TITLE
Add a contributor workflow guide for specs, requirements, and tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributor Workflow
+
+Use this guide when you are changing code, docs, specs, or tests in Ugoite. It
+connects the repository workflow, REQ-* traceability, and CI expectations in one
+place so a local green change stays aligned with the shipped product docs.
+
+## 1. Start from the canonical setup path
+
+Use the repository-managed toolchain first:
+
+```bash
+mise run setup
+```
+
+That path installs the shared dependencies and runs `uvx pre-commit install`, so
+local commits use the same pre-commit gate that CI enforces.
+
+Common follow-up commands:
+
+```bash
+mise run dev
+mise run test
+```
+
+Before adding a new workflow-specific command, check `.github/workflows/` and
+prefer the exact local command shape CI already uses.
+
+## 2. Decide which source of truth must change
+
+When behavior changes, update the canonical layer first:
+
+- Product or UX behavior: `docs/spec/features/`
+- Requirement or traceability contract: `docs/spec/requirements/`
+- User/operator instructions: `docs/guide/` and any matching README/docsite copy
+- App/documentation navigation or landing surfaces: `docsite/src/`
+
+Keep the architecture boundary explicit:
+
+- `ugoite-core` owns business logic and filesystem I/O
+- `backend` is the HTTP/MCP adapter layer
+- `ugoite-cli` is the terminal interface
+
+If a change adds or moves behavior between those layers, update the specs and
+docs in the same branch instead of leaving the contract implied.
+
+## 3. Keep REQ-* traceability complete
+
+Every new or updated test must point to a requirement in
+`docs/spec/requirements/*.yaml`.
+
+- Add the matching `REQ-*` identifier to the test name or docstring
+- Update the requirement entry so it lists the concrete test file and test name
+- Do not add a new requirement without adding the tests that enforce it
+
+The docs consistency suite in `docs/tests/` treats those mappings as part of the
+contract, not optional commentary.
+
+## 4. Keep guides and docsite surfaces in sync
+
+If a user-visible flow changes, update both the prose guide and the docsite
+surface that introduces it.
+
+Typical follow-up files include:
+
+- `docsite/src/lib/navigation.ts`
+- `docsite/src/lib/navigation.test.ts`
+- any relevant `/app/*` or `/getting-started` page
+- `README.md` when the newcomer or contributor entry path changes
+
+Do not leave a new guide, page, or application surface discoverable only from a
+deep spec page.
+
+## 5. Match local validation to CI
+
+Run the checks that correspond to the surfaces you touched, and make sure they
+match the current workflows under `.github/workflows/`.
+
+Examples:
+
+- `mise run test` for the repository-wide baseline
+- targeted `uv run pytest ...` for docs/backend/core changes when iterating
+- `cd docsite && npx vitest run ...` for docsite regressions
+- `cd frontend && npx vitest run ...` or the CI-aligned frontend checks when UI
+  behavior changes
+
+If you add a new docsite page or navigation path, include the matching vitest or
+docs regression so the route and copy stay wired.
+
+## 6. Prepare the PR as one coherent change
+
+Before opening the PR:
+
+1. Re-read the relevant `docs/spec/` files.
+2. Make sure the implementation, docs, and REQ-* test mappings all agree.
+3. Keep the diff focused on one issue/feature/fix.
+
+When in doubt, prefer the smallest change that keeps the specification,
+implementation, and contributor-facing docs in sync.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,9 @@ Examples:
 
 - `mise run test` for the repository-wide baseline
 - targeted `uv run pytest ...` for docs/backend/core changes when iterating
-- `cd docsite && npx vitest run ...` for docsite regressions
-- `cd frontend && npx vitest run ...` or the CI-aligned frontend checks when UI
-  behavior changes
+- `cd docsite && bun run test:coverage` for docsite regressions
+- `cd frontend && biome ci . && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1`
+  when UI behavior changes
 
 If you add a new docsite page or navigation path, include the matching vitest or
 docs regression so the route and copy stay wired.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ managed tool versions. Use that shared toolchain story first, then treat
 package README prerequisites as workflow notes on top of the same managed
 environment.
 
+For the full contributor workflow around specs, REQ traceability, docsite
+navigation wiring, and CI-parity checks, see
+[Contributor Workflow](CONTRIBUTING.md).
+
 ```bash
 mise run setup
 ```

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -1553,3 +1553,38 @@ requirements:
       - test_docs_req_ops_035_backend_image_runs_as_non_root
       - test_docs_req_ops_035_helm_security_defaults_are_hardened
       - test_docs_req_ops_035_hardening_docs_stay_visible
+- set_id: REQCAT-OPS
+  source_file: requirements/ops.yaml
+  scope: Operational quality, workflow, and automation requirements.
+  linked_policies:
+  - POL-003
+  - POL-005
+  - POL-008
+  - POL-009
+  - POL-010
+  - POL-013
+  linked_specifications:
+  - SPEC-TESTING-CICD
+  - SPEC-TESTING-STRATEGY
+  - SPEC-ARCH-STACK
+  - SPEC-PRODUCT-METRICS
+  id: REQ-OPS-036
+  title: Contributor Workflow Guide Stays Spec-Driven
+  description: 'Contributor-facing workflow docs MUST surface one canonical guide
+
+    that explains when to update `docs/spec/features`, `docs/spec/requirements`,
+    user guides, and docsite surfaces; how REQ-* traceability maps tests back to
+    requirements; which local commands mirror CI; and which docsite navigation
+    files must change when routes or guide entry points move.
+
+    '
+  related_spec:
+  - testing/ci-cd.md
+  - ../README.md
+  priority: medium
+  status: implemented
+  tests:
+    pytest:
+    - file: docs/tests/test_contributing_guide.py
+      tests:
+      - test_docs_req_ops_036_contributor_workflow_guide_stays_traceable

--- a/docs/tests/test_contributing_guide.py
+++ b/docs/tests/test_contributing_guide.py
@@ -1,0 +1,71 @@
+"""REQ-OPS-036 regression coverage for contributor workflow documentation."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+
+def test_docs_req_ops_036_contributor_workflow_guide_stays_traceable() -> None:
+    """REQ-OPS-036: contributor workflow docs stay traceable and CI-aligned."""
+    readme_text = README.read_text(encoding="utf-8")
+    contributing_text = CONTRIBUTING.read_text(encoding="utf-8")
+
+    details = [
+        message
+        for condition, message in (
+            (
+                not CONTRIBUTING.exists(),
+                "CONTRIBUTING.md must exist as the canonical contributor guide",
+            ),
+            (
+                "[Contributor Workflow](CONTRIBUTING.md)" not in readme_text,
+                "README.md must link to CONTRIBUTING.md from the setup section",
+            ),
+            (
+                "mise run setup" not in contributing_text,
+                "CONTRIBUTING.md must lead with the managed setup path",
+            ),
+            (
+                "uvx pre-commit install" not in contributing_text,
+                "CONTRIBUTING.md must mention the repo hook bootstrap",
+            ),
+            (
+                ".github/workflows/" not in contributing_text,
+                "CONTRIBUTING.md must point contributors at CI workflow sources",
+            ),
+            (
+                "docs/spec/features/" not in contributing_text,
+                "CONTRIBUTING.md must explain when feature specs change",
+            ),
+            (
+                "docs/spec/requirements/" not in contributing_text,
+                "CONTRIBUTING.md must explain when requirement specs change",
+            ),
+            (
+                "REQ-*" not in contributing_text,
+                "CONTRIBUTING.md must describe REQ traceability expectations",
+            ),
+            (
+                "docs/tests/" not in contributing_text,
+                "CONTRIBUTING.md must mention docs consistency tests",
+            ),
+            (
+                "docsite/src/lib/navigation.ts" not in contributing_text,
+                "CONTRIBUTING.md must mention docsite navigation wiring",
+            ),
+            (
+                "docsite/src/lib/navigation.test.ts" not in contributing_text,
+                "CONTRIBUTING.md must mention docsite navigation regression coverage",
+            ),
+            (
+                "mise run test" not in contributing_text,
+                "CONTRIBUTING.md must mention the repo-wide validation command",
+            ),
+        )
+        if condition
+    ]
+
+    if details:
+        raise AssertionError("; ".join(details))


### PR DESCRIPTION
## Summary
- add a canonical `CONTRIBUTING.md` guide for spec-driven development, REQ traceability, docsite wiring, and CI parity
- link the setup section of `README.md` to the new contributor workflow guide
- add REQ-OPS-036 and regression coverage for the contributor workflow contract

## Related Issue (required)
closes #1360

## Testing
- uvx pre-commit run --files README.md CONTRIBUTING.md docs/spec/requirements/ops.yaml docs/tests/test_contributing_guide.py --show-diff-on-failure
- uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_contributing_guide.py -q
- [x] Tests added or updated