### PR TITLE
feat: complete Rust rearchitecture phase 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "multer",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +940,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1145,15 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -1474,6 +1546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1573,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2017,6 +2096,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "link-section"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2189,12 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2132,6 +2235,23 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -2268,7 +2388,12 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c9c85ce253ff87225e7669979d877a20c98a06604ec9d6dd5f4473e08f1ae1"
 dependencies = [
+ "ctor",
  "opendal-core",
+ "opendal-layer-concurrent-limit",
+ "opendal-layer-logging",
+ "opendal-layer-retry",
+ "opendal-layer-timeout",
  "opendal-service-azdls",
  "opendal-service-fs",
  "opendal-service-gcs",
@@ -2302,6 +2427,49 @@ dependencies = [
  "url",
  "uuid",
  "web-time",
+]
+
+[[package]]
+name = "opendal-layer-concurrent-limit"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6f81ba6960e3fae1882f253b114b21d7e444e1534f209c7737a79f6243eb6f"
+dependencies = [
+ "futures",
+ "http",
+ "mea",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-logging"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ada45c6d81d1aa4c9305d0c7d4bc317c59c85866a0908a2d75a7a978aa5ee2"
+dependencies = [
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2a25a718afb81fad81cb9a0580a1cb989221fa2317f888c6a37f8dad408eb7"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-timeout"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
+dependencies = [
+ "opendal-core",
+ "tokio",
 ]
 
 [[package]]
@@ -3608,6 +3776,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3724,6 +3903,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -4047,6 +4236,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4129,6 +4319,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4146,7 +4337,9 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4167,6 +4360,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -4287,7 +4481,17 @@ dependencies = [
 name = "ugoite-server"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "axum",
+ "http",
+ "opendal 0.57.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-http",
  "ugoite-core",
+ "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 **"Local-First Knowledge Space with Resource-First MCP Integration for the Post-SaaS Era"**
 
 > **Positioning today:** local-first most directly describes Ugoite's storage
-> model and CLI `core` path today. The current browser route is still
-> server-backed, runs through the backend + frontend stack, and requires an
-> explicit `/login` flow.
+> model and CLI `core` path today. The browser route is server-backed and the
+> canonical source-development backend is the Rust `ugoite-server`.
 
 ## Vision
 
@@ -110,7 +109,7 @@ the `v0.2` roadmap.
 | Component    | Technology                           |
 | ------------ | ------------------------------------ |
 | Frontend     | Bun + SolidStart + TailwindCSS       |
-| Backend      | Python 3.13+ (FastAPI)               |
+| Backend      | Rust (`ugoite-server`, Axum)          |
 | Core         | Rust (`ugoite-domain` + `ugoite-core`) |
 | Storage      | OpenDAL + Apache Iceberg             |
 | AI Interface | MCP (resource-first integration today) |
@@ -123,11 +122,11 @@ the `v0.2` roadmap.
 frontend/           # SolidStart frontend
   ├─ src/
   └─ public/
-backend/            # FastAPI backend (REST & MCP server)
-  └─ src/
 crates/ugoite-cli/         # Command-line interface for power users
   └─ src/
 crates/ugoite-core/        # Rust core logic + Python bindings
+  └─ src/
+crates/ugoite-server/      # Rust REST & MCP server
   └─ src/
 ugoite-domain/     # Portable Rust core layer for embedding/WASM-focused use
   └─ src/

--- a/crates/ugoite-server/Cargo.toml
+++ b/crates/ugoite-server/Cargo.toml
@@ -5,4 +5,16 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+anyhow.workspace = true
+axum = { version = "0.8", features = ["multipart"] }
+http = "1"
+opendal = "0.57"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "signal"] }
+tower-http = { version = "0.6", features = ["cors", "request-id", "trace"] }
 ugoite-core = { path = "../ugoite-core" }
+uuid = { version = "1.23.2", features = ["v4"] }
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -1,3 +1,759 @@
-//! HTTP and MCP adapter boundary for Ugoite.
+//! Thin HTTP and MCP adapters over `ugoite-core`.
 
-pub use ugoite_core as core;
+use axum::{
+    extract::{DefaultBodyLimit, Multipart, Path, Query, Request, State},
+    http::{HeaderMap, Method, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{delete, get, post},
+    Json, Router,
+};
+use opendal::Operator;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::env;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    trace::TraceLayer,
+};
+use ugoite_core::{
+    asset, entry, form, index, integrity::RealIntegrityProvider, saved_sql, search, space,
+    storage::operator_from_uri,
+};
+use uuid::Uuid;
+
+pub const OPENAPI_JSON: &str = include_str!("openapi.json");
+
+#[derive(Clone)]
+pub struct AppState {
+    operator: Operator,
+    root_uri: String,
+}
+
+impl AppState {
+    pub fn new(root_uri: impl Into<String>) -> anyhow::Result<Self> {
+        let root_uri = root_uri.into();
+        Ok(Self {
+            operator: operator_from_uri(&root_uri)?,
+            root_uri,
+        })
+    }
+
+    pub fn from_env() -> anyhow::Result<Self> {
+        Self::new(env::var("UGOITE_ROOT").unwrap_or_else(|_| "./data".to_string()))
+    }
+
+    fn workspace(&self, space_id: &str) -> String {
+        format!("spaces/{space_id}")
+    }
+}
+
+#[derive(Debug)]
+pub struct ApiError {
+    status: StatusCode,
+    detail: Value,
+}
+
+impl ApiError {
+    fn new(status: StatusCode, detail: impl Into<Value>) -> Self {
+        Self {
+            status,
+            detail: detail.into(),
+        }
+    }
+
+    fn from_core(error: anyhow::Error) -> Self {
+        let message = error.to_string();
+        let normalized = message.to_lowercase();
+        let status = if normalized.contains("not found") {
+            StatusCode::NOT_FOUND
+        } else if normalized.contains("already exists") || normalized.contains("conflict") {
+            StatusCode::CONFLICT
+        } else if normalized.contains("form")
+            || normalized.contains("invalid")
+            || normalized.contains("unknown")
+            || normalized.contains("unsupported")
+        {
+            StatusCode::UNPROCESSABLE_ENTITY
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
+        let detail = if status == StatusCode::INTERNAL_SERVER_ERROR {
+            Value::String("Internal server error".to_string())
+        } else {
+            Value::String(message)
+        };
+        Self { status, detail }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (self.status, Json(json!({ "detail": self.detail }))).into_response()
+    }
+}
+
+type ApiResult<T> = Result<T, ApiError>;
+
+pub fn app(state: AppState) -> Router {
+    let protected = Router::new()
+        .route("/spaces", get(list_spaces).post(create_space))
+        .route("/spaces/{space_id}", get(get_space).patch(patch_space))
+        .route("/spaces/{space_id}/test-connection", post(test_connection))
+        .route(
+            "/spaces/{space_id}/entries",
+            get(list_entries).post(create_entry),
+        )
+        .route("/spaces/{space_id}/entries/options", get(entry_options))
+        .route(
+            "/spaces/{space_id}/entries/{entry_id}",
+            get(get_entry).put(update_entry).delete(delete_entry),
+        )
+        .route(
+            "/spaces/{space_id}/entries/{entry_id}/history",
+            get(entry_history),
+        )
+        .route(
+            "/spaces/{space_id}/entries/{entry_id}/history/{revision_id}",
+            get(entry_revision),
+        )
+        .route(
+            "/spaces/{space_id}/entries/{entry_id}/restore",
+            post(restore_entry),
+        )
+        .route(
+            "/spaces/{space_id}/forms",
+            get(list_forms).post(upsert_form),
+        )
+        .route("/spaces/{space_id}/forms/types", get(form_types))
+        .route("/spaces/{space_id}/forms/{form_name}", get(get_form))
+        .route("/spaces/{space_id}/search", get(search_entries))
+        .route("/spaces/{space_id}/query", post(query_entries))
+        .route("/spaces/{space_id}/sql", get(list_sql).post(create_sql))
+        .route(
+            "/spaces/{space_id}/sql/{sql_id}",
+            get(get_sql).put(update_sql).delete(delete_sql),
+        )
+        .route(
+            "/spaces/{space_id}/assets",
+            get(list_assets).post(upload_asset),
+        )
+        .route("/spaces/{space_id}/assets/{asset_id}", delete(delete_asset))
+        .route("/mcp/resources/{space_id}/entries/list", get(mcp_entries))
+        .route_layer(middleware::from_fn(require_auth));
+
+    Router::new()
+        .route(
+            "/",
+            get(|| async { Json(json!({"message": "Hello World!"})) }),
+        )
+        .route("/health", get(|| async { Json(json!({"status": "ok"})) }))
+        .route("/openapi.json", get(|| async { OPENAPI_JSON }))
+        .route("/auth/config", get(auth_config))
+        .merge(protected)
+        .layer(DefaultBodyLimit::max(20 * 1024 * 1024))
+        .layer(PropagateRequestIdLayer::x_request_id())
+        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+        .layer(TraceLayer::new_for_http())
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods([
+                    Method::GET,
+                    Method::POST,
+                    Method::PUT,
+                    Method::PATCH,
+                    Method::DELETE,
+                    Method::OPTIONS,
+                ])
+                .allow_headers(Any),
+        )
+        .with_state(state)
+}
+
+async fn require_auth(headers: HeaderMap, request: Request, next: Next) -> Response {
+    let authorization = headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok());
+    let api_key = headers
+        .get("x-api-key")
+        .and_then(|value| value.to_str().ok());
+    let result = ugoite_core::auth::authenticate_headers_core(
+        authorization,
+        api_key,
+        env::var("UGOITE_AUTH_BEARER_TOKENS").ok().as_deref(),
+        env::var("UGOITE_AUTH_API_KEYS").ok().as_deref(),
+        env::var("UGOITE_AUTH_BEARER_SIGNING_SECRETS")
+            .ok()
+            .as_deref(),
+        env::var("UGOITE_AUTH_BEARER_ACTIVE_KIDS").ok().as_deref(),
+        env::var("UGOITE_AUTH_REVOKED_KEY_IDS").ok().as_deref(),
+        env::var("UGOITE_BOOTSTRAP_TOKEN").ok().as_deref(),
+        env::var("UGOITE_DEV_USER_ID").ok().as_deref(),
+    );
+    if !result.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"detail": result.get("error").cloned().unwrap_or_default()})),
+        )
+            .into_response();
+    }
+    next.run(request).await
+}
+
+async fn auth_config() -> Json<Value> {
+    Json(json!({
+        "mode": env::var("UGOITE_DEV_AUTH_MODE").unwrap_or_else(|_| "token".to_string()),
+        "login_required": true
+    }))
+}
+
+fn validate_id(value: &str, name: &str) -> ApiResult<()> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            format!("Invalid {name}"),
+        ));
+    }
+    Ok(())
+}
+
+async fn ensure_space(state: &AppState, space_id: &str) -> ApiResult<()> {
+    validate_id(space_id, "space_id")?;
+    space::get_space(&state.operator, space_id)
+        .await
+        .map(|_| ())
+        .map_err(ApiError::from_core)
+}
+
+async fn list_spaces(State(state): State<AppState>) -> ApiResult<Json<Value>> {
+    let ids = space::list_spaces(&state.operator)
+        .await
+        .map_err(ApiError::from_core)?;
+    let mut items = Vec::new();
+    for id in ids {
+        let mut value = space::get_space_raw(&state.operator, &id)
+            .await
+            .map_err(ApiError::from_core)?;
+        if let Some(object) = value.as_object_mut() {
+            object.remove("hmac_key");
+            object.insert(
+                "is_admin_space".to_string(),
+                Value::Bool(id == "admin-space"),
+            );
+        }
+        items.push(value);
+    }
+    Ok(Json(Value::Array(items)))
+}
+
+#[derive(Deserialize)]
+struct SpaceCreate {
+    name: String,
+}
+
+async fn create_space(
+    State(state): State<AppState>,
+    Json(payload): Json<SpaceCreate>,
+) -> ApiResult<(StatusCode, Json<Value>)> {
+    validate_id(&payload.name, "space_id")?;
+    space::create_space(&state.operator, &payload.name, &state.root_uri)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(
+            json!({"id": payload.name, "name": payload.name, "path": state.workspace(&payload.name)}),
+        ),
+    ))
+}
+
+async fn get_space(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        space::get_space_raw(&state.operator, &space_id)
+            .await
+            .map_err(ApiError::from_core)?,
+    ))
+}
+
+async fn patch_space(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    Json(payload): Json<Value>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        space::patch_space(&state.operator, &space_id, &payload)
+            .await
+            .map_err(ApiError::from_core)?,
+    ))
+}
+
+async fn test_connection(
+    Path(space_id): Path<String>,
+    Json(payload): Json<Value>,
+) -> ApiResult<Json<Value>> {
+    validate_id(&space_id, "space_id")?;
+    let uri = payload
+        .pointer("/storage_config/uri")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            ApiError::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "storage_config.uri is required",
+            )
+        })?;
+    Ok(Json(
+        space::test_storage_connection(uri)
+            .await
+            .map_err(ApiError::from_core)?,
+    ))
+}
+
+#[derive(Deserialize)]
+struct EntryCreate {
+    id: Option<String>,
+    #[serde(alias = "content")]
+    markdown: String,
+}
+
+async fn create_entry(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    Json(payload): Json<EntryCreate>,
+) -> ApiResult<(StatusCode, Json<Value>)> {
+    ensure_space(&state, &space_id).await?;
+    let entry_id = payload.id.unwrap_or_else(|| Uuid::new_v4().to_string());
+    validate_id(&entry_id, "entry_id")?;
+    let integrity = RealIntegrityProvider::from_space(&state.operator, &space_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    entry::create_entry(
+        &state.operator,
+        &state.workspace(&space_id),
+        &entry_id,
+        &payload.markdown,
+        "api-user",
+        &integrity,
+    )
+    .await
+    .map_err(ApiError::from_core)?;
+    let created = entry::get_entry(&state.operator, &state.workspace(&space_id), &entry_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({"id": entry_id, "revision_id": created["revision_id"]})),
+    ))
+}
+
+async fn list_entries(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(Value::Array(
+        entry::list_entries(&state.operator, &state.workspace(&space_id))
+            .await
+            .map_err(ApiError::from_core)?,
+    )))
+}
+
+#[derive(Deserialize)]
+struct EntryOptionsQuery {
+    form: Option<String>,
+    q: Option<String>,
+    limit: Option<usize>,
+}
+
+async fn entry_options(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    Query(query): Query<EntryOptionsQuery>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    let options = entry::list_entry_summaries(
+        &state.operator,
+        &state.workspace(&space_id),
+        query.form.as_deref(),
+        query.q.as_deref(),
+        query.limit.unwrap_or(8).min(20),
+    )
+    .await
+    .map_err(ApiError::from_core)?;
+    Ok(Json(
+        serde_json::to_value(options).map_err(|error| ApiError::from_core(error.into()))?,
+    ))
+}
+
+async fn get_entry(
+    State(state): State<AppState>,
+    Path((space_id, entry_id)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    let mut value = entry::get_entry(&state.operator, &state.workspace(&space_id), &entry_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    if let Some(content) = value.get("content").cloned() {
+        value["markdown"] = content;
+    }
+    Ok(Json(value))
+}
+
+#[derive(Deserialize)]
+struct EntryUpdate {
+    markdown: String,
+    parent_revision_id: String,
+    assets: Option<Vec<Value>>,
+}
+
+async fn update_entry(
+    State(state): State<AppState>,
+    Path((space_id, entry_id)): Path<(String, String)>,
+    Json(payload): Json<EntryUpdate>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    let integrity = RealIntegrityProvider::from_space(&state.operator, &space_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    let value = entry::update_entry(
+        &state.operator,
+        &state.workspace(&space_id),
+        &entry_id,
+        &payload.markdown,
+        Some(&payload.parent_revision_id),
+        "api-user",
+        payload.assets,
+        &integrity,
+    )
+    .await
+    .map_err(ApiError::from_core)?;
+    Ok(Json(
+        json!({"id": entry_id, "revision_id": value["revision_id"]}),
+    ))
+}
+
+async fn delete_entry(
+    State(state): State<AppState>,
+    Path((space_id, entry_id)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    entry::delete_entry(
+        &state.operator,
+        &state.workspace(&space_id),
+        &entry_id,
+        false,
+    )
+    .await
+    .map_err(ApiError::from_core)?;
+    Ok(Json(json!({"id": entry_id, "status": "deleted"})))
+}
+
+async fn entry_history(
+    State(state): State<AppState>,
+    Path((space_id, entry_id)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        entry::get_entry_history(&state.operator, &state.workspace(&space_id), &entry_id)
+            .await
+            .map_err(ApiError::from_core)?,
+    ))
+}
+
+async fn entry_revision(
+    State(state): State<AppState>,
+    Path((space_id, entry_id, revision_id)): Path<(String, String, String)>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        entry::get_entry_revision(
+            &state.operator,
+            &state.workspace(&space_id),
+            &entry_id,
+            &revision_id,
+        )
+        .await
+        .map_err(ApiError::from_core)?,
+    ))
+}
+
+#[derive(Deserialize)]
+struct RestoreEntry {
+    revision_id: String,
+}
+
+async fn restore_entry(
+    State(state): State<AppState>,
+    Path((space_id, entry_id)): Path<(String, String)>,
+    Json(payload): Json<RestoreEntry>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    let integrity = RealIntegrityProvider::from_space(&state.operator, &space_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok(Json(
+        entry::restore_entry(
+            &state.operator,
+            &state.workspace(&space_id),
+            &entry_id,
+            &payload.revision_id,
+            "api-user",
+            &integrity,
+        )
+        .await
+        .map_err(ApiError::from_core)?,
+    ))
+}
+
+async fn list_forms(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(Value::Array(
+        form::list_forms(&state.operator, &state.workspace(&space_id))
+            .await
+            .map_err(ApiError::from_core)?,
+    )))
+}
+
+async fn form_types(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        serde_json::to_value(
+            form::list_column_types()
+                .await
+                .map_err(ApiError::from_core)?,
+        )
+        .map_err(|error| ApiError::from_core(error.into()))?,
+    ))
+}
+
+async fn get_form(
+    State(state): State<AppState>,
+    Path((space_id, form_name)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        form::get_form(&state.operator, &state.workspace(&space_id), &form_name)
+            .await
+            .map_err(ApiError::from_core)?,
+    ))
+}
+
+async fn upsert_form(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    Json(payload): Json<Value>,
+) -> ApiResult<(StatusCode, Json<Value>)> {
+    ensure_space(&state, &space_id).await?;
+    form::upsert_form(&state.operator, &state.workspace(&space_id), &payload)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok((StatusCode::CREATED, Json(payload)))
+}
+
+#[derive(Deserialize)]
+struct SearchQuery {
+    q: String,
+}
+
+async fn search_entries(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    Query(query): Query<SearchQuery>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        serde_json::to_value(
+            search::search_entries(&state.operator, &state.workspace(&space_id), &query.q)
+                .await
+                .map_err(ApiError::from_core)?,
+        )
+        .map_err(|error| ApiError::from_core(error.into()))?,
+    ))
+}
+
+async fn query_entries(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    Json(payload): Json<Value>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    let filter = payload.get("filter").cloned().unwrap_or(payload);
+    Ok(Json(Value::Array(
+        index::query_index(
+            &state.operator,
+            &state.workspace(&space_id),
+            &filter.to_string(),
+        )
+        .await
+        .map_err(ApiError::from_core)?,
+    )))
+}
+
+async fn list_sql(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(Value::Array(
+        saved_sql::list_sql(&state.operator, &state.workspace(&space_id))
+            .await
+            .map_err(ApiError::from_core)?,
+    )))
+}
+
+async fn create_sql(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    Json(payload): Json<saved_sql::SqlPayload>,
+) -> ApiResult<(StatusCode, Json<Value>)> {
+    ensure_space(&state, &space_id).await?;
+    let id = Uuid::new_v4().to_string();
+    let integrity = RealIntegrityProvider::from_space(&state.operator, &space_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    let value = saved_sql::create_sql(
+        &state.operator,
+        &state.workspace(&space_id),
+        &id,
+        &payload,
+        "api-user",
+        &integrity,
+    )
+    .await
+    .map_err(ApiError::from_core)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({"id": id, "revision_id": value["revision_id"]})),
+    ))
+}
+
+async fn get_sql(
+    State(state): State<AppState>,
+    Path((space_id, sql_id)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        saved_sql::get_sql(&state.operator, &state.workspace(&space_id), &sql_id)
+            .await
+            .map_err(ApiError::from_core)?,
+    ))
+}
+
+async fn update_sql(
+    State(state): State<AppState>,
+    Path((space_id, sql_id)): Path<(String, String)>,
+    Json(payload): Json<saved_sql::SqlPayload>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    let integrity = RealIntegrityProvider::from_space(&state.operator, &space_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok(Json(
+        saved_sql::update_sql(
+            &state.operator,
+            &state.workspace(&space_id),
+            &sql_id,
+            &payload,
+            None,
+            "api-user",
+            &integrity,
+        )
+        .await
+        .map_err(ApiError::from_core)?,
+    ))
+}
+
+async fn delete_sql(
+    State(state): State<AppState>,
+    Path((space_id, sql_id)): Path<(String, String)>,
+) -> ApiResult<StatusCode> {
+    ensure_space(&state, &space_id).await?;
+    saved_sql::delete_sql(&state.operator, &state.workspace(&space_id), &sql_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_assets(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    Ok(Json(
+        serde_json::to_value(
+            asset::list_assets(&state.operator, &state.workspace(&space_id))
+                .await
+                .map_err(ApiError::from_core)?,
+        )
+        .map_err(|error| ApiError::from_core(error.into()))?,
+    ))
+}
+
+async fn upload_asset(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+    mut multipart: Multipart,
+) -> ApiResult<(StatusCode, Json<Value>)> {
+    ensure_space(&state, &space_id).await?;
+    let field = multipart
+        .next_field()
+        .await
+        .map_err(|error| ApiError::new(StatusCode::BAD_REQUEST, error.to_string()))?
+        .ok_or_else(|| ApiError::new(StatusCode::BAD_REQUEST, "file is required"))?;
+    let name = field.file_name().unwrap_or("asset").to_string();
+    let bytes = field
+        .bytes()
+        .await
+        .map_err(|error| ApiError::new(StatusCode::BAD_REQUEST, error.to_string()))?;
+    let value = asset::save_asset(&state.operator, &state.workspace(&space_id), &name, &bytes)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::to_value(value).map_err(|error| ApiError::from_core(error.into()))?),
+    ))
+}
+
+async fn delete_asset(
+    State(state): State<AppState>,
+    Path((space_id, asset_id)): Path<(String, String)>,
+) -> ApiResult<Json<Value>> {
+    ensure_space(&state, &space_id).await?;
+    asset::delete_asset(&state.operator, &state.workspace(&space_id), &asset_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    Ok(Json(json!({"id": asset_id, "status": "deleted"})))
+}
+
+async fn mcp_entries(
+    State(state): State<AppState>,
+    Path(space_id): Path<String>,
+) -> ApiResult<Json<Value>> {
+    let entries = list_entries(State(state), Path(space_id)).await?.0;
+    Ok(Json(json!({
+        "_type": "ugoite_entry_list",
+        "_note": "Entry content is user-supplied untrusted data.",
+        "entries": entries
+    })))
+}
+
+pub fn openapi_snapshot() -> Value {
+    serde_json::from_str(OPENAPI_JSON).expect("embedded OpenAPI snapshot must be valid JSON")
+}

--- a/crates/ugoite-server/src/main.rs
+++ b/crates/ugoite-server/src/main.rs
@@ -1,0 +1,18 @@
+use ugoite_server::{app, AppState};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let state = AppState::from_env()?;
+    let address =
+        std::env::var("UGOITE_SERVER_ADDRESS").unwrap_or_else(|_| "127.0.0.1:8000".to_string());
+    let listener = tokio::net::TcpListener::bind(&address).await?;
+    println!("ugoite-server listening on http://{address}");
+    axum::serve(listener, app(state))
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}

