### PR TITLE
Show invitation expiry and copy token in Space Settings

### DIFF
--- a/frontend/src/routes/spaces/[space_id]/settings.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/settings.test.tsx
@@ -1,0 +1,152 @@
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import SpaceSettingsRoute from "./settings";
+import { setLocale } from "~/lib/i18n";
+import { spaceApi } from "~/lib/ugoite-client";
+
+vi.mock("@solidjs/router", () => ({
+  useParams: () => ({ space_id: "space-1" }),
+  A: (props: { href: string; class?: string; children: unknown }) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
+}));
+
+vi.mock("~/components/SpaceShell", () => ({
+  SpaceShell: (props: { children: unknown }) => <div>{props.children}</div>,
+}));
+
+vi.mock("~/components/SpaceSettings", () => ({
+  SpaceSettings: () => <div>Space settings</div>,
+}));
+
+vi.mock("~/lib/ugoite-client", () => ({
+  spaceApi: {
+    get: vi.fn(),
+    listMembers: vi.fn(),
+    patch: vi.fn(),
+    testConnection: vi.fn(),
+    inviteMember: vi.fn(),
+    updateMemberRole: vi.fn(),
+    revokeMember: vi.fn(),
+  },
+}));
+
+const inviteResponse = (token: string, expiresAt: string) => ({
+  invitation: {
+    token,
+    user_id: "user-1",
+    role: "viewer",
+    state: "pending",
+    invited_by: "owner",
+    invited_at: "2026-01-01T00:00:00Z",
+    expires_at: expiresAt,
+  },
+  delivery: {},
+  audit_event: {},
+});
+
+const formatExpiry = (value: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+
+describe("/spaces/:space_id/settings", () => {
+  beforeEach(() => {
+    setLocale("en");
+    vi.resetAllMocks();
+    (spaceApi.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "space-1",
+      name: "Test Space",
+      created_at: "2026-01-01T00:00:00Z",
+    });
+    (spaceApi.listMembers as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  });
+
+  it("shows invitation expiry and replaces stale invitation state", async () => {
+    (spaceApi.inviteMember as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(inviteResponse("first-token", "2026-01-01T10:30:00Z"))
+      .mockResolvedValueOnce(inviteResponse("second-token", "2026-01-02T09:15:00Z"));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(() => <SpaceSettingsRoute />);
+
+    await waitFor(() => expect(spaceApi.get).toHaveBeenCalled());
+
+    fireEvent.input(screen.getByLabelText(/user id/i), {
+      target: { value: "user-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /invite member/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("first-token")).toBeInTheDocument();
+    });
+    expect(screen.getByText(formatExpiry("2026-01-01T10:30:00Z")))
+      .toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /invite member/i }),
+      ).not.toBeDisabled();
+    });
+    fireEvent.input(screen.getByLabelText(/user id/i), {
+      target: { value: "user-2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /invite member/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("second-token")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("first-token")).not.toBeInTheDocument();
+    expect(screen.getByText(formatExpiry("2026-01-02T09:15:00Z")))
+      .toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /copy token/i }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("second-token");
+      expect(screen.getByRole("status")).toHaveTextContent(
+        /copied to clipboard/i,
+      );
+    });
+  });
+
+  it("announces copy failure when the clipboard path is unavailable", async () => {
+    (spaceApi.inviteMember as ReturnType<typeof vi.fn>).mockResolvedValue(
+      inviteResponse("fallback-token", "2026-01-01T10:30:00Z"),
+    );
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(() => false),
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(() => <SpaceSettingsRoute />);
+
+    await waitFor(() => expect(spaceApi.get).toHaveBeenCalled());
+
+    fireEvent.input(screen.getByLabelText(/user id/i), {
+      target: { value: "user-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /invite member/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("fallback-token")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /copy token/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("alert"),
+      ).toHaveTextContent(/copy to clipboard failed|clipboard is unavailable/i);
+    });
+  });
+});

