### PR TITLE
Fix dev and compose browser startup

### DIFF
--- a/docsite/deno.json
+++ b/docsite/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "node ./node_modules/astro/bin/astro.mjs dev --host 127.0.0.1 --strictPort --port 4321",
+    "dev": "deno run -A npm:astro dev --host 127.0.0.1 --strictPort --port 4321",
     "build": "deno run -A npm:astro build",
     "check": "deno run -A npm:astro check",
     "test": "deno run -A npm:vitest run",

--- a/docsite/deno.json
+++ b/docsite/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A npm:astro dev --host 127.0.0.1 --strictPort --port 4321",
+    "dev": "node ./node_modules/astro/bin/astro.mjs dev --host 127.0.0.1 --strictPort --port 4321",
     "build": "deno run -A npm:astro build",
     "check": "deno run -A npm:astro check",
     "test": "deno run -A npm:vitest run",

--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -102,13 +102,23 @@ export default defineConfig({
       },
     },
     resolve: {
+      conditions: ["development", "browser", "solid"],
       dedupe: [
+        "@solidjs/router",
+        "@solidjs/start",
         "@codemirror/autocomplete",
         "@codemirror/lang-sql",
         "@codemirror/lint",
         "@codemirror/state",
         "@codemirror/view",
+        "solid-js",
+        "solid-js/web",
       ],
+    },
+    ssr: {
+      resolve: {
+        conditions: ["development", "node", "solid"],
+      },
     },
   },
 });

--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run -A npm:vinxi dev",
+    "dev": "node ./node_modules/vinxi/bin/cli.mjs dev --host 127.0.0.1 --strictPort --port 3000",
     "build": "deno cache npm:solid-js@^1.9.10 npm:tailwindcss@4.3.0 && sh -c 'mkdir -p node_modules && for pkg in solid-js tailwindcss; do test -e node_modules/$pkg || tar -C ../node_modules -chf - $pkg | tar -C node_modules -xf -; done' && deno run -A npm:vinxi build",
     "start": "deno run -A npm:vinxi start",
     "test": "deno run -A npm:vitest run",
@@ -63,6 +63,7 @@
     "seroval": "npm:seroval@1.5.4",
     "seroval-plugins/web": "npm:seroval-plugins@1.5.4/web",
     "solid-js": "./node_modules/solid-js/dist/dev.js",
+    "solid-js/store": "./node_modules/solid-js/store/dist/dev.js",
     "solid-js/web": "./node_modules/solid-js/web/dist/dev.js",
     "solid-js/": "./node_modules/solid-js/",
     "solid-refresh/babel": "npm:solid-refresh@^0.6.3/babel",

--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "node ./node_modules/vinxi/bin/cli.mjs dev --host 127.0.0.1 --strictPort --port 3000",
+    "dev": "deno run -A npm:vinxi dev",
     "build": "deno cache npm:solid-js@^1.9.10 npm:tailwindcss@4.3.0 && sh -c 'mkdir -p node_modules && for pkg in solid-js tailwindcss; do test -e node_modules/$pkg || tar -C ../node_modules -chf - $pkg | tar -C node_modules -xf -; done' && deno run -A npm:vinxi build",
     "start": "deno run -A npm:vinxi start",
     "test": "deno run -A npm:vitest run",

--- a/frontend/src/components/SpaceSettings.test.tsx
+++ b/frontend/src/components/SpaceSettings.test.tsx
@@ -1,8 +1,9 @@
 // REQ-FE-017: Space storage configuration
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 import { SpaceSettings } from "./SpaceSettings";
 import type { Space } from "~/lib/types";
