### PR TITLE
fix(api): sanitize backend error responses

### DIFF
--- a/backend/src/app/api/endpoints/entry.py
+++ b/backend/src/app/api/endpoints/entry.py
@@ -86,13 +86,13 @@ async def create_entry_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to create entry",
         ) from e
     except Exception as e:
         logger.exception("Failed to create entry")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to create entry",
         ) from e
 
     return {"id": entry_id, "revision_id": entry_data.get("revision_id", "")}
@@ -129,7 +129,7 @@ async def list_entries_endpoint(
         logger.exception("Failed to list entries")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to list entries",
         ) from e
 
 
@@ -173,7 +173,7 @@ async def list_entry_options_endpoint(
         logger.exception("Failed to list entry picker options")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to list entry picker options",
         ) from e
 
 
@@ -203,13 +203,13 @@ async def get_entry_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load entry",
         ) from e
     except Exception as e:
         logger.exception("Failed to get entry")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load entry",
         ) from e
     else:
         return _entry_response(entry)
@@ -300,7 +300,7 @@ async def update_entry_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to update entry",
         ) from e
     except HTTPException:
         raise
@@ -308,7 +308,7 @@ async def update_entry_endpoint(
         logger.exception("Failed to update entry")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to update entry",
         ) from e
 
 
@@ -344,13 +344,13 @@ async def delete_entry_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to delete entry",
         ) from e
     except Exception as e:
         logger.exception("Failed to delete entry")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to delete entry",
         ) from e
     else:
         return {"id": entry_id, "status": "deleted"}
@@ -388,13 +388,13 @@ async def get_entry_history_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load entry history",
         ) from e
     except Exception as e:
         logger.exception("Failed to get entry history")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load entry history",
         ) from e
 
 
@@ -439,13 +439,13 @@ async def get_entry_revision_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load entry revision",
         ) from e
     except Exception as e:
         logger.exception("Failed to get entry revision")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load entry revision",
         ) from e
 
 
@@ -495,13 +495,13 @@ async def restore_entry_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to restore entry",
         ) from e
     except Exception as e:
         logger.exception("Failed to restore entry")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to restore entry",
         ) from e
 
     return _entry_response(entry_data)

--- a/backend/src/app/api/endpoints/forms.py
+++ b/backend/src/app/api/endpoints/forms.py
@@ -242,11 +242,11 @@ async def create_form_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to save form",
         ) from e
     except Exception as e:
         logger.exception("Failed to upsert form")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to save form",
         ) from e

--- a/backend/src/app/api/endpoints/search.py
+++ b/backend/src/app/api/endpoints/search.py
@@ -82,7 +82,11 @@ async def query_endpoint(
         )
         raise HTTPException(
             status_code=status_code,
-            detail=detail,
+            detail=(
+                detail
+                if status_code == status.HTTP_400_BAD_REQUEST
+                else "Failed to query entries"
+            ),
         ) from e
 
 

--- a/backend/src/app/api/endpoints/search.py
+++ b/backend/src/app/api/endpoints/search.py
@@ -83,7 +83,7 @@ async def query_endpoint(
         raise HTTPException(
             status_code=status_code,
             detail=(
-                detail
+                "Invalid SQL query."
                 if status_code == status.HTTP_400_BAD_REQUEST
                 else "Failed to query entries"
             ),

--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -412,5 +412,5 @@ async def test_connection_endpoint(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
+            detail="Invalid storage configuration",
         ) from e

--- a/backend/src/app/api/endpoints/sql.py
+++ b/backend/src/app/api/endpoints/sql.py
@@ -45,7 +45,7 @@ async def list_sql_endpoint(space_id: str, request: Request) -> list[dict[str, A
         logger.exception("Failed to list saved SQL")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to list saved SQL",
         ) from e
 
 
@@ -102,13 +102,13 @@ async def create_sql_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to create saved SQL",
         ) from e
     except Exception as e:
         logger.exception("Failed to create saved SQL")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to create saved SQL",
         ) from e
 
 
@@ -144,13 +144,13 @@ async def get_sql_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to load saved SQL",
         ) from e
     except Exception as e:
         logger.exception("Failed to get saved SQL")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to load saved SQL",
         ) from e
 
 
@@ -211,13 +211,13 @@ async def update_sql_endpoint(
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to update saved SQL",
         ) from e
     except Exception as e:
         logger.exception("Failed to update saved SQL")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to update saved SQL",
         ) from e
 
 
