### PR TITLE
fix: close followup audit boundaries

### DIFF
--- a/crates/ugoite-cli/src/commands/entry.rs
+++ b/crates/ugoite-cli/src/commands/entry.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    effective_format, load_config, operator_for_path, print_json, print_json_table,
-    resolve_space_reference, space_ws_path, validated_base_url, Format,
+    effective_format, load_config, print_json, print_json_table, resolve_space_reference,
+    validated_base_url, Format,
 };
 use crate::http;
 use anyhow::{bail, Result};
@@ -254,26 +254,22 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let integrity =
-                ugoite_core::integrity::RealIntegrityProvider::from_space(&op, &space_id).await?;
+            let service = UgoiteService::new(&root)?;
             let assets_vec: Option<Vec<serde_json::Value>> = if let Some(a) = assets {
                 Some(serde_json::from_str(&a)?)
             } else {
                 None
             };
-            let result = ugoite_core::entry::update_entry(
-                &op,
-                &ws,
-                &entry_id,
-                &markdown,
-                parent_revision_id.as_deref(),
-                &author,
-                assets_vec,
-                &integrity,
-            )
-            .await?;
+            let result = service
+                .update_entry(
+                    &space_id,
+                    &entry_id,
+                    &markdown,
+                    parent_revision_id.as_deref(),
+                    &author,
+                    assets_vec,
+                )
+                .await?;
             print_json(&result);
         }
         EntrySubCmd::Delete {
@@ -292,9 +288,10 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            ugoite_core::entry::delete_entry(&op, &ws, &entry_id, hard_delete).await?;
+            let service = UgoiteService::new(&root)?;
+            service
+                .delete_entry(&space_id, &entry_id, hard_delete)
+                .await?;
             print_json(&serde_json::json!({"deleted": true}));
         }
         EntrySubCmd::History {
@@ -310,9 +307,8 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let history = ugoite_core::entry::get_entry_history(&op, &ws, &entry_id).await?;
+            let service = UgoiteService::new(&root)?;
+            let history = service.entry_history(&space_id, &entry_id).await?;
             print_json(&history);
         }
         EntrySubCmd::Revision {
@@ -329,10 +325,10 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let rev =
-                ugoite_core::entry::get_entry_revision(&op, &ws, &entry_id, &revision_id).await?;
+            let service = UgoiteService::new(&root)?;
+            let rev = service
+                .entry_revision(&space_id, &entry_id, &revision_id)
+                .await?;
             print_json(&rev);
         }
         EntrySubCmd::Restore {
@@ -351,19 +347,10 @@ pub async fn run(cmd: EntryCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let integrity =
-                ugoite_core::integrity::RealIntegrityProvider::from_space(&op, &space_id).await?;
-            let result = ugoite_core::entry::restore_entry(
-                &op,
-                &ws,
-                &entry_id,
-                &revision_id,
-                &author,
-                &integrity,
-            )
-            .await?;
+            let service = UgoiteService::new(&root)?;
+            let result = service
+                .restore_entry(&space_id, &entry_id, &revision_id, &author)
+                .await?;
             print_json(&result);
         }
     }

--- a/crates/ugoite-cli/src/commands/index.rs
+++ b/crates/ugoite-cli/src/commands/index.rs
@@ -1,10 +1,8 @@
-use crate::config::{
-    load_config, operator_for_path, print_json, resolve_space_reference, space_ws_path,
-    validated_base_url,
-};
+use crate::config::{load_config, print_json, resolve_space_reference, validated_base_url};
 use crate::http;
 use anyhow::{bail, Result};
 use clap::{Args, Subcommand};
+use ugoite_core::service::UgoiteService;
 
 #[derive(Args)]
 pub struct IndexCmd {
@@ -48,9 +46,8 @@ pub async fn run(cmd: IndexCmd) -> Result<()> {
                     "index run is not available in backend/api mode in this release; use core mode for local reindexing"
                 );
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            ugoite_core::index::reindex_all(&op, &ws).await?;
+            let service = UgoiteService::new(&root)?;
+            service.reindex(&space_id).await?;
             print_json(&serde_json::json!({"reindexed": true}));
         }
         IndexSubCmd::Stats { space_path } => {
@@ -60,9 +57,8 @@ pub async fn run(cmd: IndexCmd) -> Result<()> {
                     "index stats is not available in backend/api mode in this release; use core mode for local index stats"
                 );
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let stats = ugoite_core::index::get_space_stats(&op, &ws).await?;
+            let service = UgoiteService::new(&root)?;
+            let stats = service.space_stats(&space_id).await?;
             print_json(&stats);
         }
     }
