### PR TITLE
[Bug]: Replace pinned 0.1.0 install examples with published release references

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ugoite --help
 Pin an exact published package version when needed:
 
 ```bash
-npm install -g ugoite@0.1.0
+npm install -g ugoite@0.0.1
 ugoite-install
 ugoite --help
 ```
@@ -198,7 +198,7 @@ ugoite --help
 Pin an exact release when you do not want the newest stable build:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/ugoite/main/scripts/install-ugoite-cli.sh | env UGOITE_VERSION=0.1.0 bash
+curl -fsSL https://raw.githubusercontent.com/ugoite/ugoite/main/scripts/install-ugoite-cli.sh | env UGOITE_VERSION=0.0.1-beta.13 bash
 ugoite --help
 ```
 
@@ -206,16 +206,16 @@ Install an exact release with a platform-specific one-liner:
 
 ```bash
 # Linux x86_64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-x86_64-unknown-linux-gnu.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-x86_64-unknown-linux-gnu.install.sh | bash
 
 # Linux arm64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-aarch64-unknown-linux-gnu.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-aarch64-unknown-linux-gnu.install.sh | bash
 
 # macOS x86_64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-x86_64-apple-darwin.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-x86_64-apple-darwin.install.sh | bash
 
 # macOS arm64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-aarch64-apple-darwin.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-aarch64-apple-darwin.install.sh | bash
 ```
 
 For contributor-oriented Cargo workflows, see [CLI Guide](docs/guide/cli.md).

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -15,7 +15,7 @@ If you want the most auditable published path, install from an exact release
 archive and verify its checksum before you extract or run anything:
 
 ```bash
-VERSION=0.1.0
+VERSION=0.0.1-beta.13
 TARGET=x86_64-unknown-linux-gnu
 BASE_URL="https://github.com/ugoite/ugoite/releases/download/v${VERSION}"
 
@@ -52,10 +52,10 @@ ugoite-install
 ugoite --help
 ```
 
-Pin an exact package version when you want the matching published release:
+Pin an exact package version when you want the matching published package:
 
 ```bash
-npm install -g ugoite@0.1.0
+npm install -g ugoite@0.0.1
 ugoite-install
 ugoite --help
 ```
@@ -76,7 +76,7 @@ ugoite --help
 Pin an exact version when you want a specific release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ugoite/ugoite/main/scripts/install-ugoite-cli.sh | env UGOITE_VERSION=0.1.0 bash
+curl -fsSL https://raw.githubusercontent.com/ugoite/ugoite/main/scripts/install-ugoite-cli.sh | env UGOITE_VERSION=0.0.1-beta.13 bash
 ugoite --help
 ```
 
@@ -84,16 +84,16 @@ Install an exact release with a platform-specific one-liner:
 
 ```bash
 # Linux x86_64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-x86_64-unknown-linux-gnu.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-x86_64-unknown-linux-gnu.install.sh | bash
 
 # Linux arm64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-aarch64-unknown-linux-gnu.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-aarch64-unknown-linux-gnu.install.sh | bash
 
 # macOS x86_64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-x86_64-apple-darwin.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-x86_64-apple-darwin.install.sh | bash
 
 # macOS arm64
-curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.1.0/ugoite-v0.1.0-aarch64-apple-darwin.install.sh | bash
+curl -fsSL https://github.com/ugoite/ugoite/releases/download/v0.0.1-beta.13/ugoite-v0.0.1-beta.13-aarch64-apple-darwin.install.sh | bash
 ```
 
 The installer writes `ugoite` into `~/.local/bin` by default. Override the
@@ -107,9 +107,9 @@ Supported release artifacts currently target:
 - `aarch64-apple-darwin`
 
 Release archives use predictable names such as
-`ugoite-v0.1.0-x86_64-unknown-linux-gnu.tar.gz` plus a matching `.sha256`
+`ugoite-v0.0.1-beta.13-x86_64-unknown-linux-gnu.tar.gz` plus a matching `.sha256`
 checksum file. Matching one-liner installer assets use predictable names such as
-`ugoite-v0.1.0-x86_64-unknown-linux-gnu.install.sh`.
+`ugoite-v0.0.1-beta.13-x86_64-unknown-linux-gnu.install.sh`.
 
 ## Build from source (contributors)
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -357,17 +357,17 @@ REQUIRED_INSTALL_CLI_SCRIPT_FRAGMENTS = {
     "shasum -a 256",
 }
 REQUIRED_CLI_INSTALLER_ASSET_FRAGMENTS = {
-    "ugoite-v0.1.0-x86_64-unknown-linux-gnu.install.sh",
-    "ugoite-v0.1.0-aarch64-unknown-linux-gnu.install.sh",
-    "ugoite-v0.1.0-x86_64-apple-darwin.install.sh",
-    "ugoite-v0.1.0-aarch64-apple-darwin.install.sh",
+    "ugoite-v0.0.1-beta.13-x86_64-unknown-linux-gnu.install.sh",
+    "ugoite-v0.0.1-beta.13-aarch64-unknown-linux-gnu.install.sh",
+    "ugoite-v0.0.1-beta.13-x86_64-apple-darwin.install.sh",
+    "ugoite-v0.0.1-beta.13-aarch64-apple-darwin.install.sh",
 }
 REQUIRED_CLI_README_FRAGMENTS = {
     "npm install -g ugoite",
     "ugoite-install",
     "install-ugoite-cli.sh",
     "ugoite --help",
-    "UGOITE_VERSION=0.1.0",
+    "UGOITE_VERSION=0.0.1-beta.13",
     *REQUIRED_CLI_INSTALLER_ASSET_FRAGMENTS,
 }
 REQUIRED_CLI_GUIDE_FRAGMENTS = {

--- a/packages/ugoite/bin/ugoite-install
+++ b/packages/ugoite/bin/ugoite-install
@@ -42,7 +42,7 @@ Bootstrap the released Ugoite Rust CLI from the public installer package.
 
 Usage:
   ugoite-install
-  UGOITE_VERSION=0.1.0 ugoite-install
+  UGOITE_VERSION=0.0.1-beta.13 ugoite-install
 
 Environment:
   UGOITE_VERSION                  Exact CLI release to install. Defaults to the package version.


### PR DESCRIPTION
Fixes #1495