### PR TITLE
docs: record CodeQL ruleset sync

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -97,11 +97,5 @@
       "events": ["push", "pull_request", "merge_group"]
     }
   ],
-  "native_code_scanning": [
-    {
-      "tool": "CodeQL",
-      "workflow": ".github/workflows/codeql.yml"
-    }
-  ],
   "excluded_from_required_status_checks": ["Release CI", "Release Publish"]
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
   schedule:
     - cron: "16 5 * * 0"
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ value:
 | Event | What it covers |
 | --- | --- |
 | `push` on `main` | Fast, low-noise checks plus post-merge automation such as `Shell CI`, `YAML Workflow CI`, `README Command Guard`, `Release CI`, `Docsite Pages`, and `CodeQL` |
-| `pull_request` | The normal developer feedback set: `Commitlint CI`, `Devcontainer CI`, `Docsite CI`, `Frontend CI`, `Python CI`, plus the cheap static checks |
+| `pull_request` | The normal developer feedback set: `Commitlint CI`, `Devcontainer CI`, `Docsite CI`, `Frontend CI`, `Python CI`, plus the cheap static checks. CodeQL also runs here as a separate workflow |
 | `merge_group` | The final gate before `main`: `Docker Build CI`, `E2E Tests`, `Pre-commit CI`, `Rust CI`, `SBOM CI`, `ScanCode`, and `Release Quickstart Verify CI` |
 
 push on `main` is reserved for fast, low-noise checks and post-merge automation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,12 @@ Keep `.github/required-status-checks.json` as the machine-readable source of
 truth, keep `docs/spec/testing/ci-cd.md` as the human-readable policy, and
 update both whenever a workflow moves between those event buckets.
 
+When CodeQL or other branch-protection policy changes depend on GitHub ruleset
+state, update the live repository ruleset as well as the checked-in JSON. PR
+1557 only unblocked after the live `main only pr` ruleset was changed to allow
+CodeQL code scanning, and merge queue plus `main` merge were re-verified after
+that repository-side update.
+
 local validation maps to the same CI event split: use `mise run test` for the
 repo baseline, `mise run test:docs` for docs, spec, or REQ-traceability changes,
 `mise run e2e` for browser flows, and focused surface commands when only one

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -502,8 +502,8 @@ requirements:
   description: 'Default-branch pull request and merge queue protection MUST use
     GitHub-native required status checks mapped directly to workflow summary jobs,
     keep that contract versioned in-repo, exclude release/publish automation
-    workflows (at minimum `Release CI` and `Release Publish`), and rely on the
-    native CodeQL code-scanning rule instead of a polling rollup workflow.
+    workflows (at minimum `Release CI` and `Release Publish`), and keep CodeQL as
+    a separate workflow instead of a required status check.
 
     '
   related_spec:

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -18,9 +18,9 @@
 | Pre-commit CI | `.github/workflows/pre-commit-ci.yml` | Merge queue | Bootstrap pinned toolchains, perform strict lockfile installs, and run the full `pre-commit` hook chain |
 | README Command Guard | `.github/workflows/readme-command-guard.yml` | Push on `main`, PR, merge queue | Keep canonical root commands documented |
 | Commitlint CI | `.github/workflows/commitlint-ci.yml` | PR, merge queue | Enforce Conventional Commits |
-| CodeQL | `.github/workflows/codeql.yml` | Push on `main`, schedule, manual | Native code scanning follow-up for Actions, JavaScript/TypeScript, Python, and Rust |
+| CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue, schedule, manual | Automated code scanning workflow for Actions, JavaScript/TypeScript, Python, and Rust |
 | PR Template Validation | `.github/workflows/pr-require-close-issue.yml` | PR body events via `pull_request_target` | Enforce required PR sections and accepted close/closes issue links |
-| Required Status Checks | `.github/required-status-checks.json` | Repository ruleset on `main` pull requests and merge queue | Versioned source of truth for direct workflow summary checks, exclusions, and native code-scanning handoff |
+| Required Status Checks | `.github/required-status-checks.json` | Repository ruleset on `main` pull requests and merge queue | Versioned source of truth for direct workflow summary checks and exclusions |
 | Release CI | `.github/workflows/release-ci.yml` | Push on `main` | Create/update release PR with release-please (no auto publish) |
 | Docsite Pages | `.github/workflows/docsite-pages.yml` | Push on `main`, manual | Publish the docsite after merge without blocking the merge queue |
 | Release Publish | `.github/workflows/release-publish.yml` | Manual (`workflow_dispatch`) | Human-approved stable/alpha/beta GitHub release publish with GHCR image push and CLI release assets |