@@ -89,9 +85,8 @@ pub async fn query_cmd(space_path: &str, sql: &str) -> Result<()> {
         print_json(&rows);
         return Ok(());
     }
-    let op = operator_for_path(&root)?;
-    let ws = space_ws_path(&root, &space_id);
-    let results = ugoite_core::index::execute_sql_query(&op, &ws, sql).await?;
+    let service = UgoiteService::new(&root)?;
+    let results = service.execute_sql_query(&space_id, sql).await?;
     print_json(&results);
     Ok(())
 }

--- a/crates/ugoite-cli/src/commands/sql.rs
+++ b/crates/ugoite-cli/src/commands/sql.rs
@@ -1,12 +1,9 @@
-use crate::config::{
-    load_config, operator_for_path, print_json, resolve_space_reference, space_ws_path,
-    validated_base_url,
-};
+use crate::config::{load_config, print_json, resolve_space_reference, validated_base_url};
 use crate::http;
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use ugoite_core::integrity::RealIntegrityProvider;
 use ugoite_core::saved_sql::SqlPayload;
+use ugoite_core::service::UgoiteService;
 
 #[derive(Args)]
 pub struct SqlCmd {
@@ -69,9 +66,8 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let sqls = ugoite_core::saved_sql::list_sql(&op, &ws).await?;
+            let service = UgoiteService::new(&root)?;
+            let sqls = service.list_saved_sql(&space_id).await?;
             print_json(&sqls);
         }
         SqlSubCmd::SavedGet { space_path, sql_id } => {
@@ -82,9 +78,8 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let sql = ugoite_core::saved_sql::get_sql(&op, &ws, &sql_id).await?;
+            let service = UgoiteService::new(&root)?;
+            let sql = service.get_saved_sql(&space_id, &sql_id).await?;
             print_json(&sql);
         }
         SqlSubCmd::SavedCreate {
@@ -109,18 +104,15 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let integrity = RealIntegrityProvider::from_space(&op, &space_id).await?;
             let payload = SqlPayload {
                 name,
                 sql,
                 variables: vars,
             };
-            let result = ugoite_core::saved_sql::create_sql(
-                &op, &ws, &sql_id, &payload, &author, &integrity,
-            )
-            .await?;
+            let service = UgoiteService::new(&root)?;
+            let result = service
+                .create_saved_sql(&space_id, &sql_id, &payload, &author)
+                .await?;
             print_json(&result);
         }
         SqlSubCmd::SavedUpdate {
@@ -146,24 +138,21 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            let integrity = RealIntegrityProvider::from_space(&op, &space_id).await?;
             let payload = SqlPayload {
                 name,
                 sql,
                 variables: vars,
             };
-            let result = ugoite_core::saved_sql::update_sql(
-                &op,
-                &ws,
-                &sql_id,
-                &payload,
-                parent_revision_id.as_deref(),
-                &author,
-                &integrity,
-            )
-            .await?;
+            let service = UgoiteService::new(&root)?;
+            let result = service
+                .update_saved_sql(
+                    &space_id,
+                    &sql_id,
+                    &payload,
+                    parent_revision_id.as_deref(),
+                    &author,
+                )
+                .await?;
             print_json(&result);
         }
         SqlSubCmd::SavedDelete { space_path, sql_id } => {
@@ -175,9 +164,8 @@ pub async fn run(cmd: SqlCmd) -> Result<()> {
                 print_json(&result);
                 return Ok(());
             }
-            let op = operator_for_path(&root)?;
-            let ws = space_ws_path(&root, &space_id);
-            ugoite_core::saved_sql::delete_sql(&op, &ws, &sql_id).await?;
+            let service = UgoiteService::new(&root)?;
+            service.delete_saved_sql(&space_id, &sql_id).await?;
             print_json(&serde_json::json!({"deleted": true}));
         }
     }

