### PR TITLE
Add repo-local Codex skills

### DIFF
--- a/.codex/skills/ugoite-implement/SKILL.md
+++ b/.codex/skills/ugoite-implement/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: ugoite-implement
+description: Use when implementing, refactoring, or fixing Ugoite code or docs and you need the repo-specific workflow.
+---
+
+# Ugoite Implementation
+
+Use this skill when you are making a change rather than just investigating.
+
+## Workflow
+
+1. Read the owning surface docs and relevant spec entries.
+2. Make the smallest change that satisfies the requirement.
+3. Add or update tests in the same surface.
+4. Run the narrowest CI-aligned check first.
+5. Expand to the repo-wide check only when the change crosses surfaces.
+
+## Surface map
+
+- `backend`: FastAPI and Python service logic.
+- `frontend`: SolidStart UI.
+- `docsite`: documentation app and doc rendering checks.
+- `ugoite-core`: Rust core plus Python bindings.
+- `ugoite-cli`: Rust CLI and release-facing command behavior.
+- `ugoite-minimum`: portable Rust core / WASM-oriented logic.
+- `e2e`: Playwright flows against running services.
+- `docs`: spec, guide, and requirement consistency.
+
+## Change discipline
+
+- Keep behavior changes narrow unless the task explicitly asks for a broader
+  migration.
+- Prefer repo-native abstractions and existing patterns over introducing new
+  ones.
+- If a change touches requirements or user-visible behavior, update the
+  relevant docs/specs at the same time.
+- Do not rename public interfaces, command flags, or file layouts unless the
+  task requires it.
+
+## OpenAI guidance
+
+- When the task is about AI guidance rather than repo code, follow the current
+  official OpenAI docs and model guidance instead of embedding a fixed model id
+  in repo instructions.
+

--- a/.codex/skills/ugoite-orient/SKILL.md
+++ b/.codex/skills/ugoite-orient/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: ugoite-orient
+description: Use when starting work in the Ugoite repo, choosing the right docs, or deciding which surface and commands apply.
+---
+
+# Ugoite Orientation
+
+Use this skill first when the task is ambiguous, cross-surface, or mostly about
+figuring out where to work.
+
+## Read first
+
+- `README.md`
+- `docs/spec/index.md`
+- `docs/spec/testing/ci-cd.md`
+- `docs/spec/testing/strategy.md`
+- `.github/workflows/`
+
+## What to determine
+
+1. Which surface owns the change: `backend`, `frontend`, `docsite`,
+   `ugoite-core`, `ugoite-cli`, `ugoite-minimum`, `docs`, `e2e`, or release.
+2. Whether the task is user-facing, spec-facing, or purely operational.
+3. Which validation lane matches the change.
+
+## Rules of thumb
+
+- Prefer the smallest surface that can safely absorb the change.
+- If docs and code disagree, treat `docs/spec/` and CI as the source of truth.
+- For OpenAI model guidance or prompting questions, use the current official
+  OpenAI docs rather than a frozen alias or repo-local guess.
+- Do not start editing until the owning surface and validation path are clear.
+
+## Output expectation
+
+Give a short routing answer:
+
+- target surface
+- primary docs to read
+- exact validation command(s) to run next
+

--- a/.codex/skills/ugoite-release/SKILL.md
+++ b/.codex/skills/ugoite-release/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: ugoite-release
+description: Use when touching release, packaging, Docker, Helm, or install/update flows.
+---
+
+# Ugoite Release
+
+Use this skill for anything that changes how Ugoite is packaged, published,
+installed, or deployed.
+
+## Read first
+
+- `docs/guide/docker-compose.md`
+- `docs/guide/container-quickstart.md`
+- `docs/guide/helm-chart.md`
+- `docs/guide/cli.md`
+- `packages/ugoite/README.md`
+- `.github/workflows/release-*.yml`
+- `.github/workflows/docker-*.yml`
+
+## Release rules
+
+- Keep version pins and SHA pins explicit.
+- Do not loosen reproducibility just to make a build pass.
+- Treat generated artifacts, installers, and release scripts as part of the
+  contract.
+- When changing packaging or install behavior, verify the published path and
+  the source path separately.
+- If a release change affects quickstart or install docs, update the matching
+  guide in the same change.
+
+## Validation
+
+- `bash scripts/check-root-artifact-hygiene.sh`
+- `docker compose -f docker-compose.yaml config`
+- `docker compose -f docker-compose.release.yaml config`
+- `bash scripts/verify-release-cli-quickstart.sh` when CLI release behavior
+  changes
+- `bash scripts/verify-release-container-quickstart.sh` when browser release
+  behavior changes
+

--- a/.codex/skills/ugoite-release/SKILL.md
+++ b/.codex/skills/ugoite-release/SKILL.md
@@ -10,6 +10,7 @@ installed, or deployed.
 
 ## Read first
 
+- `docs/spec/testing/ci-cd.md`
 - `docs/guide/docker-compose.md`
 - `docs/guide/container-quickstart.md`
 - `docs/guide/helm-chart.md`
