### PR TITLE
feat(frontend): make landing CTAs auth aware

### DIFF
--- a/frontend/src/routes/about.test.tsx
+++ b/frontend/src/routes/about.test.tsx
@@ -41,7 +41,7 @@ describe("/about", () => {
 		getSessionMock().mockReset();
 	});
 
-	it("REQ-FE-044: localizes about route copy in Japanese", () => {
+	it("REQ-FE-044: localizes about route copy in Japanese", async () => {
 		getSessionMock().mockResolvedValue({ authenticated: false });
 
 		render(() => <About />);
@@ -50,10 +50,12 @@ describe("/about", () => {
 		setLocale("ja");
 
 		expect(screen.getByRole("heading", { name: "Ugoite について" })).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute(
-			"href",
-			"/login?next=%2Fspaces",
-		);
+		await waitFor(() => {
+			expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute(
+				"href",
+				"/login?next=%2Fspaces",
+			);
+		});
 		expect(screen.getByRole("link", { name: "ホームに戻る" })).toHaveAttribute("href", "/");
 		expect(screen.getByText(/柔軟な構造と高速な検索/u)).toBeInTheDocument();
 		expect(screen.getByText("ローカルファーストの所有権")).toBeInTheDocument();

--- a/frontend/src/routes/about.test.tsx
+++ b/frontend/src/routes/about.test.tsx
@@ -1,8 +1,20 @@
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, waitFor } from "@solidjs/testing-library";
 import About from "./about";
 import { setLocale } from "~/lib/i18n";
+
+type AuthApiMock = {
+	getSession: ReturnType<typeof vi.fn>;
+};
+
+const getSessionMock = () => {
+	const mock = (globalThis as typeof globalThis & { authApiMock?: AuthApiMock }).authApiMock;
+	if (!mock) {
+		throw new Error("authApiMock is not initialized");
+	}
+	return mock.getSession;
+};
 
 vi.mock("@solidjs/router", () => ({
 	A: (props: { href: string; class?: string; children: unknown }) => (
@@ -12,20 +24,36 @@ vi.mock("@solidjs/router", () => ({
 	),
 }));
 
+vi.mock("~/lib/auth-api", () => ({
+	authApi: (() => {
+		const authApiMock: AuthApiMock = {
+			getSession: vi.fn(),
+		};
+		(globalThis as typeof globalThis & { authApiMock?: AuthApiMock }).authApiMock = authApiMock;
+		return authApiMock;
+	})(),
+}));
+
 describe("/about", () => {
 	beforeEach(() => {
 		localStorage.clear();
 		setLocale("en");
+		getSessionMock().mockReset();
 	});
 
 	it("REQ-FE-044: localizes about route copy in Japanese", () => {
+		getSessionMock().mockResolvedValue({ authenticated: false });
+
 		render(() => <About />);
 
 		expect(screen.getByText("FastAPI (Python 3.13+)")).toBeInTheDocument();
 		setLocale("ja");
 
 		expect(screen.getByRole("heading", { name: "Ugoite について" })).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute("href", "/spaces");
+		expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute(
+			"href",
+			"/login?next=%2Fspaces",
+		);
 		expect(screen.getByRole("link", { name: "ホームに戻る" })).toHaveAttribute("href", "/");
 		expect(screen.getByText(/柔軟な構造と高速な検索/u)).toBeInTheDocument();
 		expect(screen.getByText("ローカルファーストの所有権")).toBeInTheDocument();
@@ -33,5 +61,15 @@ describe("/about", () => {
 		expect(screen.getByText("技術スタック")).toBeInTheDocument();
 		expect(screen.getByText("SolidStart + Tailwind CSS")).toBeInTheDocument();
 		expect(screen.getByText("FastAPI (Python 3.13+)")).toBeInTheDocument();
+	});
+
+	it("REQ-OPS-015: authenticated about page keeps Open Spaces on /spaces", async () => {
+		getSessionMock().mockResolvedValue({ authenticated: true });
+
+		render(() => <About />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("link", { name: "Open Spaces" })).toHaveAttribute("href", "/spaces");
+		});
 	});
 });

--- a/frontend/src/routes/about.tsx
+++ b/frontend/src/routes/about.tsx
@@ -45,7 +45,7 @@ export default function About() {
 		stackAiValue: t("aboutPage.stack.ai.value"),
 	}));
 	const openSpacesHref = createMemo(() =>
-		authSession()?.authenticated ? "/spaces" : "/login?next=%2Fspaces",
+		authSession()?.authenticated === false ? "/login?next=%2Fspaces" : "/spaces",
 	);
 
 	return (

--- a/frontend/src/routes/about.tsx
+++ b/frontend/src/routes/about.tsx
@@ -1,8 +1,16 @@
 import { A } from "@solidjs/router";
-import { createMemo } from "solid-js";
+import { createMemo, createResource } from "solid-js";
+import { authApi } from "~/lib/auth-api";
 import { t } from "~/lib/i18n";
 
 export default function About() {
+	const [authSession] = createResource(async () => {
+		try {
+			return await authApi.getSession();
+		} catch {
+			return { authenticated: false };
+		}
+	});
 	const copy = createMemo(() => ({
 		title: t("aboutPage.title"),
 		subtitle: t("aboutPage.subtitle"),
@@ -36,6 +44,9 @@ export default function About() {
 		stackAiLabel: t("aboutPage.stack.ai.label"),
 		stackAiValue: t("aboutPage.stack.ai.value"),
 	}));
+	const openSpacesHref = createMemo(() =>
+		authSession()?.authenticated ? "/spaces" : "/login?next=%2Fspaces",
+	);
 
 	return (
 		<main class="ui-page mx-auto">
@@ -45,7 +56,7 @@ export default function About() {
 				</h1>
 				<p class="text-base sm:text-xl ui-muted max-w-3xl mx-auto">{copy().subtitle}</p>
 				<div class="mt-8 flex justify-center gap-3 flex-wrap">
-					<A href="/spaces" class="ui-button ui-button-primary">
+					<A href={openSpacesHref()} class="ui-button ui-button-primary">
 						{copy().openSpaces}
 					</A>
 					<A href="/" class="ui-button ui-button-secondary">

--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -1,8 +1,20 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setLocale } from "~/lib/i18n";
 import HomeRoute from "./index";
+
+type AuthApiMock = {
+	getSession: ReturnType<typeof vi.fn>;
+};
+
+const getSessionMock = () => {
+	const mock = (globalThis as typeof globalThis & { authApiMock?: AuthApiMock }).authApiMock;
+	if (!mock) {
+		throw new Error("authApiMock is not initialized");
+	}
+	return mock.getSession;
+};
 
 vi.mock("@solidjs/router", () => ({
 	A: (props: { href: string; class?: string; children: unknown }) => (
@@ -12,16 +24,33 @@ vi.mock("@solidjs/router", () => ({
 	),
 }));
 
+vi.mock("~/lib/auth-api", () => ({
+	authApi: (() => {
+		const authApiMock: AuthApiMock = {
+			getSession: vi.fn(),
+		};
+		(globalThis as typeof globalThis & { authApiMock?: AuthApiMock }).authApiMock = authApiMock;
+		return authApiMock;
+	})(),
+}));
+
 describe("home route", () => {
 	beforeEach(() => {
 		localStorage.clear();
 		setLocale("en");
+		getSessionMock().mockReset();
 	});
 
 	it("REQ-E2E-008: public home page routes Learn More to the canonical getting-started docsite flow", () => {
+		getSessionMock().mockResolvedValue({ authenticated: false });
+
 		render(() => <HomeRoute />);
 
 		expect(screen.getByRole("heading", { name: "Ugoite" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Open Spaces" })).toHaveAttribute(
+			"href",
+			"/login?next=%2Fspaces",
+		);
 		expect(screen.getByRole("link", { name: "Learn More" })).toHaveAttribute(
 			"href",
 			"https://ugoite.github.io/ugoite/getting-started",
@@ -29,6 +58,8 @@ describe("home route", () => {
 	});
 
 	it("REQ-OPS-015: public home page points first-time users to /login before /spaces", () => {
+		getSessionMock().mockResolvedValue({ authenticated: false });
+
 		render(() => <HomeRoute />);
 
 		const loginLink = screen.getByRole("link", { name: "Log in" });
@@ -37,14 +68,26 @@ describe("home route", () => {
 		expect(screen.getByRole("heading", { name: "Ugoite" })).toBeInTheDocument();
 		expect(loginLink).toHaveAttribute("href", "/login");
 		expect(loginLink).toHaveClass("ui-button-primary");
-		expect(spacesLink).toHaveAttribute("href", "/spaces");
+		expect(spacesLink).toHaveAttribute("href", "/login?next=%2Fspaces");
 		expect(spacesLink).toHaveClass("ui-button-secondary");
 		expect(screen.getByText(/Start with Log in\./i)).toHaveTextContent(
 			"/spaces requires an authenticated browser session.",
 		);
 	});
 
+	it("REQ-OPS-015: authenticated home page keeps Open Spaces on the protected /spaces route", async () => {
+		getSessionMock().mockResolvedValue({ authenticated: true });
+
+		render(() => <HomeRoute />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("link", { name: "Open Spaces" })).toHaveAttribute("href", "/spaces");
+		});
+	});
+
 	it("REQ-FE-044: localizes home route CTA copy in Japanese", () => {
+		getSessionMock().mockResolvedValue({ authenticated: false });
+
 		render(() => <HomeRoute />);
 		setLocale("ja");
 
@@ -52,7 +95,10 @@ describe("home route", () => {
 			screen.getByText("ローカルファーストの知識を、検索と自動化のために構造化"),
 		).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: "ログイン" })).toHaveAttribute("href", "/login");
-		expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute("href", "/spaces");
+		expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute(
+			"href",
+			"/login?next=%2Fspaces",
+		);
 		expect(screen.getByRole("link", { name: "詳しく見る" })).toHaveAttribute(
 			"href",
 			"https://ugoite.github.io/ugoite/getting-started",

--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -41,38 +41,42 @@ describe("home route", () => {
 		getSessionMock().mockReset();
 	});
 
-	it("REQ-E2E-008: public home page routes Learn More to the canonical getting-started docsite flow", () => {
+	it("REQ-E2E-008: public home page routes Learn More to the canonical getting-started docsite flow", async () => {
 		getSessionMock().mockResolvedValue({ authenticated: false });
 
 		render(() => <HomeRoute />);
 
 		expect(screen.getByRole("heading", { name: "Ugoite" })).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "Open Spaces" })).toHaveAttribute(
-			"href",
-			"/login?next=%2Fspaces",
-		);
+		await waitFor(() => {
+			expect(screen.getByRole("link", { name: "Open Spaces" })).toHaveAttribute(
+				"href",
+				"/login?next=%2Fspaces",
+			);
+		});
 		expect(screen.getByRole("link", { name: "Learn More" })).toHaveAttribute(
 			"href",
 			"https://ugoite.github.io/ugoite/getting-started",
 		);
 	});
 
-	it("REQ-OPS-015: public home page points first-time users to /login before /spaces", () => {
+	it("REQ-OPS-015: public home page points first-time users to /login before /spaces", async () => {
 		getSessionMock().mockResolvedValue({ authenticated: false });
 
 		render(() => <HomeRoute />);
 
 		const loginLink = screen.getByRole("link", { name: "Log in" });
-		const spacesLink = screen.getByRole("link", { name: "Open Spaces" });
 
 		expect(screen.getByRole("heading", { name: "Ugoite" })).toBeInTheDocument();
 		expect(loginLink).toHaveAttribute("href", "/login");
 		expect(loginLink).toHaveClass("ui-button-primary");
-		expect(spacesLink).toHaveAttribute("href", "/login?next=%2Fspaces");
-		expect(spacesLink).toHaveClass("ui-button-secondary");
-		expect(screen.getByText(/Start with Log in\./i)).toHaveTextContent(
-			"/spaces requires an authenticated browser session.",
-		);
+		await waitFor(() => {
+			const spacesLink = screen.getByRole("link", { name: "Open Spaces" });
+			expect(spacesLink).toHaveAttribute("href", "/login?next=%2Fspaces");
+			expect(spacesLink).toHaveClass("ui-button-secondary");
+			expect(screen.getByText(/Start with Log in\./i)).toHaveTextContent(
+				"/spaces requires an authenticated browser session.",
+			);
+		});
 	});
 
 	it("REQ-OPS-015: authenticated home page keeps Open Spaces on the protected /spaces route", async () => {
@@ -85,7 +89,7 @@ describe("home route", () => {
 		});
 	});
 
-	it("REQ-FE-044: localizes home route CTA copy in Japanese", () => {
+	it("REQ-FE-044: localizes home route CTA copy in Japanese", async () => {
 		getSessionMock().mockResolvedValue({ authenticated: false });
 
 		render(() => <HomeRoute />);
@@ -95,10 +99,12 @@ describe("home route", () => {
 			screen.getByText("ローカルファーストの知識を、検索と自動化のために構造化"),
 		).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: "ログイン" })).toHaveAttribute("href", "/login");
-		expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute(
-			"href",
-			"/login?next=%2Fspaces",
-		);
+		await waitFor(() => {
+			expect(screen.getByRole("link", { name: "スペースを開く" })).toHaveAttribute(
+				"href",
+				"/login?next=%2Fspaces",
+			);
+		});
 		expect(screen.getByRole("link", { name: "詳しく見る" })).toHaveAttribute(
 			"href",
 			"https://ugoite.github.io/ugoite/getting-started",

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { A } from "@solidjs/router";
-import { createMemo } from "solid-js";
+import { createMemo, createResource } from "solid-js";
+import { authApi } from "~/lib/auth-api";
 import { t } from "~/lib/i18n";
 
 const learnMoreHref =
@@ -8,6 +9,13 @@ const learnMoreHref =
 		: "https://ugoite.github.io/ugoite/getting-started";
 
 export default function Home() {
+	const [authSession] = createResource(async () => {
+		try {
+			return await authApi.getSession();
+		} catch {
+			return { authenticated: false };
+		}
+	});
 	const copy = createMemo(() => ({
 		subtitle: t("homePage.subtitle"),
 		login: t("homePage.login"),
@@ -21,6 +29,9 @@ export default function Home() {
 		localFirstTitle: t("homePage.card.localFirst.title"),
 		localFirstDescription: t("homePage.card.localFirst.description"),
 	}));
+	const openSpacesHref = createMemo(() =>
+		authSession()?.authenticated ? "/spaces" : "/login?next=%2Fspaces",
+	);
 
 	return (
 		<main class="ui-page text-center mx-auto">
@@ -30,7 +41,7 @@ export default function Home() {
 				<A href="/login" class="ui-button ui-button-primary">
 					{copy().login}
 				</A>
-				<A href="/spaces" class="ui-button ui-button-secondary">
+				<A href={openSpacesHref()} class="ui-button ui-button-secondary">
 					{copy().openSpaces}
 				</A>
 				<a href={learnMoreHref} class="ui-button ui-button-secondary">

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -30,7 +30,7 @@ export default function Home() {
 		localFirstDescription: t("homePage.card.localFirst.description"),
 	}));
 	const openSpacesHref = createMemo(() =>
-		authSession()?.authenticated ? "/spaces" : "/login?next=%2Fspaces",
+		authSession()?.authenticated === false ? "/login?next=%2Fspaces" : "/spaces",
 	);
 
 	return (


### PR DESCRIPTION
## Summary
Make landing-page CTAs choose the protected /spaces route only after auth state is known.

## Related Issue (required)
closes #1499

## Testing
- [x] npm run test:run -- src/routes/index.test.tsx src/routes/about.test.tsx