@@ -41,9 +41,8 @@ Required workflows must not depend on top-level `paths` filters that would make
 a check disappear. Path-aware workflows such as Devcontainer CI perform
 in-workflow change detection and still emit their summary check when the
 expensive job is skipped. Release automation (`Release CI`, `Docsite Pages`,
-`Release Publish`) stays excluded from required status checks, and CodeQL
-remains enforced through the repository's native code-scanning rule rather than
-the required-status-check list.
+`Release Publish`) stays excluded from required status checks, and CodeQL runs
+as a separate workflow rather than a required status check.
 
 Backend image builds in Docker Build CI, E2E CI, and SBOM CI pass `ugoite-core`,
 `ugoite-minimum`, and `ugoite-cli` as Buildx contexts so Rust path dependencies
@@ -84,7 +83,7 @@ E2E CI selects a deterministic tier before running tests. `merge_group` always r
 The event split is deliberately simple:
 
 push on `main` is reserved for fast, low-noise checks and post-merge automation.
-`pull_request` keeps the normal developer feedback set.
+`pull_request` keeps the normal developer feedback set, and CodeQL also runs here as a separate workflow.
 `merge_group` is the final gate for expensive validation.
 The machine-readable policy lives in `.github/required-status-checks.json`.
 The human-readable policy lives in `CONTRIBUTING.md`.
@@ -111,7 +110,6 @@ That JSON file is the source of truth for:
 
 - which direct workflow summary checks the `main only pr` ruleset requires
 - which workflows are explicitly excluded from required status checks
-- which code-scanning tools stay enforced through GitHub-native code-scanning rules
 
 Repository settings must stay aligned by applying ruleset updates from that JSON
 contract with `gh api` whenever the required-check list changes.
@@ -517,7 +515,7 @@ The root `mise.toml` also declares explicit `[monorepo].config_roots` for packag
 
 1. **Conventional Commits** are required locally (Husky + Commitlint) and in CI (`commitlint-ci`).
 2. **Static checks and tests** must pass through existing CI workflows and the native required checks declared in `.github/required-status-checks.json`.
-3. **GitHub-native required status checks** must map directly to workflow summary jobs, keep `.github/required-status-checks.json` as the machine-readable source of truth, exclude release/publish automation (`Release CI`, `Docsite Pages`, `Release Publish`), and leave CodeQL on the repository code-scanning rule instead of a synthetic rollup workflow.
+3. **GitHub-native required status checks** must map directly to workflow summary jobs, keep `.github/required-status-checks.json` as the machine-readable source of truth, exclude release/publish automation (`Release CI`, `Docsite Pages`, `Release Publish`), and keep CodeQL as a separate workflow instead of a required status check.
 4. **Release CI** runs on pushes to `main` and uses release-please to create/update a release PR with SemVer planning when `RELEASE_PLEASE_TOKEN` is configured.
 5. **Release automation bootstrap** is seeded from `.github/.release-please-manifest.json`, `packages/ugoite/package.json`, and `.github/release-please-config.json`'s `bootstrap-sha`; the manifest/package versions must start at `0.0.1`, the repository root `package.json` must stay private tooling for Husky/commitlint only, and `bootstrap-sha` bounds pre-release-please history so old merge titles do not decide current release planning.
 6. **Release CI authentication** must use a dedicated `RELEASE_PLEASE_TOKEN`. If that secret is unavailable, the workflow must no-op cleanly instead of falling back to `GITHUB_TOKEN` and turning `main` red on repository-level PR permission errors.

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -44,6 +44,12 @@ expensive job is skipped. Release automation (`Release CI`, `Docsite Pages`,
 `Release Publish`) stays excluded from required status checks, and CodeQL runs
 as a separate workflow rather than a required status check.
 
