### PR TITLE
[Bug]: Add non-Linux guidance to the published container quick start

### DIFF
--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -11,6 +11,12 @@ it still needs Docker, published image pulls, and a two-service stack. If you
 want the lightest local-first start, use the [CLI Guide](cli.md) in `core`
 mode instead.
 
+If you're using Docker Desktop on macOS or Windows, or running the stack from
+WSL, keep the shared bind-mount path inside the filesystem location that your
+platform already exposes to containers. The permission repair commands below
+are the native Linux bind-mount path, not the default first step on those
+desktop platforms.
+
 For local development from source, keep using
 [Docker Compose Guide](docker-compose.md).
 If you want the same published two-service topology on Kubernetes, use
@@ -97,7 +103,7 @@ the first browser and CLI session both have a ready workspace. The reserved
 `admin-space` still exists for admin-only workflows, but `/spaces` keeps it in a
 separate admin section so the first visible workspace path stays newcomer-friendly.
 For more detail on the explicit browser login flow, see
-[Local Development Authentication and Login](local-dev-auth-login.md).
+[Local Dev Auth Login](local-dev-auth-login.md).
 For the concrete post-login space -> form -> entry path, continue to
 [Browser Walkthrough: First Space, Form, and Entry](browser-first-entry.md).
 
@@ -149,14 +155,6 @@ ls ./spaces
 find ./spaces -maxdepth 2 -type f | head
 ```
 
-Click **Continue with Mock OAuth** to reach `/spaces`. The shipped compose file
-bootstraps the `default` space at startup so the first browser and CLI session
-both have a ready workspace. For the canonical auth-mode comparison and more
-detail on the explicit browser login flow, see
-[Local Development Authentication and Login](local-dev-auth-login.md).
-
-This published quick start intentionally advertises `mock-oauth`.
-
 ## Next steps
 
 - The `default` space is the starter workspace that the published quick start
@@ -194,18 +192,16 @@ These are the supported release-compose environment variables for the shipped
 | `UGOITE_DEV_AUTH_MODE` | `passkey-totp` | Dev login mode inside the shipped manifest. Set it to `mock-oauth` only for an explicit local demo flow. |
 | `UGOITE_DEV_USER_ID` | required | Username/user id for the explicit login flow you enable. The quick-start example above sets `dev-local-user` explicitly. |
 | `UGOITE_DEV_SIGNING_KID` | `release-compose-local-v1` | Key id paired with your install-specific bearer signing material. |
-| `UGOITE_DEV_SIGNING_SECRET` | required 32-byte random secret | Secret used to mint dev bearer tokens for this install. |
-| `UGOITE_AUTH_BEARER_SECRETS` | required 32-byte random secret | Bearer verification secret set accepted by the backend. For the quick start, reuse the same signing kid + secret pair. |
+| `UGOITE_DEV_SIGNING_SECRET` | required unique value | Secret used to mint dev bearer tokens for this install. |
+| `UGOITE_AUTH_BEARER_SECRETS` | required unique value | Bearer verification secret set accepted by the backend. For the quick start, reuse the same signing kid + secret pair. |
 | `UGOITE_AUTH_BEARER_ACTIVE_KIDS` | `release-compose-local-v1` | Active bearer-token key ids exposed to the backend. |
-| `UGOITE_DEV_AUTH_PROXY_TOKEN` | required 32-byte random secret | Shared token between frontend and backend so `/login` can reach the explicit auth endpoints. |
+| `UGOITE_DEV_AUTH_PROXY_TOKEN` | required unique value | Shared token between frontend and backend so `/login` can reach the explicit auth endpoints. |
 
 The shipped compose file keeps `BACKEND_URL=http://backend:8000` fixed inside
 the Compose network. By default it stays on `passkey-totp`; the quick-start
 example above opts into `mock-oauth` only after generating install-specific