--- a/crates/ugoite-core/src/service.rs
+++ b/crates/ugoite-core/src/service.rs
@@ -290,6 +290,18 @@ impl UgoiteService {
         .await
     }
 
+    pub async fn execute_sql_query(&self, space_id: &str, sql: &str) -> Result<Vec<Value>> {
+        index::execute_sql_query(&self.operator, &self.workspace_path(space_id), sql).await
+    }
+
+    pub async fn reindex(&self, space_id: &str) -> Result<()> {
+        index::reindex_all(&self.operator, &self.workspace_path(space_id)).await
+    }
+
+    pub async fn space_stats(&self, space_id: &str) -> Result<Value> {
+        index::get_space_stats(&self.operator, &self.workspace_path(space_id)).await
+    }
+
     pub async fn list_assets(&self, space_id: &str) -> Result<Vec<asset::AssetInfo>> {
         asset::list_assets(&self.operator, &self.workspace_path(space_id)).await
     }

--- a/crates/ugoite-server/src/openapi.json
+++ b/crates/ugoite-server/src/openapi.json
@@ -318,6 +318,233 @@
       "FormName": { "name": "form_name", "in": "path", "required": true, "schema": { "type": "string" } },
       "SqlId": { "name": "sql_id", "in": "path", "required": true, "schema": { "type": "string" } },
       "AssetId": { "name": "asset_id", "in": "path", "required": true, "schema": { "type": "string" } }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["detail"],