+Note: PR 1557 did not unblock until the live GitHub repository ruleset named
+`main only pr` was updated to allow CodeQL code scanning. The checked-in JSON
+remains the versioned contract, but GitHub evaluates the live ruleset, so a
+workflow-only change was not enough. After that repository ruleset change,
+merge queue and the `main` merge path were verified again.
+
 Backend image builds in Docker Build CI, E2E CI, and SBOM CI pass `ugoite-core`,
 `ugoite-minimum`, and `ugoite-cli` as Buildx contexts so Rust path dependencies
 resolve inside the container build. Docker Build CI, E2E CI, SBOM CI, and

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -83,8 +83,6 @@ YAML_WORKFLOW_CI_WORKFLOW_PATH = (
 )
 PRE_COMMIT_CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "pre-commit-ci.yml"
 RELEASE_CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release-ci.yml"
-CODEQL_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "codeql.yml"
-CODEQL_CONFIG_PATH = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 RELEASE_PUBLISH_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "release-publish.yml"
 )
@@ -810,7 +808,6 @@ REQUIRED_NATIVE_REQUIRED_CHECKS = {
     "YAML Workflow CI",
 }
 REQUIRED_NATIVE_REQUIRED_CHECK_EXCLUSIONS = {"Release CI", "Release Publish"}
