### PR TITLE
docs: add MCP operator-surface positioning guide

### DIFF
--- a/docs/spec/api/mcp.md
+++ b/docs/spec/api/mcp.md
@@ -2,13 +2,17 @@
 
 ## Overview
 
-Ugoite implements the Model Context Protocol (MCP) as a resource-first
-integration that lets AI clients read knowledge-base data through explicit
-trust boundaries. The current server is mounted at `/mcp` via SSE transport.
+Ugoite implements the Model Context Protocol (MCP) as the AI-facing,
+resource-first operator surface that lets clients read knowledge-base data
+through explicit trust boundaries. The current server is mounted at `/mcp` via
+SSE transport.
 
 In `v0.1`, the shipped MCP server exposes a single read-only resource. Broader
 resource coverage, prompts, and tools are planned for `v0.2`; they are not part
 of the current server surface.
+
+For when to choose MCP over the CLI or REST API, see
+[Operator Surface Positioning](operator-surfaces.md).
 
 ## Resources
 

--- a/docs/spec/api/operator-surfaces.md
+++ b/docs/spec/api/operator-surfaces.md
@@ -1,0 +1,45 @@
+# Operator Surface Positioning
+
+Ugoite exposes multiple operator surfaces on purpose. They share the same core
+logic, but they serve different primary operators, trust models, and workflow
+needs. This guide explains when to choose MCP, CLI, or REST and how that choice
+traces back to the governance model.
+
+## Governance Trace
+
+- **PHIL-004** requires AI freedom to stay inside explicit trusted constraints.
+- **POL-015** defines MCP as the governed, AI-facing operator surface.
+- **POL-010** keeps AI autonomy inside trusted tools, validated interfaces, and
+  audit paths.
+- **POL-005** keeps the CLI as the explicit human/operator automation surface.
+- **POL-004** keeps REST as the application/backend contract surface instead of
+  a duplicate business-logic layer.
+- **REQ-API-012**, **REQ-API-013**, and **REQ-API-014** keep the MCP surface
+  safe, current-state, and clearly positioned in the docs.
+
+## Surface Positioning
+
+| Surface | Primary operator | Choose it when | Current posture |
+| --- | --- | --- | --- |
+| **MCP** | AI agents and assistants | You need protocol-level AI access to Ugoite resources inside explicit trust boundaries | `v0.1` ships a resource-first baseline: one read-only `ugoite://{space_id}/entries/list` resource, no prompts, no tools |
+| **CLI** | Humans and scripts | You need explicit, inspectable automation, direct local workflows, or scriptable operator tasks | First-class operator surface for visible automation |
+| **REST API** | Frontend and typed application clients | You need stable request/response contracts for product behavior and browser/app integration | Thin adapter surface for UI and service-facing contracts |
+
+## Choosing Between MCP, CLI, and REST
+
+- Use **MCP** when an AI client should read Ugoite resources through a governed
+  protocol surface. Today that means the current resource-first baseline, not
+  prompt execution or tool-style workflows.
+- Use **CLI** when a human operator or script needs explicit commands,
+  stdout/stderr visibility, and direct local inspection.
+- Use **REST** when frontend or service clients need stable HTTP
+  request/response contracts for product behavior.
+- Keep durable business rules in `ugoite-core`; backend and CLI adapt that
+  shared logic to their own protocols instead of re-implementing it.
+
+## Current `v0.1` Boundary
+
+In `v0.1`, MCP is intentionally narrower than CLI or REST. Choose CLI or REST
+today for workflows that need writes, richer orchestration, or broader
+application behavior. Treat broader MCP resources, prompts, and tools as
+planned `v0.2` expansion rather than current surface area.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -22,7 +22,8 @@ Ugoite is a knowledge management system built on three core principles:
 
 Today the shipped AI surface is **resource-first MCP access**: one read-only
 resource is available now, while prompts and tool-style MCP workflows remain
-future work.
+future work. See [Operator Surface Positioning](api/operator-surfaces.md) for
+when to choose MCP, CLI, or REST.
 
 ---
 
@@ -67,6 +68,7 @@ future work.
 ### API Reference
 - [REST API](api/rest.md) - HTTP endpoints for frontend integration
 - [MCP Protocol](api/mcp.md) - Current resource-first MCP surface for AI agents; prompts and tool-style workflows remain future work
+- [Operator Surface Positioning](api/operator-surfaces.md) - Governance-backed guide for choosing MCP, CLI, or REST
 - [OpenAPI Spec](api/openapi.yaml) - Machine-readable API definition
 
 ### Requirements

