### PR TITLE
Fix artifact hygiene helper portability

### DIFF
--- a/scripts/check-placeholder-artifacts.sh
+++ b/scripts/check-placeholder-artifacts.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-mapfile -t placeholder_files < <(
+placeholder_files=()
+while IFS= read -r placeholder_file; do
+  placeholder_files+=("$placeholder_file")
+done < <(
   python3 - <<'PY'
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- Replace the non-portable shell read logic in `scripts/check-placeholder-artifacts.sh` with a bash-3.2-compatible loop.
- Keep the artifact hygiene guard working in CI and docs tests.

## Related Issue (required)
closes #789

## Testing
- [x] `bash scripts/check-placeholder-artifacts.sh`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests/test_artifact_hygiene.py -W error`
