### PR TITLE
Stop returning raw backend exception text from API responses

### DIFF
--- a/backend/src/app/api/endpoints/members.py
+++ b/backend/src/app/api/endpoints/members.py
@@ -1,5 +1,6 @@
 """Space member and invitation endpoints."""
 
+import logging
 from typing import Any
 
 import ugoite_core
@@ -18,6 +19,7 @@ from app.models.payloads import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("/spaces/{space_id}/members")
@@ -45,11 +47,12 @@ async def list_members_endpoint(
         if "not found" in str(exc).lower():
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=str(exc),
+                detail=f"Space not found: {space_id}",
             ) from exc
+        logger.warning("Failed to list members for %s: %s", space_id, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(exc),
+            detail="Failed to list members",
         ) from exc
 
 
@@ -92,19 +95,30 @@ async def invite_member_endpoint(
     except RuntimeError as exc:
         message = str(exc)
         lowered = message.lower()
+        if "user not found" in lowered:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"User not found: {payload.user_id}",
+            ) from exc
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail=f"Space not found: {space_id}",
             ) from exc
         if "already active" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=message,
+                detail=f"Member already active: {payload.user_id}",
             ) from exc
+        logger.warning(
+            "Failed to create invitation for %s in %s: %s",
+            payload.user_id,
+            space_id,
+            exc,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Invalid member invitation request",
         ) from exc
 
 
@@ -135,16 +149,17 @@ async def accept_member_invitation_endpoint(
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail="Invitation not found",
             ) from exc
         if "expired" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_410_GONE,
-                detail=message,
+                detail="Invitation expired",
             ) from exc
+        logger.warning("Failed to accept invitation in %s: %s", space_id, exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Invalid invitation token",
         ) from exc
 
 
@@ -183,19 +198,30 @@ async def update_member_role_endpoint(
     except RuntimeError as exc:
         message = str(exc)
         lowered = message.lower()
+        if "member not found" in lowered:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Member not found: {member_user_id}",
+            ) from exc
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail=f"Space not found: {space_id}",
             ) from exc
         if "at least one active admin" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=message,
+                detail="Space must retain at least one active admin",
             ) from exc
+        logger.warning(
+            "Failed to update role for %s in %s: %s",
+            member_user_id,
+            space_id,
+            exc,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Failed to update member role",
         ) from exc
 
 
@@ -232,17 +258,28 @@ async def revoke_member_endpoint(
     except RuntimeError as exc:
         message = str(exc)
         lowered = message.lower()
+        if "member not found" in lowered:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Member not found: {member_user_id}",
+            ) from exc
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail=f"Space not found: {space_id}",
             ) from exc
         if "at least one active admin" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=message,
+                detail="Space must retain at least one active admin",
             ) from exc
+        logger.warning(
+            "Failed to revoke member %s in %s: %s",
+            member_user_id,
+            space_id,
+            exc,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Failed to revoke member",
         ) from exc

--- a/backend/src/app/api/endpoints/members.py
+++ b/backend/src/app/api/endpoints/members.py
@@ -156,7 +156,10 @@ async def accept_member_invitation_endpoint(
                 status_code=status.HTTP_410_GONE,
                 detail="Invitation expired",
             ) from exc
-        logger.warning("Failed to accept invitation in %s: %s", space_id, exc)
+        logger.warning(
+            "Failed to accept invitation in %s: invalid_invitation_token",
+            space_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid invitation token",

--- a/backend/src/app/api/endpoints/preferences.py
+++ b/backend/src/app/api/endpoints/preferences.py
@@ -31,7 +31,7 @@ def _validate_selected_space_id(selected_space_id: str | None) -> None:
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail="Invalid selected_space_id",
         ) from exc
 
 

--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -44,9 +44,10 @@ async def _ensure_space_exists(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Space not found: {space_id}",
             ) from exc
+        logger.warning("Failed to load space %s: %s", space_id, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to load space",
         ) from exc
 
 
