### PR TITLE
fix(ci): align CodeQL with required checks

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -13,6 +13,12 @@
       "events": ["pull_request", "merge_group"]
     },
     {
+      "context": "CodeQL",
+      "workflow": ".github/workflows/codeql.yml",
+      "job_id": "required-check",
+      "events": ["push", "pull_request", "merge_group"]
+    },
+    {
       "context": "Devcontainer CI",
       "workflow": ".github/workflows/devcontainer-ci.yml",
       "job_id": "required-check",

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,3 +51,33 @@ jobs:
         uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           category: /language:${{ matrix.language }}
+
+  required-check:
+    name: CodeQL
+    if: ${{ always() }}
+    needs:
+      - analyze
+    runs-on: ubuntu-24.04
+    permissions: {}
+    steps:
+      - name: Check upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failures = {
+              job: data.get("result", "missing")
+              for job, data in needs.items()
+              if data.get("result") not in {"success", "skipped"}
+          }
+          if failures:
+              details = ", ".join(
+                  f"{job}={result}" for job, result in sorted(failures.items())
+              )
+              raise SystemExit(f"Required CI jobs failed or were cancelled: {details}")
+          print("Required CI jobs succeeded.")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ value:
 | Event | What it covers |
 | --- | --- |
 | `push` on `main` | Fast, low-noise checks plus post-merge automation such as `Shell CI`, `YAML Workflow CI`, `README Command Guard`, `Release CI`, `Docsite Pages`, and `CodeQL` |
-| `pull_request` | The normal developer feedback set: `Commitlint CI`, `Devcontainer CI`, `Docsite CI`, `Frontend CI`, `Python CI`, plus the cheap static checks. CodeQL also runs here as a separate workflow |
+| `pull_request` | The normal developer feedback set: `Commitlint CI`, `CodeQL`, `Devcontainer CI`, `Docsite CI`, `Frontend CI`, `Python CI`, plus the cheap static checks |
 | `merge_group` | The final gate before `main`: `Docker Build CI`, `E2E Tests`, `Rust CI`, `SBOM CI`, `ScanCode`, and `Release Quickstart Verify CI` |
 
 push on `main` is reserved for fast, low-noise checks and post-merge automation.
@@ -142,9 +142,7 @@ Local hooks follow the same split:
 
 When CodeQL or other branch-protection policy changes depend on GitHub ruleset
 state, update the live repository ruleset as well as the checked-in JSON. PR
-1557 only unblocked after the live `main only pr` ruleset was changed to allow
-CodeQL code scanning, and merge queue plus `main` merge were re-verified after
-that repository-side update.
+1559 switched `main only pr` to require the `CodeQL` summary check directly so the branch gate no longer depends on the separate code-quality rule, and merge queue plus `main` merge were re-verified after that repository-side update.
 
 local validation maps to the same CI event split: use `mise run test` for the
 repo baseline, `mise run test:low-memory` for devcontainers, Codespaces, and

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -503,9 +503,9 @@ requirements:
   title: Native Required Status Check Contract
   description: 'Default-branch pull request and merge queue protection MUST use
     GitHub-native required status checks mapped directly to workflow summary jobs,
-    keep that contract versioned in-repo, exclude release/publish automation
-    workflows (at minimum `Release CI` and `Release Publish`), and keep CodeQL as
-    a separate workflow instead of a required status check.
+    keep that contract versioned in-repo, require the CodeQL summary job as part
+    of the branch gate, and exclude release/publish automation workflows (at
+    minimum `Release CI` and `Release Publish`).
 
     '
   related_spec:

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -17,7 +17,7 @@
 | YAML Workflow CI | `.github/workflows/yaml-workflow-ci.yml` | Push on `main`, PR, merge queue | Run repository artifact hygiene, GitHub Action SHA pinning checks, yamllint, and actionlint |
 | README Command Guard | `.github/workflows/readme-command-guard.yml` | Push on `main`, PR, merge queue | Keep canonical root commands documented |
 | Commitlint CI | `.github/workflows/commitlint-ci.yml` | PR, merge queue | Enforce Conventional Commits |
-| CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue, schedule, manual | Automated code scanning workflow for Actions, JavaScript/TypeScript, Python, and Rust |
+| CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue, schedule, manual | Automated code scanning workflow for Actions, JavaScript/TypeScript, Python, and Rust, with a direct required summary check on PR and merge queue |
 | PR Template Validation | `.github/workflows/pr-require-close-issue.yml` | PR body events via `pull_request_target` | Enforce required PR sections and accepted close/closes issue links |
 | Required Status Checks | `.github/required-status-checks.json` | Repository ruleset on `main` pull requests and merge queue | Versioned source of truth for direct workflow summary checks and exclusions |
 | Release CI | `.github/workflows/release-ci.yml` | Push on `main` | Create/update release PR with release-please (no auto publish) |
@@ -45,15 +45,13 @@ the human-readable policy lives in `CONTRIBUTING.md`.
 Required workflows must not depend on top-level `paths` filters that would make
 a check disappear. Path-aware workflows such as Devcontainer CI perform
 in-workflow change detection and still emit their summary check when the
-expensive job is skipped. Release automation (`Release CI`, `Docsite Pages`,
-`Release Publish`) stays excluded from required status checks, and CodeQL runs
-as a separate workflow rather than a required status check.
+expensive job is skipped. Release automation (`Release CI`, `Docsite Pages`, `Release Publish`) stays excluded from required status checks, and CodeQL is required through its direct summary job rather than the code-quality gate.
 
-Note: PR 1557 did not unblock until the live GitHub repository ruleset named
-`main only pr` was updated to allow CodeQL code scanning. The checked-in JSON
-remains the versioned contract, but GitHub evaluates the live ruleset, so a
-workflow-only change was not enough. After that repository ruleset change,
-merge queue and the `main` merge path were verified again.
+Note: PR 1557 showed that GitHub code scanning and branch gates can diverge if
+the live ruleset still points at the code-quality gate. The checked-in JSON
+remains the versioned contract, but GitHub evaluates the live ruleset, so the
+repository ruleset must keep the `CodeQL` summary check aligned with the
+workflow and the code-quality gate must not become a stale second blocker.
 
 Backend image builds in Docker Build CI, E2E CI, and SBOM CI pass `ugoite-core`,
 `ugoite-minimum`, and `ugoite-cli` as Buildx contexts so Rust path dependencies
@@ -94,7 +92,7 @@ E2E CI selects a deterministic tier before running tests. `merge_group` always r
 The event split is deliberately simple:
 
 push on `main` is reserved for fast, low-noise checks and post-merge automation.
-`pull_request` keeps the normal developer feedback set, and CodeQL also runs here as a separate workflow.
+`pull_request` keeps the normal developer feedback set, and CodeQL contributes a direct required summary check.
 `merge_group` is the final gate for expensive validation.
 The machine-readable policy lives in `.github/required-status-checks.json`.
 The human-readable policy lives in `CONTRIBUTING.md`.
@@ -137,6 +135,7 @@ path-aware no-op.
 | Required Check | Workflow | Events | Notes |
 |----------------|----------|--------|-------|
 | Commitlint CI | `.github/workflows/commitlint-ci.yml` | PR, merge queue | Direct summary check for Conventional Commit enforcement |
+| CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue | Direct summary check for GitHub code scanning across Actions, JavaScript/TypeScript, Python, and Rust |
 | Devcontainer CI | `.github/workflows/devcontainer-ci.yml` | PR, merge queue | Uses an in-workflow change detector and only runs the expensive smoke build when tracked inputs changed |
 | Docker Build CI | `.github/workflows/docker-build-ci.yml` | Merge queue | Summary check covers compose validation plus reusable image build |
 | Docsite CI | `.github/workflows/docsite-ci.yml` | PR, merge queue | Direct summary check for docsite quality gates |
@@ -510,7 +509,7 @@ The root `mise.toml` also declares explicit `[monorepo].config_roots` for packag
 
 1. **Conventional Commits** are required locally (Husky + Commitlint) and in CI (`commitlint-ci`).
 2. **Static checks and tests** must pass through existing CI workflows and the native required checks declared in `.github/required-status-checks.json`.
-3. **GitHub-native required status checks** must map directly to workflow summary jobs, keep `.github/required-status-checks.json` as the machine-readable source of truth, exclude release/publish automation (`Release CI`, `Docsite Pages`, `Release Publish`), and keep CodeQL as a separate workflow instead of a required status check.
+3. **GitHub-native required status checks** must map directly to workflow summary jobs, keep `.github/required-status-checks.json` as the machine-readable source of truth, require the `CodeQL` summary job, and exclude release/publish automation (`Release CI`, `Docsite Pages`, `Release Publish`).
 4. **Release CI** runs on pushes to `main` and uses release-please to create/update a release PR with SemVer planning when `RELEASE_PLEASE_TOKEN` is configured.
 5. **Release automation bootstrap** is seeded from `.github/.release-please-manifest.json`, `packages/ugoite/package.json`, and `.github/release-please-config.json`'s `bootstrap-sha`; the manifest/package versions must stay aligned, the repository root `package.json` must stay private tooling for Husky/commitlint only, and `bootstrap-sha` bounds pre-release-please history so old merge titles do not decide current release planning.
 6. **Release CI authentication** must use a dedicated `RELEASE_PLEASE_TOKEN`. If that secret is unavailable, the workflow must no-op cleanly instead of falling back to `GITHUB_TOKEN` and turning `main` red on repository-level PR permission errors.

--- a/docs/tests/test_guides.py
+++ b/docs/tests/test_guides.py
@@ -791,6 +791,7 @@ REQUIRED_LOCAL_DEV_AUTH_SCRIPT_FRAGMENTS = {
 }
 REQUIRED_NATIVE_REQUIRED_CHECKS = {
     "Commitlint CI",
+    "CodeQL",
     "Devcontainer CI",
     "Docker Build CI",
     "Docsite CI",
@@ -815,12 +816,10 @@ REQUIRED_NATIVE_REQUIRED_CHECK_DOC_FRAGMENTS = {
     "summary check",
     "machine-readable policy lives in `.github/required-status-checks.json`",
     "human-readable policy lives in `CONTRIBUTING.md`",
-    "PR 1557 did not unblock until the live GitHub repository ruleset named",
-    "The checked-in JSON",
-    "merge queue and the `main` merge path were verified again",
+    "CodeQL is required through its direct summary job",
+    "the code-quality gate must not become a stale second blocker",
     "Release CI",
     "Release Publish",
-    "a separate workflow instead of a required status check",
     "CodeQL | `.github/workflows/codeql.yml` | Push on `main`, PR, merge queue",
 }
 REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS = {
@@ -829,7 +828,7 @@ REQUIRED_NATIVE_REQUIRED_CHECK_CONTRIBUTING_FRAGMENTS = {
     "`merge_group` is the final gate for expensive validation",
     ".github/required-status-checks.json",
     "local validation maps to the same CI event split",
-    "CodeQL also runs here as a separate workflow",
+    "require the `CodeQL` summary check directly",
     "update the live repository ruleset as well as the checked-in JSON",
     "merge queue plus `main` merge were re-verified",
 }


### PR DESCRIPTION
## Summary

Move CodeQL onto the same direct required-status-check path as the rest of the
branch gate, update the repo contract and docs to describe that model, and sync
the live `main only pr` ruleset so it no longer depends on the stale
code-quality gate.

## Related Issue (required)

close: #1559

## Testing

- [x] `uv run --with pytest --with pyyaml --with bashlex pytest -W error docs/tests/test_guides.py`
- [x] `npx -y @devcontainers/cli build --workspace-folder . --image-name ugoite-devcontainer:issue-1559`
