### PR TITLE
feat: add space invitation join flow

### DIFF
--- a/docs/spec/features/spaces.yaml
+++ b/docs/spec/features/spaces.yaml
@@ -138,9 +138,9 @@ apis:
       file: backend/src/app/api/endpoints/members.py
       function: accept_member_invitation_endpoint
     frontend:
-      path: /spaces/{space_id}/settings
-      file: frontend/src/routes/spaces/[space_id]/settings.tsx
-      function: SpaceSettingsRoute
+      path: /spaces/join
+      file: frontend/src/routes/spaces/join.tsx
+      function: SpaceInvitationJoinRoute
     ugoite_core:
       file: ugoite-core/ugoite_core/membership.py
       function: accept_invitation

--- a/docs/spec/requirements/security.yaml
+++ b/docs/spec/requirements/security.yaml
@@ -307,6 +307,10 @@ requirements:
       - test_space_member_invite_and_accept_transitions_to_active
       - test_space_member_role_change_controls_admin_permissions
       - test_space_member_revoke_removes_access
+    vitest:
+    - file: frontend/src/routes/spaces/join.test.tsx
+      tests:
+      - "REQ-SEC-007: accepts an invitation token and confirms the joined membership"
     e2e:
     - file: e2e/space-membership.test.ts
       tests:

--- a/frontend/src/lib/client.test.ts
+++ b/frontend/src/lib/client.test.ts
@@ -428,8 +428,8 @@ describe("spaceApi members", () => {
 	it("accepts invitation", async () => {
 		resetMockData();
 		await spaceApi.create("ws-accept");
-		const result = await spaceApi.acceptInvitation("ws-accept", { token: "tok", user_id: "u1" });
-		expect(result.member.user_id).toBe("u1");
+		const result = await spaceApi.acceptInvitation("ws-accept", { token: "tok" });
+		expect(result.member.state).toBe("active");
 	});
 
 	it("updates member role", async () => {
@@ -519,9 +519,7 @@ describe("error paths", () => {
 				HttpResponse.json({ detail: "Not found" }, { status: 404 }),
 			),
 		);
-		await expect(
-			spaceApi.acceptInvitation("nonexistent", { token: "tok", user_id: "u1" }),
-		).rejects.toThrow();
+		await expect(spaceApi.acceptInvitation("nonexistent", { token: "tok" })).rejects.toThrow();
 	});
 
 	it("spaceApi.updateMemberRole throws on failure", async () => {

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -39,6 +39,10 @@ describe("/spaces", () => {
 		});
 
 		expect(screen.getByRole("button", { name: "Create space" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Join with invitation" })).toHaveAttribute(
+			"href",
+			"/spaces/join",
+		);
 		expect(spaceApi.create).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -158,6 +158,9 @@ export default function SpacesIndexRoute() {
 			<div class="flex flex-wrap items-center justify-between gap-3">
 				<h1 class="ui-page-title">Spaces</h1>
 				<div class="flex flex-wrap items-center gap-2">
+					<A href="/spaces/join" class="ui-button ui-button-secondary text-sm">
+						Join with invitation
+					</A>
 					<Show when={!spacesError() && !showCreateForm() && !hasNoSpaces()}>
 						<button
 							type="button"

--- a/frontend/src/routes/spaces/join.test.tsx
+++ b/frontend/src/routes/spaces/join.test.tsx
@@ -1,0 +1,78 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SpaceInvitationJoinRoute from "./join";
+import { spaceApi } from "~/lib/space-api";
+
+// REQ-SEC-007: browser invitation acceptance flow
+const navigateMock = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+	useNavigate: () => navigateMock,
+	useSearchParams: () => [{ space_id: "default", token: "prefilled-token" }],
+	A: (props: { href: string; class?: string; children: unknown }) => (
+		<a href={props.href} class={props.class}>
+			{props.children}
+		</a>
+	),
+}));
+
+vi.mock("~/lib/space-api", () => ({
+	spaceApi: {
+		acceptInvitation: vi.fn(),
+	},
+}));
+
+describe("/spaces/join", () => {
+	beforeEach(() => {
+		navigateMock.mockReset();
+		(spaceApi.acceptInvitation as ReturnType<typeof vi.fn>).mockReset();
+	});
+
+	it("prefills invitation parameters from the query string", () => {
+		render(() => <SpaceInvitationJoinRoute />);
+
+		expect(screen.getByDisplayValue("default")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("prefilled-token")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Back to Spaces" })).toHaveAttribute("href", "/spaces");
+	});
+
+	it("REQ-SEC-007: accepts an invitation token and confirms the joined membership", async () => {
+		(spaceApi.acceptInvitation as ReturnType<typeof vi.fn>).mockResolvedValue({
+			member: {
+				user_id: "joined-user",
+				role: "editor",
+				state: "active",
+			},
+		});
+
+		render(() => <SpaceInvitationJoinRoute />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Accept invitation" }));
+
+		await waitFor(() => {
+			expect(spaceApi.acceptInvitation).toHaveBeenCalledWith("default", {
+				token: "prefilled-token",
+			});
+		});
+		expect(screen.getByText(/Invitation accepted\./i)).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Open space dashboard" })).toHaveAttribute(
+			"href",
+			"/spaces/default/dashboard",
+		);
+	});
+
+	it("shows invitation errors inline", async () => {
+		(spaceApi.acceptInvitation as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("Invalid invitation token"),
+		);
+
+		render(() => <SpaceInvitationJoinRoute />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Accept invitation" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Invalid invitation token")).toBeInTheDocument();
+		});
+	});
+});

--- a/frontend/src/routes/spaces/join.tsx
+++ b/frontend/src/routes/spaces/join.tsx
@@ -1,0 +1,139 @@
+import { A, useSearchParams } from "@solidjs/router";
+import { createSignal, Show } from "solid-js";
+import { spaceApi } from "~/lib/space-api";
+
+const toMessage = (value: unknown): string => {
+	if (value instanceof Error && value.message.trim()) {
+		return value.message;
+	}
+	if (typeof value === "string" && value.trim()) {
+		return value;
+	}
+	return "Failed to accept invitation.";
+};
+
+export default function SpaceInvitationJoinRoute() {
+	const [searchParams] = useSearchParams();
+	const [spaceId, setSpaceId] = createSignal(searchParams.space_id || "");
+	const [token, setToken] = createSignal(searchParams.token || "");
+	const [isSubmitting, setIsSubmitting] = createSignal(false);
+	const [error, setError] = createSignal("");
+	const [joinedSpaceId, setJoinedSpaceId] = createSignal("");
+	const [joinedMemberId, setJoinedMemberId] = createSignal("");
+	const [joinedRole, setJoinedRole] = createSignal("");
+	const [joinedState, setJoinedState] = createSignal("");
+
+	const handleSubmit = async (event: Event) => {
+		event.preventDefault();
+		const nextSpaceId = spaceId().trim();
+		const nextToken = token().trim();
+		if (!nextSpaceId) {
+			setError("Space ID is required.");
+			return;
+		}
+		if (!nextToken) {
+			setError("Invitation token is required.");
+			return;
+		}
+
+		setIsSubmitting(true);
+		setError("");
+		setJoinedSpaceId("");
+		setJoinedMemberId("");
+		setJoinedRole("");
+		setJoinedState("");
+
+		try {
+			const result = await spaceApi.acceptInvitation(nextSpaceId, { token: nextToken });
+			setJoinedSpaceId(nextSpaceId);
+			setJoinedMemberId(result.member.user_id);
+			setJoinedRole(result.member.role);
+			setJoinedState(result.member.state);
+		} catch (value) {
+			setError(toMessage(value));
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<main class="mx-auto max-w-2xl ui-page ui-stack">
+			<section class="ui-card ui-stack">
+				<div>
+					<h1 class="ui-page-title">Join a space</h1>
+					<p class="ui-page-subtitle mt-2">
+						Accept an invitation token from your admin and join the space in this browser session.
+					</p>
+				</div>
+
+				<p class="text-sm ui-muted">
+					Paste the space ID the admin shared with you and the invitation token from the same
+					invite. The token proves the invite; your current browser session becomes the active
+					member after acceptance.
+				</p>
+
+				<form class="ui-stack-sm" onSubmit={handleSubmit}>
+					<label class="ui-stack-sm">
+						<span class="text-sm font-medium">Space ID</span>
+						<input
+							class="ui-input"
+							type="text"
+							value={spaceId()}
+							onInput={(event) => setSpaceId(event.currentTarget.value)}
+							placeholder="e.g. team-notes"
+							autocomplete="off"
+						/>
+					</label>
+					<label class="ui-stack-sm">
+						<span class="text-sm font-medium">Invitation token</span>
+						<textarea
+							class="ui-input min-h-32 font-mono text-sm"
+							value={token()}
+							onInput={(event) => setToken(event.currentTarget.value)}
+							placeholder="Paste the invitation token here"
+							autocomplete="off"
+							spellcheck={false}
+						/>
+					</label>
+					<button
+						type="submit"
+						class="ui-button ui-button-primary w-fit"
+						disabled={!spaceId().trim() || !token().trim() || isSubmitting()}
+					>
+						{isSubmitting() ? "Accepting..." : "Accept invitation"}
+					</button>
+				</form>
+
+				<Show when={error()}>
+					<p class="ui-alert ui-alert-error text-sm">{error()}</p>
+				</Show>
+
+				<Show when={joinedSpaceId()}>
+					<div class="ui-alert ui-alert-success ui-stack-sm text-sm">
+						<p>
+							Invitation accepted. You are now an active member of <code>{joinedSpaceId()}</code>.
+						</p>
+						<Show when={joinedMemberId()}>
+							<p>
+								Joined as <code>{joinedMemberId()}</code> with <code>{joinedRole()}</code> access.
+								Current membership state: <code>{joinedState()}</code>.
+							</p>
+						</Show>
+						<A
+							href={`/spaces/${joinedSpaceId()}/dashboard`}
+							class="ui-button ui-button-primary w-fit"
+						>
+							Open space dashboard
+						</A>
+					</div>
+				</Show>
+
+				<div class="flex flex-wrap gap-3">
+					<A href="/spaces" class="ui-button ui-button-secondary">
+						Back to Spaces
+					</A>
+				</div>
+			</section>
+		</main>
+	);
+}

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -737,9 +737,10 @@ export const handlers = [
 		const spaceId = params.spaceId as string;
 		if (!mockSpaces.has(spaceId))
 			return HttpResponse.json({ detail: "Not found" }, { status: 404 });
-		const body = (await request.json()) as { token: string; user_id: string };
+		const body = (await request.json()) as { token: string; user_id?: string };
+		const userId = body.user_id || "accepted-user";
 		return HttpResponse.json({
-			member: { user_id: body.user_id, role: "editor", state: "active" },
+			member: { user_id: userId, role: "editor", state: "active" },
 		});
 	}),
 	testHttp.post("/spaces/:spaceId/members/:userId/role", async ({ params, request }) => {


### PR DESCRIPTION
## Summary

Added a browser-facing invitation acceptance flow at `/spaces/join` so invited users can paste a space ID and invite token, accept membership, and continue into the joined space.

Also exposed the join flow from the `/spaces` index, updated the invitation client/test contract, and wired the new frontend test into the `REQ-SEC-007` traceability map.

## Related Issue (required)

close: #1498

## Testing

- [x] `bunx vitest run src/routes/spaces/join.test.tsx src/routes/spaces/index.test.tsx src/lib/client.test.ts`
- [x] `bunx biome check src/routes/spaces/join.tsx src/routes/spaces/join.test.tsx src/routes/spaces/index.tsx src/routes/spaces/index.test.tsx src/lib/client.test.ts src/test/mocks/handlers.ts`
- [x] `mise run //frontend:test:coverage`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest docs/tests -v -W error --junitxml=/tmp/docs-pytest.xml`
- [x] `uv run python scripts/check_pytest_no_skips.py /tmp/docs-pytest.xml "docs tests"`
- [ ] Local devcontainer build could not be executed here because `devcontainer` CLI and Docker are not installed in this workspace.
