### PR TITLE
docs: surface devcontainer contributor path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,27 @@ Use this guide when you are changing code, docs, specs, or tests in Ugoite. It
 connects the repository workflow, REQ-* traceability, and CI expectations in one
 place so a local green change stays aligned with the shipped product docs.
 
-## 1. Start from the canonical setup path
+## 1. Choose a supported contributor setup path
 
-Use the repository-managed toolchain first:
+Ugoite supports two contributor setup paths that converge on the same local
+commands, hooks, and CI-parity checks:
+
+| Path | Choose it when | What it does for you |
+| --- | --- | --- |
+| Managed host toolchain | You are happy installing the repo toolchain on your machine or you are not using VS Code/Codespaces | Run `mise run setup` yourself to install the shared dependencies and `uvx pre-commit install`, so local commits use the same pre-commit gate that CI enforces. |
+| Devcontainer / GitHub Codespaces | You want a reproducible VS Code/Codespaces workspace or do not want to install the full toolchain on your host | `.devcontainer/devcontainer.json` preinstalls `mise`, `gh`, `oathtool`, then runs `mise install`, `mise run setup`, and `npx playwright install --with-deps chromium` for you. |
+
+If you are on the managed host toolchain path, start with:
 
 ```bash
 mise run setup
 ```
 
 That path installs the shared dependencies and runs `uvx pre-commit install`, so
-local commits use the same pre-commit gate that CI enforces.
+local commits use the same pre-commit gate that CI enforces. The devcontainer
+runs that same bootstrap for you during container creation.
 
-Common follow-up commands:
+Common follow-up commands inside either setup:
 
 ```bash
 mise run dev

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ GitHub without comparing two different onboarding maps.
   fastest browser-based evaluation path, while still running the browser stack
   with an explicit login step.
 - [Run from source](docs/guide/local-dev-auth-login.md) when you want the current
-  backend, frontend, and docsite together; the shortest contributor path is
-  `mise run setup` (dependencies + repo hooks), then `mise run dev`, followed
-  by the explicit `/login` flow.
+  backend, frontend, and docsite together; choose the repo Devcontainer /
+  GitHub Codespaces path when you want the preloaded contributor environment
+  (`mise`, `gh`, `oathtool`, `mise install`, `mise run setup`, and
+  `npx playwright install --with-deps chromium`), or run `mise run setup` on
+  your host when you already manage the toolchain yourself; both paths continue
+  with `mise run dev`, followed by the explicit `/login` flow.
   If you intentionally use the repo-root `docker compose up --build` path
   instead, export `UGOITE_DEV_SIGNING_SECRET` and
   `UGOITE_DEV_AUTH_PROXY_TOKEN` first with at least 32 characters of random
@@ -212,16 +215,23 @@ For contributor-oriented Cargo workflows, see [CLI Guide](docs/guide/cli.md).
 
 ## Setup & Development (mise)
 
-Install dependencies and repository pre-commit hooks:
-
 The repository root `mise.toml` is the contributor-facing source of truth for
-managed tool versions. Use that shared toolchain story first, then treat
-package README prerequisites as workflow notes on top of the same managed
-environment.
+managed tool versions across both supported setup paths. Use that shared
+toolchain story first, then treat package README prerequisites as workflow notes
+on top of the same managed environment.
 
 For the full contributor workflow around specs, REQ traceability, docsite
 navigation wiring, and CI-parity checks, see
 [Contributor Workflow](CONTRIBUTING.md).
+
+Choose the contributor setup path that matches your machine:
+
+| Path | Choose it when | What it handles for you |
+| --- | --- | --- |
+| Host-managed toolchain | You already want the repo toolchain on your machine or you are not using VS Code/Codespaces | You run `mise run setup` yourself to install dependencies and `uvx pre-commit install`, then continue with `mise run dev`. |
+| Devcontainer / GitHub Codespaces | You want a reproducible VS Code/Codespaces workspace or do not want to install the full toolchain on your host | `.devcontainer/devcontainer.json` preinstalls `mise`, `gh`, `oathtool`, then runs `mise install`, `mise run setup`, and `npx playwright install --with-deps chromium` for you. |
+
+Install dependencies and repository pre-commit hooks:
 
 ```bash
 mise run setup
@@ -229,6 +239,9 @@ mise run setup
 
 The setup task also runs `uvx pre-commit install` so local commits use the same
 hook chain as CI by default.
+
+The devcontainer path runs that same bootstrap for you during container
+creation, so both contributor setups land on the same local commands and hooks.
 
 Start development (backend + frontend + docsite — `passkey-totp` is the default local auth mode):
 
@@ -316,18 +329,24 @@ bun dev
 
 ---
 
-## Dev Container (VS Code) vs Docker Compose (deployment)
+## Devcontainer / GitHub Codespaces vs Docker Compose (deployment)
 
 Important: this repo provides two distinct container-based workflows:
 
-- Dev Container (development):
-  - `.devcontainer/devcontainer.json` creates a reproducible environment for developers, installs `oathtool` for manual TOTP flows, and runs `mise install` as part of the setup.
-  - Use Dev Container for onboarding, local development, and consistent dev tooling.
+- Devcontainer / GitHub Codespaces (development):
+  - `.devcontainer/devcontainer.json` is the supported contributor container
+    path. It preinstalls `mise`, `gh`, `oathtool`, then runs `mise install`,
+    `mise run setup`, and `npx playwright install --with-deps chromium` for
+    you.
+  - Use the devcontainer when you want onboarding or day-to-day development in
+    a reproducible VS Code/Codespaces workspace without installing the full
+    toolchain on your host.
 
 - Docker Compose (deployment / CI):
   - `docker-compose.yaml` is for containerized deployments or CI systems. If you use this for production, verify commands and configuration (e.g., remove `--reload` or `bun dev` and opt for production servers and built frontend assets).
 
