### PR TITLE
docs: surface auth before browser walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ contributor notes in [Contributor Workflow](CONTRIBUTING.md).
 - [Understand core concepts](docs/guide/concepts.md) when you want the mental
   model behind spaces, entries, forms, and search before you go deeper into
   auth or the specs.
-- [Create your first space, form, and entry](docs/guide/browser-first-entry.md)
-  once `/login` succeeds and you want the exact `/spaces` -> form -> entry path.
-- [Understand auth and access](docs/guide/auth-overview.md) before rollout or
-  scripting across the browser, CLI, and API.
+  - [Understand auth and access](docs/guide/auth-overview.md) before rollout or
+    scripting across the browser, CLI, and API.
+  - [Create your first space, form, and entry](docs/guide/browser-first-entry.md)
+    once `/login` succeeds and you want the exact `/spaces` -> form -> entry path.
 - [Read design and source docs](docs/spec/index.md) when you need philosophy,
   requirements, APIs, or machine-readable specs.
 

--- a/docs/guide/browser-first-entry.md
+++ b/docs/guide/browser-first-entry.md
@@ -1,8 +1,10 @@
 # Browser Walkthrough: First Space, Form, and Entry
 
-Use this guide after you have already completed the browser login flow and can
-reach `/spaces`. It is the concrete post-login path for the browser route's
-**time-to-first-entry** experience.
+## Before you start
+
+Complete the browser login flow and confirm that you can reach `/spaces`
+before using this guide. It is the concrete post-login path for the browser
+route's **time-to-first-entry** experience.
 
 If you have not signed in yet, start with either
 [Container Quick Start](container-quickstart.md) or

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -1249,8 +1249,8 @@ def test_docs_req_e2e_008_readme_start_here_mirrors_docsite_taxonomy() -> None:
         "Run from source",
         "Use the CLI",
         "Understand core concepts",
-        "Create your first space, form, and entry",
         "Understand auth and access",
+        "Create your first space, form, and entry",
         "Read design and source docs",
     ]
     missing = [fragment for fragment in required_fragments if fragment not in section]