@@ -120,7 +121,7 @@ def _validate_path_id(identifier: str, name: str) -> None:
     except ValueError as exc:  # pragma: no cover - exercised via API tests
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=f"Invalid {name}",
         ) from exc
 
 
@@ -220,7 +221,7 @@ async def list_spaces_endpoint(request: Request) -> list[dict[str, Any]]:
         logger.exception("Failed to list spaces")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(exc),
+            detail="Failed to list spaces",
         ) from exc
 
     results: list[dict[str, Any]] = []
@@ -274,15 +275,16 @@ async def create_space_endpoint(
     except RuntimeError as e:
         if "already exists" in str(e).lower():
             raise _space_exists_conflict_error(space_id) from e
+        logger.warning("Failed to create space %s: %s", space_id, e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to create space",
         ) from e
     except Exception as e:
         logger.exception("Failed to create space")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to create space",
         ) from e
 
     return {
@@ -313,17 +315,18 @@ async def get_space_endpoint(space_id: str, request: Request) -> dict[str, Any]:
         if "not found" in str(e).lower():
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=str(e),
+                detail=f"Space not found: {space_id}",
             ) from e
+        logger.warning("Failed to get space %s: %s", space_id, e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load space",
         ) from e
     except Exception as e:
         logger.exception("Failed to get space")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load space",
         ) from e
 
 
@@ -369,17 +372,18 @@ async def patch_space_endpoint(
         if "not found" in str(e).lower():
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=str(e),
+                detail=f"Space not found: {space_id}",
             ) from e
+        logger.warning("Failed to update space %s: %s", space_id, e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to update space",
         ) from e
     except Exception as e:
         logger.exception("Failed to patch space")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to update space",
         ) from e
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -101,7 +101,7 @@ def test_create_space_rejects_invalid_name(test_client: TestClient) -> None:
     """REQ-API-001: create space rejects names violating identifier rules."""
     response = test_client.post("/spaces", json={"name": "invalid space"})
     assert response.status_code == 400
-    assert "Invalid space_id" in response.json()["detail"]
+    assert response.json()["detail"] == "Invalid space_id"
 
 
 def test_create_space_req_api_001_requires_admin_space_admin(
@@ -418,6 +418,7 @@ def test_get_space_not_found(
     """Test getting a non-existent space."""
     response = test_client.get("/spaces/nonexistent")
     assert response.status_code == 404
+    assert response.json()["detail"] == "Space not found: nonexistent"
 
 
 def test_create_entry(test_client: TestClient, temp_space_root: Path) -> None:

--- a/backend/tests/test_error_sanitization.py
+++ b/backend/tests/test_error_sanitization.py
@@ -44,7 +44,7 @@ def test_server_error_detail_with_failed_prefix_is_sanitized_and_logged(
         raise RuntimeError(msg)
 
     monkeypatch.setattr(ugoite_core, "list_members", _raise)
-    caplog.set_level(logging.ERROR, logger="app.main")
+    caplog.set_level(logging.WARNING)
 
     response = test_client.get("/spaces/members-ws/members")
 

--- a/backend/tests/test_preferences.py
+++ b/backend/tests/test_preferences.py
@@ -67,7 +67,7 @@ def test_preferences_me_rejects_invalid_selected_space_id(
         json={"selected_space_id": "invalid space"},
     )
     assert response.status_code == 400
-    assert "Invalid selected_space_id" in response.json()["detail"]
+    assert response.json()["detail"] == "Invalid selected_space_id"
 
 
 def test_preferences_me_accepts_null_selected_space_id(

--- a/backend/tests/test_space_members.py
+++ b/backend/tests/test_space_members.py
@@ -286,6 +286,7 @@ def test_list_members_not_found_runtime_error(test_client: TestClient) -> None:
     ):
         response = test_client.get("/spaces/members-notfound-ws/members")
     assert response.status_code == 404
+    assert response.json()["detail"] == "Space not found: members-notfound-ws"
 
 
 def test_list_members_generic_runtime_error(test_client: TestClient) -> None:
@@ -297,6 +298,10 @@ def test_list_members_generic_runtime_error(test_client: TestClient) -> None:
     ):
         response = test_client.get("/spaces/members-rt-ws/members")
     assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_invite_member_already_active(test_client: TestClient) -> None:
@@ -311,6 +316,7 @@ def test_invite_member_already_active(test_client: TestClient) -> None:
             json={"user_id": "alice", "role": "viewer"},
         )
     assert response.status_code == 409
+    assert response.json()["detail"] == "Member already active: alice"
 
 
 def test_invite_member_not_found(test_client: TestClient) -> None:
@@ -325,6 +331,22 @@ def test_invite_member_not_found(test_client: TestClient) -> None:
             json={"user_id": "unknown-user", "role": "viewer"},
         )
     assert response.status_code == 404
