### PR TITLE
ci: support linux/arm64 multi-arch Docker images for release publish

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -160,7 +160,7 @@ jobs:
     name: Docker images
     if: ${{ inputs.push }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 40
+    timeout-minutes: 80
     permissions:
       contents: read
       packages: write
@@ -172,6 +172,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU emulation for cross-platform builds
+        uses: docker/setup-qemu-action@v3
 
       - name: Authenticate GHCR pushes
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
@@ -219,6 +222,7 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.backend-tags.outputs.tags }}
           cache-from: |
             type=gha,scope=backend-image
@@ -270,6 +274,7 @@ jobs:
           context: ./frontend
           file: ./frontend/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.frontend-tags.outputs.tags }}
           cache-from: |
             type=gha,scope=frontend-image

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -174,7 +174,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Set up QEMU emulation for cross-platform builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
 
       - name: Authenticate GHCR pushes
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4


### PR DESCRIPTION
## Summary
Enable multi-architecture Docker builds for release image publish by adding QEMU support and pinning workflow actions to immutable commit SHAs.

## Related Issue (required)
closes #1554

## Testing
- [x] Verified workflow action ref is fully pinned to SHA in `.github/workflows/docker-images.yml`
- [x] Verified PR body contains required sections and close issue reference
- [x] Pushed branch to remote for CI re-run
