### PR TITLE
Add a focused CLI test task and clearer core-mode space path errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ mise run test
 ```
 
 Run `mise run e2e:smoke` for a representative browser/container path and `mise run e2e` for the full suite.
+For CLI-only changes, `mise run test:cli` gives a faster package-focused loop before the full workspace tests.
 
 ## Responsibility boundaries
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ mise run setup
 mise run dev
 ```
 
+For CLI-only iteration, use `mise run test:cli` before the full workspace test gate.
+
 Focused gates:
 
 ```bash

--- a/crates/ugoite-cli/src/config.rs
+++ b/crates/ugoite-cli/src/config.rs
@@ -271,7 +271,7 @@ pub fn resolve_space_reference(
     }
     explicit_core_space_path(space_path).ok_or_else(|| {
         anyhow!(
-            "{command_name} requires SPACE_ID_OR_PATH as /path/to/root/spaces/<id> in core mode"
+            "{command_name} cannot use {space_path:?} in core mode. SPACE_ID_OR_PATH must be a filesystem path like /path/to/workspace/spaces/demo because core mode needs the workspace location. Use backend/api mode when you want to pass a bare Space ID."
         )
     })
 }

--- a/crates/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/crates/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -430,10 +430,12 @@ fn test_create_space_req_sto_010_requires_root_only_in_core_mode() {
     let stderr = String::from_utf8_lossy(&core_output.stderr);
     assert!(
         stderr.contains(
-            "space create requires SPACE_ID_OR_PATH as /path/to/root/spaces/<id> in core mode"
+            r#"space create cannot use "local-space" in core mode"#
         ),
         "{stderr}"
     );
+    assert!(stderr.contains("/path/to/workspace/spaces/demo"));
+    assert!(stderr.contains("Use backend/api mode when you want to pass a bare Space ID."));
 
     let legacy_output = Command::new(ugoite_bin())
         .args(["create-space", "local-space"])

--- a/crates/ugoite-cli/tests/test_cli_endpoint_routing.rs
+++ b/crates/ugoite-cli/tests/test_cli_endpoint_routing.rs
@@ -429,9 +429,7 @@ fn test_create_space_req_sto_010_requires_root_only_in_core_mode() {
     );
     let stderr = String::from_utf8_lossy(&core_output.stderr);
     assert!(
-        stderr.contains(
-            r#"space create cannot use "local-space" in core mode"#
-        ),
+        stderr.contains(r#"space create cannot use "local-space" in core mode"#),
         "{stderr}"
     );
     assert!(stderr.contains("/path/to/workspace/spaces/demo"));

--- a/crates/ugoite-cli/tests/test_cli_req_ops_006_config_helpers.rs
+++ b/crates/ugoite-cli/tests/test_cli_req_ops_006_config_helpers.rs
@@ -290,7 +290,9 @@ fn test_cli_req_ops_006_parse_space_path_variants() {
     let malformed = resolve_space_reference(&core, "/tmp/demo/spaces//nested", "entry list")
         .expect_err("malformed core path");
     let malformed_text = malformed.to_string();
-    assert!(malformed_text.contains(r#"entry list cannot use "/tmp/demo/spaces//nested" in core mode"#));
+    assert!(
+        malformed_text.contains(r#"entry list cannot use "/tmp/demo/spaces//nested" in core mode"#)
+    );
     assert!(malformed_text.contains("/path/to/workspace/spaces/demo"));
     assert!(malformed_text.contains("Use backend/api mode when you want to pass a bare Space ID."));
 

--- a/crates/ugoite-cli/tests/test_cli_req_ops_006_config_helpers.rs
+++ b/crates/ugoite-cli/tests/test_cli_req_ops_006_config_helpers.rs
@@ -282,15 +282,17 @@ fn test_cli_req_ops_006_parse_space_path_variants() {
 
     let err =
         resolve_space_reference(&core, "backend-space", "entry list").expect_err("bare core ID");
-    assert!(err.to_string().contains(
-        "entry list requires SPACE_ID_OR_PATH as /path/to/root/spaces/<id> in core mode"
-    ));
+    let err_text = err.to_string();
+    assert!(err_text.contains(r#"entry list cannot use "backend-space" in core mode"#));
+    assert!(err_text.contains("/path/to/workspace/spaces/demo"));
+    assert!(err_text.contains("Use backend/api mode when you want to pass a bare Space ID."));
 
     let malformed = resolve_space_reference(&core, "/tmp/demo/spaces//nested", "entry list")
         .expect_err("malformed core path");
-    assert!(malformed.to_string().contains(
-        "entry list requires SPACE_ID_OR_PATH as /path/to/root/spaces/<id> in core mode"
-    ));
+    let malformed_text = malformed.to_string();
+    assert!(malformed_text.contains(r#"entry list cannot use "/tmp/demo/spaces//nested" in core mode"#));
+    assert!(malformed_text.contains("/path/to/workspace/spaces/demo"));
+    assert!(malformed_text.contains("Use backend/api mode when you want to pass a bare Space ID."));
 
     assert_eq!(normalize_space_root("/"), "/");
     assert_eq!(normalize_space_root("/spaces"), "/");

--- a/crates/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
+++ b/crates/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
@@ -1111,16 +1111,12 @@ fn test_cli_req_ops_006_space_local_and_remote_paths() {
         .output()
         .expect("space create missing root");
     assert!(!missing_root_create_output.status.success());
-    assert!(
-        String::from_utf8_lossy(&missing_root_create_output.stderr).contains(
-            r#"space create cannot use "space-missing-root" in core mode"#
-        )
-    );
     let missing_root_create_stderr = String::from_utf8_lossy(&missing_root_create_output.stderr);
+    assert!(missing_root_create_stderr
+        .contains(r#"space create cannot use "space-missing-root" in core mode"#));
     assert!(missing_root_create_stderr.contains("/path/to/workspace/spaces/demo"));
-    assert!(missing_root_create_stderr.contains(
-        "Use backend/api mode when you want to pass a bare Space ID."
-    ));
+    assert!(missing_root_create_stderr
+        .contains("Use backend/api mode when you want to pass a bare Space ID."));
 
     let backend_api_mode_hint = "Run `ugoite config current` to inspect the active mode, then switch with `ugoite config set --mode backend --backend-url http://localhost:8000` or `ugoite config set --mode api --api-url http://localhost:3000/api`.";
 