+    assert response.json()["detail"] == "User not found: unknown-user"
+
+
+def test_invite_member_space_not_found(test_client: TestClient) -> None:
+    """REQ-SEC-007: invite member returns a stable 404 when the space is missing."""
+    test_client.post("/spaces", json={"name": "members-inv-space-404-ws"})
+    with patch(
+        "ugoite_core.create_invitation",
+        _amock(side_effect=RuntimeError("space not found")),
+    ):
+        response = test_client.post(
+            "/spaces/members-inv-space-404-ws/members/invitations",
+            json={"user_id": "alice-space", "role": "viewer"},
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Space not found: members-inv-space-404-ws"
 
 
 def test_invite_member_generic_runtime_error(test_client: TestClient) -> None:
@@ -339,6 +361,7 @@ def test_invite_member_generic_runtime_error(test_client: TestClient) -> None:
             json={"user_id": "alice-x", "role": "viewer"},
         )
     assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid member invitation request"
 
 
 def test_invite_member_authorization_error(test_client: TestClient) -> None:
@@ -373,6 +396,7 @@ def test_accept_invitation_expired(test_client: TestClient) -> None:
             json={"token": "expired-token"},
         )
     assert response.status_code == 410
+    assert response.json()["detail"] == "Invitation expired"
 
 
 def test_accept_invitation_not_found(test_client: TestClient) -> None:
@@ -387,6 +411,7 @@ def test_accept_invitation_not_found(test_client: TestClient) -> None:
             json={"token": "bad-token"},
         )
     assert response.status_code == 404
+    assert response.json()["detail"] == "Invitation not found"
 
 
 def test_accept_invitation_generic_runtime_error(test_client: TestClient) -> None:
@@ -401,6 +426,7 @@ def test_accept_invitation_generic_runtime_error(test_client: TestClient) -> Non
             json={"token": "bad-token"},
         )
     assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid invitation token"
 
 
 def test_update_member_role_not_found(test_client: TestClient) -> None:
@@ -415,6 +441,22 @@ def test_update_member_role_not_found(test_client: TestClient) -> None:
             json={"role": "editor"},
         )
     assert response.status_code == 404
+    assert response.json()["detail"] == "Member not found: absent-user"
+
+
+def test_update_member_role_space_not_found(test_client: TestClient) -> None:
+    """REQ-SEC-007: update member role returns a stable 404 for a missing space."""
+    test_client.post("/spaces", json={"name": "members-role-space-404-ws"})
+    with patch(
+        "ugoite_core.update_member_role",
+        _amock(side_effect=RuntimeError("space not found")),
+    ):
+        response = test_client.post(
+            "/spaces/members-role-space-404-ws/members/alice/role",
+            json={"role": "editor"},
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Space not found: members-role-space-404-ws"
 
 
 def test_update_member_role_generic_runtime_error(test_client: TestClient) -> None:
@@ -429,6 +471,7 @@ def test_update_member_role_generic_runtime_error(test_client: TestClient) -> No
             json={"role": "editor"},
         )
     assert response.status_code == 400
+    assert response.json()["detail"] == "Failed to update member role"
 
 
 def test_update_member_role_authorization_error(test_client: TestClient) -> None:
@@ -462,6 +505,21 @@ def test_revoke_member_not_found(test_client: TestClient) -> None:
             "/spaces/members-revoke-404-ws/members/absent-user",
         )
     assert response.status_code == 404