--- a/docs/spec/philosophy/foundation.yaml
+++ b/docs/spec/philosophy/foundation.yaml
@@ -81,3 +81,4 @@ philosophies:
       - POL-009
       - POL-010
       - POL-011
+      - POL-015

--- a/docs/spec/policies/policies.yaml
+++ b/docs/spec/policies/policies.yaml
@@ -80,6 +80,7 @@ policies:
   - SPEC-ARCH-INTERFACE
   - SPEC-API-REST
   - SPEC-API-OPENAPI
+  - SPEC-API-SURFACES
 - id: POL-005
   title: CLI as First-Class Operator Surface
   summary: Use CLI workflows to keep automation explicit, inspectable, and scriptable.
@@ -98,6 +99,7 @@ policies:
   - REQCAT-INTEGRITY
   linked_specifications:
   - SPEC-ARCH-STACK
+  - SPEC-API-SURFACES
   - SPEC-TESTING-STRATEGY
   - SPEC-TESTING-CICD
 - id: POL-006
@@ -195,6 +197,7 @@ policies:
   - SPEC-SECURITY-OVERVIEW
   - SPEC-SECURITY-SANDBOX
   - SPEC-ARCH-FUTURE
+  - SPEC-API-SURFACES
 - id: POL-011
   title: Security and Isolation by Default
   summary: Design for secure defaults, bounded execution, and explicit trust boundaries.
@@ -274,3 +277,20 @@ policies:
   - SPEC-ARCH-FUTURE
   - SPEC-API-OPENAPI
   - SPEC-DM-DIRECTORY
+- id: POL-015
+  title: MCP as Governed AI Operator Surface
+  summary: Position MCP as the AI-facing operator surface with explicit scope and trust boundaries.
+  description: |
+    This policy defines MCP as the operator surface for AI clients when they
+    need structured, protocol-level access to Ugoite resources inside explicit
+    trust boundaries. It keeps the current resource-first scope visible,
+    separates AI-facing access from CLI-driven human automation and REST
+    application integration, and requires expansion through documented,
+    reviewable contracts.
+  linked_philosophies:
+  - PHIL-004
+  linked_requirements:
+  - REQCAT-API
+  linked_specifications:
+  - SPEC-API-MCP
+  - SPEC-API-SURFACES

--- a/docs/spec/requirements/api.yaml
+++ b/docs/spec/requirements/api.yaml
@@ -14,10 +14,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -77,10 +79,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -135,10 +139,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -180,10 +186,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -227,10 +235,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -273,10 +283,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -319,10 +331,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -367,10 +381,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -425,10 +441,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -477,10 +495,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -521,10 +541,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -570,10 +592,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -615,10 +639,12 @@ requirements:
   - POL-011
   - POL-013
   - POL-014
+  - POL-015
   linked_specifications:
   - SPEC-API-REST
   - SPEC-API-OPENAPI
   - SPEC-API-MCP
+  - SPEC-API-SURFACES
   - SPEC-ARCH-INTERFACE
   - SPEC-ARCH-DECISIONS
   - SPEC-ARCH-FUTURE
@@ -655,3 +681,55 @@ requirements:
     - file: docsite/src/lib/app-mcp-page.test.ts
       tests:
       - 'REQ-API-013: app MCP page keeps the shipped surface resource-first and clearly scoped'
+- set_id: REQCAT-API
+  source_file: requirements/api.yaml
+  scope: REST API contracts and service behavior requirements.
+  linked_policies:
+  - POL-001
+  - POL-002
+  - POL-004
+  - POL-006
+  - POL-008
+  - POL-010
+  - POL-011
+  - POL-013
+  - POL-014
+  - POL-015
+  linked_specifications:
+  - SPEC-API-REST
+  - SPEC-API-OPENAPI
+  - SPEC-API-MCP
+  - SPEC-API-SURFACES
+  - SPEC-ARCH-INTERFACE
+  - SPEC-ARCH-DECISIONS
+  - SPEC-ARCH-FUTURE
+  - SPEC-DM-SQL-SESSIONS
+  - SPEC-STORIES-EXPERIMENTAL
+  id: REQ-API-014
+  title: Operator Surface Positioning Guide
+  description: 'Specification docs MUST position MCP as the governed AI-facing
+
+    operator surface, CLI as the explicit human/operator automation surface,
+
+    and REST as the application/frontend integration surface.
+
+    The positioning guide MUST trace PHIL-004 through policies and requirements,
+
+    and it MUST keep today''s MCP scope framed as the current resource-first
+
+    baseline rather than broader future capability.
+
+    '
+  related_spec:
+  - philosophy/foundation.yaml
+  - policies/policies.yaml
+  - index.md
+  - api/mcp.md
+  - api/operator-surfaces.md
+  priority: medium
+  status: implemented
+  tests:
+    pytest:
+    - file: docs/tests/test_mcp_docs.py
+      tests:
+      - test_docs_req_api_014_surface_guide_traces_mcp_cli_and_rest