+        "properties": {
+          "detail": { "oneOf": [{ "type": "string" }, { "type": "object" }, { "type": "array" }] }
+        }
+      },
+      "AuthConfig": {
+        "type": "object",
+        "required": ["mode", "username_hint", "supports_passkey_totp", "supports_mock_oauth", "login_required"],
+        "properties": {
+          "mode": { "type": "string", "enum": ["mock-oauth", "passkey-totp"] },
+          "username_hint": { "type": "string" },
+          "supports_passkey_totp": { "type": "boolean" },
+          "supports_mock_oauth": { "type": "boolean" },
+          "login_required": { "type": "boolean" }
+        }
+      },
+      "AuthSession": {
+        "type": "object",
+        "required": ["authenticated"],
+        "properties": {
+          "authenticated": { "type": "boolean" }
+        }
+      },
+      "SpaceSummary": {
+        "type": "object",
+        "required": ["id", "name", "created_at", "is_admin_space"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "created_at": { "oneOf": [{ "type": "number" }, { "type": "string" }] },
+          "is_admin_space": { "type": "boolean" },
+          "storage": { "$ref": "#/components/schemas/PublicStorageSummary" },
+          "settings": { "$ref": "#/components/schemas/PublicSpaceSettings" }
+        },
+        "not": {
+          "anyOf": [
+            { "required": ["hmac_key"] },
+            { "required": ["hmac_key_id"] },
+            { "required": ["last_rotation"] }
+          ]
+        }
+      },
+      "SpaceDetail": {
+        "allOf": [{ "$ref": "#/components/schemas/SpaceSummary" }]
+      },
+      "PublicStorageSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "type": { "type": "string" },
+          "root": { "type": "string" }
+        }
+      },
+      "PublicSpaceSettings": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "default_form": { "type": "string" }
+        },
+        "not": {
+          "anyOf": [
+            { "required": ["members"] },
+            { "required": ["member_invitations"] },
+            { "required": ["membership_version"] },
+            { "required": ["admin_user_ids"] },
+            { "required": ["invitations"] },
+            { "required": ["member_roles"] },
+            { "required": ["owner_user_id"] }
+          ]
+        }
+      },
+      "SpaceCreateRequest": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" }
+        }
+      },
+      "SpaceCreateResponse": {
+        "type": "object",
+        "required": ["id", "name", "path"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "path": { "type": "string" }
+        }
+      },
+      "SpacePatchRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "storage_config": { "type": "object", "additionalProperties": true },
+          "settings": { "$ref": "#/components/schemas/PublicSpaceSettings" }
+        }
+      },
+      "SpaceMember": {
+        "type": "object",
+        "required": ["user_id", "role", "state", "updated_at"],
+        "properties": {
+          "user_id": { "type": "string" },
+          "role": { "type": "string", "enum": ["admin", "editor", "viewer"] },
+          "state": { "type": "string", "enum": ["active", "invited", "revoked"] },
+          "invited_by": { "type": ["string", "null"] },
+          "invited_at": { "type": ["string", "null"] },
+          "activated_at": { "type": ["string", "null"] },
+          "revoked_at": { "type": ["string", "null"] },
+          "updated_at": { "type": "string" }
+        }
+      },
+      "Invitation": {
+        "type": "object",
+        "required": ["token", "user_id", "role", "state", "expires_at"],
+        "properties": {
+          "token": { "type": "string", "description": "Returned only when the invitation is created." },
+          "user_id": { "type": "string" },
+          "role": { "type": "string", "enum": ["admin", "editor", "viewer"] },
+          "state": { "type": "string", "enum": ["pending", "accepted", "revoked", "expired"] },
+          "invited_by": { "type": "string" },
+          "invited_at": { "type": "string" },
+          "expires_at": { "type": "string" }
+        }
+      },
+      "StorageConnectionTestRequest": {
+        "type": "object",
+        "properties": {
+          "uri": { "type": "string" },
+          "storage_config": {
+            "type": "object",
+            "required": ["uri"],
+            "properties": {
+              "uri": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "anyOf": [
+          { "required": ["uri"] },
+          { "required": ["storage_config"] }
+        ]
+      },
+      "StorageConnectionTestResponse": {
+        "type": "object",
+        "required": ["status", "mode"],
+        "properties": {
+          "status": { "type": "string", "enum": ["ok"] },
+          "mode": { "type": "string", "enum": ["memory", "local", "s3"] }
+        }
+      },
+      "EntryMutationRequest": {
+        "type": "object",
+        "required": ["markdown"],
+        "properties": {
+          "id": { "type": "string" },
+          "markdown": { "type": "string" },
+          "content": { "type": "string" },
+          "parent_revision_id": { "type": "string" },
+          "assets": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+        }
+      },
+      "EntryMutationResponse": {
+        "type": "object",
+        "required": ["id", "revision_id"],
+        "properties": {
+          "id": { "type": "string" },
+          "revision_id": { "type": "string" }
+        }
+      },
+      "Form": {
+        "type": "object",
+        "required": ["name", "fields"],
+        "properties": {
+          "name": { "type": "string" },
+          "version": { "type": "integer" },
+          "fields": { "type": "object", "additionalProperties": true },
+          "template": { "type": "string" }
+        },
+        "additionalProperties": true
+      },
+      "SqlSession": {
+        "type": "object",
+        "required": ["id", "status"],
+        "properties": {
+          "id": { "type": "string" },
+          "status": { "type": "string" },
+          "sql": { "type": "string" }
+        },
+        "additionalProperties": true
+      },
+      "SavedSql": {
+        "type": "object",
+        "required": ["id", "name", "sql"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "sql": { "type": "string" },
+          "variables": { "type": "array" }
+        },
+        "additionalProperties": true
+      },
+      "Asset": {
+        "type": "object",
+        "required": ["id", "filename"],
+        "properties": {
+          "id": { "type": "string" },
+          "filename": { "type": "string" },
+          "size": { "type": "integer" },
+          "content_type": { "type": ["string", "null"] }
+        },
+        "additionalProperties": true
+      },
+      "McpEntryResource": {
+        "type": "object",
+        "required": ["id", "title", "form", "tags", "properties", "_untrusted_content"],
+        "properties": {
+          "id": {},
+          "title": {},
+          "form": {},
+          "tags": { "type": "array" },
+          "properties": {},
+          "_untrusted_content": { "type": "boolean", "const": true }
+        }
+      }
     }
   }
 }

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -103,6 +103,43 @@ async fn openapi_snapshot_has_methods_for_runtime_routes() {
 }
 
 #[tokio::test]
