### PR TITLE
Fix Space Settings storage preflight for issue 1502

### DIFF
--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -142,6 +142,14 @@ def _validate_patch_settings(settings: dict[str, Any] | None) -> None:
         )
 
 
+def _storage_connection_error_detail(exc: Exception) -> str:
+    """Return a user-facing storage connection error message."""
+    message = str(exc).strip()
+    if message:
+        return f"Storage connection test failed: {message}"
+    return "Storage connection test failed"
+
+
 def _space_uri(space_id: str) -> str:
     """Return space URI/path for API responses."""
     return space_uri(get_root_path(), space_id)
@@ -418,5 +426,5 @@ async def test_connection_endpoint(
         logger.warning("Storage connection test failed for %s: %s", space_id, exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Storage connection test failed",
+            detail=_storage_connection_error_detail(exc),
         ) from exc

--- a/backend/src/app/api/endpoints/space.py
+++ b/backend/src/app/api/endpoints/space.py
@@ -393,7 +393,7 @@ async def test_connection_endpoint(
     payload: SpaceConnectionRequest,
     request: Request,
 ) -> dict[str, Any]:
-    """Validate the provided storage connector (stubbed for Milestone 6)."""
+    """Validate the provided storage connector."""
     identity = request_identity(request)
     _validate_path_id(space_id, "space_id")
     storage_config = _storage_config()
@@ -414,3 +414,9 @@ async def test_connection_endpoint(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid storage configuration",
         ) from e
+    except RuntimeError as exc:
+        logger.warning("Storage connection test failed for %s: %s", space_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Storage connection test failed",
+        ) from exc

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1315,6 +1315,7 @@ def test_update_space_storage_connector(
         json={
             "storage_config": {
                 "uri": "s3://bucket/path",
+                "endpoint": "https://s3.example.com",
                 "credentials_profile": "default",
             },
             "settings": {"default_form": "Meeting"},
@@ -1323,6 +1324,7 @@ def test_update_space_storage_connector(
     assert patch_res.status_code == 200
     data = patch_res.json()
     assert data["storage_config"]["uri"] == "s3://bucket/path"
+    assert data["storage_config"]["endpoint"] == "https://s3.example.com"
     assert data["settings"]["default_form"] == "Meeting"
 
 
@@ -1334,7 +1336,11 @@ def test_test_connection_endpoint(
     test_client.post("/spaces", json={"name": "test-ws"})
     res = test_client.post(
         "/spaces/test-ws/test-connection",
-        json={"storage_config": {"uri": "file:///tmp"}},
+        json={
+            "storage_config": {
+                "uri": "file:///tmp",
+            },
+        },
     )
     assert res.status_code == 200
     payload = res.json()
@@ -1357,6 +1363,24 @@ def test_test_connection_value_error_returns_400(
         )
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid storage configuration"
+
+
+def test_test_connection_runtime_error_returns_502(
+    test_client: TestClient,
+    temp_space_root: Path,
+) -> None:
+    """REQ-STO-006: runtime storage failures return a connectivity error."""
+    test_client.post("/spaces", json={"name": "conn-runtime-ws"})
+    with patch(
+        "ugoite_core.test_storage_connection",
+        _amock(side_effect=RuntimeError("connectivity failed")),
+    ):
+        response = test_client.post(
+            "/spaces/conn-runtime-ws/test-connection",
+            json={"storage_config": {"uri": "s3://bucket", "endpoint": "https://storage.example.com"}},
+        )
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Storage connection test failed"
 
 
 def test_middleware_headers(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -21,6 +21,7 @@ from starlette.responses import Response, StreamingResponse
 from app.api.endpoints.search import _is_sql_error
 from app.api.endpoints.space import (
     _sanitize_space_meta,
+    _storage_connection_error_detail,
     _validate_entry_markdown_against_form,
 )
 from app.core.auth import clear_auth_manager_cache
@@ -1385,7 +1386,16 @@ def test_test_connection_runtime_error_returns_502(
             },
         )
     assert response.status_code == 502
-    assert response.json()["detail"] == "Storage connection test failed: connectivity failed"
+    assert response.json()["detail"] == (
+        "Storage connection test failed: connectivity failed"
+    )
+
+
+def test_storage_connection_error_detail_falls_back_without_message() -> None:
+    """REQ-STO-006: empty storage errors use a stable fallback message."""
+    assert _storage_connection_error_detail(RuntimeError()) == (
+        "Storage connection test failed"
+    )
 
 
 def test_middleware_headers(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1377,7 +1377,12 @@ def test_test_connection_runtime_error_returns_502(
     ):
         response = test_client.post(
             "/spaces/conn-runtime-ws/test-connection",
-            json={"storage_config": {"uri": "s3://bucket", "endpoint": "https://storage.example.com"}},
+            json={
+                "storage_config": {
+                    "uri": "s3://bucket",
+                    "endpoint": "https://storage.example.com",
+                },
+            },
         )
     assert response.status_code == 502
     assert response.json()["detail"] == "Storage connection test failed"

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1385,7 +1385,7 @@ def test_test_connection_runtime_error_returns_502(
             },
         )
     assert response.status_code == 502
-    assert response.json()["detail"] == "Storage connection test failed"
+    assert response.json()["detail"] == "Storage connection test failed: connectivity failed"
 
 
 def test_middleware_headers(

--- a/docs/guide/space-settings-storage.md
+++ b/docs/guide/space-settings-storage.md
@@ -50,6 +50,10 @@ Open **Settings** when you want to:
 3. save connector metadata for a planned migration
 4. rename the space or inspect other space-level configuration
 
+**Test Connection** validates the target using the saved URI plus any optional
+endpoint you enter, then runs a storage probe through the backend. It reports a
+connection failure if the target cannot be reached.
+
 ## What to read next if you are changing storage
 
 If you are preparing an actual cutover, continue with the

--- a/docs/guide/storage-migration.md
+++ b/docs/guide/storage-migration.md
@@ -24,6 +24,8 @@ manual prep**, not a live location switch.
    - `s3://` changes the trust, cost, and credential model to cloud object
      storage.
 2. Validate the destination first with **Test Connection** in Space Settings.
+   For remote targets, provide the endpoint so the backend can probe the
+   configured service before you cut over.
 3. Copy the existing space data with tooling that matches your current storage
    backend.
 4. Update the saved Storage URI only after you know the new location is

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -174,13 +174,17 @@ Content-Type: application/json
 }
 ```
 
-**Response**: `200 OK` or `400 Bad Request`
+**Response**: `200 OK`, `400 Bad Request`, or `502 Bad Gateway`
 
 Notes:
-- Test Connection validates a proposed connector target only; it does not switch
-  the space's active write location or move existing data.
+- Test Connection validates a proposed connector target by building an
+  OpenDAL operator from the supplied URI and options, then running a storage
+  health check; it does not switch the space's active write location or move
+  existing data.
 - `storage_config.uri` must use a supported connector scheme such as `memory://`, `fs://`, or `s3://`, or be a plain local path starting with `/` or `.`.
 - `storage_config.endpoint`, when provided, must be an `http` or `https` URL and must not target loopback or link-local hosts.
+- Connectivity failures return `502 Bad Gateway` so callers can distinguish
+  invalid configuration from an unreachable target.
 
 ---
 

--- a/docs/spec/requirements/frontend.yaml
+++ b/docs/spec/requirements/frontend.yaml
@@ -778,7 +778,8 @@ requirements:
   title: Space Storage Configuration
   description: 'Space settings MUST allow saving storage connector metadata (local,
 
-    S3, remote) with connection validation before saving.
+    S3, remote) with connection validation before saving. The test flow MUST
+    surface any optional remote endpoint needed for a real backend probe.
 
     The UI MUST explain that changing `storage_config.uri` updates saved metadata
 

--- a/docs/spec/requirements/storage.yaml
+++ b/docs/spec/requirements/storage.yaml
@@ -252,7 +252,8 @@ requirements:
 
     such as loopback or link-local hosts MUST be rejected before the core binding
 
-    attempts a connection test.
+    attempts a connection test, and unreachable targets MUST return a
+    connectivity failure rather than a false success.
 
     '
   related_spec:
@@ -267,10 +268,14 @@ requirements:
       - test_update_space_storage_connector
       - test_test_connection_endpoint
       - test_test_connection_req_sto_006_rejects_link_local_endpoint_before_core
+      - test_test_connection_runtime_error_returns_502
     - file: ugoite-core/tests/test_bindings.py
       tests:
       - test_storage_req_sto_006_rejects_link_local_endpoint
       - test_storage_req_sto_006_strips_inputs_before_validation
+    - file: ugoite-core/tests/test_space.rs
+      tests:
+      - test_space_req_sto_006_test_storage_connection_unknown_rejects_unsupported_scheme
 - set_id: REQCAT-STORAGE
   source_file: requirements/storage.yaml
   scope: Storage architecture, data persistence, and portability requirements.

--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -1,10 +1,40 @@
-import { defineConfig } from "@solidjs/start/config";
-import tailwindcss from "@tailwindcss/vite";
 import type { ProxyOptions } from "vite";
-import { VitePWA } from "vite-plugin-pwa";
 
-const env =
-	(globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
+type ProcessLike = {
+	env?: Record<string, string | undefined>;
+};
+
+const processLike = globalThis.process as ProcessLike | undefined;
+const currentEnv = processLike?.env;
+if (!currentEnv || typeof currentEnv !== "object") {
+	/* v8 ignore start */
+	if (processLike) {
+		Object.defineProperty(processLike, "env", {
+			configurable: true,
+			writable: true,
+			value: {},
+		});
+	} else {
+		Object.defineProperty(globalThis, "process", {
+			configurable: true,
+			writable: true,
+			value: {
+				env: {},
+				cwd: () => new URL(".", import.meta.url).pathname,
+			},
+		});
+	}
+	/* v8 ignore stop */
+}
+
+/* v8 ignore next */
+const env = (globalThis.process as ProcessLike | undefined)?.env ?? {};
+
+const [{ defineConfig }, { default: tailwindcss }, { VitePWA }] = await Promise.all([
+	import("@solidjs/start/config"),
+	import("@tailwindcss/vite"),
+	import("vite-plugin-pwa"),
+]);
 
 const backendUrl = env.BACKEND_URL;
 const useViteProxy = env.VITE_API_PROXY === "true";

--- a/frontend/src/components/SpaceSettings.test.tsx
+++ b/frontend/src/components/SpaceSettings.test.tsx
@@ -14,6 +14,7 @@ const mockSpace: Space = {
 	},
 	storage_config: {
 		uri: "s3://planned-bucket/test-space",
+		endpoint: "https://s3.example.com",
 	},
 };
 
@@ -26,6 +27,43 @@ describe("SpaceSettings", () => {
 	it("should display storage config", () => {
 		render(() => <SpaceSettings space={mockSpace} onSave={vi.fn()} />);
 		expect(screen.getByDisplayValue("s3://planned-bucket/test-space")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("https://s3.example.com")).toBeInTheDocument();
+	});
+
+	it("should include an edited endpoint when saving and testing remote storage", async () => {
+		const onSave = vi.fn().mockResolvedValue({});
+		const onTestConnection = vi.fn().mockResolvedValue({ status: "ok" });
+		render(() => (
+			<SpaceSettings space={mockSpace} onSave={onSave} onTestConnection={onTestConnection} />
+		));
+
+		const endpointInput = screen.getByLabelText(/storage endpoint/i);
+		fireEvent.input(endpointInput, {
+			target: { value: "https://s3-backup.example.com" },
+		});
+
+		const saveButton = screen.getByRole("button", { name: /save/i });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(onSave).toHaveBeenCalledWith({
+				name: "Test Space",
+				storage_config: {
+					uri: "s3://planned-bucket/test-space",
+					endpoint: "https://s3-backup.example.com",
+				},
+			});
+		});
+
+		const testButton = screen.getByRole("button", { name: /test connection/i });
+		fireEvent.click(testButton);
+
+		await waitFor(() => {
+			expect(onTestConnection).toHaveBeenCalledWith({
+				uri: "s3://planned-bucket/test-space",
+				endpoint: "https://s3-backup.example.com",
+			});
+		});
 	});
 
 	it("should call onSave when save button is clicked", async () => {
@@ -41,7 +79,10 @@ describe("SpaceSettings", () => {
 		await waitFor(() => {
 			expect(onSave).toHaveBeenCalledWith({
 				name: "Updated Space",
-				storage_config: { uri: "s3://planned-bucket/test-space" },
+				storage_config: {
+					uri: "s3://planned-bucket/test-space",
+					endpoint: "https://s3.example.com",
+				},
 			});
 		});
 	});
@@ -56,7 +97,10 @@ describe("SpaceSettings", () => {
 		fireEvent.click(testButton);
 
 		await waitFor(() => {
-			expect(onTestConnection).toHaveBeenCalledWith({ uri: "s3://planned-bucket/test-space" });
+			expect(onTestConnection).toHaveBeenCalledWith({
+				uri: "s3://planned-bucket/test-space",
+				endpoint: "https://s3.example.com",
+			});
 		});
 	});
 

--- a/frontend/src/components/SpaceSettings.test.tsx
+++ b/frontend/src/components/SpaceSettings.test.tsx
@@ -15,6 +15,8 @@ const mockSpace: Space = {
 	storage_config: {
 		uri: "s3://planned-bucket/test-space",
 		endpoint: "https://s3.example.com",
+		credentials_profile: "default",
+		region: "us-west-2",
 	},
 };
 
@@ -51,6 +53,8 @@ describe("SpaceSettings", () => {
 				storage_config: {
 					uri: "s3://planned-bucket/test-space",
 					endpoint: "https://s3-backup.example.com",
+					credentials_profile: "default",
+					region: "us-west-2",
 				},
 			});
 		});
@@ -62,6 +66,8 @@ describe("SpaceSettings", () => {
 			expect(onTestConnection).toHaveBeenCalledWith({
 				uri: "s3://planned-bucket/test-space",
 				endpoint: "https://s3-backup.example.com",
+				credentials_profile: "default",
+				region: "us-west-2",
 			});
 		});
 	});
@@ -82,6 +88,8 @@ describe("SpaceSettings", () => {
 				storage_config: {
 					uri: "s3://planned-bucket/test-space",
 					endpoint: "https://s3.example.com",
+					credentials_profile: "default",
+					region: "us-west-2",
 				},
 			});
 		});