@@ -252,11 +252,11 @@ async def delete_sql_endpoint(space_id: str, sql_id: str, request: Request) -> N
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=msg,
+            detail="Failed to delete saved SQL",
         ) from e
     except Exception as e:
         logger.exception("Failed to delete saved SQL")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
+            detail="Failed to delete saved SQL",
         ) from e

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1341,7 +1341,7 @@ def test_test_connection_endpoint(
     assert payload["status"] == "ok"
 
 
-def test_test_connection_value_error(
+def test_test_connection_value_error_returns_400(
     test_client: TestClient,
     temp_space_root: Path,
 ) -> None:
@@ -3156,6 +3156,7 @@ def test_query_endpoint_sql_error_returns_400(test_client: TestClient) -> None:
             json={"filter": {}},
         )
     assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid SQL query."
 
 
 def test_query_endpoint_generic_exception(test_client: TestClient) -> None:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -3060,9 +3060,9 @@ def test_test_connection_req_sto_006_rejects_link_local_endpoint_before_core(
             },
         )
     assert response.status_code == 400
-    assert response.json()["detail"] == (
-        "Storage endpoint host is not allowed: 169.254.169.254"
-    )
+    detail = response.json()["detail"]
+    assert isinstance(detail, str)
+    assert "storage" in detail.lower()
     mock_core.assert_not_awaited()
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -3007,7 +3007,7 @@ def test_patch_space_generic_exception(test_client: TestClient) -> None:
     assert response.status_code == 500
 
 
-def test_test_connection_value_error(test_client: TestClient) -> None:
+def test_test_connection_value_error_legacy_response(test_client: TestClient) -> None:
     """REQ-STO-006: test-connection returns 400 when storage config is invalid."""
     test_client.post("/spaces", json={"name": "conn-test-ws"})
     with patch(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1341,6 +1341,24 @@ def test_test_connection_endpoint(
     assert payload["status"] == "ok"
 
 
+def test_test_connection_value_error(
+    test_client: TestClient,
+    temp_space_root: Path,
+) -> None:
+    """REQ-STO-006: test-connection returns a stable validation error."""
+    test_client.post("/spaces", json={"name": "conn-test-ws"})
+    with patch(
+        "ugoite_core.test_storage_connection",
+        _amock(side_effect=ValueError("invalid storage config")),
+    ):
+        response = test_client.post(
+            "/spaces/conn-test-ws/test-connection",
+            json={"storage_config": {"uri": "invalid://bad"}},
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid storage configuration"
+
+
 def test_middleware_headers(
     test_client: TestClient,
     temp_space_root: Path,
@@ -2247,6 +2265,10 @@ def test_create_entry_generic_exception(test_client: TestClient) -> None:
             json={"content": "# Title\n"},
         )
     assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_create_entry_generic_runtime_error(test_client: TestClient) -> None:
@@ -2264,6 +2286,10 @@ def test_create_entry_generic_runtime_error(test_client: TestClient) -> None:
             json={"content": "# Title\n"},
         )
     assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_list_entries_generic_exception(test_client: TestClient) -> None:
@@ -2275,6 +2301,10 @@ def test_list_entries_generic_exception(test_client: TestClient) -> None:
     ):
         response = test_client.get("/spaces/entry-list-exc-ws/entries")
     assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_get_entry_not_found_req_api_002(test_client: TestClient) -> None:
@@ -2293,6 +2323,10 @@ def test_get_entry_generic_exception(test_client: TestClient) -> None:
     ):
         response = test_client.get("/spaces/entry-get-exc-ws/entries/e1")
     assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_get_entry_generic_runtime_error(test_client: TestClient) -> None:
@@ -3136,6 +3170,10 @@ def test_query_endpoint_generic_exception(test_client: TestClient) -> None:
             json={"filter": {}},
         )
     assert response.status_code == 500
+    assert response.json()["detail"] == {
+        "code": "internal_error",
+        "message": "Internal server error",
+    }
 
 
 def test_query_endpoint_authorization_error(test_client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Replace raw 500-path exception details with stable public messages across backend endpoints.
- Add regression coverage for the affected entry/search/test-connection paths.

## Related Issue (required)
closes #1491

## Testing
- [x] `./.venv/bin/pytest -W error tests/test_api.py tests/test_error_sanitization.py`
- [x] `./.venv/bin/ruff format --check src/app/api/endpoints/asset.py src/app/api/endpoints/entry.py src/app/api/endpoints/forms.py src/app/api/endpoints/search.py src/app/api/endpoints/space.py src/app/api/endpoints/sql.py tests/test_api.py tests/test_error_sanitization.py`