-secrets. It also pre-wires the signing/bearer settings needed for the explicit
-`mock-oauth` browser login flow. For the canonical auth-mode comparison, see
-[Local Development Authentication and Login](local-dev-auth-login.md). For a
-broader environment reference, see [Environment Variable Matrix](env-matrix.md).
+secrets. For a broader mode-by-mode reference, see
+[Environment Variable Matrix](env-matrix.md).
 
 ## Version selectors
 

--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -11,11 +11,12 @@ it still needs Docker, published image pulls, and a two-service stack. If you
 want the lightest local-first start, use the [CLI Guide](cli.md) in `core`
 mode instead.
 
-If you're using Docker Desktop on macOS or Windows, or running the stack from
-WSL, keep the shared bind-mount path inside the filesystem location that your
-platform already exposes to containers. The permission repair commands below
-are the native Linux bind-mount path, not the default first step on those
-desktop platforms.
+If you're using Docker Desktop on macOS or Windows, keep the shared bind-mount
+path inside the filesystem location that your platform already exposes to
+containers. If you're running the stack from WSL, keep the path inside the
+distro-local Linux filesystem that your WSL distro exposes to containers. The
+permission repair commands below are the native Linux bind-mount path, not the
+default first step on those desktop platforms.
 
 For local development from source, keep using
 [Docker Compose Guide](docker-compose.md).
@@ -102,8 +103,9 @@ involved. The shipped compose file bootstraps the `default` space at startup so
 the first browser and CLI session both have a ready workspace. The reserved
 `admin-space` still exists for admin-only workflows, but `/spaces` keeps it in a
 separate admin section so the first visible workspace path stays newcomer-friendly.
-For more detail on the explicit browser login flow, see
-[Local Dev Auth Login](local-dev-auth-login.md).
+For more detail on the explicit browser login flow and the canonical auth-mode
+comparison, see [Local Development Authentication and Login]
+(local-dev-auth-login.md).
 For the concrete post-login space -> form -> entry path, continue to
 [Browser Walkthrough: First Space, Form, and Entry](browser-first-entry.md).
 
@@ -192,16 +194,17 @@ These are the supported release-compose environment variables for the shipped
 | `UGOITE_DEV_AUTH_MODE` | `passkey-totp` | Dev login mode inside the shipped manifest. Set it to `mock-oauth` only for an explicit local demo flow. |
 | `UGOITE_DEV_USER_ID` | required | Username/user id for the explicit login flow you enable. The quick-start example above sets `dev-local-user` explicitly. |
 | `UGOITE_DEV_SIGNING_KID` | `release-compose-local-v1` | Key id paired with your install-specific bearer signing material. |
-| `UGOITE_DEV_SIGNING_SECRET` | required unique value | Secret used to mint dev bearer tokens for this install. |
-| `UGOITE_AUTH_BEARER_SECRETS` | required unique value | Bearer verification secret set accepted by the backend. For the quick start, reuse the same signing kid + secret pair. |
+| `UGOITE_DEV_SIGNING_SECRET` | required 32-byte random secret | Secret used to mint dev bearer tokens for this install. |
+| `UGOITE_AUTH_BEARER_SECRETS` | required 32-byte random secret | Bearer verification secret set accepted by the backend. For the quick start, reuse the same signing kid + secret pair. |
 | `UGOITE_AUTH_BEARER_ACTIVE_KIDS` | `release-compose-local-v1` | Active bearer-token key ids exposed to the backend. |
-| `UGOITE_DEV_AUTH_PROXY_TOKEN` | required unique value | Shared token between frontend and backend so `/login` can reach the explicit auth endpoints. |
+| `UGOITE_DEV_AUTH_PROXY_TOKEN` | required 32-byte random secret | Shared token between frontend and backend so `/login` can reach the explicit auth endpoints. |
 
 The shipped compose file keeps `BACKEND_URL=http://backend:8000` fixed inside
 the Compose network. By default it stays on `passkey-totp`; the quick-start
 example above opts into `mock-oauth` only after generating install-specific
-secrets. For a broader mode-by-mode reference, see
-[Environment Variable Matrix](env-matrix.md).
+secrets. For the canonical auth-mode comparison, see
+[Local Development Authentication and Login](local-dev-auth-login.md). For a
+broader mode-by-mode reference, see [Environment Variable Matrix](env-matrix.md).
 
 ## Version selectors
 

