### PR TITLE
Define a minimal-but-strict split between pre-commit, PR CI, and merge/main quality gates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,6 @@
 		"GH_TOKEN": "${localEnv:GH_TOKEN}",
 		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
 	},
-	"postCreateCommand": "sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends oathtool && sudo rm -rf /var/lib/apt/lists/*",
+	"postCreateCommand": "sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends oathtool shfmt shellcheck && sudo rm -rf /var/lib/apt/lists/*",
 	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && cd /workspace/e2e && npx playwright --version && npx playwright install --with-deps chromium"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,7 @@ repos:
         name: cargo llvm-cov (ugoite-core 45%)
         entry: bash -c "cd ugoite-core && uv run cargo llvm-cov --summary-only --fail-under-lines 45 --jobs 1"
         language: system
+        stages: [pre-push]
         files: ^ugoite-core/(src/.*\.rs|tests/.*\.rs|Cargo\.toml)$
         pass_filenames: false
 
@@ -97,6 +98,7 @@ repos:
         name: cargo llvm-cov (ugoite-minimum 100%)
         entry: bash -c "python3 scripts/check_minimum_coverage.py"
         language: system
+        stages: [pre-push]
         files: ^ugoite-minimum/(src/.*\.rs|tests/.*\.rs|Cargo\.toml)$
         pass_filenames: false
 
@@ -111,6 +113,7 @@ repos:
         name: cargo llvm-cov (ugoite-cli 100%)
         entry: bash -c "cd ugoite-cli && cargo clean -p ugoite-cli && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 cargo llvm-cov clean --workspace && CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 RUSTFLAGS='-C debuginfo=0' CARGO_BUILD_JOBS=1 cargo llvm-cov --summary-only --fail-under-lines 100 --no-default-features --jobs 1 || { cargo llvm-cov report --text --show-missing-lines; exit 1; }"
         language: system
+        stages: [pre-push]
         files: ^ugoite-cli/
         pass_filenames: false
 
@@ -169,6 +172,7 @@ repos:
         name: docsite vitest coverage (100%)
         entry: bash -c "cd docsite && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
         language: system
+        stages: [pre-push]
         pass_filenames: false
         files: ^docsite/
 
@@ -176,5 +180,6 @@ repos:
         name: frontend vitest coverage (100%)
         entry: bash -c "cd frontend && bun run test:run --coverage"
         language: system
+        stages: [pre-push]
         pass_filenames: false
         files: ^frontend/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ commands, hooks, and CI-parity checks:
 
 | Path | Choose it when | What it does for you |
 | --- | --- | --- |
-| Managed host toolchain | You are happy installing the repo toolchain on your machine or you are not using VS Code/Codespaces | Run `mise run setup` yourself to install the shared dependencies and `uvx pre-commit install`, so local commits use the same hook chain by default. |
+| Managed host toolchain | You are happy installing the repo toolchain on your machine or you are not using VS Code/Codespaces | Run `mise run setup` yourself to install the shared dependencies, the fast default hook chain, and the heavier pre-push coverage hook, so local commits stay quick by default. |
 | Devcontainer / GitHub Codespaces | You want a reproducible VS Code/Codespaces workspace or do not want to install the full toolchain on your host | `.devcontainer/devcontainer.json` preinstalls `mise`, `gh`, `oathtool`, then runs `mise install`, `mise run setup`, and `npx playwright install --with-deps chromium` for you. |
 
 If you are on the managed host toolchain path, start with:
@@ -20,9 +20,10 @@ If you are on the managed host toolchain path, start with:
 mise run setup
 ```
 
-That path installs the shared dependencies and runs `uvx pre-commit install`, so
-local commits use the same hook chain by default. The devcontainer runs that
-same bootstrap for you during container creation.
+That path installs the shared dependencies and runs `uvx pre-commit install`
+plus the pre-push hook install, so local commits use the fast hook chain by
+default while the heavier coverage gates still run before push. The devcontainer
+runs that same bootstrap for you during container creation.
 
 Common follow-up commands inside either setup:
 
@@ -130,6 +131,14 @@ push on `main` is reserved for fast, low-noise checks and post-merge automation.
 Keep `.github/required-status-checks.json` as the machine-readable source of
 truth, keep `docs/spec/testing/ci-cd.md` as the human-readable policy, and
 update both whenever a workflow moves between those event buckets.
+
+Local hooks follow the same split:
+
+- `uvx pre-commit run --all-files` is the fast default commit-time path
+- `uvx pre-commit run --hook-stage pre-push --all-files` exercises the heavier
+  coverage gates before push
+- `uvx pre-commit install --hook-type pre-push` keeps the heavier stage
+  available automatically after `mise run setup`
 
 When CodeQL or other branch-protection policy changes depend on GitHub ruleset
 state, update the live repository ruleset as well as the checked-in JSON. PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Common follow-up commands inside either setup:
 ```bash
 mise run dev
 mise run test