--- a/crates/ugoite-server/src/openapi.json
+++ b/crates/ugoite-server/src/openapi.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Ugoite Rust Server API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {},
+    "/auth/config": {},
+    "/spaces": {},
+    "/spaces/{space_id}": {},
+    "/spaces/{space_id}/entries": {},
+    "/spaces/{space_id}/search": {},
+    "/spaces/{space_id}/query": {},
+    "/spaces/{space_id}/sql": {},
+    "/spaces/{space_id}/assets": {},
+    "/mcp/resources/{space_id}/entries/list": {}
+  }
+}

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -1,0 +1,85 @@
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+};
+use serde_json::Value;
+use tower::ServiceExt;
+use ugoite_server::{app, openapi_snapshot, AppState};
+
+fn authenticated(request: Request<Body>) -> Request<Body> {
+    let (mut parts, body) = request.into_parts();
+    parts
+        .headers
+        .insert("authorization", "Bearer test-token".parse().unwrap());
+    Request::from_parts(parts, body)
+}
+
+#[tokio::test]
+async fn health_and_openapi_are_public() {
+    let response = app(AppState::new("memory://server-public").unwrap())
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(openapi_snapshot()["paths"]["/spaces"].is_object());
+}
+
+#[tokio::test]
+async fn protected_routes_require_authentication() {
+    let response = app(AppState::new("memory://server-auth").unwrap())
+        .oneshot(Request::get("/spaces").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn space_entry_search_and_mcp_contract() {
+    std::env::set_var(
+        "UGOITE_AUTH_BEARER_TOKENS",
+        r#"{"test-token":{"user_id":"test-user"}}"#,
+    );
+    let router = app(AppState::new("memory://server-contract").unwrap());
+    let create_space = authenticated(
+        Request::post("/spaces")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"name":"demo"}"#))
+            .unwrap(),
+    );
+    assert_eq!(
+        router.clone().oneshot(create_space).await.unwrap().status(),
+        StatusCode::CREATED
+    );
+
+    let create_entry = authenticated(
+        Request::post("/spaces/demo/entries")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"id":"first","markdown":"---\nform: Entry\n---\n# First\n\n## Body\nhello"}"#,
+            ))
+            .unwrap(),
+    );
+    assert_eq!(
+        router.clone().oneshot(create_entry).await.unwrap().status(),
+        StatusCode::CREATED
+    );
+
+    let list = authenticated(
+        Request::get("/spaces/demo/entries")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let response = router.clone().oneshot(list).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body[0]["id"], "first");
+
+    let mcp = authenticated(
+        Request::get("/mcp/resources/demo/entries/list")
+            .body(Body::empty())
+            .unwrap(),
+    );
+    let response = router.oneshot(mcp).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
     "npm:@codemirror/lint@^6.9.6": "6.9.7",
     "npm:@codemirror/state@^6.6.0": "6.6.0",
     "npm:@codemirror/view@^6.43.0": "6.43.1",