--- a/frontend/src/routes/spaces/[space_id]/settings.tsx
+++ b/frontend/src/routes/spaces/[space_id]/settings.tsx
@@ -18,6 +18,11 @@ const localDevAuthGuideUrl = getDocsiteHref(
 const managedRoles = ["admin", "editor", "viewer"] as const;
 type ManagedRole = (typeof managedRoles)[number];
 
+const invitationExpiryFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
 const toMessage = (value: unknown): string => {
   if (typeof value === "string" && value.trim()) return value;
   if (value instanceof Error && value.message.trim()) return value.message;
@@ -53,6 +58,45 @@ const authHintFromError = (
   return null;
 };
 
+const formatInvitationExpiry = (expiresAt: string) => {
+  const date = new Date(expiresAt);
+  return Number.isNaN(date.getTime())
+    ? expiresAt
+    : invitationExpiryFormatter.format(date);
+};
+
+const copyToClipboard = async (text: string) => {
+  const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(text);
+      return;
+    } catch {
+      // Fall back to the legacy clipboard path below.
+    }
+  }
+
+  if (typeof document === "undefined" || !document.body) {
+    throw new Error("Clipboard is unavailable in this environment.");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  const copied = typeof document.execCommand === "function" &&
+    document.execCommand("copy");
+  textarea.remove();
+
+  if (!copied) {
+    throw new Error("Copy to clipboard failed.");
+  }
+};
+
 export default function SpaceSettingsRoute() {
   const params = useParams<{ space_id: string }>();
   const spaceId = () => params.space_id;
@@ -67,7 +111,14 @@ export default function SpaceSettingsRoute() {
   const [inviteUserId, setInviteUserId] = createSignal("");
   const [inviteRole, setInviteRole] = createSignal<ManagedRole>("viewer");
   const [inviteEmail, setInviteEmail] = createSignal("");
-  const [inviteToken, setInviteToken] = createSignal("");
+  const [inviteDetails, setInviteDetails] = createSignal<{
+    token: string;
+    expiresAt: string;
+  } | null>(null);
+  const [inviteFeedback, setInviteFeedback] = createSignal<{
+    kind: "success" | "error";
+    message: string;
+  } | null>(null);
   const [memberActionError, setMemberActionError] = createSignal("");
   const [memberActionPending, setMemberActionPending] = createSignal(false);
 
@@ -90,14 +141,18 @@ export default function SpaceSettingsRoute() {
     }
     setMemberActionPending(true);
     setMemberActionError("");
-    setInviteToken("");
+    setInviteDetails(null);
+    setInviteFeedback(null);
     try {
       const response = await spaceApi.inviteMember(spaceId(), {
         user_id: userId,
         role: inviteRole(),
         email: inviteEmail().trim() || undefined,
       });
-      setInviteToken(response.invitation.token);
+      setInviteDetails({
+        token: response.invitation.token,
+        expiresAt: response.invitation.expires_at,
+      });
       setInviteUserId("");
       setInviteEmail("");
       await refetchMembers();
@@ -105,6 +160,23 @@ export default function SpaceSettingsRoute() {
       setMemberActionError(toMessage(error) || "Failed to invite member.");
     } finally {
       setMemberActionPending(false);
+    }
+  };
+
+  const handleCopyInviteToken = async () => {
+    const details = inviteDetails();
+    if (!details) return;
+    try {
+      await copyToClipboard(details.token);
+      setInviteFeedback({
+        kind: "success",
+        message: "Invitation token copied to clipboard.",
+      });
+    } catch (error) {
+      setInviteFeedback({
+        kind: "error",
+        message: toMessage(error) || "Failed to copy invitation token.",
+      });
     }
   };
 
@@ -247,10 +319,45 @@ export default function SpaceSettingsRoute() {
             Invite Member
           </button>
 
-          <Show when={inviteToken()}>
-            <div class="ui-alert ui-alert-info text-sm">
-              Invitation token (share once): <code>{inviteToken()}</code>
-            </div>
+          <Show when={inviteDetails()}>
+            {(details) => (
+              <div class="ui-alert ui-alert-info text-sm ui-stack-sm">
+                <p class="font-medium">Invitation token (share once)</p>
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <code class="break-all">{details().token}</code>
+                  <button
+                    type="button"
+                    class="ui-button ui-button-secondary ui-button-sm w-fit"
+                    onClick={() => void handleCopyInviteToken()}
+                  >
+                    Copy token
+                  </button>
+                </div>
+                <p class="text-xs ui-muted">
+                  Expires at{" "}
+                  <time
+                    datetime={details().expiresAt}
+                    title={details().expiresAt}
+                  >
+                    {formatInvitationExpiry(details().expiresAt)}
+                  </time>
+                </p>
+                <p class="text-xs ui-muted">
+                  Treat this token as a secret and share it once.
+                </p>
+                <Show when={inviteFeedback()}>
+                  {(feedback) => (
+                    <p
+                      class="text-xs"
+                      role={feedback().kind === "error" ? "alert" : "status"}
+                      aria-live="polite"
+                    >
+                      {feedback().message}
+                    </p>
+                  )}
+                </Show>
+              </div>
+            )}
           </Show>
           <Show when={memberActionError()}>
             <p class="text-sm ui-text-danger">{memberActionError()}</p>


### PR DESCRIPTION
## Summary

Show the invitation expiry alongside the returned token in Space Settings and add a copy action with accessible success and failure feedback.

## Related Issue (required)

close: #1504

## Testing

- [x] `deno task test -- 'src/routes/spaces/[space_id]/settings.test.tsx'`
