### PR TITLE
fix: devcontainer CI browser dependency install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,5 +42,5 @@
 		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
 	},
 	"postCreateCommand": "sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends oathtool && sudo rm -rf /var/lib/apt/lists/*",
-	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && cd /workspace/e2e && npx playwright --version && npx playwright install --with-deps chromium"
+	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && cd /workspace/e2e && npx playwright --version && if [ -z \"${UGOITE_SKIP_PLAYWRIGHT_DEPS:-}\" ]; then npx playwright install --with-deps chromium; fi"
 }

--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -165,6 +165,8 @@ jobs:
       - name: Build and smoke test devcontainer
         uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3
         with:
+          env: |
+            UGOITE_SKIP_PLAYWRIGHT_DEPS=1
           runCmd: |
             gh --version
             mise --version


### PR DESCRIPTION
## Summary
Move the devcontainer browser dependency install workaround into a separate change so the pre-commit cleanup PR stays focused.

## Related Issue (required)
closes #1581

## Testing
- [x] jq empty .devcontainer/devcontainer.json
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/devcontainer-ci.yml"); puts "ok"'\n- [x] git cherry-pick --continue completed cleanly