+async fn openapi_snapshot_has_public_contract_schemas() {
+    let snapshot = openapi_snapshot();
+    let schemas = snapshot
+        .pointer("/components/schemas")
+        .and_then(Value::as_object)
+        .expect("components.schemas object");
+
+    for schema in [
+        "ErrorResponse",
+        "AuthConfig",
+        "AuthSession",
+        "SpaceSummary",
+        "SpaceDetail",
+        "PublicStorageSummary",
+        "PublicSpaceSettings",
+        "SpaceCreateRequest",
+        "SpaceCreateResponse",
+        "SpacePatchRequest",
+        "SpaceMember",
+        "Invitation",
+        "StorageConnectionTestRequest",
+        "StorageConnectionTestResponse",
+        "EntryMutationRequest",
+        "EntryMutationResponse",
+        "Form",
+        "SqlSession",
+        "SavedSql",
+        "Asset",
+        "McpEntryResource",
+    ] {
+        assert!(schemas.contains_key(schema), "missing schema: {schema}");
+    }
+    assert!(schemas["SpaceSummary"]["not"].is_object());
+    assert!(schemas["PublicSpaceSettings"]["not"].is_object());
+}
+
+#[tokio::test]
 async fn protected_routes_require_authentication() {
     let response = app(AppState::new("memory://server-auth").unwrap())
         .oneshot(Request::get("/spaces").body(Body::empty()).unwrap())

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -72,6 +72,35 @@ fn architecture_check() -> Result<()> {
         }
     }
 
+    for path in collect_files(Path::new("crates/ugoite-cli/src/commands"))? {
+        let path_text = path.to_string_lossy();
+        if path_text.ends_with("form.rs") || path_text.ends_with("space.rs") {
+            continue;
+        }
+        let content = fs::read_to_string(&path).with_context(|| format!("read {path_text}"))?;
+        for raw_call in [
+            "ugoite_core::entry::update_entry",
+            "ugoite_core::entry::delete_entry",
+            "ugoite_core::entry::get_entry_history",
+            "ugoite_core::entry::get_entry_revision",
+            "ugoite_core::entry::restore_entry",
+            "ugoite_core::index::execute_sql_query",
+            "ugoite_core::index::get_space_stats",
+            "ugoite_core::index::reindex_all",
+            "ugoite_core::saved_sql::create_sql",
+            "ugoite_core::saved_sql::delete_sql",
+            "ugoite_core::saved_sql::get_sql",
+            "ugoite_core::saved_sql::list_sql",
+            "ugoite_core::saved_sql::update_sql",
+        ] {
+            if content.contains(raw_call) {
+                violations.push(format!(
+                    "{path_text} calls {raw_call} directly; use UgoiteService for stateful CLI operations"
+                ));
+            }
+        }
+    }
+
     let domain_manifest = fs::read_to_string("crates/ugoite-domain/Cargo.toml")
         .context("read ugoite-domain Cargo.toml")?;
     let domain_dependencies = domain_manifest

--- a/docs/spec/api/openapi.yaml
+++ b/docs/spec/api/openapi.yaml
@@ -318,6 +318,233 @@
       "FormName": { "name": "form_name", "in": "path", "required": true, "schema": { "type": "string" } },
       "SqlId": { "name": "sql_id", "in": "path", "required": true, "schema": { "type": "string" } },
       "AssetId": { "name": "asset_id", "in": "path", "required": true, "schema": { "type": "string" } }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["detail"],
