### PR TITLE
docs: surface ugoite-minimum contributor path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,22 @@ mise run test
 Before adding a new workflow-specific command, check `.github/workflows/` and
 prefer the exact local command shape CI already uses.
 
+### Portable Rust / embedding path
+
+Use `ugoite-minimum` when the change must stay pure, portable, and small enough
+for WASM-oriented or embedding consumers instead of depending on storage
+adapters, indexing engines, Python bindings, or HTTP routes.
+
+- Start with `ugoite-minimum/README.md` for the responsibility boundary and
+  `docs/spec/architecture/future-proofing.md` for the portability goals.
+- Run `mise run //ugoite-minimum:test` for the package-local Rust quality gates.
+- Run `mise run //ugoite-minimum:build:wasm` when the change touches portable
+  APIs or other browser/embedding-facing surfaces.
+
+If the change needs OpenDAL-backed workflows, backend endpoints, or CLI UX, keep
+it in `ugoite-core`, `backend`, or `ugoite-cli` instead of pushing adapter logic
+down into `ugoite-minimum`.
+
 ## 2. Decide which source of truth must change
 
 When behavior changes, update the canonical layer first:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ GitHub without comparing two different onboarding maps.
   commands live in the [Docker Compose Guide](docs/guide/docker-compose.md).
 - [Use the CLI](docs/guide/cli.md) for terminal-first workflows and scripting.
 
+If you only need the portable Rust layer for WASM, embedding, or pure helper
+work, start with [`ugoite-minimum`](ugoite-minimum/README.md) and the portable
+contributor notes in [Contributor Workflow](CONTRIBUTING.md).
+
 ### After your first step
 
 - [Understand core concepts](docs/guide/concepts.md) when you want the mental
@@ -75,6 +79,7 @@ demo login mode (`mock-oauth`) by default so browser evaluators can reach
 | --- | --- | --- | --- |
 | [Try the published release](docs/guide/container-quickstart.md) | You want the fastest visual evaluation of the published browser experience | Medium: Docker + published image pulls + frontend/backend containers + explicit login | Browser-first, but still multi-service and login-gated |
 | [Use the CLI](docs/guide/cli.md) in `core` mode | You want the lightest local-first workflow with direct filesystem access | Lowest: released CLI install + local filesystem path; no container stack required | Terminal-first experience; no browser UI or server-backed collaboration features |
+| [Work on `ugoite-minimum`](ugoite-minimum/README.md) | You are contributing portable Rust, WASM-oriented, or embedding-friendly logic without the full app stack | Medium: source checkout + `mise run setup`, then package-local `//ugoite-minimum` quality gates | Narrower scope than the full repo path; no frontend/backend/docsite behavior in scope |
 | [Run from source](docs/guide/local-dev-auth-login.md) with `mise run dev` | You are contributing, debugging, or want the full repo surfaces together | Highest: source checkout + toolchain install + backend/frontend/docsite processes + auth setup | Full contributor surface, but also the heaviest path |
 
 Today's shipped AI surface is resource-first MCP access. Read-oriented MCP

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -1591,8 +1591,10 @@ requirements:
 
     that explains when to update `docs/spec/features`, `docs/spec/requirements`,
     user guides, and docsite surfaces; how REQ-* traceability maps tests back to
-    requirements; which local commands mirror CI; and which docsite navigation
-    files must change when routes or guide entry points move.
+    requirements; which local commands mirror CI; which docsite navigation files
+    must change when routes or guide entry points move; and when contributors
+    should choose the narrower `ugoite-minimum` path plus its package-local
+    quality gates instead of the full stack.
 
     '
   related_spec:

--- a/docs/tests/test_contributing_guide.py
+++ b/docs/tests/test_contributing_guide.py
@@ -24,8 +24,34 @@ def test_docs_req_ops_036_contributor_workflow_guide_stays_traceable() -> None:
                 "README.md must link to CONTRIBUTING.md from the setup section",
             ),
             (
+                "[`ugoite-minimum`](ugoite-minimum/README.md)" not in readme_text,
+                "README.md must surface the portable ugoite-minimum entry path",
+            ),
+            (
                 "mise run setup" not in contributing_text,
                 "CONTRIBUTING.md must lead with the managed setup path",
+            ),
+            (
+                "ugoite-minimum/README.md" not in contributing_text,
+                "CONTRIBUTING.md must link to the ugoite-minimum boundary guide",
+            ),
+            (
+                "docs/spec/architecture/future-proofing.md" not in contributing_text,
+                (
+                    "CONTRIBUTING.md must link to the portability goals for "
+                    "ugoite-minimum work"
+                ),
+            ),
+            (
+                "mise run //ugoite-minimum:test" not in contributing_text,
+                (
+                    "CONTRIBUTING.md must mention the package-local "
+                    "ugoite-minimum quality gate"
+                ),
+            ),
+            (
+                "mise run //ugoite-minimum:build:wasm" not in contributing_text,
+                "CONTRIBUTING.md must mention the ugoite-minimum WASM build gate",
             ),
             (
                 "uvx pre-commit install" not in contributing_text,


### PR DESCRIPTION
## Summary
- surface `ugoite-minimum` as a newcomer and contributor entry path in the README
- document when to choose the portable Rust/WASM path in CONTRIBUTING
- extend REQ-OPS-036 and its docs regression to keep the path visible

## Related Issue (required)
closes #1397

## Testing
- PYTEST_ADDOPTS='-s' python3 -m pytest docs/tests/test_contributing_guide.py -q -W error
- PYTEST_ADDOPTS='-s' uv run --active --with bashlex python3 -m pytest docs/tests -v -W error
- PYTEST_ADDOPTS='-s' mise run setup
- PYTEST_ADDOPTS='-s' mise run test

- [x] Tests added or updated where needed