-These two environments are separate and intended for different uses—use the Dev Container for development and Docker Compose for deployments.
+These two environments are separate and intended for different uses—use the
+devcontainer for contributor development and Docker Compose for deployments.
 
 ---
 
@@ -504,8 +523,10 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE).
 ## Contributing
 
 Contributions welcome! Start with [Run from source](docs/guide/local-dev-auth-login.md)
-for the canonical `mise run setup` -> `mise run dev` -> `/login` workflow. If
-you are using an AI coding agent in this repository, also read
+for the canonical contributor workflow, or open the repo Devcontainer / GitHub
+Codespaces path when you want the preloaded contributor environment before
+continuing with `mise run dev` and `/login`. If you are using an AI coding
+agent in this repository, also read
 [AGENTS.md](AGENTS.md).
 
 1. Check [open issues](https://github.com/ugoite/ugoite/issues) and [pull requests](https://github.com/ugoite/ugoite/pulls) for current work items

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -1592,9 +1592,11 @@ requirements:
     that explains when to update `docs/spec/features`, `docs/spec/requirements`,
     user guides, and docsite surfaces; how REQ-* traceability maps tests back to
     requirements; which local commands mirror CI; which docsite navigation files
-    must change when routes or guide entry points move; and when contributors
-    should choose the narrower `ugoite-minimum` path plus its package-local
-    quality gates instead of the full stack.
+    must change when routes or guide entry points move; which supported
+    contributor setup paths exist, including when to choose the repo
+    devcontainer and which tools/bootstrap steps it provides; and when
+    contributors should choose the narrower `ugoite-minimum` path plus its
+    package-local quality gates instead of the full stack.
 
     '
   related_spec:
@@ -1607,6 +1609,7 @@ requirements:
     - file: docs/tests/test_contributing_guide.py
       tests:
       - test_docs_req_ops_036_contributor_workflow_guide_stays_traceable
+      - test_docs_req_ops_036_contributor_docs_surface_devcontainer_setup_path
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/docs/tests/test_contributing_guide.py
+++ b/docs/tests/test_contributing_guide.py
@@ -29,7 +29,7 @@ def test_docs_req_ops_036_contributor_workflow_guide_stays_traceable() -> None:
             ),
             (
                 "mise run setup" not in contributing_text,
-                "CONTRIBUTING.md must lead with the managed setup path",
+                "CONTRIBUTING.md must keep the managed host setup path explicit",
             ),
             (
                 "ugoite-minimum/README.md" not in contributing_text,
@@ -99,6 +99,40 @@ def test_docs_req_ops_036_contributor_workflow_guide_stays_traceable() -> None:
             ),
         )
         if condition
+    ]
+
+    if details:
+        raise AssertionError("; ".join(details))
+
+
+def test_docs_req_ops_036_contributor_docs_surface_devcontainer_setup_path() -> None:
+    """REQ-OPS-036: contributor docs keep the devcontainer setup path explicit."""
+    readme_text = README.read_text(encoding="utf-8")
+    contributing_text = CONTRIBUTING.read_text(encoding="utf-8")
+
+    expected_fragments = [
+        "Devcontainer / GitHub Codespaces",
+        ".devcontainer/devcontainer.json",
+        "reproducible VS Code/Codespaces workspace",
+        "toolchain on your host",
+        "`mise`",
+        "`gh`",
+        "`oathtool`",
+        "`mise install`",
+        "`mise run setup`",
+        "`npx playwright install --with-deps chromium`",
+    ]
+    details = [
+        f"{label} missing devcontainer setup fragments: {', '.join(missing)}"
+        for label, text in (
+            ("README.md", readme_text),
+            ("CONTRIBUTING.md", contributing_text),
+        )
+        if (
+            missing := [
+                fragment for fragment in expected_fragments if fragment not in text
+            ]
+        )
     ]
 
     if details:


### PR DESCRIPTION
## Summary
- surface Devcontainer / GitHub Codespaces as a supported contributor setup path in README and CONTRIBUTING
- document when to choose it and what it preinstalls and bootstraps for contributors
- extend REQ-OPS-036 coverage and requirement mappings for the devcontainer path

## Related Issue (required)
closes #1398

## Testing
- [x] uvx ruff check docs/tests/test_contributing_guide.py
- [x] uvx ruff format --check docs/tests/test_contributing_guide.py
- [x] uv run --with pytest --with pyyaml --with bashlex pytest -W error docs/tests/test_contributing_guide.py docs/tests/test_guides.py::test_docs_req_ops_032_setup_installs_pre_commit_hooks docs/tests/test_guides.py::test_docs_req_e2e_008_source_contributor_path_stays_canonical_across_docs docs/tests/test_requirements.py -v
- [x] TMPDIR=$PWD/.tmp-runtime XDG_CACHE_HOME=$PWD/.cache-home UV_CACHE_DIR=$PWD/.cache-home/uv PIP_CACHE_DIR=$PWD/.cache-home/pip mise run test:docs