+mise run test:low-memory
 ```
 
 Before adding a new workflow-specific command, check `.github/workflows/` and
@@ -137,7 +138,8 @@ CodeQL code scanning, and merge queue plus `main` merge were re-verified after
 that repository-side update.
 
 local validation maps to the same CI event split: use `mise run test` for the
-repo baseline, `mise run test:docs` for docs, spec, or REQ-traceability changes,
+repo baseline, `mise run test:low-memory` for devcontainers, Codespaces, and
+memory-constrained machines, `mise run test:docs` for docs, spec, or REQ-traceability changes,
 `mise run e2e` for browser flows, and focused surface commands when only one
 package changed.
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Choose the contributor setup path that matches your machine:
 
 | Path | Choose it when | What it handles for you |
 | --- | --- | --- |
-| Host-managed toolchain | You already want the repo toolchain on your machine or you are not using VS Code/Codespaces | You run `mise run setup` yourself to install dependencies and `uvx pre-commit install`, then continue with `mise run dev`. |
+| Host-managed toolchain | You already want the repo toolchain on your machine or you are not using VS Code/Codespaces | You run `mise run setup` yourself to install dependencies plus the fast pre-commit hook chain and the heavier pre-push coverage hook, then continue with `mise run dev`. |
 | Devcontainer / GitHub Codespaces | You want a reproducible VS Code/Codespaces workspace or do not want to install the full toolchain on your host | `.devcontainer/devcontainer.json` preinstalls `mise`, `gh`, `oathtool`, then runs `mise install`, `mise run setup`, and `npx playwright install --with-deps chromium` for you. |
 
 Install dependencies and repository pre-commit hooks:
@@ -244,8 +244,7 @@ Install dependencies and repository pre-commit hooks:
 mise run setup
 ```
 
-The setup task also runs `uvx pre-commit install` so local commits use the same
-hook chain by default.
+The setup task also runs `uvx pre-commit install` and installs the pre-push hook so local commits stay fast while the heavier coverage gates still run before push.
 
 The devcontainer path runs that same bootstrap for you during container
 creation, so both contributor setups land on the same local commands and hooks.

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -223,11 +223,13 @@ requirements:
   - SPEC-PRODUCT-METRICS
   id: REQ-OPS-006
   title: Rust Pre-commit and CI Coverage Parity
-  description: 'Rust pre-commit hooks MUST enforce format, lint, and coverage gates
+  description: 'Rust default hooks MUST enforce format and lint gates across
 
-    across ugoite-minimum, ugoite-core, and ugoite-cli, including 100% line-coverage
+    ugoite-minimum, ugoite-core, and ugoite-cli, while the heavier coverage gates
 
-    parity for both ugoite-minimum and ugoite-cli with Rust CI and the local
+    move to a pre-push/manual hook stage that still keeps 100% line-coverage parity
+
+    for both ugoite-minimum and ugoite-cli with Rust CI and the local
 
     `mise run test` path.
 
@@ -274,11 +276,11 @@ requirements:
   - SPEC-PRODUCT-METRICS
   id: REQ-OPS-007
   title: Docsite Format/Lint/Test Parity
-  description: 'Docsite quality gates MUST define explicit format, lint, typecheck,
+  description: 'Docsite quality gates MUST define explicit format, lint,
 
-    build validation, and behavior-test coverage validation in both pre-commit
+    typecheck, build validation, and behavior-test coverage validation across the
 
-    hooks and Docsite CI.
+    default pre-commit hooks, the heavier pre-push coverage hook, and Docsite CI.
 
     '
   related_spec:

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -103,9 +103,11 @@ The human-readable policy lives in `CONTRIBUTING.md`.
   `Rust CI`, `SBOM CI`, `ScanCode`, and `Release Quickstart Verify CI`.
 
 Local validation should mirror the same split. Use `mise run test` for the
