### PR TITLE
[Feature]: Split CI by event (push / pull_request / merge_group / main) and document the policy

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -16,73 +16,73 @@
       "context": "Devcontainer CI",
       "workflow": ".github/workflows/devcontainer-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["pull_request", "merge_group"]
     },
     {
       "context": "Docker Build CI",
       "workflow": ".github/workflows/docker-build-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["merge_group"]
     },
     {
       "context": "Docsite CI",
       "workflow": ".github/workflows/docsite-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["pull_request", "merge_group"]
     },
     {
       "context": "E2E Tests",
       "workflow": ".github/workflows/e2e-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["pull_request", "merge_group"]
     },
     {
       "context": "Frontend CI",
       "workflow": ".github/workflows/frontend-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["pull_request", "merge_group"]
     },
     {
       "context": "Pre-commit CI",
       "workflow": ".github/workflows/pre-commit-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["merge_group"]
     },
     {
       "context": "Python CI",
       "workflow": ".github/workflows/python-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["pull_request", "merge_group"]
     },
     {
       "context": "Release Quickstart Verify CI",
       "workflow": ".github/workflows/release-quickstart-verify-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["merge_group"]
     },
     {
       "context": "README Command Guard",
       "workflow": ".github/workflows/readme-command-guard.yml",
       "job_id": "required-check",
-      "events": ["pull_request", "merge_group"]
+      "events": ["push", "pull_request", "merge_group"]
     },
     {
       "context": "Rust CI",
       "workflow": ".github/workflows/rust-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["merge_group"]
     },
     {
       "context": "SBOM CI",
       "workflow": ".github/workflows/sbom-ci.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["merge_group"]
     },
     {
       "context": "ScanCode",
       "workflow": ".github/workflows/scancode.yml",
       "job_id": "required-check",
-      "events": ["push", "pull_request", "merge_group"]
+      "events": ["merge_group"]
     },
     {
       "context": "Shell CI",

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-  merge_group:
-    branches:
-      - main
   schedule:
     - cron: "16 5 * * 0"
   workflow_dispatch:

--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
   merge_group:
     branches:
       - main
@@ -55,7 +52,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
-          BEFORE_SHA: ${{ github.event.before || '' }}
           HEAD_SHA: ${{ github.sha }}
         run: |
           python3 - <<'PY'
@@ -87,33 +83,22 @@ jobs:
           if event_name == "merge_group":
               should_run = True
               selection_reason = "merge_group always runs devcontainer smoke"
-          else:
-              base_sha = (
-                  os.environ["PR_BASE_SHA"].strip()
-                  if event_name == "pull_request"
-                  else os.environ["BEFORE_SHA"].strip()
+            else:
+              base_sha = os.environ["PR_BASE_SHA"].strip()
+              if not base_sha:
+                raise SystemExit("pull_request tiering requires PR_BASE_SHA")
+
+              raw = subprocess.check_output(
+                ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
+                text=True,
               )
-              if not base_sha or set(base_sha) == {"0"}:
-                  should_run = True
-                  selection_reason = (
-                      f"{event_name} without a comparable base runs devcontainer smoke"
-                  )
-              else:
-                  raw = subprocess.check_output(
-                      ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
-                      text=True,
-                  )
-                  changed_files = [
-                      line.strip()
-                      for line in raw.splitlines()
-                      if line.strip()
-                  ]
-                  should_run = any(matches(path) for path in changed_files)
-                  selection_reason = (
-                      f"{event_name} touched devcontainer or setup inputs"
-                      if should_run
-                      else f"{event_name} skipped devcontainer smoke because no tracked inputs changed"
-                  )
+              changed_files = [line.strip() for line in raw.splitlines() if line.strip()]
+              should_run = any(matches(path) for path in changed_files)
+              selection_reason = (
+                f"{event_name} touched devcontainer or setup inputs"
+                if should_run
+                else f"{event_name} skipped devcontainer smoke because no tracked inputs changed"
+              )
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
               handle.write(f"should_run={'true' if should_run else 'false'}\n")

--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -83,21 +83,23 @@ jobs:
           if event_name == "merge_group":
               should_run = True
               selection_reason = "merge_group always runs devcontainer smoke"
-            else:
+          else:
               base_sha = os.environ["PR_BASE_SHA"].strip()
               if not base_sha:
-                raise SystemExit("pull_request tiering requires PR_BASE_SHA")
+                  raise SystemExit("pull_request tiering requires PR_BASE_SHA")
 
               raw = subprocess.check_output(
-                ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
-                text=True,
+                  ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
+                  text=True,
               )
-              changed_files = [line.strip() for line in raw.splitlines() if line.strip()]
+              changed_files = [
+                  line.strip() for line in raw.splitlines() if line.strip()
+              ]
               should_run = any(matches(path) for path in changed_files)
               selection_reason = (
-                f"{event_name} touched devcontainer or setup inputs"
-                if should_run
-                else f"{event_name} skipped devcontainer smoke because no tracked inputs changed"
+                  f"{event_name} touched devcontainer or setup inputs"
+                  if should_run
+                  else f"{event_name} skipped devcontainer smoke because no tracked inputs changed"
               )
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:

--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -1,9 +1,6 @@
 name: Docker Build CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/docsite-ci.yml
+++ b/.github/workflows/docsite-ci.yml
@@ -1,9 +1,6 @@
 name: Docsite CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -56,7 +56,7 @@ jobs:
           from pathlib import PurePosixPath
 
           event_name = os.environ["EVENT_NAME"]
-            if event_name == "merge_group":
+          if event_name == "merge_group":
               test_type = "full"
               selection_reason = "merge_group requires full E2E coverage"
           else:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,9 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -59,9 +56,9 @@ jobs:
           from pathlib import PurePosixPath
 
           event_name = os.environ["EVENT_NAME"]
-          if event_name in {"merge_group", "push"}:
+            if event_name == "merge_group":
               test_type = "full"
-              selection_reason = f"{event_name} requires full E2E coverage"
+              selection_reason = "merge_group requires full E2E coverage"
           else:
               base_sha = os.environ["PR_BASE_SHA"].strip()
               head_sha = os.environ["HEAD_SHA"].strip()

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,9 +1,6 @@
 name: Frontend CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/pre-commit-ci.yml
+++ b/.github/workflows/pre-commit-ci.yml
@@ -1,12 +1,6 @@
 name: Pre-commit CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   merge_group:
     branches:
       - main

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,9 +1,6 @@
 name: Python CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/readme-command-guard.yml
+++ b/.github/workflows/readme-command-guard.yml
@@ -1,6 +1,9 @@
 name: README Command Guard
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/release-quickstart-verify-ci.yml
+++ b/.github/workflows/release-quickstart-verify-ci.yml
@@ -1,12 +1,6 @@
 name: Release Quickstart Verify CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   merge_group:
     branches:
       - main

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,12 +1,6 @@
 name: Rust CI
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   merge_group:
     branches:
       - main

--- a/.github/workflows/sbom-ci.yml
+++ b/.github/workflows/sbom-ci.yml
@@ -1,12 +1,6 @@
 name: SBOM CI
 
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   merge_group:
     branches:
       - main

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -1,12 +1,6 @@
 name: ScanCode
 
 on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   merge_group:
     branches:
       - main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,8 +131,9 @@ truth, keep `docs/spec/testing/ci-cd.md` as the human-readable policy, and
 update both whenever a workflow moves between those event buckets.
 
 local validation maps to the same CI event split: use `mise run test` for the
-repo baseline, `mise run test:docs` for docs or policy changes, `mise run e2e`
-for browser flows, and focused surface commands when only one package changed.
+repo baseline, `mise run test:docs` for docs, spec, or REQ-traceability changes,
+`mise run e2e` for browser flows, and focused surface commands when only one
+package changed.
 
 ## 7. Prepare the PR as one coherent change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,11 +102,6 @@ match the current workflows under `.github/workflows/`.
 
 Examples:
 
-- `mise run test` for the repository-wide baseline
-- `mise run test:docs` before pushing docs, spec, or REQ-traceability changes
-- targeted `uv run pytest ...` for docs/backend/core changes when iterating
-- `cd docsite && bun run test:coverage` for docsite regressions
-- `cd frontend && biome ci . && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1`
   when UI behavior changes
 
 Use `mise run test:docs` when `README.md`, `CONTRIBUTING.md`, `docs/spec/`,
@@ -116,7 +111,30 @@ REQ mapping regressions locally first.
 If you add a new docsite page or navigation path, include the matching vitest or
 docs regression so the route and copy stay wired.
 
-## 6. Prepare the PR as one coherent change
+## 6. Match CI events to the review stage
+
+Ugoite splits CI by event so the expensive gates only run when they add real
+value:
+
+| Event | What it covers |
+| --- | --- |
+| `push` on `main` | Fast, low-noise checks plus post-merge automation such as `Shell CI`, `YAML Workflow CI`, `README Command Guard`, `Release CI`, `Docsite Pages`, and `CodeQL` |
+| `pull_request` | The normal developer feedback set: `Commitlint CI`, `Devcontainer CI`, `Docsite CI`, `Frontend CI`, `Python CI`, plus the cheap static checks |
+| `merge_group` | The final gate before `main`: `Docker Build CI`, `E2E Tests`, `Pre-commit CI`, `Rust CI`, `SBOM CI`, `ScanCode`, and `Release Quickstart Verify CI` |
+
+push on `main` is reserved for fast, low-noise checks and post-merge automation.
+`pull_request` keeps the normal developer feedback set.
+`merge_group` is the final gate for expensive validation.
+
+Keep `.github/required-status-checks.json` as the machine-readable source of
+truth, keep `docs/spec/testing/ci-cd.md` as the human-readable policy, and
+update both whenever a workflow moves between those event buckets.
+
+local validation maps to the same CI event split: use `mise run test` for the
+repo baseline, `mise run test:docs` for docs or policy changes, `mise run e2e`
+for browser flows, and focused surface commands when only one package changed.
+
+## 7. Prepare the PR as one coherent change
 
 Before opening the PR:
 

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -4,39 +4,46 @@
 
 | Workflow | File | Triggers | Purpose |
 |----------|------|----------|---------|
-| Python CI | `.github/workflows/python-ci.yml` | Push on `main`, PR, merge queue | Lint, type check, pytest, and local dev seed runtime visibility |
-| Rust CI | `.github/workflows/rust-ci.yml` | Push, PR, merge queue | Minimum/core/CLI format, lint, test, and coverage |
-| Frontend CI | `.github/workflows/frontend-ci.yml` | Push, PR, merge queue | Lint (biome), tests with mandatory 100% coverage |
-| Docsite CI | `.github/workflows/docsite-ci.yml` | Push, PR, merge queue | Lint, format check, typecheck, validation build, and tests with mandatory 100% coverage |
-| E2E Tests | `.github/workflows/e2e-ci.yml` | Push, PR, merge queue | Path-aware smoke/full E2E with merge-queue full coverage |
-| Docker Build CI | `.github/workflows/docker-build-ci.yml` | Push on `main`, PR, merge queue | Build backend/frontend images and validate compose |
-| Devcontainer CI | `.github/workflows/devcontainer-ci.yml` | Push on `main`, PR, merge queue | Build/smoke devcontainer with authenticated pulls and in-workflow change detection |
-| SBOM CI | `.github/workflows/sbom-ci.yml` | Push, PR, merge queue | Generate CycloneDX SBOMs, sign/attest, and run vulnerability gate |
-| ScanCode | `.github/workflows/scancode.yml` | Push on `main`, PR, merge queue, manual | Run license/compliance and vulnerability scanning |
+| Python CI | `.github/workflows/python-ci.yml` | PR, merge queue | Lint, type check, pytest, and local dev seed runtime visibility |
+| Rust CI | `.github/workflows/rust-ci.yml` | Merge queue | Minimum/core/CLI format, lint, test, and coverage |
+| Frontend CI | `.github/workflows/frontend-ci.yml` | PR, merge queue | Lint (biome), tests with mandatory 100% coverage |
+| Docsite CI | `.github/workflows/docsite-ci.yml` | PR, merge queue | Lint, format check, typecheck, validation build, and tests with mandatory 100% coverage |
+| E2E Tests | `.github/workflows/e2e-ci.yml` | PR, merge queue | Path-aware smoke/full E2E with merge-queue full coverage |
+| Docker Build CI | `.github/workflows/docker-build-ci.yml` | Merge queue | Build backend/frontend images and validate compose |
+| Devcontainer CI | `.github/workflows/devcontainer-ci.yml` | PR, merge queue | Build/smoke devcontainer with authenticated pulls and in-workflow change detection |
+| SBOM CI | `.github/workflows/sbom-ci.yml` | Merge queue, manual | Generate CycloneDX SBOMs, sign/attest, and run vulnerability gate |
+| ScanCode | `.github/workflows/scancode.yml` | Merge queue, manual | Run license/compliance and vulnerability scanning |
 | Shell CI | `.github/workflows/shell-ci.yml` | Push on `main`, PR, merge queue | Run shell formatting, lint, and syntax checks |
 | YAML Workflow CI | `.github/workflows/yaml-workflow-ci.yml` | Push on `main`, PR, merge queue | Run repository artifact hygiene, GitHub Action SHA pinning checks, yamllint, and actionlint |
-| Pre-commit CI | `.github/workflows/pre-commit-ci.yml` | Push on `main`, PR, merge queue | Bootstrap pinned toolchains, perform strict lockfile installs, and run the full `pre-commit` hook chain |
-| README Command Guard | `.github/workflows/readme-command-guard.yml` | PR, merge queue | Keep canonical root commands documented |
+| Pre-commit CI | `.github/workflows/pre-commit-ci.yml` | Merge queue | Bootstrap pinned toolchains, perform strict lockfile installs, and run the full `pre-commit` hook chain |
+| README Command Guard | `.github/workflows/readme-command-guard.yml` | Push on `main`, PR, merge queue | Keep canonical root commands documented |
 | Commitlint CI | `.github/workflows/commitlint-ci.yml` | PR, merge queue | Enforce Conventional Commits |
-| CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue, schedule, manual | Native code scanning for Actions, JavaScript/TypeScript, Python, and Rust |
+| CodeQL | `.github/workflows/codeql.yml` | Push on `main`, schedule, manual | Native code scanning follow-up for Actions, JavaScript/TypeScript, Python, and Rust |
 | PR Template Validation | `.github/workflows/pr-require-close-issue.yml` | PR body events via `pull_request_target` | Enforce required PR sections and accepted close/closes issue links |
 | Required Status Checks | `.github/required-status-checks.json` | Repository ruleset on `main` pull requests and merge queue | Versioned source of truth for direct workflow summary checks, exclusions, and native code-scanning handoff |
 | Release CI | `.github/workflows/release-ci.yml` | Push on `main` | Create/update release PR with release-please (no auto publish) |
+| Docsite Pages | `.github/workflows/docsite-pages.yml` | Push on `main`, manual | Publish the docsite after merge without blocking the merge queue |
 | Release Publish | `.github/workflows/release-publish.yml` | Manual (`workflow_dispatch`) | Human-approved stable/alpha/beta GitHub release publish with GHCR image push and CLI release assets |
-| Release Quickstart Verify CI | `.github/workflows/release-quickstart-verify-ci.yml` | Push on `main`, PR, merge queue | Build current-branch release-like Docker and CLI assets, then verify browser and CLI quickstart paths before merge |
+| Release Quickstart Verify CI | `.github/workflows/release-quickstart-verify-ci.yml` | Merge queue | Build current-branch release-like Docker and CLI assets, then verify browser and CLI quickstart paths before merge |
 | Release Quickstart Verify | `.github/workflows/release-quickstart-verify.yml` | Manual (`workflow_dispatch`), reusable (`workflow_call`) | Download published release assets, run the release compose stack, verify browser stories with Playwright, and verify released CLI install/auth flows |
 
 GitHub branch protection and merge queue now rely on GitHub-native required status
 checks declared in `.github/required-status-checks.json`. Each required workflow
 emits a stable summary check with the workflow name, so the repository ruleset
 can require direct workflow health instead of a polling rollup workflow.
+The split is intentional: push on `main` stays small and mostly covers fast
+static checks plus post-merge automation, pull requests carry the normal
+developer feedback set, and `merge_group` is the final gate for the expensive
+cross-surface validation that protects `main`. The machine-readable policy
+lives in `.github/required-status-checks.json`, and the human-readable policy
+lives in `CONTRIBUTING.md`.
 Required workflows must not depend on top-level `paths` filters that would make
 a check disappear. Path-aware workflows such as Devcontainer CI perform
 in-workflow change detection and still emit their summary check when the
-expensive job is skipped. Release automation (`Release CI`, `Release Publish`)
-stays excluded from required status checks, and CodeQL remains enforced through
-the repository's native code-scanning rule rather than the required-status-check
-list.
+expensive job is skipped. Release automation (`Release CI`, `Docsite Pages`,
+`Release Publish`) stays excluded from required status checks, and CodeQL
+remains enforced through the repository's native code-scanning rule rather than
+the required-status-check list.
 
 Backend image builds in Docker Build CI, E2E CI, and SBOM CI pass `ugoite-core`,
 `ugoite-minimum`, and `ugoite-cli` as Buildx contexts so Rust path dependencies
@@ -70,12 +77,32 @@ resolution in place: root Node tooling uses `npm ci --no-fund --no-audit`, Bun
 projects use `bun install --frozen-lockfile`, and Python `uv.lock` environments
 use `uv sync --locked`.
 
-E2E CI selects a deterministic tier before running tests. `merge_group` and
-pushes to `main` always run the full compose-backed suite. Pull requests only
-drop to the smoke tier when every changed file stays inside docs/docsite
-metadata paths (`docs/**`, `docsite/**`, `README.md`, `LICENSE`, `AGENTS.md`,
-and `.github/ISSUE_TEMPLATE/**`); any application or workflow-input change
-keeps the full suite.
+E2E CI selects a deterministic tier before running tests. `merge_group` always runs the full compose-backed suite. Pull requests only drop to the smoke tier when every changed file stays inside docs/docsite metadata paths (`docs/**`, `docsite/**`, `README.md`, `LICENSE`, `AGENTS.md`, and `.github/ISSUE_TEMPLATE/**`), in which case the pull request drops to the smoke tier. Any application or workflow-input change keeps the full suite.
+
+## CI Event Split
+
+The event split is deliberately simple:
+
+push on `main` is reserved for fast, low-noise checks and post-merge automation.
+`pull_request` keeps the normal developer feedback set.
+`merge_group` is the final gate for expensive validation.
+The machine-readable policy lives in `.github/required-status-checks.json`.
+The human-readable policy lives in `CONTRIBUTING.md`.
+
+- `push` on `main` is reserved for fast, low-noise checks and post-merge
+  automation: `Shell CI`, `YAML Workflow CI`, `README Command Guard`,
+  `Release CI`, `Docsite Pages`, and `CodeQL`.
+- `pull_request` carries the normal developer feedback set: `Commitlint CI`,
+  `Devcontainer CI`, `Docsite CI`, `Frontend CI`, `Python CI`, plus the fast
+  static checks that are cheap to rerun.
+- `merge_group` is the final gate before `main`: `Docker Build CI`, `E2E Tests`,
+  `Pre-commit CI`, `Rust CI`, `SBOM CI`, `ScanCode`, and
+  `Release Quickstart Verify CI`.
+
+Local validation should mirror the same split. Use `mise run test` for the
+routine repo-wide baseline, `mise run test:docs` when `README.md`,
+`CONTRIBUTING.md`, `docs/spec/`, or `docs/tests/` change, and target the
+surface-specific commands when you are iterating on a narrower area.
 
 ## Native Required Status Checks
 
@@ -98,18 +125,18 @@ path-aware no-op.
 | Required Check | Workflow | Events | Notes |
 |----------------|----------|--------|-------|
 | Commitlint CI | `.github/workflows/commitlint-ci.yml` | PR, merge queue | Direct summary check for Conventional Commit enforcement |
-| Devcontainer CI | `.github/workflows/devcontainer-ci.yml` | Push on `main`, PR, merge queue | Uses an in-workflow change detector and only runs the expensive smoke build when tracked inputs changed |
-| Docker Build CI | `.github/workflows/docker-build-ci.yml` | Push on `main`, PR, merge queue | Summary check covers compose validation plus reusable image build |
-| Docsite CI | `.github/workflows/docsite-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for docsite quality gates |
-| E2E Tests | `.github/workflows/e2e-ci.yml` | Push on `main`, PR, merge queue | Summary check covers image export, tier selection, and Playwright execution |
-| Frontend CI | `.github/workflows/frontend-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for Biome + Vitest coverage |
-| Pre-commit CI | `.github/workflows/pre-commit-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for the full `.pre-commit-config.yaml` hook chain |
-| Python CI | `.github/workflows/python-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for Ruff, ty, backend pytest, local dev seed runtime coverage, and docs tests |
-| Release Quickstart Verify CI | `.github/workflows/release-quickstart-verify-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for current-branch release quickstart coverage |
-| README Command Guard | `.github/workflows/readme-command-guard.yml` | PR, merge queue | Direct summary check for canonical root commands |
-| Rust CI | `.github/workflows/rust-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for minimum/core/CLI Rust gates |
-| SBOM CI | `.github/workflows/sbom-ci.yml` | Push on `main`, PR, merge queue | Summary check covers image export plus SBOM/signing/security gates |
-| ScanCode | `.github/workflows/scancode.yml` | Push on `main`, PR, merge queue | Direct summary check for compliance scanning |
+| Devcontainer CI | `.github/workflows/devcontainer-ci.yml` | PR, merge queue | Uses an in-workflow change detector and only runs the expensive smoke build when tracked inputs changed |
+| Docker Build CI | `.github/workflows/docker-build-ci.yml` | Merge queue | Summary check covers compose validation plus reusable image build |
+| Docsite CI | `.github/workflows/docsite-ci.yml` | PR, merge queue | Direct summary check for docsite quality gates |
+| E2E Tests | `.github/workflows/e2e-ci.yml` | PR, merge queue | Summary check covers image export, tier selection, and Playwright execution |
+| Frontend CI | `.github/workflows/frontend-ci.yml` | PR, merge queue | Direct summary check for Biome + Vitest coverage |
+| Pre-commit CI | `.github/workflows/pre-commit-ci.yml` | Merge queue | Direct summary check for the full `.pre-commit-config.yaml` hook chain |
+| Python CI | `.github/workflows/python-ci.yml` | PR, merge queue | Direct summary check for Ruff, ty, backend pytest, local dev seed runtime coverage, and docs tests |
+| Release Quickstart Verify CI | `.github/workflows/release-quickstart-verify-ci.yml` | Merge queue | Direct summary check for current-branch release quickstart coverage |
+| README Command Guard | `.github/workflows/readme-command-guard.yml` | Push on `main`, PR, merge queue | Direct summary check for canonical root commands |
+| Rust CI | `.github/workflows/rust-ci.yml` | Merge queue | Direct summary check for minimum/core/CLI Rust gates |
+| SBOM CI | `.github/workflows/sbom-ci.yml` | Merge queue | Summary check covers image export plus SBOM/signing/security gates |
+| ScanCode | `.github/workflows/scancode.yml` | Merge queue | Direct summary check for compliance scanning |
 | Shell CI | `.github/workflows/shell-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for shell quality gates |
 | YAML Workflow CI | `.github/workflows/yaml-workflow-ci.yml` | Push on `main`, PR, merge queue | Direct summary check for root hygiene, action SHA pinning, and workflow linting |
 
@@ -301,11 +328,13 @@ jobs:
 `Release Quickstart Verify CI` lives at
 `./.github/workflows/release-quickstart-verify-ci.yml`. It keeps the release
 quickstart continuously verifiable before merge by building current-branch
-release-like Docker and CLI assets, exposing them through `file://`-backed
-`UGOITE_RELEASE_ASSET_BASE_URL` and `UGOITE_DOWNLOAD_BASE_URL` paths, and then
-reusing the same container + CLI quickstart scripts that post-publish
-verification uses. `Release Quickstart Verify` stays the post-publish/manual
-check for exact published releases, so the pre-merge path adds coverage without replacing release verification.
+release-like Docker and CLI assets before merge, exposing them through
+`file://`-backed `UGOITE_RELEASE_ASSET_BASE_URL` and `UGOITE_DOWNLOAD_BASE_URL`
+paths, and then reusing the same container + CLI quickstart scripts that
+post-publish verification uses. The merge-queue final gate adds coverage
+without replacing release verification.
+
+Build current-branch release-like Docker and CLI assets before merge.
 
 ## Devcontainer CI
 
@@ -349,18 +378,21 @@ jobs:
 
 Devcontainer CI now uses an in-workflow change detector instead of top-level
 `paths` filters so the required summary check is always emitted on pull
-requests, merge queue entries, and pushes to `main`. The detector reads
-`DEVCONTAINER_INPUT_PATTERNS`, which must keep covering current and future
-`mise.toml` files plus docs guide tests that validate devcontainer setup
-contracts. When no tracked input changed on a pull request or `push`, the smoke
-build is skipped but the summary check still reports success with an explicit
-selection reason. `merge_group` always runs the smoke build because GitHub does
-not support `paths` filtering there and branch health cannot depend on a
-disappearing required check. The canonical devcontainer also uses exact version
-tags for its base image and public Features, and `.github/dependabot.yml`
-tracks `package-ecosystem: "devcontainers"` at `/` so Feature updates stay
-reviewable in normal PR flow while the base image tag stays explicitly pinned
-in `devcontainer.json`.
+requests and merge queue entries. The detector reads `DEVCONTAINER_INPUT_PATTERNS`,
+which must keep covering current and future `mise.toml` files plus docs guide
+tests that validate devcontainer setup contracts. When no tracked input changed
+on a pull request, the smoke build is skipped but the summary check still
+reports success with an explicit selection reason. `merge_group` always runs the
+smoke build because GitHub does not support `paths` filtering there and branch
+health cannot depend on a disappearing required check. The canonical
+devcontainer also uses exact version tags for its base image and public
+Features, and `.github/dependabot.yml` tracks `package-ecosystem: "devcontainers"`
+at `/` so Feature updates stay reviewable in normal PR flow while the base
+image tag stays explicitly pinned in `devcontainer.json`.
+
+The canonical devcontainer also uses exact version tags for its base image and public Features.
+`.github/dependabot.yml` tracks `package-ecosystem: "devcontainers"` at `/`.
+The base image tag stays explicitly pinned in `devcontainer.json`.
 
 ## Rust CI
 
@@ -473,11 +505,11 @@ jobs:
     - uvx pre-commit run --all-files
 ```
 
-Pre-commit CI keeps `.pre-commit-config.yaml` itself continuously executable in CI
-instead of only relying on the individual workflows behind each hook. The
-workflow bootstraps the same pinned toolchains used elsewhere in the repository,
-uses strict lockfile-backed installs for Bun and uv projects, and exposes a
-direct summary check through `.github/required-status-checks.json`.
+Pre-commit CI keeps `.pre-commit-config.yaml` itself continuously executable in CI instead of only relying on the individual workflows behind each hook. The
+workflow is merge-queue only, so it acts as the final hook-level gate before
+`main`. It bootstraps the same pinned toolchains used elsewhere in the
+repository, uses strict lockfile-backed installs for Bun and uv projects, and
+exposes a direct summary check through `.github/required-status-checks.json`.
 
 The root `mise.toml` also declares explicit `[monorepo].config_roots` for package-level task configs so top-level `mise run dev`, `mise run test`, and `mise run e2e` stay warning-free on current mise releases.
 
@@ -485,7 +517,7 @@ The root `mise.toml` also declares explicit `[monorepo].config_roots` for packag
 
 1. **Conventional Commits** are required locally (Husky + Commitlint) and in CI (`commitlint-ci`).
 2. **Static checks and tests** must pass through existing CI workflows and the native required checks declared in `.github/required-status-checks.json`.
-3. **GitHub-native required status checks** must map directly to workflow summary jobs, exclude release/publish automation (`Release CI`, `Release Publish`), and leave CodeQL on the repository code-scanning rule instead of a synthetic rollup workflow.
+3. **GitHub-native required status checks** must map directly to workflow summary jobs, keep `.github/required-status-checks.json` as the machine-readable source of truth, exclude release/publish automation (`Release CI`, `Docsite Pages`, `Release Publish`), and leave CodeQL on the repository code-scanning rule instead of a synthetic rollup workflow.
 4. **Release CI** runs on pushes to `main` and uses release-please to create/update a release PR with SemVer planning when `RELEASE_PLEASE_TOKEN` is configured.
 5. **Release automation bootstrap** is seeded from `.github/.release-please-manifest.json`, `packages/ugoite/package.json`, and `.github/release-please-config.json`'s `bootstrap-sha`; the manifest/package versions must start at `0.0.1`, the repository root `package.json` must stay private tooling for Husky/commitlint only, and `bootstrap-sha` bounds pre-release-please history so old merge titles do not decide current release planning.
 6. **Release CI authentication** must use a dedicated `RELEASE_PLEASE_TOKEN`. If that secret is unavailable, the workflow must no-op cleanly instead of falling back to `GITHUB_TOKEN` and turning `main` red on repository-level PR permission errors.
@@ -498,6 +530,23 @@ The root `mise.toml` also declares explicit `[monorepo].config_roots` for packag
 13. **Release quick-start smoke validation** may be exercised with `scripts/verify-release-cli-quickstart.sh`, which must keep both the generic installer path and the per-target `.install.sh` asset path aligned with the documented `space list` and `space create` workflow for an exact release version.
 14. **Published release verification** must stay wired through `.github/workflows/release-quickstart-verify.yml`, which downloads exact release assets, starts `docker-compose.release.yaml`, runs `smoke.test.ts` plus `search-ui.test.ts`, and verifies a released CLI install can authenticate to and operate against the running release backend; `Release Publish` must delegate to that reusable workflow after finalizing the GitHub Release.
 15. **Public installer package** metadata lives in `packages/ugoite/package.json`, must stay non-private with `publishConfig.access=public`, must remain packable via `npm pack --dry-run`, must expose `ugoite-install` as the package-managed bootstrap to the canonical `scripts/install-ugoite-cli.sh` flow, and `README.md` plus `docs/guide/cli.md` must make the split between the public package and the private root tooling package explicit.
+
+## CI Event Split
+
+The contributor workflow mirrors the repository's CI event split:
+
+- `push` on `main` is for fast, low-noise checks and post-merge automation.
+- `pull_request` is for the normal developer feedback set.
+- `merge_group` is the final gate for the expensive cross-surface validation that protects `main`.
+
+Keep `.github/required-status-checks.json` as the machine-readable source of truth, keep `docs/spec/testing/ci-cd.md` as the canonical CI policy reference, and update both whenever workflow triggers move between those event buckets.
+
+Use local commands that mirror the same split:
+
+- `mise run test` for the repository-wide baseline
+- `mise run test:docs` for docs, spec, or CONTRIBUTING changes
+- `mise run e2e` for browser and merge-queue-adjacent flows
+- targeted surface-specific commands when only one package changed
 
 ## Environment Variables
 

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -121,6 +121,7 @@ PR_TEMPLATE_WORKFLOW_PATH = (
 PRE_COMMIT_CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
 PR_TEMPLATE_PATH = REPO_ROOT / ".github" / "pull_request_template.md"
 README_PATH = REPO_ROOT / "README.md"
+CONTRIBUTING_PATH = REPO_ROOT / "CONTRIBUTING.md"
 BACKEND_README_PATH = REPO_ROOT / "backend" / "README.md"
 BACKEND_PYPROJECT_PATH = REPO_ROOT / "backend" / "pyproject.toml"
 STACK_SPEC_PATH = REPO_ROOT / "docs" / "spec" / "architecture" / "stack.md"
@@ -226,10 +227,7 @@ REQUIRED_PRE_COMMIT_CI_WORKFLOW_FRAGMENTS = {
     "uvx pre-commit run --all-files",
 }
 REQUIRED_PRE_COMMIT_CI_DOC_FRAGMENTS = {
-    (
-        "| Pre-commit CI | `.github/workflows/pre-commit-ci.yml` | Push on `main`, "
-        "PR, merge queue |"
-    ),
+    "| Pre-commit CI | `.github/workflows/pre-commit-ci.yml` | Merge queue |",
     (
         "Bootstrap pinned toolchains, perform strict lockfile installs, and run "
         "the full `pre-commit` hook chain"
@@ -618,8 +616,6 @@ REQUIRED_RELEASE_QUICKSTART_VERIFY_DOC_FRAGMENTS = {
     "search-ui.test.ts",
 }
 REQUIRED_RELEASE_QUICKSTART_VERIFY_CI_WORKFLOW_FRAGMENTS = {
-    "push:",
-    "pull_request:",
     "merge_group:",
     "Build release-like Docker images",
     "Build release-like CLI archive",
@@ -640,13 +636,13 @@ REQUIRED_RELEASE_QUICKSTART_VERIFY_CI_WORKFLOW_FRAGMENTS = {
 REQUIRED_RELEASE_QUICKSTART_VERIFY_CI_DOC_FRAGMENTS = {
     (
         "| Release Quickstart Verify CI | "
-        "`.github/workflows/release-quickstart-verify-ci.yml` |"
+        "`.github/workflows/release-quickstart-verify-ci.yml` | Merge queue |"
     ),
     "./.github/workflows/release-quickstart-verify-ci.yml",
-    "Build current-branch release-like Docker and CLI assets",
+    "Build current-branch release-like Docker and CLI assets before merge",
     "UGOITE_RELEASE_ASSET_BASE_URL",
     "UGOITE_DOWNLOAD_BASE_URL",
-    "pre-merge path adds coverage without replacing release verification",
+    "merge-queue final gate",
 }
 REQUIRED_RELEASE_CHANGELOG_WORKFLOW_FRAGMENTS = {
     "scripts/render_release_notes.py",
@@ -818,10 +814,22 @@ REQUIRED_NATIVE_CODE_SCANNING_TOOLS = {"CodeQL"}
 REQUIRED_NATIVE_REQUIRED_CHECK_DOC_FRAGMENTS = {
     "| Required Status Checks | `.github/required-status-checks.json` |",
     "GitHub-native required status checks",
+    "push on `main` is reserved for fast, low-noise checks and post-merge automation",
+    "`pull_request` keeps the normal developer feedback set",
+    "`merge_group` is the final gate for expensive validation",
     "summary check",
+    "machine-readable policy lives in `.github/required-status-checks.json`",
+    "human-readable policy lives in `CONTRIBUTING.md`",
     "Release CI",
     "Release Publish",
     "CodeQL",
+}
+REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS = {
+    "push on `main` is reserved for fast, low-noise checks and post-merge automation",
+    "`pull_request` keeps the normal developer feedback set",
+    "`merge_group` is the final gate for expensive validation",
+    ".github/required-status-checks.json",
+    "local validation maps to the same CI event split",
 }
 REQUIRED_DEVCONTAINER_CHANGE_DETECTION_DOC_FRAGMENTS = {
     "in-workflow change detector",
@@ -3774,7 +3782,7 @@ def test_docs_req_ops_022_e2e_ci_is_tiered_for_prs_and_full_on_merge_queue() -> 
     ci_cd_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
 
     workflow_fragments = {
-        'event_name in {"merge_group", "push"}',
+        'event_name == "merge_group"',
         "docs/**",
         "docsite/**",
         (
@@ -3789,10 +3797,9 @@ def test_docs_req_ops_022_e2e_ci_is_tiered_for_prs_and_full_on_merge_queue() -> 
 
     doc_fragments = {
         "Pull requests only",
-        "`merge_group` and",
-        "pushes to `main` always run the full compose-backed suite.",
+        "`merge_group` always runs the full compose-backed suite.",
         "pull_request with docs/docsite-only paths => smoke",
-        "| E2E Tests | `.github/workflows/e2e-ci.yml` | Push, PR, merge queue |",
+        "| E2E Tests | `.github/workflows/e2e-ci.yml` | PR, merge queue |",
     }
     missing_doc_fragments = sorted(
         fragment for fragment in doc_fragments if fragment not in ci_cd_text
@@ -5060,12 +5067,23 @@ def _collect_required_status_check_doc_details() -> list[str]:
         for fragment in REQUIRED_NATIVE_REQUIRED_CHECK_DOC_FRAGMENTS
         if fragment not in guide_text
     )
+    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+    missing_contributing_fragments = sorted(
+        fragment
+        for fragment in REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS
+        if fragment not in contributing_text
+    )
 
     details: list[str] = []
     if missing_doc_fragments:
         details.append(
             "ci-cd guide missing native required-check fragments: "
             + ", ".join(missing_doc_fragments),
+        )
+    if missing_contributing_fragments:
+        details.append(
+            "CONTRIBUTING.md missing native required-check fragments: "
+            + ", ".join(missing_contributing_fragments),
         )
     if "All Tests Status" in guide_text:
         details.append(
@@ -5719,7 +5737,7 @@ def _collect_release_quickstart_verify_ci_details() -> list[str]:
     )
 
     details: list[str] = []
-    for event_name in ("push", "pull_request", "merge_group"):
+    for event_name in ("merge_group",):
         details.extend(
             _collect_required_status_check_event_details(
                 workflow,


### PR DESCRIPTION
## Summary

Split CI by event so push/main stays lightweight, PRs stay focused, and merge_group carries the heavy merge-queue gate.

## Related Issue (required)

closes #1556

## Testing

- [x] `uv run --with pytest --with pyyaml --with bashlex pytest -W error docs/tests/test_guides.py::test_docs_req_ops_013_native_required_checks_contract docs/tests/test_guides.py::test_docs_req_ops_022_e2e_ci_is_tiered_for_prs_and_full_on_merge_queue docs/tests/test_guides.py::test_docs_req_ops_029_pre_commit_ci_is_required docs/tests/test_guides.py::test_docs_req_ops_030_pre_merge_release_quickstart_ci_is_required -q`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest -W error docs/tests/test_guides.py -q`
- [x] `uv run --with pyyaml python3 - <<'PY' ... PY` workflow YAML parse check