--- a/docsite/src/lib/onboarding.test.ts
+++ b/docsite/src/lib/onboarding.test.ts
@@ -29,20 +29,20 @@ test("REQ-E2E-008: onboarding content keeps try, source, and CLI paths as the fi
 
 test("REQ-E2E-008: onboarding content keeps browser, auth, and deeper reference docs available after the first step", () => {
 	expect(nextStepCards.map((card) => card.title)).toEqual([
-		"Create your first space, form, and entry",
 		"Understand auth and access",
+		"Create your first space, form, and entry",
 		"Read design and source docs",
 		"Run and troubleshoot the stack",
 	]);
 	expect(nextStepCards.map((card) => card.href)).toEqual([
-		"/docs/guide/browser-first-entry",
 		"/docs/guide/auth-overview",
+		"/docs/guide/browser-first-entry",
 		"/docs/spec/index",
 		"/docs/guide/operations",
 	]);
 	expect(nextStepCards.map((card) => card.badge)).toEqual([
-		"Browser walkthrough",
 		"Access",
+		"Browser walkthrough",
 		"Reference",
 		"Ops",
 	]);
@@ -70,21 +70,21 @@ test("REQ-E2E-008: onboarding content keeps browser caveats explicit on browser-
 	expect(primaryStartCards[2]?.description).toContain(
 		"avoid container infrastructure",
 	);
-	expect(nextStepCards[0]?.description).toContain("After login");
+	expect(nextStepCards[1]?.description).toContain("After login");
 	expect(nextStepCards[3]?.description).toContain("health checks");
-	expect(nextStepCards[0]?.description).toContain("starter entry");
-	expect(nextStepCards[0]?.description).toContain("browser surface");
+	expect(nextStepCards[1]?.description).toContain("starter entry");
+	expect(nextStepCards[1]?.description).toContain("browser surface");
 });
 
 test("REQ-E2E-008: onboarding content keeps the browser next step aligned to the walkthrough", () => {
 	expect(nextStepCards[0]).toMatchObject({
-		badge: "Browser walkthrough",
-		href: "/docs/guide/browser-first-entry",
+		badge: "Access",
+		href: "/docs/guide/auth-overview",
 	});
-	expect(nextStepCards[0]?.description).toContain("starter entry");
-	expect(nextStepCards[0]?.description).toContain("After login");
-	expect(nextStepCards[0]?.description).toContain("forms/search path");
-	expect(nextStepCards[0]?.description).toContain(
+	expect(nextStepCards[1]?.description).toContain("starter entry");
+	expect(nextStepCards[1]?.description).toContain("After login");
+	expect(nextStepCards[1]?.description).toContain("forms/search path");
+	expect(nextStepCards[1]?.description).toContain(
 		"what each main browser surface is for",
 	);
 });

--- a/docsite/src/lib/onboarding.ts
+++ b/docsite/src/lib/onboarding.ts
@@ -88,20 +88,20 @@ export const primaryStartCards = [
 
 export const nextStepCards = [
 	{
-		badge: "Browser walkthrough",
-		description:
-			"After login, follow the concrete `/spaces` -> space -> starter entry -> forms/search path, including when to create a new space and what each main browser surface is for.",
-		href: "/docs/guide/browser-first-entry",
-		icon: "🖥️",
-		title: "Create your first space, form, and entry",
-	},
-	{
 		badge: "Access",
 		description:
 			"Review browser, CLI, and API sign-in flows before rollout or scripting.",
 		href: "/docs/guide/auth-overview",
 		icon: "🔐",
 		title: "Understand auth and access",
+	},
+	{
+		badge: "Browser walkthrough",
+		description:
+			"After login, follow the concrete `/spaces` -> space -> starter entry -> forms/search path, including when to create a new space and what each main browser surface is for.",
+		href: "/docs/guide/browser-first-entry",
+		icon: "🖥️",
+		title: "Create your first space, form, and entry",
 	},
 	{
 		badge: "Reference",

--- a/e2e/docsite-onboarding.test.ts
+++ b/e2e/docsite-onboarding.test.ts
@@ -43,8 +43,8 @@ test.describe("Docsite onboarding-first navigation", () => {
 			"Use the CLI",
 		]);
 		await expect(page.locator("#next-steps a h3")).toHaveText([
-			"Create your first space, form, and entry",
 			"Understand auth and access",
+			"Create your first space, form, and entry",
 			"Read design and source docs",
 			"Run and troubleshoot the stack",
 		]);
@@ -65,8 +65,8 @@ test.describe("Docsite onboarding-first navigation", () => {
 			"Use the CLI",
 		]);
 		await expect(page.locator("#next .doc-card h3")).toHaveText([
-			"Create your first space, form, and entry",
 			"Understand auth and access",
+			"Create your first space, form, and entry",
 			"Read design and source docs",
 			"Run and troubleshoot the stack",
 		]);


### PR DESCRIPTION
## Summary
- Move auth ahead of the browser walkthrough in the docsite onboarding order.
- Open the browser guide with an explicit login prerequisite note.
- Update the matching docs, docsite, and Playwright fixtures.

## Related Issue (required)
closes #1485

## Testing
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest -W error docs/tests/test_guides.py::test_docs_req_e2e_008_readme_start_here_mirrors_docsite_taxonomy docs/tests/test_guides.py::test_docs_req_ops_015_local_dev_auth_docs_cover_manual_modes docs/tests/test_guides.py::test_docs_req_fe_060_browser_walkthrough_points_storage_summary_to_intro`
- [x] `bun run test:run src/lib/onboarding.test.ts`
- [x] `E2E_AUTH_BEARER_TOKEN=dummy bunx playwright test docsite-onboarding.test.ts`
