### PR TITLE
Add persistent All spaces link to SpaceShell

### DIFF
--- a/frontend/src/components/SpaceShell.test.tsx
+++ b/frontend/src/components/SpaceShell.test.tsx
@@ -49,6 +49,10 @@ describe("SpaceShell", () => {
         <div>Content</div>
       </SpaceShell>
     ));
+    expect(screen.getByRole("link", { name: "All spaces" })).toHaveAttribute(
+      "href",
+      "/spaces",
+    );
     const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
     expect(dashboardLink).toHaveAttribute("href", "/spaces/my-space/dashboard");
   });

--- a/frontend/src/components/SpaceShell.tsx
+++ b/frontend/src/components/SpaceShell.tsx
@@ -28,6 +28,9 @@ export function SpaceShell(props: SpaceShellProps) {
 
       <header class="ui-topbar">
         <div class="ui-topbar-inner">
+          <a href="/spaces" class="text-sm ui-link whitespace-nowrap">
+            All spaces
+          </a>
           <div class="ui-topbar-center">
             <div class="ui-floating ui-tabs">
               <a


### PR DESCRIPTION
## Summary

Add a persistent All spaces link to the shared Space shell so every Space-scoped screen has an easy route back to /spaces.

## Related Issue (required)

close: #1500

## Testing

- [x] `deno task test -- src/components/SpaceShell.test.tsx`
