### PR TITLE
fix(ci): publish backend release images on native arm64 runners

### DIFF
--- a/.github/workflows/docker-build-ci.yml
+++ b/.github/workflows/docker-build-ci.yml
@@ -38,8 +38,6 @@ jobs:
       contents: read
       packages: write
     uses: ./.github/workflows/docker-images.yml
-    with:
-      push: false
 
   required-check:
     name: Docker Build CI

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -3,22 +3,8 @@ name: Docker Images
 on:
   workflow_call:
     inputs:
-      push:
-        description: "Push images to GHCR"
-        required: true
-        type: boolean
       target:
         description: "Git ref (branch, tag, or SHA) to build"
-        required: false
-        type: string
-        default: ""
-      version:
-        description: "Release version without the leading v"
-        required: false
-        type: string
-        default: ""
-      channel:
-        description: "Release channel for publish aliases"
         required: false
         type: string
         default: ""
@@ -46,7 +32,6 @@ on:
 jobs:
   docker-images-ci:
     name: Docker images (CI)
-    if: ${{ inputs.push == false }}
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     permissions:
@@ -155,98 +140,3 @@ jobs:
           name: ${{ inputs.artifact_name != '' && inputs.artifact_name || 'docker-images-ci' }}
           path: exported-images
           if-no-files-found: error
-
-  docker-images-publish:
-    name: Docker images (${{ matrix.image }})
-    if: ${{ inputs.push }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: backend
-            image_repository: ghcr.io/${{ github.repository }}/backend
-            context: ./backend
-            dockerfile: ./backend/Dockerfile
-            cache_scope: backend-image
-            build_contexts: |
-              core=./ugoite-core
-              minimum=./ugoite-minimum
-              module=./ugoite-cli
-          - image: frontend
-            image_repository: ghcr.io/${{ github.repository }}/frontend
-            context: ./frontend
-            dockerfile: ./frontend/Dockerfile
-            cache_scope: frontend-image
-            build_contexts: |
-              shared=./shared
-    runs-on: ubuntu-24.04
-    timeout-minutes: 80
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ inputs.target != '' && inputs.target || github.sha }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Set up QEMU emulation for cross-platform builds
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
-
-      - name: Authenticate GHCR pushes
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute GHCR tags
-        id: tags
-        env:
-          CHANNEL: ${{ inputs.channel }}
-          IMAGE: ${{ matrix.image_repository }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          if [ -z "$VERSION" ]; then
-            echo "version input is required when push=true" >&2
-            exit 1
-          fi
-
-          tags=("$IMAGE:$VERSION")
-          case "$CHANNEL" in
-            stable)
-              tags+=("$IMAGE:latest" "$IMAGE:stable")
-              ;;
-            alpha|beta)
-              tags+=("$IMAGE:$CHANNEL")
-              ;;
-            *)
-              echo "unsupported channel: $CHANNEL" >&2
-              exit 1
-              ;;
-          esac
-
-          {
-            echo "tags<<EOF"
-            printf '%s\n' "${tags[@]}"
-            echo "EOF"
-          } >>"$GITHUB_OUTPUT"
-
-      - name: Build ${{ matrix.image }} image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.tags.outputs.tags }}
-          cache-from: |
-            type=gha,scope=${{ matrix.cache_scope }}
-            type=gha,scope=docker-build-common
-          cache-to: |
-            type=gha,mode=max,scope=${{ matrix.cache_scope }}
-          build-contexts: ${{ matrix.build_contexts }}