--- a/crates/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
+++ b/crates/ugoite-cli/tests/test_cli_req_ops_006_coverage.rs
@@ -1113,9 +1113,14 @@ fn test_cli_req_ops_006_space_local_and_remote_paths() {
     assert!(!missing_root_create_output.status.success());
     assert!(
         String::from_utf8_lossy(&missing_root_create_output.stderr).contains(
-            "space create requires SPACE_ID_OR_PATH as /path/to/root/spaces/<id> in core mode"
+            r#"space create cannot use "space-missing-root" in core mode"#
         )
     );
+    let missing_root_create_stderr = String::from_utf8_lossy(&missing_root_create_output.stderr);
+    assert!(missing_root_create_stderr.contains("/path/to/workspace/spaces/demo"));
+    assert!(missing_root_create_stderr.contains(
+        "Use backend/api mode when you want to pass a bare Space ID."
+    ));
 
     let backend_api_mode_hint = "Run `ugoite config current` to inspect the active mode, then switch with `ugoite config set --mode backend --backend-url http://localhost:8000` or `ugoite config set --mode api --api-url http://localhost:3000/api`.";
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -22,6 +22,8 @@ ugoite space list
 ugoite entry list demo
 ```
 
-Use a full Space path in core mode and a bare Space ID in backend/API mode. `ugoite config current` prints the routing mode.
+Use a full `/path/to/root/spaces/<id>` path in core mode and a bare Space ID in backend/API mode. `ugoite config current` prints the routing mode. When core mode rejects a value, the error echoes the rejected input and points you back to the filesystem path form.
 
 Space, Entry, Form, search, saved SQL, SQL-session, and most asset operations use the corresponding adapter. `index run` and `index stats` are core-only. Remote CLI asset upload, service-account CRUD, and audit-log commands are unavailable in this release.
+
+For CLI-only iteration, `mise run test:cli` runs the CLI package tests before the full workspace gate.

--- a/docs/spec/testing/strategy.md
+++ b/docs/spec/testing/strategy.md
@@ -10,3 +10,5 @@ Tests are organized around the shared Rust core and thin adapters.
 Requirement IDs embedded in test names/source provide traceability. A requirement without a current test reference is labeled `untraced`; deleted paths are not retained as evidence.
 
 Use focused crate/package tests while developing, then run `mise run ci` or the merge/release gates as appropriate.
+
+For CLI-only work, start with `mise run test:cli` so you can iterate on `ugoite-cli` without running the full workspace suite.

--- a/mise.toml
+++ b/mise.toml
@@ -75,6 +75,10 @@ run = [
   "deno task frontend:test",
 ]
 
+[tasks."test:cli"]
+description = "Run the CLI package tests"
+run = "cargo test -p ugoite-cli --locked"
+
 [tasks.ci]
 run = [
   "mise run fmt:check",


### PR DESCRIPTION
## Summary

Add a package-managed CLI test task for focused iteration, and make core-mode space path errors point at the rejected value, the filesystem path form, and backend/API mode as the bare-ID alternative.

## Related Issue (required)

closes #1483
closes #1392

## Testing

- [x] `cargo test -p ugoite-cli --locked`
- [x] `cargo run -p xtask -- docs-current-stack-check`