+        "properties": {
+          "detail": { "oneOf": [{ "type": "string" }, { "type": "object" }, { "type": "array" }] }
+        }
+      },
+      "AuthConfig": {
+        "type": "object",
+        "required": ["mode", "username_hint", "supports_passkey_totp", "supports_mock_oauth", "login_required"],
+        "properties": {
+          "mode": { "type": "string", "enum": ["mock-oauth", "passkey-totp"] },
+          "username_hint": { "type": "string" },
+          "supports_passkey_totp": { "type": "boolean" },
+          "supports_mock_oauth": { "type": "boolean" },
+          "login_required": { "type": "boolean" }
+        }
+      },
+      "AuthSession": {
+        "type": "object",
+        "required": ["authenticated"],
+        "properties": {
+          "authenticated": { "type": "boolean" }
+        }
+      },
+      "SpaceSummary": {
+        "type": "object",
+        "required": ["id", "name", "created_at", "is_admin_space"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "created_at": { "oneOf": [{ "type": "number" }, { "type": "string" }] },
+          "is_admin_space": { "type": "boolean" },
+          "storage": { "$ref": "#/components/schemas/PublicStorageSummary" },
+          "settings": { "$ref": "#/components/schemas/PublicSpaceSettings" }
+        },
+        "not": {
+          "anyOf": [
+            { "required": ["hmac_key"] },
+            { "required": ["hmac_key_id"] },
+            { "required": ["last_rotation"] }
+          ]
+        }
+      },
+      "SpaceDetail": {
+        "allOf": [{ "$ref": "#/components/schemas/SpaceSummary" }]
+      },
+      "PublicStorageSummary": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "type": { "type": "string" },
+          "root": { "type": "string" }
+        }
+      },
+      "PublicSpaceSettings": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "default_form": { "type": "string" }
+        },
+        "not": {
+          "anyOf": [
+            { "required": ["members"] },
+            { "required": ["member_invitations"] },
+            { "required": ["membership_version"] },
+            { "required": ["admin_user_ids"] },
+            { "required": ["invitations"] },
+            { "required": ["member_roles"] },
+            { "required": ["owner_user_id"] }
+          ]
+        }
+      },
+      "SpaceCreateRequest": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" }
+        }
+      },
+      "SpaceCreateResponse": {
+        "type": "object",
+        "required": ["id", "name", "path"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "path": { "type": "string" }
+        }
+      },
+      "SpacePatchRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "storage_config": { "type": "object", "additionalProperties": true },
+          "settings": { "$ref": "#/components/schemas/PublicSpaceSettings" }
+        }
+      },
+      "SpaceMember": {
+        "type": "object",
+        "required": ["user_id", "role", "state", "updated_at"],
+        "properties": {
+          "user_id": { "type": "string" },
+          "role": { "type": "string", "enum": ["admin", "editor", "viewer"] },
+          "state": { "type": "string", "enum": ["active", "invited", "revoked"] },
+          "invited_by": { "type": ["string", "null"] },
+          "invited_at": { "type": ["string", "null"] },
+          "activated_at": { "type": ["string", "null"] },
+          "revoked_at": { "type": ["string", "null"] },
+          "updated_at": { "type": "string" }
+        }
+      },
+      "Invitation": {
+        "type": "object",
+        "required": ["token", "user_id", "role", "state", "expires_at"],
+        "properties": {
+          "token": { "type": "string", "description": "Returned only when the invitation is created." },
+          "user_id": { "type": "string" },
+          "role": { "type": "string", "enum": ["admin", "editor", "viewer"] },
+          "state": { "type": "string", "enum": ["pending", "accepted", "revoked", "expired"] },
+          "invited_by": { "type": "string" },
+          "invited_at": { "type": "string" },
+          "expires_at": { "type": "string" }
+        }
+      },
+      "StorageConnectionTestRequest": {
+        "type": "object",
+        "properties": {
+          "uri": { "type": "string" },
+          "storage_config": {
+            "type": "object",
+            "required": ["uri"],
+            "properties": {
+              "uri": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "anyOf": [
+          { "required": ["uri"] },
+          { "required": ["storage_config"] }
+        ]
+      },
+      "StorageConnectionTestResponse": {
+        "type": "object",
+        "required": ["status", "mode"],
+        "properties": {
+          "status": { "type": "string", "enum": ["ok"] },
+          "mode": { "type": "string", "enum": ["memory", "local", "s3"] }
+        }
+      },
+      "EntryMutationRequest": {
+        "type": "object",
+        "required": ["markdown"],
+        "properties": {
+          "id": { "type": "string" },
+          "markdown": { "type": "string" },
+          "content": { "type": "string" },
+          "parent_revision_id": { "type": "string" },
+          "assets": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+        }
+      },
+      "EntryMutationResponse": {
+        "type": "object",
+        "required": ["id", "revision_id"],
+        "properties": {
+          "id": { "type": "string" },
+          "revision_id": { "type": "string" }
+        }
+      },
+      "Form": {
+        "type": "object",
+        "required": ["name", "fields"],
+        "properties": {
+          "name": { "type": "string" },
+          "version": { "type": "integer" },
+          "fields": { "type": "object", "additionalProperties": true },
+          "template": { "type": "string" }
+        },
+        "additionalProperties": true
+      },
+      "SqlSession": {
+        "type": "object",
+        "required": ["id", "status"],
+        "properties": {
+          "id": { "type": "string" },
+          "status": { "type": "string" },
+          "sql": { "type": "string" }
+        },
+        "additionalProperties": true
+      },
+      "SavedSql": {
+        "type": "object",
+        "required": ["id", "name", "sql"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "sql": { "type": "string" },
+          "variables": { "type": "array" }
+        },
+        "additionalProperties": true
+      },
+      "Asset": {
+        "type": "object",
+        "required": ["id", "filename"],
+        "properties": {
+          "id": { "type": "string" },
+          "filename": { "type": "string" },
+          "size": { "type": "integer" },
+          "content_type": { "type": ["string", "null"] }
+        },
+        "additionalProperties": true
+      },
+      "McpEntryResource": {
+        "type": "object",
+        "required": ["id", "title", "form", "tags", "properties", "_untrusted_content"],
+        "properties": {
+          "id": {},
+          "title": {},
+          "form": {},
+          "tags": { "type": "array" },
+          "properties": {},
+          "_untrusted_content": { "type": "boolean", "const": true }
+        }
+      }
     }
   }
 }

