### PR TITLE
[Feature]: Add ugoite-minimum to the README directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ ugoite-cli/         # Command-line interface for power users
   └─ src/
 ugoite-core/        # Rust core logic + Python bindings
   └─ src/
+ugoite-minimum/     # Portable Rust core layer for embedding/WASM-focused use
+  └─ src/
 docs/
   ├─ guide/         # User-facing guides and operator workflows
   ├─ spec/          # Technical specifications (YAML + Markdown)


### PR DESCRIPTION
## Summary
- Add ugoite-minimum to the README directory structure

## Related Issue (required)
Closes #1396

## Testing
- [x] Not run (PR body update only)
