### PR TITLE
Clarify local dev docsite port and launcher roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ mise run setup
 mise run dev
 ```
 
+For the local dev stack URLs, browser auth flow, and docsite port, see [docs/guide/local-dev-auth-login.md](docs/guide/local-dev-auth-login.md).
+
 Focused gates:
 
 ```bash

--- a/docs/guide/local-dev-auth-login.md
+++ b/docs/guide/local-dev-auth-login.md
@@ -5,7 +5,13 @@ mise run setup
 mise run dev
 ```
 
-The integrated launcher starts the Rust server, browser, and docsite and defaults to `mock-oauth`.
+The integrated launcher starts three processes:
+
+- Rust server: REST API and auth backend.
+- Browser app: the server-backed SolidStart UI.
+- Docsite: the Astro docs site at `http://127.0.0.1:4321`.
+
+The integrated launcher defaults to `mock-oauth`.
 
 ```bash
 ugoite config set --mode backend --backend-url http://127.0.0.1:8000
@@ -13,6 +19,6 @@ eval "$(ugoite auth login --mock-oauth)"
 ugoite auth profile
 ```
 
-Use the server URL printed by the launcher when its port differs. Direct loopback use reads the configured bootstrap token; proxied/container development may additionally require `UGOITE_DEV_AUTH_PROXY_TOKEN`.
+Use the server and browser URLs printed by the launcher when their ports differ. Direct loopback use reads the configured bootstrap token; proxied/container development may additionally require `UGOITE_DEV_AUTH_PROXY_TOKEN`.
 
 Although username/TOTP options exist in the CLI shape, the current Rust server rejects `/auth/login`.


### PR DESCRIPTION
## Summary

Clarify the local dev guide with the docsite URL, the three launched processes, and a link from the README development section.

## Related Issue (required)

close: #1484

## Testing

- [x] `cargo run -p xtask -- docs-current-stack-check`