--- a/frontend/src/components/HelloWorld.tsx
+++ b/frontend/src/components/HelloWorld.tsx
@@ -1,5 +1,5 @@
 import { createSignal, onMount } from "solid-js";
-import { apiFetch } from "../lib/api";
+import { apiFetch } from "../lib/ugoite-client";
 
 export default function HelloWorld() {
   const [message, setMessage] = createSignal<string>("");

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -1,6 +1,5 @@
 // Library exports
 export * from "./types";
-export * from "./api";
 export * from "./ugoite-client";
 export * from "./form-store";
 export * from "./asset-store";

--- a/frontend/src/lib/ugoite-client/http.ts
+++ b/frontend/src/lib/ugoite-client/http.ts
@@ -1,0 +1,8 @@
+export {
+  apiFetch,
+  type ApiFetchOptions,
+  getBackendBase,
+  joinUrl,
+  type RuntimeCapabilities,
+  runtimeCapabilities,
+} from "../api";

--- a/frontend/src/lib/ugoite-client/index.ts
+++ b/frontend/src/lib/ugoite-client/index.ts
@@ -5,7 +5,8 @@ export {
   joinUrl,
   type RuntimeCapabilities,
   runtimeCapabilities,
-} from "../api";
+} from "./http";
+export type * from "./types";
 export { assetApi } from "../asset-api";
 export { authApi } from "../auth-api";
 export { entryApi } from "../entry-api";

--- a/frontend/src/lib/ugoite-client/types.ts
+++ b/frontend/src/lib/ugoite-client/types.ts
@@ -1,0 +1,1 @@
+export type * from "../types";


### PR DESCRIPTION
## Summary

- Route remaining CLI entry/index/saved-SQL stateful core-mode operations through `UgoiteService` and add an architecture check to keep that boundary from regressing.
- Add OpenAPI component schemas for the current public REST/MCP contract, including redacted Space DTOs, storage connection test payloads, member/invitation DTOs, entry mutations, SQL, assets, and MCP resources.
- Make the frontend client boundary explicit with `ugoite-client/http.ts` and `types.ts`, remove raw API re-export from `frontend/src/lib/index.ts`, and route production frontend HTTP usage through `ugoite-client`.

## Related Issue (required)

close: #1758

## Testing

- [x] `mise run ci`
- [x] `mise run dev` plus `curl http://127.0.0.1:3000/`, `/api/auth/config`, `/api/auth/mock-oauth`, and authenticated `/api/spaces`
- [x] `docker compose up -d` plus static frontend, `/health`, `/api/auth/config`, `/api/auth/mock-oauth`, and authenticated `/api/spaces` on the assigned localhost port