+    assert response.json()["detail"] == "Member not found: absent-user"
+
+
+def test_revoke_member_space_not_found(test_client: TestClient) -> None:
+    """REQ-SEC-007: revoke member returns a stable 404 when the space is missing."""
+    test_client.post("/spaces", json={"name": "members-revoke-space-404-ws"})
+    with patch(
+        "ugoite_core.revoke_member",
+        _amock(side_effect=RuntimeError("space not found")),
+    ):
+        response = test_client.delete(
+            "/spaces/members-revoke-space-404-ws/members/alice",
+        )
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Space not found: members-revoke-space-404-ws"
 
 
 def test_revoke_member_generic_runtime_error(test_client: TestClient) -> None:
@@ -475,6 +533,7 @@ def test_revoke_member_generic_runtime_error(test_client: TestClient) -> None:
             "/spaces/members-revoke-rt-ws/members/alice",
         )
     assert response.status_code == 400
+    assert response.json()["detail"] == "Failed to revoke member"
 
 
 def test_update_member_role_last_admin_conflict(test_client: TestClient) -> None:
@@ -489,6 +548,7 @@ def test_update_member_role_last_admin_conflict(test_client: TestClient) -> None
             json={"role": "viewer"},
         )
     assert response.status_code == 409
+    assert response.json()["detail"] == "Space must retain at least one active admin"
 
 
 def test_revoke_member_last_admin_conflict(test_client: TestClient) -> None:
@@ -502,6 +562,7 @@ def test_revoke_member_last_admin_conflict(test_client: TestClient) -> None:
             "/spaces/members-revoke-admin-conflict-ws/members/alice",
         )
     assert response.status_code == 409
+    assert response.json()["detail"] == "Space must retain at least one active admin"
 
 
 def test_revoke_member_authorization_error(test_client: TestClient) -> None:

--- a/backend/tests/test_space_members.py
+++ b/backend/tests/test_space_members.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
@@ -414,12 +415,17 @@ def test_accept_invitation_not_found(test_client: TestClient) -> None:
     assert response.json()["detail"] == "Invitation not found"
 
 
-def test_accept_invitation_generic_runtime_error(test_client: TestClient) -> None:
-    """REQ-SEC-007: accept invitation returns 400 on generic runtime error."""
+def test_accept_invitation_generic_runtime_error(
+    test_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """REQ-SEC-007: accept invitation returns 400 with sanitized generic failures."""
     test_client.post("/spaces", json={"name": "members-accept-rt-ws"})
+    raw_message = "token validation failed for bad-token"
+    caplog.set_level(logging.WARNING)
     with patch(
         "ugoite_core.accept_invitation",
-        _amock(side_effect=RuntimeError("bad request")),
+        _amock(side_effect=RuntimeError(raw_message)),
     ):
         response = test_client.post(
             "/spaces/members-accept-rt-ws/members/accept",
@@ -427,6 +433,11 @@ def test_accept_invitation_generic_runtime_error(test_client: TestClient) -> Non
         )
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid invitation token"
+    assert raw_message not in caplog.text
+    assert (
+        "Failed to accept invitation in members-accept-rt-ws: "
+        "invalid_invitation_token" in caplog.text
+    )
 
 
 def test_update_member_role_not_found(test_client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- replace raw exception details in `space.py`, `members.py`, and `preferences.py` with stable public-facing messages
- keep raw failure text in server logs instead of echoing it back across the HTTP boundary
- extend backend tests to lock the new 400/404/409/500 response details and coverage branches

## Related Issue (required)
closes #1357

## Testing
- uvx pre-commit run --files backend/src/app/api/endpoints/space.py backend/src/app/api/endpoints/members.py backend/src/app/api/endpoints/preferences.py backend/tests/test_api.py backend/tests/test_preferences.py backend/tests/test_space_members.py backend/tests/test_error_sanitization.py --show-diff-on-failure
- cd backend && uv run pytest --no-cov tests/test_api.py tests/test_preferences.py tests/test_space_members.py tests/test_error_sanitization.py -q
- [x] Tests added or updated