@@ -100,6 +108,8 @@ describe("SpaceSettings", () => {
 			expect(onTestConnection).toHaveBeenCalledWith({
 				uri: "s3://planned-bucket/test-space",
 				endpoint: "https://s3.example.com",
+				credentials_profile: "default",
+				region: "us-west-2",
 			});
 		});
 	});
@@ -145,7 +155,11 @@ describe("SpaceSettings", () => {
 		await waitFor(() => {
 			expect(onSave).toHaveBeenCalledWith({
 				name: "Test Space",
-				storage_config: { uri: "file:///var/lib/ugoite/migrated" },
+				storage_config: {
+					uri: "file:///var/lib/ugoite/migrated",
+					credentials_profile: "default",
+					region: "us-west-2",
+				},
 			});
 		});
 	});

--- a/frontend/src/components/SpaceSettings.test.tsx
+++ b/frontend/src/components/SpaceSettings.test.tsx
@@ -72,6 +72,30 @@ describe("SpaceSettings", () => {
 		});
 	});
 
+	it("should omit the endpoint when saving remote storage without one", async () => {
+		const onSave = vi.fn().mockResolvedValue({});
+		render(() => <SpaceSettings space={mockSpace} onSave={onSave} />);
+
+		const endpointInput = screen.getByLabelText(/storage endpoint/i);
+		fireEvent.input(endpointInput, {
+			target: { value: "" },
+		});
+
+		const saveButton = screen.getByRole("button", { name: /save/i });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(onSave).toHaveBeenCalledWith({
+				name: "Test Space",
+				storage_config: {
+					uri: "s3://planned-bucket/test-space",
+					credentials_profile: "default",
+					region: "us-west-2",
+				},
+			});
+		});
+	});
+
 	it("should call onSave when save button is clicked", async () => {
 		const onSave = vi.fn().mockResolvedValue({});
 		render(() => <SpaceSettings space={mockSpace} onSave={onSave} />);
@@ -181,6 +205,27 @@ describe("SpaceSettings", () => {
 		render(() => <SpaceSettings space={space as any} onSave={vi.fn()} />);
 		const uriInput = screen.getByPlaceholderText(/file:\/\/\/local\/path/i);
 		expect(uriInput).toHaveValue("");
+	});
+
+	it("should save a new local storage config when no existing config is present", async () => {
+		const onSave = vi.fn().mockResolvedValue({});
+		const space = { id: "test", name: "Test", created_at: "2025-01-01T00:00:00Z" };
+		render(() => <SpaceSettings space={space as any} onSave={onSave} />);
+
+		const uriInput = screen.getByLabelText(/storage uri/i);
+		fireEvent.input(uriInput, { target: { value: "file:///var/lib/ugoite/fresh" } });
+
+		const saveButton = screen.getByRole("button", { name: /save/i });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(onSave).toHaveBeenCalledWith({
+				name: "Test",
+				storage_config: {
+					uri: "file:///var/lib/ugoite/fresh",
+				},
+			});
+		});
 	});
 
 	it("test connection button not shown when onTestConnection not provided", () => {

--- a/frontend/src/components/SpaceSettings.tsx
+++ b/frontend/src/components/SpaceSettings.tsx
@@ -2,7 +2,7 @@ import { createMemo, createSignal, Show } from "solid-js";
 import { getDocsiteHref } from "~/lib/docsite-links";
 import { t } from "~/lib/i18n";
 import { summarizeSpaceStorage } from "~/lib/storage-topology";
-import type { Space, SpacePatchPayload } from "~/lib/types";
+import type { Space, SpacePatchPayload, StorageConnectionConfig } from "~/lib/types";
 
 const storageMigrationGuideUrl = getDocsiteHref(
 	"/docs/guide/storage-migration",
@@ -12,7 +12,7 @@ const storageMigrationGuideUrl = getDocsiteHref(
 export interface SpaceSettingsProps {
 	space: Space;
 	onSave: (payload: SpacePatchPayload) => Promise<void>;
-	onTestConnection?: (config: Record<string, unknown>) => Promise<{ status: string }>;
+	onTestConnection?: (config: StorageConnectionConfig) => Promise<{ status: string }>;
 }
 
 /**
@@ -22,12 +22,27 @@ export interface SpaceSettingsProps {
 export function SpaceSettings(props: SpaceSettingsProps) {
 	const [name, setName] = createSignal(props.space.name);
 	const [storageUri, setStorageUri] = createSignal(props.space.storage_config?.uri || "");
+	const [storageEndpoint, setStorageEndpoint] = createSignal(
+		props.space.storage_config?.endpoint || "",
+	);
 	const [isSaving, setIsSaving] = createSignal(false);
 	const [isTesting, setIsTesting] = createSignal(false);
 	const [testStatus, setTestStatus] = createSignal<"success" | "error" | null>(null);
 	const [testMessage, setTestMessage] = createSignal<string>("");
 	const [saveError, setSaveError] = createSignal<string | null>(null);
 	const storageSummary = createMemo(() => summarizeSpaceStorage(props.space));
+
+	const buildStorageConfig = (): StorageConnectionConfig => {
+		const uri = storageUri().trim();
+		const storage_config: StorageConnectionConfig = {
+			uri,
+		};
+		const endpoint = storageEndpoint().trim();
+		if (uri.toLowerCase().startsWith("s3://") && endpoint) {
+			storage_config.endpoint = endpoint;
+		}
+		return storage_config;
+	};
 
 	const handleSave = async (e: Event) => {
 		e.preventDefault();
@@ -37,9 +52,7 @@ export function SpaceSettings(props: SpaceSettingsProps) {
 		try {
 			await props.onSave({
 				name: name(),
-				storage_config: {
-					uri: storageUri(),
-				},
+				storage_config: buildStorageConfig(),
 			});
 		} catch (err) {
 			/* v8 ignore start */
@@ -60,7 +73,7 @@ export function SpaceSettings(props: SpaceSettingsProps) {
 		setTestMessage("");
 
 		try {
-			const result = await props.onTestConnection({ uri: storageUri() });
+			const result = await props.onTestConnection(buildStorageConfig());
 			setTestStatus("success");
 			setTestMessage(`Connection successful (${result.status})`);
 		} catch (err) {
@@ -135,6 +148,23 @@ export function SpaceSettings(props: SpaceSettingsProps) {
 								Supported planning targets: <code>file://</code> (local), <code>s3://</code> (S3
 								bucket)
 							</p>
+							<div class="ui-field">
+								<label for="storage-endpoint" class="ui-label">
+									Storage Endpoint (optional)
+								</label>
+								<input
+									id="storage-endpoint"
+									type="url"
+									value={storageEndpoint()}
+									onInput={(e) => setStorageEndpoint(e.currentTarget.value)}
+									placeholder="https://s3.example.com"
+									class="ui-input"
+								/>
+								<p class="text-sm ui-muted">
+									Use this for remote storage services that need an explicit HTTP or HTTPS endpoint.
+									Leave it blank for local paths and memory-backed test targets.
+								</p>
+							</div>
 							<div class="ui-card mt-3 space-y-3">
 								<div>
 									<h4 class="text-sm font-semibold">Plan connector metadata deliberately</h4>
@@ -166,8 +196,8 @@ export function SpaceSettings(props: SpaceSettingsProps) {
 									>
 										storage migration guide
 									</a>{" "}
-									and use Test Connection as a preflight check for the target credentials and
-									reachability before you plan a manual migration.
+									and use Test Connection to probe the configured target before you plan a manual
+									migration.
 								</p>
 							</div>
 						</div>
@@ -177,7 +207,7 @@ export function SpaceSettings(props: SpaceSettingsProps) {
 							<button
 								type="button"
 								onClick={handleTestConnection}
-								disabled={isTesting() || !storageUri()}
+								disabled={isTesting() || !storageUri().trim()}
 								class="ui-button ui-button-secondary"
 							>
 								<Show when={isTesting()} fallback="Test Connection">

--- a/frontend/src/components/SpaceSettings.tsx
+++ b/frontend/src/components/SpaceSettings.tsx
@@ -35,11 +35,18 @@ export function SpaceSettings(props: SpaceSettingsProps) {
 	const buildStorageConfig = (): StorageConnectionConfig => {
 		const uri = storageUri().trim();
 		const storage_config: StorageConnectionConfig = {
+			...(props.space.storage_config ?? {}),
 			uri,
 		};
 		const endpoint = storageEndpoint().trim();
-		if (uri.toLowerCase().startsWith("s3://") && endpoint) {
-			storage_config.endpoint = endpoint;
+		if (uri.toLowerCase().startsWith("s3://")) {
+			if (endpoint) {
+				storage_config.endpoint = endpoint;
+			} else {
+				delete storage_config.endpoint;
+			}
+		} else {
+			delete storage_config.endpoint;
 		}
 		return storage_config;
 	};

--- a/frontend/src/lib/preferences-local.test.ts
+++ b/frontend/src/lib/preferences-local.test.ts
@@ -1,3 +1,6 @@
+// REQ-FE-003: Portable selected space preferences with local fallback
+// REQ-FE-044: Portable locale preferences with local fallback
+// REQ-FE-059: Portable theme preferences with local fallback
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("preferences-local", () => {

--- a/frontend/src/lib/preferences-local.test.ts
+++ b/frontend/src/lib/preferences-local.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("preferences-local", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.resetModules();
+	});
+
+	it("returns empty preferences when browser storage is unavailable", async () => {
+		vi.stubGlobal("window", undefined);
+		vi.resetModules();
+
+		const { emptyUserPreferences, readLocalPreferences, writeLocalPreferences } = await import(
+			"./preferences-local"
+		);
+
+		expect(readLocalPreferences()).toEqual(emptyUserPreferences());
+		expect(() =>
+			writeLocalPreferences({
+				selected_space_id: "space-a",
+				locale: "ja",
+				ui_theme: "classic",
+				color_mode: "dark",
+				primary_color: "blue",
+			}),
+		).not.toThrow();
+	});
+
+	it("returns empty preferences when localStorage is malformed", async () => {
+		const invalidStorage = {};
+		vi.stubGlobal("window", { localStorage: invalidStorage });
+		vi.stubGlobal("localStorage", invalidStorage);
+		vi.resetModules();
+
+		const { emptyUserPreferences, readLocalPreferences } = await import("./preferences-local");
+
+		expect(readLocalPreferences()).toEqual(emptyUserPreferences());
+	});
+});

--- a/frontend/src/lib/preferences-local.ts
+++ b/frontend/src/lib/preferences-local.ts
@@ -19,7 +19,16 @@ const safeStorage = () => {
 	/* v8 ignore start */
 	if (isServer || typeof window === "undefined") return null;
 	/* v8 ignore stop */
-	return window.localStorage;
+	const storage = window.localStorage;
+	if (
+		!storage ||
+		typeof storage.getItem !== "function" ||
+		typeof storage.setItem !== "function" ||
+		typeof storage.removeItem !== "function"
+	) {
+		return null;
+	}
+	return storage;
 };
 
 const readAllowedValue = <T extends string>(key: string, allowed: readonly T[]): T | null => {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -15,6 +15,12 @@ export interface SpaceStorage {
 	root?: string;
 }
 
+export interface StorageConnectionConfig {
+	uri: string;
+	endpoint?: string;
+	[key: string]: unknown;
+}
+
 /** Space metadata */
 export interface Space {
 	id: string;
@@ -22,14 +28,14 @@ export interface Space {
 	created_at: string;
 	is_admin_space?: boolean;
 	storage?: SpaceStorage;
-	storage_config?: Record<string, unknown>;
+	storage_config?: StorageConnectionConfig;
 	settings?: Record<string, unknown>;
 }
 
 /** Space patch payload */
 export interface SpacePatchPayload {
 	name?: string;
-	storage_config?: Record<string, unknown>;
+	storage_config?: StorageConnectionConfig;
 	settings?: Record<string, unknown>;
 }
 
@@ -45,7 +51,7 @@ export type UserPreferencesPatchPayload = Partial<UserPreferences>;
 
 /** Test connection payload */
 export interface TestConnectionPayload {
-	storage_config: Record<string, unknown>;
+	storage_config: StorageConnectionConfig;
 }
 
 export interface SpaceMember {

--- a/frontend/src/routes/spaces/[space_id]/settings.tsx
+++ b/frontend/src/routes/spaces/[space_id]/settings.tsx
@@ -4,7 +4,7 @@ import { SpaceShell } from "~/components/SpaceShell";
 import { SpaceSettings } from "~/components/SpaceSettings";
 import { getDocsiteHref } from "~/lib/docsite-links";
 import { spaceApi } from "~/lib/space-api";
-import type { SpaceMember, SpacePatchPayload } from "~/lib/types";
+import type { SpaceMember, SpacePatchPayload, StorageConnectionConfig } from "~/lib/types";
 
 const localDevAuthGuideUrl = getDocsiteHref(
 	"/docs/guide/local-dev-auth-login",
@@ -69,10 +69,9 @@ export default function SpaceSettingsRoute() {
 		await refetch();
 	};
 
-	const handleTestConnection = async (config: Record<string, unknown>) => {
-		const uri = typeof config.uri === "string" ? config.uri : "";
+	const handleTestConnection = async (config: StorageConnectionConfig) => {
 		return await spaceApi.testConnection(spaceId(), {
-			storage_config: { uri },
+			storage_config: config,
 		});
 	};
 

--- a/frontend/src/routes/spaces/[space_id]/test-connection.tsx
+++ b/frontend/src/routes/spaces/[space_id]/test-connection.tsx
@@ -1,11 +1,13 @@
 import { A, useParams } from "@solidjs/router";
 import { createResource, createSignal, Show } from "solid-js";
 import { spaceApi } from "~/lib/space-api";
+import type { StorageConnectionConfig } from "~/lib/types";
 
 export default function SpaceTestConnectionRoute() {
 	const params = useParams<{ space_id: string }>();
 	const spaceId = () => params.space_id;
 	const [uri, setUri] = createSignal("");
+	const [endpoint, setEndpoint] = createSignal("");
 	const [status, setStatus] = createSignal<string | null>(null);
 	const [error, setError] = createSignal<string | null>(null);
 	const [isTesting, setIsTesting] = createSignal(false);
@@ -13,15 +15,28 @@ export default function SpaceTestConnectionRoute() {
 	const [space] = createResource(async () => {
 		const ws = await spaceApi.get(spaceId());
 		setUri(ws.storage_config?.uri || "");
+		setEndpoint(ws.storage_config?.endpoint || "");
 		return ws;
 	});
+
+	const buildStorageConfig = (): StorageConnectionConfig => {
+		const trimmedUri = uri().trim();
+		const storage_config: StorageConnectionConfig = { uri: trimmedUri };
+		const trimmedEndpoint = endpoint().trim();
+		if (trimmedUri.toLowerCase().startsWith("s3://") && trimmedEndpoint) {
+			storage_config.endpoint = trimmedEndpoint;
+		}
+		return storage_config;
+	};
 
 	const handleTest = async () => {
 		setError(null);
 		setStatus(null);
 		setIsTesting(true);
 		try {
-			const result = await spaceApi.testConnection(spaceId(), { uri: uri() });
+			const result = await spaceApi.testConnection(spaceId(), {
+				storage_config: buildStorageConfig(),
+			});
 			setStatus(result.status);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to test connection");
@@ -62,11 +77,25 @@ export default function SpaceTestConnectionRoute() {
 						onInput={(e) => setUri(e.currentTarget.value)}
 						placeholder="file:///local/path or s3://bucket/path"
 					/>
+					<label class="ui-label text-sm mt-3 mb-2" for="storage-endpoint">
+						Storage Endpoint (optional)
+					</label>
+					<input
+						id="storage-endpoint"
+						type="url"
+						class="ui-input w-full"
+						value={endpoint()}
+						onInput={(e) => setEndpoint(e.currentTarget.value)}
+						placeholder="https://s3.example.com"
+					/>
+					<p class="text-sm ui-muted mt-2">
+						Use this for remote storage services that need an explicit HTTP or HTTPS endpoint.
+					</p>
 					<button
 						type="button"
 						class="ui-button ui-button-primary mt-3"
 						onClick={handleTest}
-						disabled={isTesting() || !uri()}
+						disabled={isTesting() || !uri().trim()}
 					>
 						{isTesting() ? "Testing..." : "Test Connection"}
 					</button>

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -4,6 +4,45 @@ import { afterAll, afterEach, beforeAll } from "vitest";
 // Import MSW server - will be created when mocks are available
 let server: ReturnType<typeof import("msw/node").setupServer>;
 
+const createStorageMock = () => {
+	const data = new Map<string, string>();
+	return {
+		getItem: (key: string) => data.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			data.set(key, String(value));
+		},
+		removeItem: (key: string) => {
+			data.delete(key);
+		},
+		clear: () => {
+			data.clear();
+		},
+		key: (index: number) => Array.from(data.keys())[index] ?? null,
+		get length() {
+			return data.size;
+		},
+	};
+};
+
+const ensureStorage = (name: "localStorage" | "sessionStorage") => {
+	const storage = globalThis[name];
+	if (storage && typeof storage.getItem === "function") return;
+	const mock = createStorageMock();
+	Object.defineProperty(globalThis, name, {
+		configurable: true,
+		value: mock,
+	});
+	if (typeof window !== "undefined") {
+		Object.defineProperty(window, name, {
+			configurable: true,
+			value: mock,
+		});
+	}
+};
+
+ensureStorage("localStorage");
+ensureStorage("sessionStorage");
+
 beforeAll(async () => {
 	const { server: mswServer } = await import("./mocks/server");
 	server = mswServer;

--- a/ugoite-core/src/python_bindings.rs
+++ b/ugoite-core/src/python_bindings.rs
@@ -51,6 +51,38 @@ fn get_operator(_py: Python<'_>, config: &Bound<'_, PyDict>) -> PyResult<Operato
     storage::operator_from_uri(&uri).map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
+fn get_storage_connection_operator(config: &Bound<'_, PyDict>) -> PyResult<Operator> {
+    let uri = config
+        .get_item("uri")?
+        .ok_or_else(|| PyValueError::new_err("Missing 'uri' in storage config"))?
+        .extract::<String>()?;
+
+    let mut extra_options = Vec::new();
+    for key in [
+        "endpoint",
+        "region",
+        "access_key_id",
+        "secret_access_key",
+        "session_token",
+    ] {
+        let Some(raw_value) = config.get_item(key)? else {
+            continue;
+        };
+        let value = raw_value.extract::<String>()?;
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            extra_options.push((key.to_string(), trimmed.to_string()));
+        }
+    }
+
+    if extra_options.is_empty() {
+        storage::operator_from_uri(&uri).map_err(|e| PyValueError::new_err(e.to_string()))
+    } else {
+        Operator::from_uri((uri.as_str(), extra_options))
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+}
+
 pub(crate) fn json_to_py(py: Python<'_>, value: Value) -> PyResult<PyObject> {
     match value {
         Value::Null => Ok(py.None()),
@@ -310,21 +342,25 @@ fn test_storage_connection_py<'a>(
         .get_item("uri")?
         .ok_or_else(|| PyValueError::new_err("Missing 'uri'"))?
         .extract()?;
-    let payload = if uri.starts_with("memory://") {
-        serde_json::json!({"status": "ok", "mode": "memory"})
+    let mode = if uri.starts_with("memory://") {
+        "memory"
     } else if uri.starts_with("file://")
         || uri.starts_with("fs://")
         || uri.starts_with('/')
         || uri.starts_with('.')
     {
-        serde_json::json!({"status": "ok", "mode": "local"})
+        "local"
     } else if uri.starts_with("s3://") {
-        serde_json::json!({"status": "ok", "mode": "s3"})
+        "s3"
     } else {
-        return Err(PyValueError::new_err("Unsupported storage connector"));
+        "unknown"
     };
+    let op = get_storage_connection_operator(&storage_config)?;
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        Python::with_gil(|py| json_to_py(py, payload))
+        op.check()
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        Python::with_gil(|py| json_to_py(py, serde_json::json!({"status": "ok", "mode": mode})))
     })
 }
 

--- a/ugoite-core/tests/test_space.rs
+++ b/ugoite-core/tests/test_space.rs
@@ -138,33 +138,24 @@ async fn test_space_req_sto_002_test_storage_connection_memory() -> anyhow::Resu
     Ok(())
 }
 
+#[cfg(unix)]
 #[tokio::test]
 /// REQ-STO-002
 async fn test_space_req_sto_002_test_storage_connection_local() -> anyhow::Result<()> {
-    let result = space::test_storage_connection("/tmp/test").await?;
+    let dir = tempdir()?;
+    let local_uri = format!("file://{}", dir.path().display());
+    let result = space::test_storage_connection(&local_uri).await?;
     assert_eq!(result["status"], "ok");
     assert_eq!(result["mode"], "local");
 
-    let result2 = space::test_storage_connection("./relative").await?;
-    assert_eq!(result2["mode"], "local");
-
     Ok(())
 }
 
 #[tokio::test]
-/// REQ-STO-002
-async fn test_space_req_sto_002_test_storage_connection_s3() -> anyhow::Result<()> {
-    let result = space::test_storage_connection("s3://my-bucket/path").await?;
-    assert_eq!(result["status"], "ok");
-    assert_eq!(result["mode"], "s3");
-    Ok(())
-}
-
-#[tokio::test]
-/// REQ-STO-002
-async fn test_space_req_sto_002_test_storage_connection_unknown() -> anyhow::Result<()> {
-    let result = space::test_storage_connection("ftp://somehost").await?;
-    assert_eq!(result["status"], "ok");
-    assert_eq!(result["mode"], "unknown");
+/// REQ-STO-006
+async fn test_space_req_sto_006_test_storage_connection_unknown_rejects_unsupported_scheme(
+) -> anyhow::Result<()> {
+    let result = space::test_storage_connection("ftp://somehost").await;
+    assert!(result.is_err());
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Reworked Space Settings Test Connection to send a real storage preflight payload, including optional remote endpoint handling for object storage.
- Hardened backend and core storage connection checks so failures now return actionable errors instead of silently classifying URIs.
- Updated docs/specs and frontend tests to match the new preflight flow.

## Related Issue (required)

closes #1502

## Testing

- [x] `cd /Volumes/myssd/work/ugoite-1/wt/issue-1502/frontend && node ./node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1 --reporter=junit --outputFile=vitest-junit.xml`
- [x] `cd /Volumes/myssd/work/ugoite-1/wt/issue-1502/frontend && ./node_modules/.bin/biome ci .`
- [x] `cd /Volumes/myssd/work/ugoite-1/wt/issue-1502/backend && uv run ty check .`
- [x] `cd /Volumes/myssd/work/ugoite-1/wt/issue-1502/backend && uv run pytest -W error tests/test_api.py -k 'test_update_space_storage_connector or test_test_connection_endpoint or test_test_connection_value_error_returns_400 or test_test_connection_runtime_error_returns_502 or test_test_connection_req_sto_006_rejects_link_local_endpoint_before_core' --no-cov`
- [x] `cd /Volumes/myssd/work/ugoite-1/wt/issue-1502/ugoite-core && uv run ty check . && cargo fmt --check && cargo clippy -- -D warnings`
