### PR TITLE
docs: split README evaluator and contributor entry paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ GitHub without comparing two different onboarding maps.
   fastest browser-based evaluation path, while still running the browser stack
   with an explicit login step.
 - [Run from source](docs/guide/local-dev-auth-login.md) when you want the current
-  backend, frontend, and docsite together; the shortest contributor path is
-  `mise run setup` (dependencies + repo hooks), then `mise run dev`, followed
-  by the explicit `/login` flow.
+  backend, frontend, and docsite together for full-stack evaluation or
+  debugging; start with `mise run setup` (dependencies + repo hooks), then
+  `mise run dev`, followed by the explicit `/login` flow. If you are
+  contributing to one surface at a time, use the
+  [Contributor Workflow](CONTRIBUTING.md) after setup for targeted commands and
+  validation.
   If you intentionally use the repo-root `docker compose up --build` path
   instead, export `UGOITE_DEV_SIGNING_SECRET` and
   `UGOITE_DEV_AUTH_PROXY_TOKEN` first with at least 32 characters of random
@@ -81,7 +84,8 @@ demo login mode (`mock-oauth`) by default so browser evaluators can reach
 | [Try the published release](docs/guide/container-quickstart.md) | You want the fastest visual evaluation of the published browser experience | Medium: Docker + published image pulls + frontend/backend containers + explicit login | Browser-first, but still multi-service and login-gated |
 | [Use the CLI](docs/guide/cli.md) in `core` mode | You want the lightest local-first workflow with direct filesystem access | Lowest: released CLI install + local filesystem path; no container stack required | Terminal-first experience; no browser UI or server-backed collaboration features |
 | [Work on `ugoite-minimum`](ugoite-minimum/README.md) | You are contributing portable Rust, WASM-oriented, or embedding-friendly logic without the full app stack | Medium: source checkout + `mise run setup`, then package-local `//ugoite-minimum` quality gates | Narrower scope than the full repo path; no frontend/backend/docsite behavior in scope |
-| [Run from source](docs/guide/local-dev-auth-login.md) with `mise run dev` | You are contributing, debugging, or want the full repo surfaces together | Highest: source checkout + toolchain install + backend/frontend/docsite processes + auth setup | Full contributor surface, but also the heaviest path |
+| [Run from source](docs/guide/local-dev-auth-login.md) with `mise run dev` | You want the current backend, frontend, and docsite together for source-based evaluation or full-stack debugging | Highest: source checkout + toolchain install + backend/frontend/docsite processes + auth setup | Full repo surface, but also the heaviest path |
+| [Contributor Workflow](CONTRIBUTING.md) | You are changing docs, frontend, backend, or core and want the canonical setup plus targeted commands | Medium: source checkout + `mise run setup`; add only the surface-specific commands or services you need | Flexible contributor path, but cross-surface or auth changes may still need the full `mise run dev` stack |
 
 Today's shipped AI surface is resource-first MCP access. Read-oriented MCP
 resources are available now; broader tool-driven AI workflows remain part of

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -1328,6 +1328,19 @@ def test_docs_req_e2e_008_readme_start_here_mirrors_docsite_taxonomy() -> None:
             "README Start Here section must surface source compose secret "
             "prerequisites before repo-root compose startup",
         ),
+        (
+            "[Contributor Workflow](CONTRIBUTING.md)" not in section
+            or "targeted commands" not in section
+            or "docs, frontend, backend, or core" not in section,
+            "README Start Here section must split source contributor guidance "
+            "into a dedicated targeted-workflow row",
+        ),
+        (
+            "You are contributing, debugging, or want the full repo surfaces "
+            "together" in section,
+            "README Start Here table must not collapse contributor and "
+            "source-evaluation guidance into one row",
+        ),
     )
     details = [message for condition, message in detail_candidates if condition]
     if details:


### PR DESCRIPTION
## Summary
- split the README source row so full-stack source evaluation stays distinct from contributor-targeted workflows
- add a dedicated Contributor Workflow row that points contributors at the CI-aligned guide for narrower docs, frontend, backend, or core changes
- extend README docs regression coverage so the Start Here table keeps the split entry-path guidance

## Related Issue (required)
closes #1401

## Testing
- [x] uvx ruff check --select ALL --ignore-noqa docs/tests/test_guides.py
- [x] uvx ruff format --check docs/tests/test_guides.py
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -k readme_start_here_mirrors_docsite_taxonomy or source_contributor_path_stays_canonical_across_docs -v -W error
- [x] TMPDIR=/workspace/.worktrees/issue-1401/.pytest-tmp UV_CACHE_DIR=/workspace/.uv-cache uv run --with pytest --with pyyaml --with bashlex pytest docs/tests -v -W error --junitxml=docs-pytest.xml
- [x] python3 scripts/check_pytest_no_skips.py docs-pytest.xml docs tests
- [x] README command guard grep equivalent from .github/workflows/readme-command-guard.yml