### PR TITLE
docs: complete rearchitecture north star scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 **"Local-First Knowledge Space with Resource-First MCP Integration for the Post-SaaS Era"**
 
-> **Positioning today:** local-first most directly describes Ugoite's storage
-> model and CLI `core` path today. The browser route is server-backed and the
-> canonical source-development backend is the Rust `ugoite-server`.
-
 ## Vision
 
 Ugoite is a knowledge management system built on three core principles:
@@ -49,7 +45,7 @@ GitHub without comparing two different onboarding maps.
 - [Use the CLI](docs/guide/cli.md) for terminal-first workflows and scripting.
 
 If you only need the portable Rust layer for WASM, embedding, or pure helper
-work, start with [`ugoite-domain`](ugoite-domain/README.md) and the portable
+work, start with [`ugoite-domain`](crates/ugoite-domain/README.md) and the portable
 contributor notes in [Contributor Workflow](CONTRIBUTING.md).
 
 ### After your first step
@@ -68,10 +64,10 @@ For a brand-new browser space, use the
 [Browser Walkthrough](docs/guide/browser-first-entry.md) when you want the
 concrete first productive in-app sequence after login.
 
-Local-first applies most directly to Ugoite's storage model and the CLI's
-`core` mode today. The current browser path still needs a running backend +
-frontend stack and an explicit login flow, even though the data remains in
-user-controlled local storage.
+For the current runtime split, see [Control Surfaces](docs/architecture/control-surfaces.md).
+The browser experience runs through the Rust `ugoite-server`, while the CLI can
+use the direct `core` path for local filesystem-backed spaces. The long-term
+direction is captured in [North Star](docs/architecture/north-star.md).
 
 Auth defaults differ by entry path: `mise run dev` uses `passkey-totp` by
 default so source contributors exercise the explicit local passkey + 2FA flow,
@@ -88,7 +84,7 @@ and why source and published defaults differ.
 | --- | --- | --- | --- |
 | [Try the published release](docs/guide/container-quickstart.md) | You want the fastest visual evaluation of the published browser experience | Medium: Docker + published image pulls + frontend/backend containers + explicit login | Browser-first, but still multi-service and login-gated |
 | [Use the CLI](docs/guide/cli.md) in `core` mode | You want the lightest local-first workflow with direct filesystem access | Lowest: released CLI install + local filesystem path; no container stack required | Terminal-first experience; no browser UI or server-backed collaboration features |
-| [Work on `ugoite-domain`](ugoite-domain/README.md) | You are contributing portable Rust, WASM-oriented, or embedding-friendly logic without the full app stack | Medium: source checkout + `mise run setup`, then package-local `//ugoite-domain` quality gates | Narrower scope than the full repo path; no frontend/backend/docsite behavior in scope |
+| [Work on `ugoite-domain`](crates/ugoite-domain/README.md) | You are contributing portable Rust, WASM-oriented, or embedding-friendly logic without the full app stack | Medium: source checkout + `mise run setup`, then package-local `//ugoite-domain` quality gates | Narrower scope than the full repo path; no frontend/backend/docsite behavior in scope |
 | [Run from source](docs/guide/local-dev-auth-login.md) with `mise run dev` | You want the current backend, frontend, and docsite together for source-based evaluation or full-stack debugging | Highest: source checkout + toolchain install + backend/frontend/docsite processes + auth setup | Full repo surface, but also the heaviest path |
 | [Contributor Workflow](CONTRIBUTING.md) | You are changing docs, frontend, backend, or core and want the canonical setup plus targeted commands | Medium: source checkout + `mise run setup`; add only the surface-specific commands or services you need | Flexible contributor path, but cross-surface or auth changes may still need the full `mise run dev` stack |
 
@@ -108,7 +104,7 @@ the `v0.2` roadmap.
 
 | Component    | Technology                           |
 | ------------ | ------------------------------------ |