+import { setLocale } from "~/lib/i18n";
 
 const mockSpace: Space = {
 	id: "ws-1",
@@ -21,6 +22,10 @@ const mockSpace: Space = {
 };
 
 describe("SpaceSettings", () => {
+	beforeEach(() => {
+		setLocale("en");
+	});
+
 	it("should display space name", () => {
 		render(() => <SpaceSettings space={mockSpace} onSave={vi.fn()} />);
 		expect(screen.getByDisplayValue("Test Space")).toBeInTheDocument();

--- a/frontend/src/components/SpaceShell.test.tsx
+++ b/frontend/src/components/SpaceShell.test.tsx
@@ -1,8 +1,9 @@
 // REQ-FE-010: SpaceShell layout component
 import "@testing-library/jest-dom/vitest";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 import { SpaceShell } from "./SpaceShell";
+import { setLocale } from "~/lib/i18n";
 import { loadingState } from "~/lib/loading";
 
 vi.mock("@solidjs/router", () => ({
@@ -27,6 +28,10 @@ vi.mock("@solidjs/router", () => ({
 }));
 
 describe("SpaceShell", () => {
+	beforeEach(() => {
+		setLocale("en");
+	});
+
 	it("renders children", () => {
 		render(() => (
 			<SpaceShell spaceId="my-space">

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,62 +1,67 @@
 import { defineConfig } from "vitest/config";
 import solidPlugin from "vite-plugin-solid";
 
-const frontendTestOrigin = process.env.FRONTEND_TEST_ORIGIN ?? "http://localhost:3000";
+const frontendTestOrigin = process.env.FRONTEND_TEST_ORIGIN ??
+  "http://localhost:3000";
 
 export default defineConfig({
-	plugins: [solidPlugin() as never],
-	define: {
-		"process.env.NODE_ENV": JSON.stringify("test"),
-		"process.env.FRONTEND_TEST_ORIGIN": JSON.stringify(frontendTestOrigin),
-	},
-	test: {
-		environment: "jsdom",
-		globals: true,
-		setupFiles: ["./src/test/setup.ts"],
-		env: {
-			FRONTEND_TEST_ORIGIN: frontendTestOrigin,
-		},
-		include: ["src/**/*.{test,spec}.{js,ts,tsx}"],
-		testTimeout: 10000,
-		coverage: {
-			provider: "v8",
-			reporter: ["text", "json", "html"],
-			exclude: [
-				"src/test/**",
-				"src/**/*.test.*",
-				"src/**/*.spec.*",
-				// Framework boilerplate - cannot be unit-tested in isolation
-				"src/entry-client.tsx",
-				"src/entry-server.tsx",
-				"src/global.d.ts",
-				"src/error-handler.ts",
-				"src/app.tsx",
-				// Route components - SolidStart SSR framework glue
-				"src/routes/**",
-				// Type-only and barrel re-export files
-				"src/lib/types.ts",
-				"src/lib/index.ts",
-				"src/components/index.ts",
-			],
-			thresholds: {
-				lines: 100,
-				functions: 100,
-				branches: 100,
-				statements: 100,
-			},
-		},
-	},
-	resolve: {
-		conditions: ["development", "browser"],
-		alias: {
-			"~": "/src",
-		},
-		dedupe: [
-			"@codemirror/autocomplete",
-			"@codemirror/lang-sql",
-			"@codemirror/lint",
-			"@codemirror/state",
-			"@codemirror/view",
-		],
-	},
+  plugins: [solidPlugin() as never],
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("test"),
+    "process.env.FRONTEND_TEST_ORIGIN": JSON.stringify(frontendTestOrigin),
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    env: {
+      FRONTEND_TEST_ORIGIN: frontendTestOrigin,
+    },
+    include: ["src/**/*.{test,spec}.{js,ts,tsx}"],
+    testTimeout: 10000,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      exclude: [
+        "src/test/**",
+        "src/**/*.test.*",
+        "src/**/*.spec.*",
+        // Framework boilerplate - cannot be unit-tested in isolation
+        "src/entry-client.tsx",
+        "src/entry-server.tsx",
+        "src/global.d.ts",
+        "src/error-handler.ts",
+        "src/app.tsx",
+        // Route components - SolidStart SSR framework glue
+        "src/routes/**",
+        // Type-only and barrel re-export files
+        "src/lib/types.ts",
+        "src/lib/index.ts",
+        "src/components/index.ts",
+      ],
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 100,
+        statements: 100,
+      },
+    },
+  },
+  resolve: {
+    conditions: ["development", "browser"],
+    alias: {
+      "~": "/src",
+    },
+    dedupe: [
+      "@solidjs/router",
+      "@solidjs/start",
+      "@codemirror/autocomplete",
+      "@codemirror/lang-sql",
+      "@codemirror/lint",
+      "@codemirror/state",
+      "@codemirror/view",
+      "solid-js",
+      "solid-js/web",
+    ],
+  },
 });

--- a/tools/dev.ts
+++ b/tools/dev.ts
@@ -1,18 +1,53 @@
+const repoRoot = new URL("..", import.meta.url).pathname;
+const frontendUrl = "http://localhost:3000";
+const backendUrl = "http://localhost:8000";
+
+const shellQuote = (value: string): string =>
+  `'${value.replaceAll("'", `'\\''`)}'`;
+
 const commands = [
   new Deno.Command("cargo", {
+    cwd: repoRoot,
     env: {
+      UGOITE_ROOT: Deno.env.get("UGOITE_ROOT") ?? repoRoot,
+      UGOITE_BOOTSTRAP_DEFAULT_SPACE:
+        Deno.env.get("UGOITE_BOOTSTRAP_DEFAULT_SPACE") ?? "true",
       UGOITE_BOOTSTRAP_TOKEN: Deno.env.get("UGOITE_BOOTSTRAP_TOKEN") ??
         "dev-token",
+      UGOITE_DEV_AUTH_MODE: Deno.env.get("UGOITE_DEV_AUTH_MODE") ??
+        "mock-oauth",
       UGOITE_DEV_USER_ID: Deno.env.get("UGOITE_DEV_USER_ID") ??
         "dev-local-user",
     },
     args: ["run", "-p", "ugoite-server"],
   }),
-  new Deno.Command("deno", {
-    args: ["task", "frontend:dev"],
+  new Deno.Command("sh", {
+    cwd: `${repoRoot}frontend`,
+    args: [
+      "-lc",
+      [
+        `BACKEND_URL=${shellQuote(Deno.env.get("BACKEND_URL") ?? backendUrl)}`,
+        `UGOITE_STATIC_SPA=${
+          shellQuote(Deno.env.get("UGOITE_STATIC_SPA") ?? "true")
+        }`,
+        `VITE_API_PROXY=${
+          shellQuote(Deno.env.get("VITE_API_PROXY") ?? "true")
+        }`,
+        "node ./node_modules/vinxi/bin/cli.mjs dev --host 127.0.0.1 --strictPort --port 3000",
+      ].join(" "),
+    ],
   }),
-  new Deno.Command("deno", {
-    args: ["task", "docsite:dev"],
+  new Deno.Command("node", {
+    cwd: `${repoRoot}docsite`,
+    args: [
+      "./node_modules/astro/bin/astro.mjs",
+      "dev",
+      "--host",
+      "127.0.0.1",
+      "--strictPort",
+      "--port",
+      "4321",
+    ],
   }),
 ];
 

--- a/tools/dev.ts
+++ b/tools/dev.ts
@@ -1,9 +1,4 @@
 const repoRoot = new URL("..", import.meta.url).pathname;
-const frontendUrl = "http://localhost:3000";
-const backendUrl = "http://localhost:8000";
-
-const shellQuote = (value: string): string =>
-  `'${value.replaceAll("'", `'\\''`)}'`;
 
 const commands = [
   new Deno.Command("cargo", {
@@ -21,33 +16,18 @@ const commands = [
     },
     args: ["run", "-p", "ugoite-server"],
   }),
-  new Deno.Command("sh", {
+  new Deno.Command("deno", {
     cwd: `${repoRoot}frontend`,
-    args: [
-      "-lc",
-      [
-        `BACKEND_URL=${shellQuote(Deno.env.get("BACKEND_URL") ?? backendUrl)}`,
-        `UGOITE_STATIC_SPA=${
-          shellQuote(Deno.env.get("UGOITE_STATIC_SPA") ?? "true")
-        }`,
-        `VITE_API_PROXY=${
-          shellQuote(Deno.env.get("VITE_API_PROXY") ?? "true")
-        }`,
-        "node ./node_modules/vinxi/bin/cli.mjs dev --host 127.0.0.1 --strictPort --port 3000",
-      ].join(" "),
-    ],
+    args: ["task", "dev"],
+    env: {
+      BACKEND_URL: Deno.env.get("BACKEND_URL") ?? "http://localhost:8000",
+      UGOITE_STATIC_SPA: Deno.env.get("UGOITE_STATIC_SPA") ?? "true",
+      VITE_API_PROXY: Deno.env.get("VITE_API_PROXY") ?? "true",
+    },
   }),
-  new Deno.Command("node", {
+  new Deno.Command("deno", {
     cwd: `${repoRoot}docsite`,
-    args: [
-      "./node_modules/astro/bin/astro.mjs",
-      "dev",
-      "--host",
-      "127.0.0.1",
-      "--strictPort",
-      "--port",
-      "4321",
-    ],
+    args: ["task", "dev"],
   }),
 ];
 


### PR DESCRIPTION
## Summary

- Revert the temporary Node-based dev path back to the Deno workflow, and verify it after deleting the legacy `node_modules` caches.
- Keep the non-Docker `mise run dev` flow and the `docker compose up` flow working with the browser by validating both startup paths end to end after the cache reset.

## Related Issue (required)

close: #654

## Testing

- [x] `mise run setup`
- [x] `cd frontend && deno task test`
- [x] `mise run test`
- [x] `mise run dev` and browser verification at `http://127.0.0.1:3000/spaces`
- [x] `docker compose up -d` and browser verification at `http://127.0.0.1:8000/spaces`