@@ -38,4 +39,3 @@ installed, or deployed.
   changes
 - `bash scripts/verify-release-container-quickstart.sh` when browser release
   behavior changes
-

--- a/.codex/skills/ugoite-validate/SKILL.md
+++ b/.codex/skills/ugoite-validate/SKILL.md
@@ -18,14 +18,16 @@ triage.
 ## Surface checks
 
 - `backend`: `cd backend && uv run ty check .`
-- `backend`: `cd backend && uv run pytest -W error`
+- `backend`: `cd backend && uv run pytest -W error --junitxml=../backend-pytest.xml`
+- `backend`: `python3 scripts/check_pytest_no_skips.py backend-pytest.xml "backend tests"`
 - `frontend`: `cd frontend && biome ci .`
 - `frontend`: `mise run //frontend:test:coverage`
 - `docsite`: `mise run //docsite:test:coverage`
 - `ugoite-core`: `cd ugoite-core && uv run ty check .`
 - `ugoite-core`: `cd ugoite-core && cargo fmt --check`
 - `ugoite-core`: `cd ugoite-core && cargo clippy -- -D warnings`
-- `ugoite-core`: `cd ugoite-core && uv run pytest -W error`
+- `ugoite-core`: `cd ugoite-core && uv run pytest -W error --junitxml=../core-pytest.xml`
+- `ugoite-core`: `python3 scripts/check_pytest_no_skips.py core-pytest.xml "ugoite-core tests"`
 - `ugoite-cli`: `cd ugoite-cli && cargo fmt --check`
 - `ugoite-cli`: `cd ugoite-cli && cargo clippy --no-default-features -- -D warnings`
 - `ugoite-cli`: `mise run //ugoite-cli:test:coverage`
@@ -39,4 +41,3 @@ triage.
   the repo-wide test task.
 - If CI and local results disagree, check workflow pins, lockfiles, and
   `mise.toml` versions before changing implementation.
-

--- a/.codex/skills/ugoite-validate/SKILL.md
+++ b/.codex/skills/ugoite-validate/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ugoite-validate
+description: Use when running or interpreting Ugoite validation, CI, tests, lint, or coverage commands.
+---
+
+# Ugoite Validation
+
+Use this skill for test selection, CI parity, linting, coverage, and failure
+triage.
+
+## Baseline
+
+- `mise run test`
+- `mise run test:docs` when changing `README.md`, `CONTRIBUTING.md`,
+  `docs/spec/`, or `docs/tests/`
+- `mise run e2e` for end-to-end or cross-surface behavior
+
+## Surface checks
+
+- `backend`: `cd backend && uv run ty check .`
+- `backend`: `cd backend && uv run pytest -W error`
+- `frontend`: `cd frontend && biome ci .`
+- `frontend`: `mise run //frontend:test:coverage`
+- `docsite`: `mise run //docsite:test:coverage`
+- `ugoite-core`: `cd ugoite-core && uv run ty check .`
+- `ugoite-core`: `cd ugoite-core && cargo fmt --check`
+- `ugoite-core`: `cd ugoite-core && cargo clippy -- -D warnings`
+- `ugoite-core`: `cd ugoite-core && uv run pytest -W error`
+- `ugoite-cli`: `cd ugoite-cli && cargo fmt --check`
+- `ugoite-cli`: `cd ugoite-cli && cargo clippy --no-default-features -- -D warnings`
+- `ugoite-cli`: `mise run //ugoite-cli:test:coverage`
+- `ugoite-minimum`: `mise run //ugoite-minimum:test`
+
+## Failure triage
+
+- Re-run the smallest failing command first.
+- If a docs test fails, inspect the matching guide or spec before touching code.
+- If a coverage gate fails, use the package-local coverage command rather than
+  the repo-wide test task.
+- If CI and local results disagree, check workflow pins, lockfiles, and
+  `mise.toml` versions before changing implementation.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,13 @@ Before marking any task as complete:
 
 ---
 
+## 🤖 Codex Skills
+
+Repo-local Codex skills live under `.codex/skills/` and should be treated as the
+preferred task-specific playbooks for this repository. Use the orientation,
+implementation, validation, and release skills when they match the task, and
+keep them aligned with `README.md`, `docs/spec/`, and `.github/workflows/`.
+
 ## 💡 Best Practices
 
 - **2025 Standards**: Research current best practices before implementing new features


### PR DESCRIPTION
## Summary

Add repo-local Codex skills for orientation, implementation, validation, and release workflows, plus an AGENTS.md pointer so future Codex runs pick them up naturally. Tighten the validation skill to mirror the backend and ugoite-core CI pytest contracts, including JUnit output and no-skips enforcement, and add the CI/CD spec to the release skill's first-read list.

## Related Issue (required)

close: #1688

## Testing

- [x] `mise run test:docs`
- [ ] `mise run test`
- [ ] Manual review of the updated skill guidance against `docs/spec/testing/ci-cd.md`