-routine repo-wide baseline, `mise run test:docs` when `README.md`,
-`CONTRIBUTING.md`, `docs/spec/`, or `docs/tests/` change, and target the
-surface-specific commands when you are iterating on a narrower area.
+routine repo-wide baseline, `mise run test:low-memory` for devcontainers,
+Codespaces, and memory-constrained machines, `mise run test:docs` when
+`README.md`, `CONTRIBUTING.md`, `docs/spec/`, or `docs/tests/` change, and
+target the surface-specific commands when you are iterating on a narrower
+area.
 
 ## Native Required Status Checks
 
@@ -223,6 +225,10 @@ jobs:
 The root `mise run test` contract must enforce the same frontend 100% coverage
 gate by depending on `//frontend:test:coverage`, so local verification and CI
 fail for the same coverage regressions.
+The low-memory root contract depends on
+`//frontend:test:coverage:low-memory`, which keeps the same coverage gate while
+making the constrained execution profile explicit for devcontainers and
+Codespaces.
 Dependabot groups frontend `vitest` and `@vitest/*` Bun updates together so the
 coverage runner packages stay aligned and cannot quietly drift into mixed-version
 warnings during that enforced coverage path.
@@ -243,6 +249,10 @@ jobs:
 The root `mise run test` contract must enforce the same docsite 100% coverage
 gate by depending on `//docsite:test:coverage`, so local verification and CI
 fail for the same coverage regressions.
+The low-memory root contract depends on
+`//docsite:test:coverage:low-memory`, which keeps the same coverage gate while
+making the constrained execution profile explicit for devcontainers and
+Codespaces.
 
 ## E2E CI
 

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -30,12 +30,18 @@ GitHub branch protection and merge queue now rely on GitHub-native required stat
 checks declared in `.github/required-status-checks.json`. Each required workflow
 emits a stable summary check with the workflow name, so the repository ruleset
 can require direct workflow health instead of a polling rollup workflow.
-The split is intentional: push on `main` stays small and mostly covers fast
-static checks plus post-merge automation, pull requests carry the normal
-developer feedback set, and `merge_group` is the final gate for the expensive
-cross-surface validation that protects `main`. The machine-readable policy
-lives in `.github/required-status-checks.json`, and the human-readable policy
-lives in `CONTRIBUTING.md`.
+The split is intentional:
+
+- local pre-commit stays fast and mostly covers formatting, linting, root
+  hygiene, and targeted file-surface checks
+- heavy coverage hooks stay available as pre-push checks so they do not slow
+  every commit
+- pull requests carry the normal developer feedback set
+- `merge_group` is the final gate for the expensive cross-surface validation
+  that protects `main`
+
+The machine-readable policy lives in `.github/required-status-checks.json`, and
+the human-readable policy lives in `CONTRIBUTING.md`.
 Required workflows must not depend on top-level `paths` filters that would make
 a check disappear. Path-aware workflows such as Devcontainer CI perform
 in-workflow change detection and still emit their summary check when the
@@ -107,7 +113,9 @@ routine repo-wide baseline, `mise run test:low-memory` for devcontainers,
 Codespaces, and memory-constrained machines, `mise run test:docs` when
 `README.md`, `CONTRIBUTING.md`, `docs/spec/`, or `docs/tests/` change, and
 target the surface-specific commands when you are iterating on a narrower
-area.
+area. For the hook chain, `uvx pre-commit run --all-files` exercises the fast
+default hooks, while `uvx pre-commit run --hook-stage pre-push --all-files`
+exercises the heavier coverage gates before pushing.
 
 ## Native Required Status Checks
 
@@ -474,20 +482,17 @@ The canonical contributor bootstrap is:
 ```bash
 mise run setup
 uvx pre-commit run --all-files
+uvx pre-commit run --hook-stage pre-push --all-files
 ```
 
-`mise run setup` installs dependencies and runs `uvx pre-commit install`, so
-local commits use the same hook chain by default. Re-run `uvx pre-commit
-install` manually only if the hooks need repair.
+`mise run setup` installs dependencies and runs `uvx pre-commit install`, and
+also installs the pre-push hook, so local commits stay fast while the heavier
+coverage gates still run before push. Re-run `uvx pre-commit install` manually
+only if the hooks need repair.
 
 Hooks configured in `.pre-commit-config.yaml`:
