### PR TITLE
docs: add test:docs guidance to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,15 @@ match the current workflows under `.github/workflows/`.
 Examples:
 
 - `mise run test` for the repository-wide baseline
+- `mise run test:docs` before pushing docs, spec, or REQ-traceability changes
 - targeted `uv run pytest ...` for docs/backend/core changes when iterating
 - `cd docsite && bun run test:coverage` for docsite regressions
 - `cd frontend && biome ci . && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1`
   when UI behavior changes
+
+Use `mise run test:docs` when `README.md`, `CONTRIBUTING.md`, `docs/spec/`,
+or `docs/tests/` change so the docs consistency suite catches guide drift and
+REQ mapping regressions locally first.
 
 If you add a new docsite page or navigation path, include the matching vitest or
 docs regression so the route and copy stay wired.

--- a/docs/tests/test_contributing_guide.py
+++ b/docs/tests/test_contributing_guide.py
@@ -63,6 +63,14 @@ def test_docs_req_ops_036_contributor_workflow_guide_stays_traceable() -> None:
                 "mise run test" not in contributing_text,
                 "CONTRIBUTING.md must mention the repo-wide validation command",
             ),
+            (
+                "mise run test:docs" not in contributing_text,
+                "CONTRIBUTING.md must mention the docs consistency validation command",
+            ),
+            (
+                "docs, spec, or REQ-traceability changes" not in contributing_text,
+                "CONTRIBUTING.md must explain when to run the docs validation command",
+            ),
         )
         if condition
     ]


### PR DESCRIPTION
## Summary
- add `mise run test:docs` to the CONTRIBUTING local validation examples
- explain when docs, spec, and REQ-traceability changes should run the docs suite locally
- extend the CONTRIBUTING docs regression to enforce the new guidance

## Related Issue (required)
closes #1399

## Testing
- TMPDIR=/workspace/.tmp UV_CACHE_DIR=/workspace/.uv-cache uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_contributing_guide.py -q
- TMPDIR=/workspace/.tmp UV_CACHE_DIR=/workspace/.uv-cache mise run test:docs

- [x] Tests added or updated where needed