-| Frontend     | Bun + SolidStart + TailwindCSS       |
+| Frontend     | Deno + SolidStart + TailwindCSS      |
 | Backend      | Rust (`ugoite-server`, Axum)          |
 | Core         | Rust (`ugoite-domain` + `ugoite-core`) |
 | Storage      | OpenDAL + Apache Iceberg             |

--- a/deno.json
+++ b/deno.json
@@ -27,7 +27,9 @@
       "frontend/deno.json",
       "docsite/deno.json",
       "e2e/deno.json",
-      "docs/architecture/release-rearchitecture.md"
+      "docs/architecture/north-star.md",
+      "docs/architecture/release-rearchitecture.md",
+      "docs/architecture/release-scope.md"
     ],
     "exclude": [
       "target",

--- a/docs/architecture/north-star.md
+++ b/docs/architecture/north-star.md
@@ -1,0 +1,17 @@
+# North Star
+
+Ugoite's long-term direction is to make the Space independent from any single
+server.
+
+Today, the browser experience runs through the Rust `ugoite-server` runtime, and
+the CLI can operate through the direct core path. Over time, Ugoite is designed
+to move more of the Space engine into portable Rust/WASM and browser-local
+storage.
+
+Servers remain useful, but optional. They can relay, mirror, index,
+authenticate, or expose MCP resources. They do not have to own the truth.
+
+This document is intentionally directional. Browser-local storage, peer
+replication, signed operation logs, and distributed trust are not formal release
+requirements. They are constraints on how today's adapter boundaries should be
+kept small and replaceable.

--- a/docs/architecture/release-rearchitecture.md
+++ b/docs/architecture/release-rearchitecture.md
@@ -60,5 +60,9 @@ the Rust server, removed Python, and completed the package-manager-free Deno
 workspace. Phase 6 fixes adapter boundaries: `ugoite-server` stays a thin HTTP
 adapter, the CLI uses the shared core service facade for direct-core operations,
 and frontend code exposes a server-backed client boundary with explicit
-capabilities. Later phases consolidate the remaining Actions and harden release
-artifacts.
+capabilities.
+
+Phase 9 keeps the post-SaaS direction in documentation rather than expanding the
+release implementation scope. See [North Star](north-star.md) for the long-term
+frontend-owned and peer-replicated direction, and
+[Release Scope](release-scope.md) for the boundary around the formal release.

--- a/docs/architecture/release-scope.md
+++ b/docs/architecture/release-scope.md
@@ -1,0 +1,24 @@
+# Release Scope
+
+The pre-release Rust and Deno rearchitecture keeps the formal release scope
+focused on the current production path:
+
+- Rust `ugoite-server` for the browser HTTP, auth, static asset, and MCP adapter
+  runtime.
+- Shared Rust crates for domain, storage, core services, CLI, WASM wrappers, and
+  release-critical repository tooling.
+- Deno as the repository TypeScript runtime for frontend, docsite, E2E, and
+  lightweight tooling.
+- `ci-required` and `codeql-required` as the normal pull request checks, with
+  heavier merge and release validation behind `mise run ci:merge` and
+  `mise run ci:release`.
+
+The release scope does not include browser-owned storage, OPFS or IndexedDB
+persistence, peer-to-peer sync, relay protocols, distributed trust graphs, or a
+signed operation log. Those belong to the North Star and future architecture
+work.
+
+The practical rule is simple: improve the current server-backed browser and
+direct-core CLI paths, but keep server, CLI, frontend, WASM, and storage code on
+thin adapter boundaries so future runtimes can be added without rewriting the
+core model.


### PR DESCRIPTION
## Summary

- Add Phase 9 North Star and release-scope architecture docs for the Rust/Deno rearchitecture.
- Move README's current-runtime caveat into architecture references and update remaining `ugoite-domain` / frontend tooling links to the Rust+Deno layout.
- Add the new Phase 9 architecture docs to the Deno formatting surface.

## Related Issue (required)

close: #1743

## Testing

- [x] `mise run ci`
- [x] `mise run ci:merge`
- [x] `mise run ci:release`