+    "npm:@oslojs/encoding@^1.1.0": "1.1.0",
     "npm:@playwright/test@^1.60.0": "1.60.0",
     "npm:@solidjs/router@~0.16.1": "0.16.1_solid-js@1.9.13",
     "npm:@solidjs/start@^1.3.2": "1.3.2_vinxi@0.5.11__@types+node@25.9.1__yaml@2.9.0_@testing-library+jest-dom@6.9.1_@types+node@25.9.1_solid-js@1.9.13_vite@8.0.16__@types+node@25.9.1__yaml@2.9.0_yaml@2.9.0",
@@ -21,13 +22,20 @@
     "npm:@types/node@25.9.1": "25.9.1",
     "npm:@types/node@^25.9.1": "25.9.1",
     "npm:@vitest/coverage-v8@^4.1.8": "4.1.8_vitest@4.1.8_@types+node@25.9.1_jsdom@29.1.1_msw@2.14.6__typescript@6.0.3__@types+node@25.9.1_typescript@6.0.3_vite@8.0.16__@types+node@25.9.1__yaml@2.9.0_yaml@2.9.0",
+    "npm:astro@*": "6.4.6_@types+node@25.9.1_yaml@2.9.0",
     "npm:astro@^6.4.2": "6.4.6_@types+node@25.9.1_yaml@2.9.0",
     "npm:baseline-browser-mapping@^2.10.33": "2.10.37",
     "npm:browserslist@^4.28.2": "4.28.2",