--- a/docs/guide/troubleshooting-compose-startup.md
+++ b/docs/guide/troubleshooting-compose-startup.md
@@ -5,10 +5,10 @@ the normal login flow. It covers the earlier failure modes that happen before
 [Troubleshooting Unauthorized Spaces Page](troubleshooting-unauthorized-spaces.md)
 becomes relevant.
 
-On Docker Desktop for macOS or Windows, and on WSL, start by checking the shared
-filesystem path that your platform mounts into containers. The Linux ACL and
-ownership commands below are the native bind-mount repair path, not the first
-step for those desktop setups.
+On Docker Desktop for macOS or Windows, start by checking the shared filesystem
+path that your platform mounts into containers. If you're on WSL, start by
+checking the distro-local Linux filesystem path that your WSL instance mounts
+into containers. The Linux ACL and ownership commands below are the native bind-mount repair path, not the first step for those desktop setups.
 
 Use the same Compose command prefix that you used to start the stack:
 

--- a/docs/guide/troubleshooting-compose-startup.md
+++ b/docs/guide/troubleshooting-compose-startup.md
@@ -5,6 +5,11 @@ the normal login flow. It covers the earlier failure modes that happen before
 [Troubleshooting Unauthorized Spaces Page](troubleshooting-unauthorized-spaces.md)
 becomes relevant.
 
+On Docker Desktop for macOS or Windows, and on WSL, start by checking the shared
+filesystem path that your platform mounts into containers. The Linux ACL and
+ownership commands below are the native bind-mount repair path, not the first
+step for those desktop setups.
+
 Use the same Compose command prefix that you used to start the stack:
 
 - Source checkout: `docker compose`

--- a/docs/tests/test_release_compose_directory_permissions.py
+++ b/docs/tests/test_release_compose_directory_permissions.py
@@ -53,6 +53,20 @@ def test_docs_req_ops_017_release_quickstart_avoids_world_writable_spaces() -> N
                 ),
             ),
             (
+                "Docker Desktop on macOS or Windows" not in quickstart_text,
+                (
+                    "container-quickstart.md must call out the Docker Desktop and "
+                    "WSL path separately from Linux bind mounts"
+                ),
+            ),
+            (
+                "native Linux bind-mount path" not in quickstart_text,
+                (
+                    "container-quickstart.md must say the permission repair "
+                    "commands are Linux-only guidance"
+                ),
+            ),
+            (
                 'setfacl -m u:10001:rwx,d:u:10001:rwx "$SPACE_PATH"'
                 not in troubleshooting_text,
                 ("troubleshooting-compose-startup.md must try ACL-based writes first"),
@@ -76,6 +90,20 @@ def test_docs_req_ops_017_release_quickstart_avoids_world_writable_spaces() -> N
                 (
                     "troubleshooting-compose-startup.md must explain why the "
                     "fallback preserves host ownership"
+                ),
+            ),
+            (
+                "Docker Desktop for macOS or Windows" not in troubleshooting_text,
+                (
+                    "troubleshooting-compose-startup.md must call out the "
+                    "Docker Desktop and WSL path separately from Linux bind mounts"
+                ),
+            ),
+            (
+                "native bind-mount repair path" not in troubleshooting_text,
+                (
+                    "troubleshooting-compose-startup.md must say the repair "
+                    "commands are Linux-only guidance"
                 ),
             ),
             (


### PR DESCRIPTION
## Summary
Tighten the published container quick start and troubleshooting guidance for desktop and WSL mount paths, and restore the canonical auth-mode wording plus stricter auth-secret guidance.

## Related Issue (required)
Closes #1501

## Testing
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_release_compose_auth_secrets.py docs/tests/test_release_compose_directory_permissions.py -q
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -k 'req_ops_015_local_dev_auth_docs_cover_manual_modes or req_ops_015_auth_profile_docs_describe_mode_and_next_step' -q
