### PR TITLE
feat: add low-memory repo-wide test profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Common follow-up commands inside either setup:
 ```bash
 mise run dev
 mise run test
+mise run test:low-memory
 ```
 
 Before adding a new workflow-specific command, check `.github/workflows/` and
@@ -137,7 +138,8 @@ CodeQL code scanning, and merge queue plus `main` merge were re-verified after
 that repository-side update.
 
 local validation maps to the same CI event split: use `mise run test` for the
-repo baseline, `mise run test:docs` for docs, spec, or REQ-traceability changes,
+repo baseline, `mise run test:low-memory` for devcontainers, Codespaces, and
+memory-constrained machines, `mise run test:docs` for docs, spec, or REQ-traceability changes,
 `mise run e2e` for browser flows, and focused surface commands when only one
 package changed.
 

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -103,9 +103,11 @@ The human-readable policy lives in `CONTRIBUTING.md`.
   `Rust CI`, `SBOM CI`, `ScanCode`, and `Release Quickstart Verify CI`.
 
 Local validation should mirror the same split. Use `mise run test` for the
-routine repo-wide baseline, `mise run test:docs` when `README.md`,
-`CONTRIBUTING.md`, `docs/spec/`, or `docs/tests/` change, and target the
-surface-specific commands when you are iterating on a narrower area.
+routine repo-wide baseline, `mise run test:low-memory` for devcontainers,
+Codespaces, and memory-constrained machines, `mise run test:docs` when
+`README.md`, `CONTRIBUTING.md`, `docs/spec/`, or `docs/tests/` change, and
+target the surface-specific commands when you are iterating on a narrower
+area.
 
 ## Native Required Status Checks
 
@@ -223,6 +225,10 @@ jobs:
 The root `mise run test` contract must enforce the same frontend 100% coverage
 gate by depending on `//frontend:test:coverage`, so local verification and CI
 fail for the same coverage regressions.
+The low-memory root contract depends on
+`//frontend:test:coverage:low-memory`, which keeps the same coverage gate while
+making the constrained execution profile explicit for devcontainers and
+Codespaces.
 Dependabot groups frontend `vitest` and `@vitest/*` Bun updates together so the
 coverage runner packages stay aligned and cannot quietly drift into mixed-version
 warnings during that enforced coverage path.
@@ -243,6 +249,10 @@ jobs:
 The root `mise run test` contract must enforce the same docsite 100% coverage
 gate by depending on `//docsite:test:coverage`, so local verification and CI
 fail for the same coverage regressions.
+The low-memory root contract depends on
+`//docsite:test:coverage:low-memory`, which keeps the same coverage gate while
+making the constrained execution profile explicit for devcontainers and
+Codespaces.
 
 ## E2E CI
 

--- a/docs/tests/test_contributing_guide.py
+++ b/docs/tests/test_contributing_guide.py
@@ -90,6 +90,13 @@ def test_docs_req_ops_036_contributor_workflow_guide_stays_traceable() -> None:
                 "CONTRIBUTING.md must mention the repo-wide validation command",
             ),
             (
+                "mise run test:low-memory" not in contributing_text,
+                (
+                    "CONTRIBUTING.md must mention the low-memory repo-wide "
+                    "validation command"
+                ),
+            ),
+            (
                 "mise run test:docs" not in contributing_text,
                 "CONTRIBUTING.md must mention the docs consistency validation command",
             ),

--- a/docsite/mise.toml
+++ b/docsite/mise.toml
@@ -24,6 +24,10 @@ description = "Run docsite unit tests with Vitest"
 run = "bash ../scripts/ensure-bun-package-install.sh && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
 description = "Run docsite unit tests with 100% coverage enforcement"
 
+[tasks."test:coverage:low-memory"]
+run = "bash ../scripts/ensure-bun-package-install.sh && NODE_OPTIONS=\"--max-old-space-size=2048\" VITEST_MAX_WORKERS=1 node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
+description = "Run docsite unit tests with 100% coverage enforcement under low-memory settings"
+
 [tasks.build]
 run = "bun run build"
 

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -13,3 +13,7 @@ description = "Run frontend unit/component tests with Vitest"
 [tasks."test:coverage"]
 run = "bash ../scripts/ensure-bun-package-install.sh && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
 description = "Run frontend unit/component tests with 100% coverage enforcement"
+
+[tasks."test:coverage:low-memory"]
+run = "bash ../scripts/ensure-bun-package-install.sh && NODE_OPTIONS=\"--max-old-space-size=2048\" VITEST_MAX_WORKERS=1 node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
+description = "Run frontend unit/component tests with 100% coverage enforcement under low-memory settings"

--- a/mise.toml
+++ b/mise.toml
@@ -65,6 +65,31 @@ run = [
 ]
 description = "Run tests for all packages (ugoite-minimum, ugoite-core, backend, frontend, docsite, ugoite-cli)"
 
+[tasks."test:low-memory"]
+description = "Run the repo-wide test gate with conservative parallelism and memory usage"
+run = """
+bash -lc '
+set -euo pipefail
+export MISE_JOBS=1
+export CARGO_BUILD_JOBS=1
+export CARGO_INCREMENTAL=0
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_PROFILE_TEST_DEBUG=0
+export RUSTFLAGS="-C debuginfo=0"
+export VITEST_MAX_WORKERS=1
+export NODE_OPTIONS="--max-old-space-size=2048"
+
+mise run //ugoite-core:build
+mise run //backend:test:no-build
+mise run //frontend:test:coverage:low-memory
+mise run //docsite:test:coverage:low-memory
+mise run //ugoite-cli:test:coverage
+mise run //ugoite-core:test:no-build
+mise run //ugoite-minimum:test
+mise run test:docs
+'
+"""
+
 [tasks."test:docs"]
 description = "Check consistency between documentation and implementation"
 run = [


### PR DESCRIPTION
## Summary
- Adds a documented repo gate
- Adds low-memory Vitest aliases for frontend and docsite
- Documents the path in CONTRIBUTING.md and the CI/CD spec
- Adds a docs regression test so the contributor guide keeps mentioning the new command

## Related Issue (required)
Closes #1674

## Testing
- [x] Devcontainer: verified the updated command path
- [x] `mise run test:docs`
- [x] `uvx pre-commit run --all-files`
