### PR TITLE
fix: skip devcontainer browser deps in ci

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,5 +42,5 @@
 		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
 	},
 	"postCreateCommand": "sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends oathtool shfmt shellcheck && sudo rm -rf /var/lib/apt/lists/*",
-	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && cd /workspace/e2e && npx playwright --version && npx playwright install --with-deps chromium"
+	"onCreateCommand": "eval \"$(mise activate bash --shims)\" >> ~/.bashrc && sudo chown -R vscode:vscode /workspace/frontend/node_modules /workspace/backend/.venv && mise trust -- --non-interactive && mise install --yes && mise run setup && cd /workspace/e2e && npx playwright --version && if [ -z \"${UGOITE_SKIP_PLAYWRIGHT_DEPS:-}\" ]; then npx playwright install --with-deps chromium; fi"
 }

--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -165,6 +165,8 @@ jobs:
       - name: Build and smoke test devcontainer
         uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3
         with:
+          env: |
+            UGOITE_SKIP_PLAYWRIGHT_DEPS=1
           runCmd: |
             gh --version
             mise --version

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -407,11 +407,10 @@ health cannot depend on a disappearing required check. The canonical
 devcontainer also uses exact version tags for its base image and public
 Features, and `.github/dependabot.yml` tracks `package-ecosystem: "devcontainers"`
 at `/` so Feature updates stay reviewable in normal PR flow while the base
-image tag stays explicitly pinned in `devcontainer.json`.
-
-The canonical devcontainer also uses exact version tags for its base image and public Features.
-`.github/dependabot.yml` tracks `package-ecosystem: "devcontainers"` at `/`.
-The base image tag stays explicitly pinned in `devcontainer.json`.
+image tag stays explicitly pinned in `devcontainer.json`. Devcontainer CI also
+sets `UGOITE_SKIP_PLAYWRIGHT_DEPS=1` so the CI-only smoke path can skip the apt
+and browser-dependency install while contributor bootstrap keeps the full
+`npx playwright install --with-deps chromium` step.
 
 ## Rust CI
 

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -403,13 +403,11 @@ tests that validate devcontainer setup contracts. When no tracked input changed
 on a pull request, the smoke build is skipped but the summary check still
 reports success with an explicit selection reason. `merge_group` always runs the
 smoke build because GitHub does not support `paths` filtering there and branch
-health cannot depend on a disappearing required check. The canonical
-devcontainer also uses exact version tags for its base image and public
-Features, and `.github/dependabot.yml` tracks `package-ecosystem: "devcontainers"`
-at `/` so Feature updates stay reviewable in normal PR flow while the base
-image tag stays explicitly pinned in `devcontainer.json`. Devcontainer CI also
-sets `UGOITE_SKIP_PLAYWRIGHT_DEPS=1` so the CI-only smoke path can skip the apt
-and browser-dependency install while contributor bootstrap keeps the full
+health cannot depend on a disappearing required check. The canonical devcontainer also uses exact version tags for its base image and public Features. The canonical devcontainer also uses exact version pinning for Dependabot-updatable features.
+`.github/dependabot.yml` tracks `package-ecosystem: "devcontainers"` at `/`.
+The base image tag stays explicitly pinned in `devcontainer.json`. Devcontainer
+CI also sets `UGOITE_SKIP_PLAYWRIGHT_DEPS=1` so the CI-only smoke path can skip
+the apt and browser-dependency install while contributor bootstrap keeps the full
 `npx playwright install --with-deps chromium` step.
 
 ## Rust CI


### PR DESCRIPTION
## Summary

Skip the CI-only Playwright browser-dependency install in devcontainer smoke runs by setting `UGOITE_SKIP_PLAYWRIGHT_DEPS=1` in Devcontainer CI, while keeping the contributor devcontainer bootstrap unchanged. I also documented the CI-only skip in the devcontainer testing spec.

## Related Issue (required)

close: #1581

## Testing

- [x] `uv run --with pytest --with pyyaml --with bashlex pytest -W error docs/tests/test_guides.py::test_docs_req_ops_012_devcontainer_change_detection_covers_inputs -v`
- [x] `uv run --with pyyaml python - <<'PY' ... yaml.safe_load(...) ... PY`
- [ ] `devcontainer up` in the worktree surfaced an existing worktree/gitdir hook-path issue during `mise run setup`; the Playwright skip guard itself was exercised in the devcontainer command and the repo-side checks above passed.