-- **Ruff**: Auto-formats and lints Python
-- **Rust fmt/lint/test parity**: `ugoite-minimum`, `ugoite-core`, and `ugoite-cli` run Rust quality gates before commit, with both `ugoite-minimum` and `ugoite-cli` enforcing 100% line coverage via `cargo llvm-cov`
-- **Docsite parity hooks**: Lint, format check, typecheck, validation build, and 100% Vitest coverage for `docsite/`
-- **Yamllint**: Validates YAML syntax/style on committed YAML files
-- **Actionlint**: Validates `.github/workflows/*` syntax and workflow semantics
-- **Root artifact hygiene**: Blocks placeholder files, tracked+ignored paths, generated dependency trees, and oversized tracked artifacts
-- **Ty**: Type checks Python projects (`backend/` and `ugoite-core/`)
+- **Fast default hooks**: Ruff, Yamllint, Actionlint, root artifact hygiene, shell quality, Rust fmt/clippy, backend ty, and docsite lint/typecheck/validation
+- **Pre-push coverage hooks**: Rust coverage gates for `ugoite-minimum`, `ugoite-core`, and `ugoite-cli`, plus 100% Vitest coverage for `frontend/` and `docsite/`
 
 Conventional Commit enforcement (local):
 

--- a/docs/tests/test_contributing_guide.py
+++ b/docs/tests/test_contributing_guide.py
@@ -90,6 +90,13 @@ def test_docs_req_ops_036_contributor_workflow_guide_stays_traceable() -> None:
                 "CONTRIBUTING.md must mention the repo-wide validation command",
             ),
             (
+                "mise run test:low-memory" not in contributing_text,
+                (
+                    "CONTRIBUTING.md must mention the low-memory repo-wide "
+                    "validation command"
+                ),
+            ),
+            (
                 "mise run test:docs" not in contributing_text,
                 "CONTRIBUTING.md must mention the docs consistency validation command",
             ),

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -199,6 +199,7 @@ REQUIRED_YAML_WORKFLOW_CI_STEPS = {
     "Run actionlint",
 }
 REQUIRED_PRE_COMMIT_SETUP_COMMAND = "uvx pre-commit install"