--- a/.github/workflows/docker-release-images.yml
+++ b/.github/workflows/docker-release-images.yml
@@ -1,0 +1,246 @@
+name: Release Docker Images
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: "Git ref (branch, tag, or SHA) to build"
+        required: false
+        type: string
+        default: ""
+      version:
+        description: "Release version without the leading v"
+        required: true
+        type: string
+      channel:
+        description: "Release channel for publish aliases"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-release-image-metadata:
+    name: Prepare release image metadata
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      backend_image: ${{ steps.metadata.outputs.backend_image }}
+      frontend_image: ${{ steps.metadata.outputs.frontend_image }}
+      backend_tags_json: ${{ steps.metadata.outputs.backend_tags_json }}
+      frontend_tags_json: ${{ steps.metadata.outputs.frontend_tags_json }}
+    steps:
+      - name: Compute GHCR repositories and tags
+        id: metadata
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          channel = os.environ["CHANNEL"]
+          repository = os.environ["REPOSITORY"]
+
+          def build_tags(image: str) -> list[str]:
+              base = f"ghcr.io/{repository}/{image}"
+              tags = [f"{base}:{version}"]
+              if channel == "stable":
+                  tags.extend((f"{base}:latest", f"{base}:stable"))
+              elif channel in {"alpha", "beta"}:
+                  tags.append(f"{base}:{channel}")
+              else:
+                  raise SystemExit(f"unsupported channel: {channel}")
+              return tags
+
+          outputs = {
+              "backend_image": f"ghcr.io/{repository}/backend",
+              "frontend_image": f"ghcr.io/{repository}/frontend",
+              "backend_tags_json": json.dumps(build_tags("backend")),
+              "frontend_tags_json": json.dumps(build_tags("frontend")),
+          }
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as handle:
+              for key, value in outputs.items():
+                  handle.write(f"{key}={value}\n")
+          PY
+
+  publish-backend-by-platform:
+    name: Publish backend image (${{ matrix.platform }})
+    needs: prepare-release-image-metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            platform_slug: linux-amd64
+            cache_scope: backend-release-linux-amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            platform_slug: linux-arm64
+            cache_scope: backend-release-linux-arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.target != '' && inputs.target || github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Authenticate GHCR pushes
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image by digest
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.prepare-release-image-metadata.outputs.backend_image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: |
+            type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: |
+            type=gha,mode=max,scope=${{ matrix.cache_scope }}
+          build-contexts: |
+            core=./ugoite-core
+            minimum=./ugoite-minimum
+            module=./ugoite-cli
+
+      - name: Record backend image digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST_DIR: ${{ runner.temp }}/backend-digests
+        run: |
+          set -euo pipefail
+          mkdir -p "$DIGEST_DIR"
+          touch "$DIGEST_DIR/${DIGEST#sha256:}"
+
+      - name: Upload backend digest artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: backend-digest-${{ matrix.platform_slug }}
+          path: ${{ runner.temp }}/backend-digests/*
+          if-no-files-found: error
+
+  publish-backend-manifest:
+    name: Publish backend image manifest
+    needs:
+      - prepare-release-image-metadata
+      - publish-backend-by-platform
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Authenticate GHCR pushes
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download backend digest artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: backend-digest-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/backend-digests
+
+      - name: Create backend multi-arch manifest
+        env:
+          BACKEND_IMAGE: ${{ needs.prepare-release-image-metadata.outputs.backend_image }}
+          BACKEND_TAGS_JSON: ${{ needs.prepare-release-image-metadata.outputs.backend_tags_json }}
+          DIGEST_DIR: ${{ runner.temp }}/backend-digests
+        run: |
+          set -euo pipefail
+          refs=()
+          while IFS= read -r digest_path; do
+            [ -n "$digest_path" ] || continue
+            refs+=("${BACKEND_IMAGE}@sha256:$(basename "$digest_path")")
+          done < <(find "$DIGEST_DIR" -maxdepth 1 -type f -print | sort)
+          if [ "${#refs[@]}" -eq 0 ]; then
+            echo "no backend image digests were downloaded" >&2
+            exit 1
+          fi
+          mapfile -t tags < <(python3 - <<'PY'
+          import json
+          import os
+
+          for tag in json.loads(os.environ["BACKEND_TAGS_JSON"]):
+              print(tag)
+          PY
+          )
+          cmd=(docker buildx imagetools create)
+          for tag in "${tags[@]}"; do
+            cmd+=( -t "$tag" )
+          done
+          cmd+=("${refs[@]}")
+          "${cmd[@]}"
+          docker buildx imagetools inspect "${tags[0]}"
+
+  publish-frontend-image:
+    name: Publish frontend image
+    needs: prepare-release-image-metadata
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.target != '' && inputs.target || github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU emulation for cross-platform builds
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+
+      - name: Authenticate GHCR pushes
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ join(fromJSON(needs.prepare-release-image-metadata.outputs.frontend_tags_json), '\n') }}
+          cache-from: |
+            type=gha,scope=frontend-image
+            type=gha,scope=docker-build-common
+          cache-to: |
+            type=gha,mode=max,scope=frontend-image
+          build-contexts: |
+            shared=./shared

--- a/.github/workflows/docker-release-images.yml
+++ b/.github/workflows/docker-release-images.yml
@@ -236,7 +236,7 @@ jobs:
           file: ./frontend/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ join(fromJSON(needs.prepare-release-image-metadata.outputs.frontend_tags_json), '\n') }}
+          tags: ${{ join(fromJSON(needs.prepare-release-image-metadata.outputs.frontend_tags_json), ',') }}
           cache-from: |
             type=gha,scope=frontend-image
             type=gha,scope=docker-build-common

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -19,7 +19,6 @@ jobs:
       packages: write
     uses: ./.github/workflows/docker-images.yml
     with:
-      push: false
       export_artifacts: true
       artifact_name: e2e-docker-images
       backend_local_tag: ugoite-backend:e2e

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -106,9 +106,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: ./.github/workflows/docker-images.yml
+    uses: ./.github/workflows/docker-release-images.yml
     with:
-      push: true
       target: ${{ inputs.target }}
       version: ${{ inputs.version }}
       channel: ${{ inputs.channel }}
@@ -121,7 +120,6 @@ jobs:
       packages: write
     uses: ./.github/workflows/docker-images.yml
     with:
-      push: false
       target: ${{ inputs.target }}
       export_artifacts: true
       artifact_name: release-docker-images

--- a/.github/workflows/release-quickstart-verify-ci.yml
+++ b/.github/workflows/release-quickstart-verify-ci.yml
@@ -20,7 +20,6 @@ jobs:
       packages: write
     uses: ./.github/workflows/docker-images.yml
     with:
-      push: false
       export_artifacts: true
       artifact_name: release-quickstart-images
       backend_local_tag: ghcr.io/${{ github.repository }}/backend:ci-quickstart

--- a/.github/workflows/sbom-ci.yml
+++ b/.github/workflows/sbom-ci.yml
@@ -19,7 +19,6 @@ jobs:
       packages: write
     uses: ./.github/workflows/docker-images.yml
     with:
-      push: false
       export_artifacts: true
       artifact_name: sbom-docker-images
       backend_local_tag: ugoite-backend:sbom

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -62,10 +62,9 @@ the reusable `.github/workflows/docker-images.yml` image-definition contract for
 CI validation and local-image artifact export, while Release Publish uses
 `.github/workflows/docker-release-images.yml` for native-arm64 backend
 publishing and `.github/workflows/docker-images.yml` for exact-version archive
-export. Repository Dockerfiles pin external base/tool images to exact version
-tags, and base-image references should carry digests when public registries
-expose them, so local and CI builds stay reproducible under Dependabot-managed
-Docker update PRs.
+export. Repository Dockerfiles pin external base/tool images to exact version tags,
+and base-image references should carry digests when public registries expose
+them, so local and CI builds stay reproducible under Dependabot-managed Docker update PRs.
 
 The root `mise.toml` `[tools]` table and workflow bootstrap steps also pin
 exact patch versions for Node, Bun, Python, Biome, Rust, and uv. `setup-node`,

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -57,14 +57,15 @@ merge queue and the `main` merge path were verified again.
 
 Backend image builds in Docker Build CI, E2E CI, and SBOM CI pass `ugoite-core`,
 `ugoite-minimum`, and `ugoite-cli` as Buildx contexts so Rust path dependencies
-resolve inside the container build. Docker Build CI, E2E CI, SBOM CI, and
-Release Publish share the reusable `.github/workflows/docker-images.yml`
-image-definition contract so image build behavior cannot silently drift between
-CI validation, local-image artifact export, and release publishing. Repository
-Dockerfiles pin external base/tool images to exact version tags, and
-base-image references should carry digests when public registries expose them,
-so local and CI builds stay reproducible under Dependabot-managed Docker update
-PRs.
+resolve inside the container build. Docker Build CI, E2E CI, and SBOM CI share
+the reusable `.github/workflows/docker-images.yml` image-definition contract for
+CI validation and local-image artifact export, while Release Publish uses
+`.github/workflows/docker-release-images.yml` for native-arm64 backend
+publishing and `.github/workflows/docker-images.yml` for exact-version archive
+export. Repository Dockerfiles pin external base/tool images to exact version
+tags, and base-image references should carry digests when public registries
+expose them, so local and CI builds stay reproducible under Dependabot-managed
+Docker update PRs.
 
 The root `mise.toml` `[tools]` table and workflow bootstrap steps also pin
 exact patch versions for Node, Bun, Python, Biome, Rust, and uv. `setup-node`,
@@ -517,7 +518,7 @@ The root `mise.toml` also declares explicit `[monorepo].config_roots` for packag
 7. **Human review** must confirm the planned release scope before publishing.
 8. **Release Publish** is manual (`workflow_dispatch`) and requires explicit `APPROVED` confirmation.
 9. **Stable/alpha/beta channels** are validated by channel-specific SemVer patterns at publish time.
-10. **Release Publish** authenticates to GHCR with `GITHUB_TOKEN`, pushes `ghcr.io/ugoite/ugoite/backend` and `ghcr.io/ugoite/ugoite/frontend`, keeps tags aligned to the requested version (`<semver>` plus `latest`/`stable` for stable releases, or `<channel>` for alpha/beta), checks out the requested target before generating notes, prepends channel-scoped repository notes rendered by `scripts/render_release_notes.py` from `docs/version/changelog/<channel>.yaml`, creates the draft GitHub Release, exports exact-version container image archives, and finalizes that release, delegates release image archive export to `.github/workflows/docker-images.yml` with `export_artifacts: true`, uploads `ugoite-backend-v<version>.docker.tar.gz`, `ugoite-frontend-v<version>.docker.tar.gz`, and `docker-compose.release.yaml` as GitHub Release assets alongside matching `.sha256` checksum files, commits the workspace `Cargo.lock` so clean checkouts can honor `cargo build --locked`, builds CLI archives for `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, and `aarch64-apple-darwin` through `.github/workflows/cli-release-binaries.yml`, uses `scripts/render-cli-release-installer.sh` to generate matching `ugoite-v<version>-<target>.install.sh` assets, uses the standard `macos-15` runner for the Intel macOS cross-build and `macos-14` for the Apple Silicon build, uploads those assets plus `.sha256` checksum files, and then finalizes the release.
+10. **Release Publish** authenticates to GHCR with `GITHUB_TOKEN`, publishes `ghcr.io/ugoite/ugoite/backend` on native `ubuntu-24.04` and `ubuntu-24.04-arm` runners before merging the backend manifest, pushes `ghcr.io/ugoite/ugoite/frontend`, keeps tags aligned to the requested version (`<semver>` plus `latest`/`stable` for stable releases, or `<channel>` for alpha/beta), checks out the requested target before generating notes, prepends channel-scoped repository notes rendered by `scripts/render_release_notes.py` from `docs/version/changelog/<channel>.yaml`, creates the draft GitHub Release, exports exact-version container image archives, and finalizes that release, delegates release image publishing to `.github/workflows/docker-release-images.yml` and release image archive export to `.github/workflows/docker-images.yml` with `export_artifacts: true`, uploads `ugoite-backend-v<version>.docker.tar.gz`, `ugoite-frontend-v<version>.docker.tar.gz`, and `docker-compose.release.yaml` as GitHub Release assets alongside matching `.sha256` checksum files, commits the workspace `Cargo.lock` so clean checkouts can honor `cargo build --locked`, builds CLI archives for `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, and `aarch64-apple-darwin` through `.github/workflows/cli-release-binaries.yml`, uses `scripts/render-cli-release-installer.sh` to generate matching `ugoite-v<version>-<target>.install.sh` assets, uses the standard `macos-15` runner for the Intel macOS cross-build and `macos-14` for the Apple Silicon build, uploads those assets plus `.sha256` checksum files, and then finalizes the release.
 11. **Container quick start** must stay documented in `README.md`, `docs/guide/container-quickstart.md`, and `docker-compose.release.yaml` so users can download the shipped compose file, prepare the documented env file, and pull and run published images without rebuilding from source, and those docs must keep a dedicated `Environment Variables` section aligned with the shipped release-compose overrides.
 12. **CLI installation** must stay documented in `README.md`, `docs/guide/cli.md`, and `scripts/install-ugoite-cli.sh` so users can install the released CLI and run `ugoite --help` without cloning the repository; the docs must also expose exact per-target one-liners for the `ugoite-v<version>-<target>.install.sh` release assets.
 13. **Release quick-start smoke validation** may be exercised with `scripts/verify-release-cli-quickstart.sh`, which must keep both the generic installer path and the per-target `.install.sh` asset path aligned with the documented `space list` and `space create` workflow for an exact release version.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -472,7 +472,7 @@ REQUIRED_DOCKER_RELEASE_IMAGES_REUSABLE_FRAGMENTS = {
     "push-by-digest=true",
     "docker buildx imagetools create",
     "join(fromJSON(needs.prepare-release-image-metadata.outputs.frontend_tags_json), "
-    "'\\n')",
+    "',')",
 }
 REQUIRED_RELEASE_QUICKSTART_README_FRAGMENTS = {
     "docker-compose.release.yaml",

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -102,6 +102,9 @@ SBOM_CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "sbom-ci.yml"
 DOCKER_IMAGES_REUSABLE_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "docker-images.yml"
 )
+DOCKER_RELEASE_IMAGES_REUSABLE_WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "docker-release-images.yml"
+)
 DEVCONTAINER_CI_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "devcontainer-ci.yml"
 )
@@ -379,8 +382,8 @@ REQUIRED_RELEASE_PUBLISH_PERMISSIONS = {
     "packages": "write",
 }
 REQUIRED_RELEASE_PUBLISH_WORKFLOW_FRAGMENTS = {
+    "./.github/workflows/docker-release-images.yml",
     "./.github/workflows/docker-images.yml",
-    "push: true",
     "export_artifacts: true",
     "artifact_name: release-docker-images",
     (
@@ -432,10 +435,6 @@ REQUIRED_PUBLIC_PACKAGE_INSTALLER_FRAGMENTS = {
 }
 REQUIRED_DOCKER_IMAGES_REUSABLE_FRAGMENTS = {
     "workflow_call",
-    "docker/login-action@",
-    "registry: ghcr.io",
-    "ghcr.io/${{ github.repository }}/backend",
-    "ghcr.io/${{ github.repository }}/frontend",
     "export_artifacts:",
     "artifact_name:",
     "backend_local_tag:",
@@ -449,9 +448,31 @@ REQUIRED_DOCKER_IMAGES_REUSABLE_FRAGMENTS = {
         "exported-images/frontend-image.tar.gz"
     ),
     "actions/upload-artifact@",
-    "$IMAGE:latest",
-    "$IMAGE:stable",
-    "$IMAGE:$CHANNEL",
+    "Docker images (CI)",
+    "Export local Docker image archives",
+}
+REQUIRED_DOCKER_RELEASE_IMAGES_REUSABLE_FRAGMENTS = {
+    "workflow_call",
+    "Prepare release image metadata",
+    "backend_tags_json",
+    "frontend_tags_json",
+    'backend_image": f"ghcr.io/{repository}/backend"',
+    'frontend_image": f"ghcr.io/{repository}/frontend"',
+    "publish-backend-by-platform",
+    "platform_slug",
+    "linux/amd64",
+    "ubuntu-24.04-arm",
+    "linux/arm64",
+    "publish-backend-manifest",
+    "publish-frontend-image",
+    "docker/setup-buildx-action@",
+    "docker/setup-qemu-action@",
+    "docker/login-action@",
+    "docker/build-push-action@",
+    "push-by-digest=true",
+    "docker buildx imagetools create",
+    "join(fromJSON(needs.prepare-release-image-metadata.outputs.frontend_tags_json), "
+    "'\\n')",
 }
 REQUIRED_RELEASE_QUICKSTART_README_FRAGMENTS = {
     "docker-compose.release.yaml",
@@ -5218,6 +5239,10 @@ def _collect_release_publish_container_details() -> list[str]:
         DOCKER_IMAGES_REUSABLE_WORKFLOW_PATH.read_text(encoding="utf-8"),
         REQUIRED_DOCKER_IMAGES_REUSABLE_FRAGMENTS,
     )
+    missing_release_reusable_fragments = _missing_required_fragments(
+        DOCKER_RELEASE_IMAGES_REUSABLE_WORKFLOW_PATH.read_text(encoding="utf-8"),
+        REQUIRED_DOCKER_RELEASE_IMAGES_REUSABLE_FRAGMENTS,
+    )
     missing_readme_fragments = _missing_required_fragments(
         README_PATH.read_text(encoding="utf-8"),
         REQUIRED_RELEASE_QUICKSTART_README_FRAGMENTS,
@@ -5241,8 +5266,8 @@ def _collect_release_publish_container_details() -> list[str]:
             "release-publish permissions mismatch: " + ", ".join(missing_permissions),
         ),
         (
-            publish_images_uses != "./.github/workflows/docker-images.yml",
-            "release-publish must delegate image builds to docker-images.yml",
+            publish_images_uses != "./.github/workflows/docker-release-images.yml",
+            "release-publish must delegate image builds to docker-release-images.yml",
         ),
         (
             export_images_uses != "./.github/workflows/docker-images.yml",
@@ -5275,6 +5300,11 @@ def _collect_release_publish_container_details() -> list[str]:
             bool(missing_reusable_fragments),
             "docker-images reusable workflow missing fragments: "
             + ", ".join(missing_reusable_fragments),
+        ),
+        (
+            bool(missing_release_reusable_fragments),
+            "docker-release-images reusable workflow missing fragments: "
+            + ", ".join(missing_release_reusable_fragments),
         ),
         (
             bool(missing_readme_fragments),


### PR DESCRIPTION
## Summary

- split reusable Docker workflows so `.github/workflows/docker-images.yml` is CI and artifact-export only
- add `.github/workflows/docker-release-images.yml` for release publishing, with backend built per platform and merged into a manifest
- publish backend `linux/arm64` on `ubuntu-24.04-arm` instead of QEMU on x64, while keeping frontend on the cheaper existing multi-arch path
- remove obsolete `push: false` inputs from CI callers and keep release archive export on the CI-oriented workflow

## Related Issue (required)

closes #1593

## Testing

- [x] `uvx ruff check --select ALL --ignore-noqa .`
- [x] `uvx ruff format --check .`
- [x] `bash scripts/check-root-artifact-hygiene.sh`
- [x] `git ls-files -- '*.yml' '*.yaml' ':(exclude)charts/*/templates/*.yaml' | xargs uvx --from yamllint yamllint --strict -d '{extends: relaxed, rules: {line-length: disable}}'`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests -v -W error --junitxml=docs-pytest.xml`
- [x] `python3 scripts/check_pytest_no_skips.py docs-pytest.xml "docs tests"`
