### PR TITLE
[Feature]: Align the docsite CLI landing page with the verify-first install guidance

### DIFF
--- a/docsite/src/lib/app-cli-published-install.test.ts
+++ b/docsite/src/lib/app-cli-published-install.test.ts
@@ -8,16 +8,21 @@ const cliPage = readFileSync(
 );
 
 test("REQ-OPS-018: app CLI landing page exposes the released install path before source builds", () => {
-	const publishedHeading = "Published install (recommended)";
+	const verifyFirstHeading = "Verify-first archive install (recommended)";
+	const bootstrapHeading = "Bootstrap helper (secondary)";
 	const sourceHeading = "Build from source (contributors)";
 
-	expect(cliPage).toContain(publishedHeading);
+	expect(cliPage).toContain(verifyFirstHeading);
+	expect(cliPage).toContain("VERSION=0.0.1-beta.13");
 	expect(cliPage).toContain(
 		"npm install -g ugoite && ugoite-install && ugoite --help",
 	);
 	expect(cliPage).toContain(sourceHeading);
 	expect(cliPage).toContain('href={withBasePath("/docs/guide/cli")}');
-	expect(cliPage.indexOf(publishedHeading)).toBeLessThan(
+	expect(cliPage.indexOf(verifyFirstHeading)).toBeLessThan(
+		cliPage.indexOf(bootstrapHeading),
+	);
+	expect(cliPage.indexOf(bootstrapHeading)).toBeLessThan(
 		cliPage.indexOf(sourceHeading),
 	);
 });

--- a/docsite/src/pages/app/cli/index.astro
+++ b/docsite/src/pages/app/cli/index.astro
@@ -5,6 +5,8 @@ import { withBasePath } from "../../../lib/base-path";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+const localDevAuthGuideHref = withBasePath("/docs/guide/local-dev-auth-login");
+
 const toc = [
   { id: "overview", title: "Overview" },
   { id: "setup", title: "Quick Start" },
@@ -55,7 +57,7 @@ const verifyFirstCommand = [
           <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">1. Verify-first archive install (recommended)</p>
           <TerminalCommand command={verifyFirstCommand} />
           <p style="font-size: 0.75rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">
-            This matches the checksum-first release flow in the canonical <a href={withBasePath("/docs/guide/cli")}>CLI Guide</a>. If you want fewer steps after trusting the helper itself, use the bootstrap helper below instead.
+            This Linux x86_64 example matches the checksum-first release flow in the canonical <a href={withBasePath("/docs/guide/cli")}>CLI Guide</a>. Swap <code>TARGET</code> for your platform's published archive before copying it on macOS, or use the bootstrap helper below if you already trust the installer script.
           </p>
         </div>
         <div>
@@ -83,7 +85,12 @@ const verifyFirstCommand = [
         </div>
         <div>
           <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">7. List spaces from source</p>
+          <TerminalCommand command="cargo run -q -p ugoite-cli -- config current && cargo run -q -p ugoite-cli -- space list" />
           <TerminalCommand command="mkdir -p ./spaces && cargo run -q -p ugoite-cli -- space list ./spaces" />
+          <p style="font-size: 0.75rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">
+            Backend mode drops the local-root argument because the CLI now talks to the server. Use <code>config current</code> before copy-pasting commands when you switch between modes, and follow{" "}
+            <a href={localDevAuthGuideHref} target="_blank" rel="noreferrer">Local Dev Auth/Login</a> for the full browser + CLI auth walkthrough.
+          </p>
         </div>
       </div>
   </section>

--- a/docsite/src/pages/app/cli/index.astro
+++ b/docsite/src/pages/app/cli/index.astro
@@ -78,7 +78,11 @@ const verifyFirstCommand = [
           <TerminalCommand command="cargo run -q -p ugoite-cli -- config set --mode backend --backend-url http://127.0.0.1:8000" />
         </div>
         <div>
-          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">6. List spaces from source</p>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">6. Authenticate against the backend</p>
+          <TerminalCommand command="cargo run -q -p ugoite-cli -- auth login --mock-oauth" />
+        </div>
+        <div>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">7. List spaces from source</p>
           <TerminalCommand command="mkdir -p ./spaces && cargo run -q -p ugoite-cli -- space list ./spaces" />
         </div>
       </div>

--- a/docsite/src/pages/app/cli/index.astro
+++ b/docsite/src/pages/app/cli/index.astro
@@ -74,7 +74,11 @@ const verifyFirstCommand = [
           <TerminalCommand command="cargo run -q -p ugoite-cli -- --help" />
         </div>
         <div>
-          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">5. List spaces from source</p>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">5. Switch to backend mode</p>
+          <TerminalCommand command="cargo run -q -p ugoite-cli -- config set --mode backend --backend-url http://127.0.0.1:8000" />
+        </div>
+        <div>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">6. List spaces from source</p>
           <TerminalCommand command="mkdir -p ./spaces && cargo run -q -p ugoite-cli -- space list ./spaces" />
         </div>
       </div>

--- a/docsite/src/pages/app/cli/index.astro
+++ b/docsite/src/pages/app/cli/index.astro
@@ -5,8 +5,6 @@ import { withBasePath } from "../../../lib/base-path";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const localDevAuthGuideHref = withBasePath("/docs/guide/local-dev-auth-login");
-
 const toc = [
   { id: "overview", title: "Overview" },
   { id: "setup", title: "Quick Start" },
@@ -19,6 +17,20 @@ const commandOutputs = await fs
   .readFile(generatedPath, "utf-8")
   .then((raw) => JSON.parse(raw) as { command: string; output: string }[])
   .catch(() => []);
+
+const verifyFirstCommand = [
+  "VERSION=0.0.1-beta.13",
+  "TARGET=x86_64-unknown-linux-gnu",
+  'BASE_URL="https://github.com/ugoite/ugoite/releases/download/v${VERSION}"',
+  "",
+  'curl -fsSLO "${BASE_URL}/ugoite-v${VERSION}-${TARGET}.tar.gz"',
+  'curl -fsSLO "${BASE_URL}/ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"',
+  'sha256sum -c "ugoite-v${VERSION}-${TARGET}.tar.gz.sha256"',
+  'tar -xzf "ugoite-v${VERSION}-${TARGET}.tar.gz"',
+  'mkdir -p "$HOME/.local/bin"',
+  'install -m 0755 ugoite "$HOME/.local/bin/ugoite"',
+  "ugoite --help",
+].join("\n");
 ---
 
 <BaseLayout title="CLI | Ugoite" description="Command-line interface for scriptable knowledge management." toc={toc}
@@ -40,36 +52,32 @@ const commandOutputs = await fs
       <h2 style="font-size: 1.25rem; font-weight: 700; margin-bottom: 1rem;">Quick Start</h2>
       <div style="display: grid; gap: 0.75rem;">
         <div>
-          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">1. Published install (recommended)</p>
-          <TerminalCommand command="npm install -g ugoite && ugoite-install && ugoite --help" />
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">1. Verify-first archive install (recommended)</p>
+          <TerminalCommand command={verifyFirstCommand} />
           <p style="font-size: 0.75rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">
-            Use this when you want the released CLI without cloning the repository. For the full installer and archive options, continue to the canonical <a href={withBasePath("/docs/guide/cli")}>CLI Guide</a>.
+            This matches the checksum-first release flow in the canonical <a href={withBasePath("/docs/guide/cli")}>CLI Guide</a>. If you want fewer steps after trusting the helper itself, use the bootstrap helper below instead.
           </p>
         </div>
         <div>
-          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">2. Build from source (contributors)</p>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">2. Bootstrap helper (secondary)</p>
+          <TerminalCommand command="npm install -g ugoite && ugoite-install && ugoite --help" />
+          <p style="font-size: 0.75rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">
+            Use this when you already trust the helper and want the quicker handoff to the shared installer script.
+          </p>
+        </div>
+        <div>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">3. Build from source (contributors)</p>
           <TerminalCommand command="mise run setup" />
         </div>
         <div>
-          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">3. Check the CLI from source</p>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">4. Check the CLI from source</p>
           <TerminalCommand command="cargo run -q -p ugoite-cli -- --help" />
         </div>
         <div>
-          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">4. List spaces from source</p>
+          <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">5. List spaces from source</p>
           <TerminalCommand command="mkdir -p ./spaces && cargo run -q -p ugoite-cli -- space list ./spaces" />
         </div>
       </div>
-      <div>
-        <p style="font-size: 0.8125rem; font-weight: 600; margin-bottom: 0.375rem;">5. Switch to backend mode</p>
-        <TerminalCommand command="cargo run -q -p ugoite-cli -- config set --mode backend --backend-url http://127.0.0.1:8000" />
-        <TerminalCommand command="cargo run -q -p ugoite-cli -- auth login --mock-oauth" />
-        <TerminalCommand command="cargo run -q -p ugoite-cli -- config current && cargo run -q -p ugoite-cli -- space list" />
-        <p style="font-size: 0.75rem; color: var(--doc-muted); margin-top: 0.5rem; line-height: 1.6;">
-          Backend mode drops the local-root argument because the CLI now talks to the server. Use <code>config current</code> before copy-pasting commands when you switch between modes, and follow{" "}
-          <a href={localDevAuthGuideHref} target="_blank" rel="noreferrer">Local Dev Auth/Login</a> for the full browser + CLI auth walkthrough.
-        </p>
-      </div>
-    </div>
   </section>
 
   {commandOutputs.length > 0 && (


### PR DESCRIPTION
## Summary
- Updated the docsite CLI landing page to lead with the verify-first archive install and call out the Linux x86_64 example explicitly.
- Kept the bootstrap helper as the secondary option and restored the backend-mode routing/auth example.

## Related Issue (required)
Closes #1503

## Testing
- [x] bun test src/lib/app-cli-published-install.test.ts src/lib/app-cli-backend-mode.test.ts
- [x] bun run build