+REQUIRED_PRE_COMMIT_SETUP_PRE_PUSH_COMMAND = "--hook-type pre-push"
 REQUIRED_PRE_COMMIT_SETUP_RESET_COMMAND = (
     "if git config --local --get core.hooksPath >/dev/null; "
     "then git config --local --unset-all "
@@ -206,14 +207,25 @@ REQUIRED_PRE_COMMIT_SETUP_RESET_COMMAND = (
 )
 REQUIRED_PRE_COMMIT_SETUP_README_FRAGMENTS = {
     "Install dependencies and repository pre-commit hooks:",
-    "The setup task also runs `uvx pre-commit install` so local commits use the same",
-    "hook chain by default.",
+    "The setup task also runs `uvx pre-commit install` and installs the pre-push",
+    "hook so local commits stay fast while the heavier coverage gates still run",
+    "before push.",
+    "pre-push hook",
+    "coverage gates still run before push",
 }
 REQUIRED_PRE_COMMIT_SETUP_DOC_FRAGMENTS = {
     "The canonical contributor bootstrap is:",
     "mise run setup",
-    "`mise run setup` installs dependencies and runs `uvx pre-commit install`, so",
-    "local commits use the same hook chain by default.",
+    "`mise run setup` installs dependencies and runs `uvx pre-commit install`, and",
+    "also installs the pre-push hook, so local commits stay fast while the heavier",
+    "coverage gates still run before push.",
+    "pre-push hook",
+    "uvx pre-commit run --hook-stage pre-push --all-files",
+}
+REQUIRED_PRE_COMMIT_SETUP_CONTRIBUTING_FRAGMENTS = {
+    "Local hooks follow the same split:",
+    "uvx pre-commit run --hook-stage pre-push --all-files",
+    "uvx pre-commit install --hook-type pre-push",
 }
 REQUIRED_PYTHON_TEST_STRICTNESS_DOC_FRAGMENTS = {
     "Local backend, ugoite-core, and docs pytest tasks also",
@@ -1905,9 +1917,26 @@ def _collect_req_ops_006_rust_precommit_parity_details() -> list[str]:
 
 def _collect_req_ops_006_pre_commit_details() -> list[str]:
     pre_commit = _load_pre_commit_config()
+    return [
+        *_collect_req_ops_006_pre_commit_hook_details(pre_commit),
+        *_collect_req_ops_006_pre_commit_command_details(pre_commit),
+        *_collect_req_ops_006_pre_commit_stage_details(pre_commit),
+    ]
+
+
+def _collect_req_ops_006_pre_commit_hook_details(
+    pre_commit: dict[str, object],
+) -> list[str]:
     configured_hooks = _collect_pre_commit_hook_ids(pre_commit)
     missing_hooks = sorted(REQUIRED_RUST_PRE_COMMIT_HOOKS.difference(configured_hooks))
+    if not missing_hooks:
+        return []
+    return ["pre-commit missing hooks: " + ", ".join(missing_hooks)]
 
+
+def _collect_req_ops_006_pre_commit_command_details(
+    pre_commit: dict[str, object],
+) -> list[str]:
     hook_entries = _collect_pre_commit_hooks(pre_commit)
     clippy_cli_entry = ""
     cargo_clippy_cli = hook_entries.get("cargo-clippy-cli")
@@ -1923,19 +1952,42 @@ def _collect_req_ops_006_pre_commit_details() -> list[str]:
     if isinstance(cargo_llvm_cov_cli, dict):
         cli_cov_entry = str(cargo_llvm_cov_cli.get("entry", ""))
 
-    missing_parts: list[str] = []
-    if missing_hooks:
-        missing_parts.append("pre-commit missing hooks: " + ", ".join(missing_hooks))
+    details: list[str] = []
     if "--no-default-features" not in clippy_cli_entry:
-        missing_parts.append("cargo-clippy-cli must pass --no-default-features")
+        details.append("cargo-clippy-cli must pass --no-default-features")
     if REQUIRED_MINIMUM_COVERAGE_COMMAND not in minimum_cov_entry:
-        missing_parts.append("cargo-llvm-cov-minimum must run the wrapper")
+        details.append("cargo-llvm-cov-minimum must run the wrapper")
     if "--fail-under-lines 100" not in cli_cov_entry:
-        missing_parts.append("cargo-llvm-cov-cli must enforce 100% line coverage")
+        details.append("cargo-llvm-cov-cli must enforce 100% line coverage")
     if "--no-default-features" not in cli_cov_entry:
-        missing_parts.append("cargo-llvm-cov-cli must pass --no-default-features")
+        details.append("cargo-llvm-cov-cli must pass --no-default-features")
+    return details
 
-    return missing_parts
+
+def _collect_req_ops_006_pre_commit_stage_details(
+    pre_commit: dict[str, object],
+) -> list[str]:
+    minimum_cov_stages = _collect_pre_commit_hook_stages(
+        pre_commit,
+        "cargo-llvm-cov-minimum",
+    )
+    core_cov_stages = _collect_pre_commit_hook_stages(
+        pre_commit,
+        "cargo-llvm-cov-core",
+    )
+    cli_cov_stages = _collect_pre_commit_hook_stages(
+        pre_commit,
+        "cargo-llvm-cov-cli",
+    )
+
+    details: list[str] = []
+    if "pre-push" not in minimum_cov_stages:
+        details.append("cargo-llvm-cov-minimum must run at pre-push")
+    if "pre-push" not in core_cov_stages:
+        details.append("cargo-llvm-cov-core must run at pre-push")
+    if "pre-push" not in cli_cov_stages:
+        details.append("cargo-llvm-cov-cli must run at pre-push")
+    return details
 
 
 def _collect_req_ops_006_ci_details() -> list[str]:
@@ -3487,6 +3539,7 @@ def test_docs_req_ops_021_frontend_coverage_gate_is_explicit() -> None:
     root_mise = tomllib.loads(MISE_PATH.read_text(encoding="utf-8"))
     root_runs = _get_task_run_commands(root_mise, "test")
     frontend_mise = tomllib.loads(FRONTEND_MISE_PATH.read_text(encoding="utf-8"))
+    pre_commit = _load_pre_commit_config()
     frontend_package = _load_json_mapping(FRONTEND_PACKAGE_JSON_PATH)
     frontend_bun_lock = _read_required_text(
         FRONTEND_BUN_LOCK_PATH,
@@ -3506,6 +3559,10 @@ def test_docs_req_ops_021_frontend_coverage_gate_is_explicit() -> None:
         FRONTEND_CI_WORKFLOW_PATH,
         job_name="ci",
         step_name=REQUIRED_FRONTEND_COVERAGE_STEP_NAME,
+    )
+    coverage_stages = _collect_pre_commit_hook_stages(
+        pre_commit,
+        "frontend-vitest-coverage",
     )
     guide_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
     missing_doc_fragments = sorted(
@@ -3576,6 +3633,10 @@ def test_docs_req_ops_021_frontend_coverage_gate_is_explicit() -> None:
         (
             REQUIRED_FRONTEND_COVERAGE_COMMAND not in coverage_run,
             'frontend/mise.toml [tasks."test:coverage"] must run node vitest coverage',
+        ),
+        (
+            "pre-push" not in coverage_stages,
+            "frontend-vitest-coverage must run at pre-push",
         ),
         (
             coverage_step_run is None,
@@ -3933,6 +3994,7 @@ def test_docs_req_ops_024_docsite_coverage_gate_is_explicit() -> None:
     root_mise = tomllib.loads(MISE_PATH.read_text(encoding="utf-8"))
     root_runs = _get_task_run_commands(root_mise, "test")
     docsite_mise = tomllib.loads(DOCSITE_MISE_PATH.read_text(encoding="utf-8"))
+    pre_commit = _load_pre_commit_config()
     coverage_task = _load_mise_task_mapping(
         docsite_mise,
         task_name="test:coverage",
@@ -3946,6 +4008,10 @@ def test_docs_req_ops_024_docsite_coverage_gate_is_explicit() -> None:
         DOCSITE_CI_WORKFLOW_PATH,
         job_name="ci",
         step_name=REQUIRED_DOCSITE_COVERAGE_STEP_NAME,
+    )
+    coverage_stages = _collect_pre_commit_hook_stages(
+        pre_commit,
+        "docsite-vitest-coverage",
     )
     guide_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
     missing_doc_fragments = sorted(
@@ -3962,6 +4028,10 @@ def test_docs_req_ops_024_docsite_coverage_gate_is_explicit() -> None:
         (
             REQUIRED_DOCSITE_COVERAGE_COMMAND not in coverage_run,
             'docsite/mise.toml [tasks."test:coverage"] must run node vitest coverage',
+        ),
+        (
+            "pre-push" not in coverage_stages,
+            "docsite-vitest-coverage must run at pre-push",
         ),
         (
             coverage_step_run is None,
@@ -4186,6 +4256,7 @@ def test_docs_req_ops_032_setup_installs_pre_commit_hooks() -> None:
     devcontainer = _load_json_mapping(DEVCONTAINER_JSON_PATH)
     readme_text = README_PATH.read_text(encoding="utf-8")
     ci_cd_text = CI_CD_SPEC_PATH.read_text(encoding="utf-8")
+    contributing_text = CONTRIBUTING_PATH.read_text(encoding="utf-8")
 
     root_setup_runs = _get_task_run_commands(root_mise, "setup")
     on_create_command = devcontainer.get("onCreateCommand")
@@ -4199,6 +4270,11 @@ def test_docs_req_ops_032_setup_installs_pre_commit_hooks() -> None:
         for fragment in REQUIRED_PRE_COMMIT_SETUP_DOC_FRAGMENTS
         if fragment not in ci_cd_text
     )
+    missing_contributing_fragments = sorted(
+        fragment
+        for fragment in REQUIRED_PRE_COMMIT_SETUP_CONTRIBUTING_FRAGMENTS
+        if fragment not in contributing_text
+    )
 
     detail_candidates = (
         (
@@ -4209,6 +4285,13 @@ def test_docs_req_ops_032_setup_installs_pre_commit_hooks() -> None:
         (
             REQUIRED_PRE_COMMIT_SETUP_COMMAND not in root_setup_runs,
             "root mise.toml tasks.setup must install pre-commit hooks",
+        ),
+        (
+            not any(
+                REQUIRED_PRE_COMMIT_SETUP_PRE_PUSH_COMMAND in command
+                for command in root_setup_runs
+            ),
+            "root mise.toml tasks.setup must install the pre-push hook",
         ),
         (
             not isinstance(on_create_command, str),
@@ -4235,6 +4318,11 @@ def test_docs_req_ops_032_setup_installs_pre_commit_hooks() -> None:
             bool(missing_doc_fragments),
             "ci-cd guide missing setup hook fragments: "
             + ", ".join(missing_doc_fragments),
+        ),
+        (
+            bool(missing_contributing_fragments),
+            "CONTRIBUTING.md missing setup hook fragments: "
+            + ", ".join(missing_contributing_fragments),
         ),
     )
     details = [message for condition, message in detail_candidates if condition]
@@ -5934,6 +6022,19 @@ def _collect_pre_commit_hooks(
 
 def _collect_pre_commit_hook_ids(config: dict[str, object]) -> set[str]:
     return set(_collect_pre_commit_hooks(config))
+
+
+def _collect_pre_commit_hook_stages(
+    config: dict[str, object],
+    hook_id: str,
+) -> tuple[str, ...]:
+    hook = _collect_pre_commit_hooks(config).get(hook_id)
+    if not isinstance(hook, dict):
+        return ()
+    stages = hook.get("stages", [])
+    if isinstance(stages, list):
+        return tuple(item for item in stages if isinstance(item, str))
+    return ()
 
 
 def _get_env_value(config: dict[str, object], key: str) -> str | None:

--- a/docsite/mise.toml
+++ b/docsite/mise.toml
@@ -24,6 +24,10 @@ description = "Run docsite unit tests with Vitest"
 run = "bash ../scripts/ensure-bun-package-install.sh && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
 description = "Run docsite unit tests with 100% coverage enforcement"
 
+[tasks."test:coverage:low-memory"]
+run = "bash ../scripts/ensure-bun-package-install.sh && NODE_OPTIONS=\"--max-old-space-size=2048\" VITEST_MAX_WORKERS=1 node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
+description = "Run docsite unit tests with 100% coverage enforcement under low-memory settings"
+
 [tasks.build]
 run = "bun run build"
 

--- a/frontend/mise.toml
+++ b/frontend/mise.toml
@@ -13,3 +13,7 @@ description = "Run frontend unit/component tests with Vitest"
 [tasks."test:coverage"]
 run = "bash ../scripts/ensure-bun-package-install.sh && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
 description = "Run frontend unit/component tests with 100% coverage enforcement"
+
+[tasks."test:coverage:low-memory"]
+run = "bash ../scripts/ensure-bun-package-install.sh && NODE_OPTIONS=\"--max-old-space-size=2048\" VITEST_MAX_WORKERS=1 node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1"
+description = "Run frontend unit/component tests with 100% coverage enforcement under low-memory settings"

--- a/mise.toml
+++ b/mise.toml
@@ -65,6 +65,31 @@ run = [
 ]
 description = "Run tests for all packages (ugoite-minimum, ugoite-core, backend, frontend, docsite, ugoite-cli)"
 
+[tasks."test:low-memory"]
+description = "Run the repo-wide test gate with conservative parallelism and memory usage"
+run = """
+bash -lc '
+set -euo pipefail
+export MISE_JOBS=1
+export CARGO_BUILD_JOBS=1
+export CARGO_INCREMENTAL=0
+export CARGO_PROFILE_DEV_DEBUG=0
+export CARGO_PROFILE_TEST_DEBUG=0
+export RUSTFLAGS="-C debuginfo=0"
+export VITEST_MAX_WORKERS=1
+export NODE_OPTIONS="--max-old-space-size=2048"
+
+mise run //ugoite-core:build
+mise run //backend:test:no-build
+mise run //frontend:test:coverage:low-memory
+mise run //docsite:test:coverage:low-memory
+mise run //ugoite-cli:test:coverage
+mise run //ugoite-core:test:no-build
+mise run //ugoite-minimum:test
+mise run test:docs
+'
+"""
+
 [tasks."test:docs"]
 description = "Check consistency between documentation and implementation"
 run = [

--- a/mise.toml
+++ b/mise.toml
@@ -35,6 +35,7 @@ run = [
 	"mise run //e2e:install",
 	"if git config --local --get core.hooksPath >/dev/null; then git config --local --unset-all core.hooksPath; fi",
 	"uvx pre-commit install",
+	"uvx pre-commit install --hook-type pre-push",
 ]
 
 [tasks.dev]


### PR DESCRIPTION
## Summary
- Move expensive coverage hooks to pre-push so normal commits stay fast
- Keep default pre-commit focused on deterministic formatting/lint/hygiene checks
- Document the split in the repo guides and CI policy docs
- Align devcontainer setup so the default hook chain works there too

## Related Issue (required)
Closes #1675

## Testing
- [x] Devcontainer verification
- [x] `mise run test:docs`
- [x] `uvx pre-commit run --all-files`
- [x] `uvx pre-commit run --hook-stage pre-push --all-files`