-REQUIRED_NATIVE_CODE_SCANNING_TOOLS = {"CodeQL"}
 REQUIRED_NATIVE_REQUIRED_CHECK_DOC_FRAGMENTS = {
     "| Required Status Checks | `.github/required-status-checks.json` |",
     "GitHub-native required status checks",
@@ -822,7 +819,8 @@ REQUIRED_NATIVE_REQUIRED_CHECK_DOC_FRAGMENTS = {
     "human-readable policy lives in `CONTRIBUTING.md`",
     "Release CI",
     "Release Publish",
-    "CodeQL",
+    "a separate workflow instead of a required status check",
+    "CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue, schedule, manual",
 }
 REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS = {
     "push on `main` is reserved for fast, low-noise checks and post-merge automation",
@@ -830,6 +828,7 @@ REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS = {
     "`merge_group` is the final gate for expensive validation",
     ".github/required-status-checks.json",
     "local validation maps to the same CI event split",
+    "CodeQL also runs here as a separate workflow",
 }
 REQUIRED_DEVCONTAINER_CHANGE_DETECTION_DOC_FRAGMENTS = {
     "in-workflow change detector",
@@ -4903,7 +4902,6 @@ def _collect_required_status_check_config_details(
         )
 
     details.extend(_collect_required_status_check_exclusion_details(config))
-    details.extend(_collect_required_status_check_code_scanning_details(config))
     details.extend(_collect_required_status_check_ruleset_details(config))
     return details
 
@@ -4930,112 +4928,6 @@ def _collect_required_status_check_exclusion_details(
         missing_exclusions,
     )
     return [message]
-
-
-def _collect_required_status_check_code_scanning_details(
-    config: dict[str, object],
-) -> list[str]:
-    native_code_scanning = config.get("native_code_scanning", [])
-    if not isinstance(native_code_scanning, list):
-        message = "required-status-checks.json native_code_scanning must be a list"
-        raise TypeError(message)
-
-    configured_tools = {
-        tool_entry.get("tool")
-        for tool_entry in native_code_scanning
-        if isinstance(tool_entry, dict) and isinstance(tool_entry.get("tool"), str)
-    }
-    missing_tools = sorted(
-        REQUIRED_NATIVE_CODE_SCANNING_TOOLS.difference(configured_tools),
-    )
-    details: list[str] = []
-    if missing_tools:
-        details.append(
-            "required-status-checks.json missing native code-scanning tools: "
-            + ", ".join(missing_tools),
-        )
-
-    if not CODEQL_CONFIG_PATH.exists():
-        details.append(
-            ".github/codeql/codeql-config.yml must exist for CodeQL config",
-        )
-        return details
-
-    details.extend(_collect_codeql_workflow_config_details())
-
-    codeql_config = _load_yaml_base_mapping(CODEQL_CONFIG_PATH)
-    ignored_paths = codeql_config.get("paths-ignore", [])
-    if not isinstance(ignored_paths, list):
-        message = ".github/codeql/codeql-config.yml paths-ignore must be a list"
-        raise TypeError(message)
-    required_ignored_paths = {
-        "vendor/reqsign/**",
-        "ugoite-core/vendor/reqsign/**",
-    }
-    missing_ignored_paths = sorted(
-        required_ignored_paths.difference(
-            path for path in ignored_paths if isinstance(path, str)
-        ),
-    )
-    if missing_ignored_paths:
-        details.append(
-            ".github/codeql/codeql-config.yml must ignore vendored reqsign paths "
-            "to avoid third-party alerts blocking native CodeQL status: "
-            + ", ".join(missing_ignored_paths),
-        )
-
-    return details
-
-
-def _collect_codeql_workflow_config_details() -> list[str]:
-    codeql_workflow = _load_yaml_base_mapping(CODEQL_WORKFLOW_PATH)
-    jobs = codeql_workflow.get("jobs", {})
-    if not isinstance(jobs, dict):
-        message = ".github/workflows/codeql.yml must define jobs"
-        raise TypeError(message)
-    analyze_job = jobs.get("analyze", {})
-    if not isinstance(analyze_job, dict):
-        message = ".github/workflows/codeql.yml must define analyze job"
-        raise TypeError(message)
-
-    initialize_step = _find_codeql_initialize_step(analyze_job)
-    if not isinstance(initialize_step, dict):
-        return [
-            (
-                "codeql.yml must initialize CodeQL with "
-                "github/codeql-action/init pinned to a commit SHA"
-            ),
-        ]
-
-    with_block = initialize_step.get("with", {})
-    if not isinstance(with_block, dict):
-        return ["codeql.yml Initialize CodeQL step must define with block"]
-    if with_block.get("config-file") != "./.github/codeql/codeql-config.yml":
-        return [
-            "codeql.yml Initialize CodeQL step must use "
-            "./.github/codeql/codeql-config.yml",
-        ]
-    return []
-
-
-def _find_codeql_initialize_step(
-    analyze_job: dict[object, object],
-) -> dict[object, object] | None:
-    steps = analyze_job.get("steps", [])
-    if not isinstance(steps, list):
-        message = ".github/workflows/codeql.yml analyze job must define steps"
-        raise TypeError(message)
-
-    return next(
-        (
-            step
-            for step in steps
-            if isinstance(step, dict)
-            and step.get("name") == "Initialize CodeQL"
-            and _uses_pinned_action(step.get("uses"), "github/codeql-action/init")
-        ),
-        None,
-    )
 
 
 def _collect_required_status_check_ruleset_details(

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -820,7 +820,7 @@ REQUIRED_NATIVE_REQUIRED_CHECK_DOC_FRAGMENTS = {
     "Release CI",
     "Release Publish",
     "a separate workflow instead of a required status check",
-    "CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue, schedule, manual",
+    "CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue",
 }
 REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS = {
     "push on `main` is reserved for fast, low-noise checks and post-merge automation",

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -817,6 +817,9 @@ REQUIRED_NATIVE_REQUIRED_CHECK_DOC_FRAGMENTS = {
     "summary check",
     "machine-readable policy lives in `.github/required-status-checks.json`",
     "human-readable policy lives in `CONTRIBUTING.md`",
+    "PR 1557 did not unblock until the live GitHub repository ruleset named",
+    "The checked-in JSON",
+    "merge queue and the `main` merge path were verified again",
     "Release CI",
     "Release Publish",
     "a separate workflow instead of a required status check",
@@ -829,6 +832,8 @@ REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS = {
     ".github/required-status-checks.json",
     "local validation maps to the same CI event split",
     "CodeQL also runs here as a separate workflow",
+    "update the live repository ruleset as well as the checked-in JSON",
+    "merge queue plus `main` merge were re-verified",
 }
 REQUIRED_DEVCONTAINER_CHANGE_DETECTION_DOC_FRAGMENTS = {
     "in-workflow change detector",


### PR DESCRIPTION
## Summary
Record the live GitHub ruleset change that unblocked CodeQL on PR 1557 and keep the audit trail in the CI policy docs.

## Related Issue (required)
close: #1560

## Testing
- [x] uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_guides.py -q
- [x] The docs note captures the difference between the checked-in JSON contract and the live GitHub ruleset
- [x] The docs regression now enforces the audit-trail fragments