+    "npm:clsx@^2.1.1": "2.1.1",
+    "npm:cookie@^1.0.2": "1.1.1",
+    "npm:devalue@^5.6.3": "5.8.1",
+    "npm:es-module-lexer@2": "2.1.0",
+    "npm:html-escaper@^3.0.3": "3.0.3",
     "npm:js-tokens@10": "10.0.0",
     "npm:jsdom@^29.1.1": "29.1.1",
     "npm:marked@^18.0.4": "18.0.5",
     "npm:msw@^2.14.6": "2.14.6_typescript@6.0.3_@types+node@25.9.1",
+    "npm:piccolore@~0.1.3": "0.1.3",
     "npm:playwright@*": "1.60.0",
     "npm:prismjs@1.30.0": "1.30.0",
     "npm:solid-js@^1.9.13": "1.9.13",
@@ -35,6 +43,8 @@
     "npm:tailwindcss@4.3.0": "4.3.0",
     "npm:tailwindcss@^4.3.0": "4.3.0",
     "npm:typescript@^6.0.3": "6.0.3",
+    "npm:unstorage@^1.17.5": "1.17.5_db0@0.3.4_ioredis@5.11.1",
+    "npm:vinxi@*": "0.5.11_@types+node@25.9.1_yaml@2.9.0",
     "npm:vinxi@~0.5.11": "0.5.11_@types+node@25.9.1_yaml@2.9.0",
     "npm:vite-plugin-pwa@^1.3.0": "1.3.0_vite@8.0.16__@types+node@25.9.1__yaml@2.9.0_workbox-build@7.4.1_workbox-window@7.4.1_@types+node@25.9.1_yaml@2.9.0",
     "npm:vite-plugin-solid@^2.11.12": "2.11.12_@testing-library+jest-dom@6.9.1_solid-js@1.9.13_vite@8.0.16__@types+node@25.9.1__yaml@2.9.0_@types+node@25.9.1_yaml@2.9.0",
