### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,22 @@
+---
 version: 2
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "daily"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "bun"
     directory: "/frontend"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
     groups:
@@ -17,31 +27,43 @@ updates:
 
   - package-ecosystem: "bun"
     directory: "/docsite"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "npm"
     directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "npm"
     directory: "/e2e"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "uv"
     directory: "/backend"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "uv"
     directory: "/ugoite-core"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "cargo"
     directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
     groups:
@@ -52,25 +74,39 @@ updates:
           - "iceberg"
     ignore:
       - dependency-name: "arrow-array"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       - dependency-name: "arrow-schema"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       - dependency-name: "parquet"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       - dependency-name: "iceberg"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: "docker"
     directory: "/backend"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/frontend"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary

- Configure Dependabot multi-ecosystem grouping so all tracked dependency update ecosystems join the `all-dependencies` PR.
- Keep existing per-ecosystem guardrails for Vitest alignment and Rust Arrow/Iceberg update ignores.
- Restore unsupported storage schemes to return an error so the merge-queue Rust regression test passes.

## Related Issue (required)

close: #1732

## Testing

- [x] `uv run --with yamllint yamllint .github/dependabot.yml`
- [x] `uv run --with pytest --with pyyaml --with bashlex pytest -W error docs/tests/test_guides.py::test_docs_req_ops_012_devcontainer_refs_are_pinned_and_updatable docs/tests/test_guides.py::test_docs_req_ops_021_frontend_coverage_gate_is_explicit docs/tests/test_guides.py::test_docs_req_ops_031_github_actions_are_sha_pinned_and_updatable docs/tests/test_cli_language_docs.py::test_docs_req_ops_014_cli_language_is_consistent -v`
- [x] `uv run --with pyyaml python - <<'PY' ...` validated 11 grouped Dependabot update entries
- [x] `cd ugoite-core && cargo fmt --check`
- [x] `cd ugoite-core && cargo check`
- [ ] `cd ugoite-core && cargo test --test test_space test_space_req_sto_006_test_storage_connection_unknown_rejects_unsupported_scheme -- --exact` did not complete locally because macOS PyO3 linking failed before running the test binary; CI runs the Linux Rust test path.
- [ ] `mise run test` not run; targeted docs/YAML/Rust checks were run and full CI will run on the PR.