--- a/docs/spec/specifications.yaml
+++ b/docs/spec/specifications.yaml
@@ -53,6 +53,16 @@
   source_file: api/mcp.md
   linked_policies:
   - POL-011
+  - POL-015
+  linked_requirements:
+  - REQCAT-API
+- id: SPEC-API-SURFACES
+  source_file: api/operator-surfaces.md
+  linked_policies:
+  - POL-004
+  - POL-005
+  - POL-010
+  - POL-015
   linked_requirements:
   - REQCAT-API
 - id: SPEC-API-OPENAPI

--- a/docs/tests/test_mcp_docs.py
+++ b/docs/tests/test_mcp_docs.py
@@ -2,6 +2,7 @@
 
 REQ-API-012: MCP resource input safety.
 REQ-API-013: Current MCP surface documentation.
+REQ-API-014: Operator-surface positioning guidance.
 """
 
 from __future__ import annotations
@@ -165,5 +166,58 @@ def test_docs_req_api_013_current_mcp_surface_stays_resource_first() -> None:
         )
         if not ok
     ]
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_api_014_surface_guide_traces_mcp_cli_and_rest() -> None:
+    """REQ-API-014: operator-surface docs position MCP, CLI, and REST."""
+    guide = (REPO_ROOT / "docs" / "spec" / "api" / "operator-surfaces.md").read_text(
+        encoding="utf-8",
+    )
+    spec_index = (REPO_ROOT / "docs" / "spec" / "index.md").read_text(
+        encoding="utf-8",
+    )
+    mcp_doc = (REPO_ROOT / "docs" / "spec" / "api" / "mcp.md").read_text(
+        encoding="utf-8",
+    )
+
+    details = [
+        f"docs/spec/api/operator-surfaces.md missing fragment: {fragment!r}"
+        for fragment in (
+            "PHIL-004",
+            "POL-015",
+            "POL-010",
+            "POL-005",
+            "POL-004",
+            "REQ-API-012",
+            "REQ-API-013",
+            "REQ-API-014",
+            "| **MCP** |",
+            "| **CLI** |",
+            "| **REST API** |",
+            "Use **MCP** when",
+            "Use **CLI** when",
+            "Use **REST** when",
+            "AI-facing operator surface",
+            "resource-first baseline",
+            "no prompts, no tools",
+        )
+        if fragment not in guide
+    ]
+
+    for ok, message in (
+        (
+            "[Operator Surface Positioning](api/operator-surfaces.md)" in spec_index,
+            "docs/spec/index.md must link to the operator-surface positioning guide",
+        ),
+        (
+            "[Operator Surface Positioning](operator-surfaces.md)" in mcp_doc,
+            "docs/spec/api/mcp.md must link to the operator-surface positioning guide",
+        ),
+    ):
+        if not ok:
+            details.append(message)
+
     if details:
         raise AssertionError("; ".join(details))


### PR DESCRIPTION
## Summary
- add an explicit POL-015 policy that defines MCP as the governed AI-facing operator surface
- add a short operator-surface positioning guide for MCP vs CLI vs REST and wire it into the spec index/MCP spec
- extend API governance metadata and docs tests with REQ-API-014 so the new positioning guidance stays checked in CI

## Related Issue (required)
closes #1400

## Testing
- [x] uvx ruff check --select ALL --ignore-noqa .
- [x] uvx ruff format --check .
- [x] UV_CACHE_DIR=/workspace/.worktrees/issue-1400/.uv-cache uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_mcp_docs.py docs/tests/test_spec_governance.py docs/tests/test_requirements.py -W error
- [x] bun install --frozen-lockfile
- [x] bun run lint
- [x] bun run format:check
- [x] bun run typecheck
- [x] bun run test:validation
- [x] TMPDIR=/workspace/.worktrees/issue-1400/.tmp TMP=/workspace/.worktrees/issue-1400/.tmp TEMP=/workspace/.worktrees/issue-1400/.tmp node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1