@@ -43,7 +53,8 @@
     "npm:vitefu@^1.1.2": "1.1.3_vite@8.0.16__@types+node@25.9.1__yaml@2.9.0_@types+node@25.9.1_yaml@2.9.0",
     "npm:vitest@*": "4.1.8_@types+node@25.9.1_@vitest+coverage-v8@4.1.8_jsdom@29.1.1_vite@8.0.16__@types+node@25.9.1__yaml@2.9.0_msw@2.14.6__typescript@6.0.3__@types+node@25.9.1_typescript@6.0.3_yaml@2.9.0",
     "npm:vitest@^4.1.8": "4.1.8_@types+node@25.9.1_@vitest+coverage-v8@4.1.8_jsdom@29.1.1_vite@8.0.16__@types+node@25.9.1__yaml@2.9.0_msw@2.14.6__typescript@6.0.3__@types+node@25.9.1_typescript@6.0.3_yaml@2.9.0",
-    "npm:yaml@^2.9.0": "2.9.0"
+    "npm:yaml@^2.9.0": "2.9.0",
+    "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -8399,13 +8410,22 @@
     "members": {
       "docsite": {
         "dependencies": [
+          "npm:@oslojs/encoding@^1.1.0",
           "npm:@tailwindcss/vite@4.3.0",
           "npm:astro@^6.4.2",
+          "npm:clsx@^2.1.1",
+          "npm:cookie@^1.0.2",
+          "npm:devalue@^5.6.3",
+          "npm:es-module-lexer@2",
+          "npm:html-escaper@^3.0.3",
           "npm:marked@^18.0.4",
+          "npm:piccolore@~0.1.3",
           "npm:std-env@^3.10.0",
+          "npm:unstorage@^1.17.5",
           "npm:vite@8.0.16",
           "npm:vitest@^4.1.8",
-          "npm:yaml@^2.9.0"
+          "npm:yaml@^2.9.0",
+          "npm:zod@^4.4.3"
         ],
         "packageJson": {
           "dependencies": [

--- a/docs/architecture/release-rearchitecture.md
+++ b/docs/architecture/release-rearchitecture.md
@@ -1,5 +1,9 @@
 # Pre-release Rust and Deno rearchitecture
 
+> Migration status: Phases 0 through 3 are implemented. `mise run dev` starts
+> the Rust `ugoite-server`; the Python backend remains temporarily for Phase 4
+> removal and contract comparison.
+
 ## Decision
 
 Ugoite's release architecture converges on Rust for application, storage,

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -5,9 +5,9 @@
 The formal release architecture converges on two required checks:
 `ci-required` and `codeql-required`. Root `mise.toml` is the only task entry
 point and defines `mise run ci`, `mise run ci:merge`, and
-`mise run ci:release`. During Phase 0/1, legacy workflows remain transitional;
-repository rules and workflows will converge on the two-check contract as the
-later server and CI migration phases land.
+`mise run ci:release`. The live repository ruleset and workflows use this
+two-check contract. Phase 3 moves source development to `ugoite-server`; the
+Python backend remains only as a temporary Phase 4 comparison/removal surface.
 
 See [`../../architecture/release-rearchitecture.md`](../../architecture/release-rearchitecture.md)
 for the target architecture and deletion policy.

--- a/docs/spec/testing/strategy.md
+++ b/docs/spec/testing/strategy.md
@@ -29,13 +29,13 @@ Ugoite follows **Test-Driven Development (TDD)**:
 | ugoite-domain | cargo test | `ugoite-domain/tests/` |
 | ugoite-core | cargo test + pytest | `crates/ugoite-core/tests/` |
 | ugoite-cli | cargo test | `crates/ugoite-cli/tests/` |
-| backend | pytest | `backend/tests/` |
+| ugoite-server | cargo test | `crates/ugoite-server/tests/` |
 | frontend | vitest | `frontend/src/**/*.test.ts(x)` |
 | docsite | vitest | `docsite/src/**/*.test.ts` |
 
 ### Integration Tests
 
-- Backend: FastAPI TestClient with memory filesystem
+- Server: Axum router contract tests with memory storage
 - Frontend: Component tests with mocked API
 
 ### End-to-End Tests

--- a/docsite/deno.json
+++ b/docsite/deno.json
@@ -7,14 +7,24 @@
     "coverage": "deno run -A npm:vitest run --coverage --maxWorkers=1"
   },
   "imports": {
+    "@oslojs/encoding": "npm:@oslojs/encoding@^1.1.0",
     "@tailwindcss/vite": "npm:@tailwindcss/vite@4.3.0",
     "astro": "npm:astro@^6.4.2",
     "astro/": "npm:astro@^6.4.2/",
+    "clsx": "npm:clsx@^2.1.1",
+    "cookie": "npm:cookie@^1.0.2",
+    "devalue": "npm:devalue@^5.6.3",
+    "es-module-lexer": "npm:es-module-lexer@^2.0.0",
+    "html-escaper": "npm:html-escaper@^3.0.3",
     "marked": "npm:marked@^18.0.4",
+    "piccolore": "npm:piccolore@^0.1.3",
     "std-env": "npm:std-env@^3.10.0",
+    "unstorage": "npm:unstorage@^1.17.5",
     "vite": "npm:vite@8.0.16",
     "vitest": "npm:vitest@^4.1.8",
     "vitest/": "npm:vitest@^4.1.8/",
-    "yaml": "npm:yaml@^2.9.0"
+    "yaml": "npm:yaml@^2.9.0",
+    "zod": "npm:zod@^4.4.3",
+    "zod/v4": "npm:zod@^4.4.3/v4"
   }
 }

--- a/tools/dev.ts
+++ b/tools/dev.ts
@@ -1,16 +1,12 @@
 const commands = [
-  new Deno.Command("uv", {
-    cwd: "backend",
-    args: [
-      "run",
-      "uvicorn",
-      "src.app.main:app",
-      "--reload",
-      "--host",
-      "0.0.0.0",
-      "--port",
-      "8000",
-    ],
+  new Deno.Command("cargo", {
+    env: {
+      UGOITE_BOOTSTRAP_TOKEN: Deno.env.get("UGOITE_BOOTSTRAP_TOKEN") ??
+        "dev-token",
+      UGOITE_DEV_USER_ID: Deno.env.get("UGOITE_DEV_USER_ID") ??
+        "dev-local-user",
+    },
+    args: ["run", "-p", "ugoite-server"],
   }),
   new Deno.Command("deno", {
     args: ["task", "frontend:dev"],


### PR DESCRIPTION
## Summary

- implement the Axum-based `ugoite-server` adapter for Phase 3 REST and MCP surfaces
- switch `mise run dev` from FastAPI/uvicorn to the Rust server
- add server API contract tests, an OpenAPI snapshot, and missing Deno docsite build imports
- document Phase 3 migration status and Rust server testing

## Related Issue (required)

close: #1739

## Testing

- [x] `mise run ci`
- [x] `mise run ci:merge`
- [x] `cargo test -p ugoite-server --locked`
- [x] `deno task docsite:build`
