### PR TITLE
[Bug]: Extend API error sanitization beyond members.py to the remaining endpoints

### DIFF
--- a/backend/src/app/api/endpoints/asset.py
+++ b/backend/src/app/api/endpoints/asset.py
@@ -56,7 +56,7 @@ async def upload_asset_endpoint(
         logger.exception("Failed to save asset")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to save asset",
         ) from e
 
 
@@ -85,7 +85,7 @@ async def list_assets_endpoint(
         logger.exception("Failed to list assets")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to list assets",
         ) from e
 
 
@@ -126,13 +126,13 @@ async def delete_asset_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to delete asset",
         ) from e
     except Exception as e:
         logger.exception("Failed to delete asset")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to delete asset",
         ) from e
     else:
         return {"status": "deleted", "id": asset_id}

--- a/backend/src/app/api/endpoints/audit.py
+++ b/backend/src/app/api/endpoints/audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 import ugoite_core
@@ -16,6 +17,7 @@ from app.api.endpoints.space import (
 from app.core.authorization import raise_authorization_http_error, request_identity
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 class AuditQueryParams(BaseModel):
@@ -64,16 +66,18 @@ async def list_audit_events_endpoint(
         message = str(exc)
         lowered = message.lower()
         if "integrity" in lowered or "chain" in lowered:
+            logger.warning("Failed to list audit events for %s: %s", space_id, exc)
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=message,
+                detail="Audit event chain integrity check failed",
             ) from exc
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail=f"Audit events not found for space: {space_id}",
             ) from exc
+        logger.warning("Failed to list audit events for %s: %s", space_id, exc)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=message,
+            detail="Failed to list audit events",
         ) from exc

--- a/backend/src/app/api/endpoints/forms.py
+++ b/backend/src/app/api/endpoints/forms.py
@@ -102,7 +102,7 @@ async def list_forms_endpoint(space_id: str, request: Request) -> list[dict[str,
         logger.exception("Failed to list forms")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to list forms",
         ) from e
     else:
         return visible_forms
@@ -132,7 +132,7 @@ async def list_form_types_endpoint(space_id: str, request: Request) -> list[str]
         logger.exception("Failed to list form types")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to list form types",
         ) from e
 
 
@@ -167,7 +167,7 @@ async def get_form_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load form definition",
         ) from e
 
 

--- a/backend/src/app/api/endpoints/search.py
+++ b/backend/src/app/api/endpoints/search.py
@@ -123,5 +123,5 @@ async def search_endpoint(
         logger.exception("Search failed")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to search entries",
         ) from e

--- a/backend/src/app/api/endpoints/service_accounts.py
+++ b/backend/src/app/api/endpoints/service_accounts.py
@@ -46,11 +46,11 @@ async def list_service_accounts_endpoint(
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail="Service account not found",
             ) from exc
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Invalid service account request",
         ) from exc
 
 
@@ -89,11 +89,11 @@ async def create_service_account_endpoint(
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail="Service account not found",
             ) from exc
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Invalid service account request",
         ) from exc
 
 
@@ -137,11 +137,11 @@ async def create_service_account_key_endpoint(
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail="Service account key not found",
             ) from exc
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Invalid service account key request",
         ) from exc
 
 
@@ -188,11 +188,11 @@ async def rotate_service_account_key_endpoint(
         if "not found" in lowered:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=message,
+                detail="Service account key not found",
             ) from exc
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=message,
+            detail="Invalid service account key request",
         ) from exc
 
 

--- a/backend/src/app/api/endpoints/sql_sessions.py
+++ b/backend/src/app/api/endpoints/sql_sessions.py
@@ -58,17 +58,17 @@ async def create_sql_session_endpoint(
         if msg.startswith("UGOITE_SQL_VALIDATION"):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail=msg,
+                detail="UGOITE_SQL_VALIDATION: Invalid SQL session query",
             ) from exc
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to create SQL session",
         ) from exc
     except Exception as e:
         logger.exception("Failed to create SQL session")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to create SQL session",
         ) from e
 
 
@@ -103,7 +103,7 @@ async def get_sql_session_endpoint(
         logger.exception("Failed to load SQL session")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load SQL session",
         ) from e
 
 
@@ -139,7 +139,7 @@ async def get_sql_session_count_endpoint(
         logger.exception("Failed to load SQL session count")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load SQL session count",
         ) from e
     else:
         return {"count": count}
@@ -180,7 +180,7 @@ async def get_sql_session_rows_endpoint(
         logger.exception("Failed to load SQL session rows")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load SQL session rows",
         ) from e
 
 


### PR DESCRIPTION
## Summary
- Extend API error sanitization beyond members.py to the remaining endpoints

## Related Issue (required)
Closes #1394

## Testing
- [x] Not run (PR body update only)
