### PR TITLE
Define cache-aware mise build, test, package, and verify contracts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,19 +12,17 @@ RUN rustup target add wasm32-unknown-unknown
 COPY deno.json deno.lock ./
 COPY Cargo.toml Cargo.lock ./
 COPY frontend ./frontend
-COPY docsite ./docsite
-COPY docs ./docs
 COPY scripts ./scripts
 COPY crates ./crates
 COPY vendor ./vendor
 COPY shared ./shared
 RUN cd frontend && deno install --allow-scripts=npm:@tailwindcss/oxide,npm:esbuild,npm:sharp
-RUN cd docsite && deno install --allow-scripts=npm:@tailwindcss/oxide,npm:esbuild,npm:sharp
+RUN bash scripts/build-ugoite-wasm.sh release target/wasm/ugoite_wasm.release.wasm
+RUN bash scripts/activate-ugoite-wasm.sh release
 RUN UGOITE_STATIC_SPA=true deno task frontend:build
 RUN deno run -A frontend/scripts/generate-static-index.ts \
   frontend/.output/public/_build/.vite/manifest.json \
   frontend/.output/public/index.html
-RUN deno task docsite:build
 
 FROM rust:1.96-bookworm AS rust-build
 WORKDIR /repo

--- a/README.md
+++ b/README.md
@@ -29,8 +29,75 @@ mise run fmt
 mise run lint
 mise run check
 mise run test
+mise run build
+mise run package
+mise run verify
+mise run e2e:smoke
 ```
 
+CI mappings:
+
+- pull requests: `mise run ci`
+- merge queue and pushes to `main`: `mise run ci:merge`
+- local release candidate validation: `mise run ci:release`
+
+Tasks are defined at the repository root; package-scoped `mise run //...` commands are not supported. `build:*` tasks may be skipped locally when declared outputs are newer than their inputs, but test tasks remain authoritative and are never satisfied by cached success markers.
+
+## Run with Docker Compose
+
+Source build:
+
+```bash
+docker compose up --build -d
+docker compose port ugoite 8000
+```
+
+Release image:
+
+```bash
+export UGOITE_VERSION=<release-tag>
+export UGOITE_BOOTSTRAP_TOKEN="$(openssl rand -hex 32)"
+docker compose -f docker-compose.release.yaml up -d
+```
+
+Both configurations run one image and mount the authoritative workspace at `/data`. The supplied image runs as a non-root user.
+
+## CLI examples
+
+Core mode:
+
+```bash
+ugoite config set --mode core
+ugoite space list /path/to/workspace
+ugoite space create /path/to/workspace/spaces/demo
+ugoite entry list /path/to/workspace/spaces/demo
+ugoite query /path/to/workspace/spaces/demo --sql "SELECT id, title FROM entries LIMIT 10"
+```
+
+Server-backed mode:
+
+```bash
+ugoite config set --mode backend --backend-url http://127.0.0.1:8000
+eval "$(ugoite auth login --mock-oauth)"
+ugoite space list
+```
+
+The username/TOTP CLI shape exists, but the Rust server currently rejects `/auth/login`; development uses `mock-oauth`.
+
+## API and documentation
+
+- Human API summary: [`docs/spec/api/rest.md`](docs/spec/api/rest.md)
+- Generated OpenAPI snapshot: [`docs/spec/api/openapi.yaml`](docs/spec/api/openapi.yaml)
+- MCP resource surface: [`docs/spec/api/mcp.md`](docs/spec/api/mcp.md)
+- Architecture: [`docs/architecture/north-star.md`](docs/architecture/north-star.md)
+- Operator guides: [`docs/guide`](docs/guide)
+- Executable specification registry: [`docs/spec`](docs/spec)
+
+The server-generated `/openapi.json` is authoritative. `cargo run -p xtask -- openapi-check` verifies the checked-in YAML snapshot.
+
+## Distribution safety
+
+Prefer package-manager or release-archive installation. The optional npm installer verifies release checksums before installing a binary. Do not present `curl | sh` as the recommended installation path.
 ## License
 
 MIT

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
   "nodeModulesDir": "auto",
   "tasks": {
     "dev": "deno run -A tools/dev.ts",
-    "check": "deno check tools/**/*.ts e2e/**/*.ts && deno task frontend:build && deno task --cwd docsite check",
+    "check": "deno check tools/**/*.ts e2e/**/*.ts && deno task --cwd frontend check && deno task --cwd docsite check",
     "test": "deno test -A tools/*_test.ts && deno task frontend:test && deno task docsite:test",
     "frontend:dev": "deno task --cwd frontend dev",
     "frontend:build": "deno task --cwd frontend build",

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -11,8 +11,30 @@ The required build/test gate is `.github/workflows/ci.yml`. Separate workflows r
 
 Root task composition:
 
-- `ci`: formatting check, lint, architecture/OpenAPI/type checks, and tests;
-- `ci:merge`: `ci`, frontend/docsite builds, and E2E smoke;
-- `ci:release`: local release candidate gate adding release Rust builds, WASM check, and local image verification.
+- `build:*`: deterministic compile/build steps with declared inputs and outputs;
+- `test:*`: authoritative assertions that may reuse `build:*` outputs but always execute when called;
+- `package:*`: staging under `target/artifacts/` only; packaging must fail if required build outputs are absent;
+- `verify:*`: checks packaged outputs without rebuilding them;
+- `ci`: formatting check, lint, architecture/OpenAPI/type checks, and non-E2E tests;
+- `ci:merge`: `ci`, build/package/verify, and E2E smoke;
+- `ci:release`: `ci:merge` plus the full E2E suite.
 
-The uploaded repository does not contain a publishing workflow, so `ci:release` proves local readiness only. All task names are root `mise.toml` tasks; package-scoped task syntax is invalid.
+Deployable artifacts are staged below `target/artifacts/` with a machine-readable `manifest.json` and `SHA256SUMS`. This layout is for promotion by later workflows; deployment workflows must not compile source code again.
+
+Build reuse and test-result caching are different concepts. `sources`/`outputs` may skip deterministic `build:*` work when inputs are unchanged, but they are never evidence that a test passed.
+
+Current artifact layout:
+
+```text
+target/artifacts/
+  manifest.json
+  SHA256SUMS
+  docsite/
+  cli/
+  helm/
+  image/
+```
+
+Build identity currently includes explicit environment such as `DOCSITE_ORIGIN`, `DOCSITE_BASE`, and `UGOITE_IMAGE_TAG`. To force a clean rebuild, remove `target/rust`, `target/wasm`, `target/artifacts`, `frontend/.output`, `docsite/dist`, and `frontend/src/lib/generated/ugoite_wasm.wasm`.
+
+All task names are root `mise.toml` tasks; package-scoped task syntax is invalid.

--- a/docsite/README.md
+++ b/docsite/README.md
@@ -9,6 +9,15 @@ deno task --cwd docsite test
 deno task --cwd docsite build
 ```
 
+Repository-level orchestration stays at the root:
+
+```bash
+mise run build:docsite
+mise run test:docsite
+mise run package:docsite
+mise run verify:docsite
+```
+
 Do not add product documentation, custom navigation, search code, or hand-authored routes under `docsite/`. Starlight owns those responsibilities; `docs/` owns the content.
 
 ## Why the collection loader is custom
@@ -36,3 +45,5 @@ DOCSITE_BASE=/ugoite/ \
 ```
 
 `DOCSITE_BASE` is never inferred from `GITHUB_ACTIONS`; preview and validation workflows therefore cannot accidentally emit repository-prefixed links.
+
+`DOCSITE_ORIGIN` and `DOCSITE_BASE` are explicit build inputs. Repository-wide checks are `mise run check`, `mise run test`, `mise run package`, and `mise run verify`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,9 +13,9 @@ Endpoint semantics come from the Rust `ugoite-api-client` crate through the `ugo
 From the repository root:
 
 ```bash
-deno task frontend:dev
-deno task frontend:build
-deno task frontend:test
+mise run build:wasm
+mise run build:frontend
+mise run test:frontend
 ```
 
-Or use `mise run dev`, `mise run check`, and `mise run test` for repository-wide workflows. The build first compiles the WASM adapter with `scripts/build-ugoite-wasm.sh`.
+Package-local Deno tasks are low-level commands. The supported orchestration surface is the root Mise task graph, which activates the correct WASM output before frontend build and test runs.

--- a/frontend/deno.json
+++ b/frontend/deno.json
@@ -1,11 +1,11 @@
 {
   "tasks": {
-    "dev": "deno task build:wasm && deno run -A npm:vinxi dev",
-    "build": "deno task build:wasm && deno cache npm:solid-js@^1.9.10 npm:tailwindcss@4.3.0 && sh -c 'mkdir -p node_modules && for pkg in solid-js tailwindcss; do test -e node_modules/$pkg || tar -C ../node_modules -chf - $pkg | tar -C node_modules -xf -; done' && deno run -A npm:vinxi build",
+    "dev": "deno run -A npm:vinxi dev",
+    "build": "deno cache npm:solid-js@^1.9.10 npm:tailwindcss@4.3.0 && sh -c 'mkdir -p node_modules && for pkg in solid-js tailwindcss; do test -e node_modules/$pkg || tar -C ../node_modules -chf - $pkg | tar -C node_modules -xf -; done' && deno run -A npm:vinxi build",
+    "check": "deno check app.config.ts error-handler.ts scripts/generate-static-index.ts vitest.config.ts",
     "start": "deno run -A npm:vinxi start",
-    "test": "deno task build:wasm && deno run -A npm:vitest run",
-    "coverage": "deno task build:wasm && deno run -A npm:vitest run --coverage --maxWorkers=1",
-    "build:wasm": "bash ../scripts/build-ugoite-wasm.sh"
+    "test": "deno run -A npm:vitest run",
+    "coverage": "deno run -A npm:vitest run --coverage --maxWorkers=1"
   },
   "imports": {
     "@codemirror/autocomplete": "npm:@codemirror/autocomplete@^6.20.2",
@@ -27,6 +27,8 @@
     "@tailwindcss/oxide": "npm:@tailwindcss/oxide@4.3.0",
     "@tailwindcss/vite": "npm:@tailwindcss/vite@4.3.0",
     "@testing-library/dom": "npm:@testing-library/dom@^10.4.0",
+    "@testing-library/jest-dom": "npm:@testing-library/jest-dom@^6.6.3",
+    "@testing-library/jest-dom/vitest": "npm:@testing-library/jest-dom@^6.6.3/vitest",
     "@testing-library/jest-dom/": "npm:@testing-library/jest-dom@^6.6.3/",
     "@mswjs/interceptors": "npm:@mswjs/interceptors@^0.41.3",
     "@open-draft/deferred-promise": "npm:@open-draft/deferred-promise@^3.0.0",
@@ -53,6 +55,7 @@
     "merge-anything": "npm:merge-anything@^5.1.7",
     "module": "node:module",
     "msw": "npm:msw@^2.14.6",
+    "msw/node": "npm:msw@^2.14.6/node",
     "msw/": "npm:msw@^2.14.6/",
     "outvariant": "npm:outvariant@^1.4.3",
     "path-to-regexp": "npm:path-to-regexp@^6.3.0",
@@ -90,6 +93,8 @@
     "vite-plugin-pwa": "npm:vite-plugin-pwa@^1.3.0",
     "vite-plugin-solid": "npm:vite-plugin-solid@^2.11.12",
     "vitest": "npm:vitest@^4.1.8",
+    "vitest/config": "npm:vitest@^4.1.8/config",
+    "vitest/globals": "npm:vitest@^4.1.8/globals",
     "vitest/": "npm:vitest@^4.1.8/",
     "workbox-build": "npm:workbox-build@^7.4.0",
     "workbox-window": "npm:workbox-window@^7.4.0",

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ DENO_NO_UPDATE_CHECK = "1"
 
 [tools]
 deno = "2.8.3"
+helm = "3.19.0"
 rust = "1.93.0"
 
 [tasks.setup]
@@ -23,7 +24,11 @@ run = [
 
 [tasks.dev]
 description = "Run the current backend, frontend, and docsite development servers"
-run = "deno task dev"
+depends = ["build:wasm:debug"]
+run = [
+  "bash scripts/activate-ugoite-wasm.sh debug",
+  "deno task dev",
+]
 
 [tasks.fmt]
 run = [
@@ -43,6 +48,128 @@ run = [
   "deno lint tools e2e frontend/src docsite/src",
 ]
 
+[tasks."build:wasm:debug"]
+description = "Build the debug WASM adapter once for reuse"
+sources = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "crates/ugoite-domain/Cargo.toml",
+  "crates/ugoite-domain/src/**/*.rs",
+  "crates/ugoite-api-client/Cargo.toml",
+  "crates/ugoite-api-client/src/**/*.rs",
+  "crates/ugoite-wasm/Cargo.toml",
+  "crates/ugoite-wasm/src/**/*.rs",
+  "scripts/build-ugoite-wasm.sh",
+]
+outputs = ["target/wasm/ugoite_wasm.debug.wasm"]
+run = "bash scripts/build-ugoite-wasm.sh debug target/wasm/ugoite_wasm.debug.wasm"
+
+[tasks."build:wasm:release"]
+description = "Build the release WASM adapter once for reuse"
+sources = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "crates/ugoite-domain/Cargo.toml",
+  "crates/ugoite-domain/src/**/*.rs",
+  "crates/ugoite-api-client/Cargo.toml",
+  "crates/ugoite-api-client/src/**/*.rs",
+  "crates/ugoite-wasm/Cargo.toml",
+  "crates/ugoite-wasm/src/**/*.rs",
+  "scripts/build-ugoite-wasm.sh",
+]
+outputs = ["target/wasm/ugoite_wasm.release.wasm"]
+run = "bash scripts/build-ugoite-wasm.sh release target/wasm/ugoite_wasm.release.wasm"
+
+[tasks."build:wasm"]
+description = "Activate the debug WASM adapter for local workflows"
+depends = ["build:wasm:debug"]
+run = "bash scripts/activate-ugoite-wasm.sh debug"
+
+[tasks."build:frontend"]
+description = "Build the production frontend using the release WASM adapter"
+depends = ["build:wasm:release"]
+sources = [
+  "deno.json",
+  "deno.lock",
+  "frontend/deno.json",
+  "frontend/app.config.ts",
+  "frontend/error-handler.ts",
+  "frontend/vitest.config.ts",
+  "frontend/tsconfig.json",
+  "frontend/public/**/*",
+  "frontend/scripts/**/*.ts",
+  "frontend/src/**/*",
+  "shared/**/*",
+  "scripts/activate-ugoite-wasm.sh",
+]
+outputs = ["frontend/.output/public/index.html"]
+run = [
+  "bash scripts/activate-ugoite-wasm.sh release",
+  "deno task frontend:build",
+]
+
+[tasks."build:docsite"]
+description = "Build the docsite with explicit origin and base inputs"
+depends = ["prepare:docsite:inputs"]
+sources = [
+  "deno.json",
+  "deno.lock",
+  "docsite/README.md",
+  "docsite/astro.config.mjs",
+  "docsite/deno.json",
+  "docsite/src/**/*",
+  "docsite/tailwind.config.mjs",
+  "docsite/tsconfig.json",
+  "docsite/vitest.config.ts",
+  "docs/**/*",
+  "shared/**/*",
+  "target/build-metadata/docsite-inputs.txt",
+]
+outputs = ["docsite/dist/index.html"]
+env = { DOCSITE_ORIGIN = "http://localhost:4321", DOCSITE_BASE = "/" }
+run = "deno task docsite:build"
+
+[tasks."prepare:docsite:inputs"]
+description = "Record docsite build identity inputs"
+env = { DOCSITE_ORIGIN = "http://localhost:4321", DOCSITE_BASE = "/" }
+run = [
+  "mkdir -p target/build-metadata",
+  "tmpfile=\"$(mktemp)\" && printf 'DOCSITE_ORIGIN=%s\\nDOCSITE_BASE=%s\\n' \"$DOCSITE_ORIGIN\" \"$DOCSITE_BASE\" > \"$tmpfile\" && if ! cmp -s \"$tmpfile\" target/build-metadata/docsite-inputs.txt 2>/dev/null; then mv \"$tmpfile\" target/build-metadata/docsite-inputs.txt; else rm -f \"$tmpfile\"; fi",
+]
+
+[tasks."build:rust:release"]
+description = "Build supported release binaries"
+sources = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "crates/ugoite-domain/**/*",
+  "crates/ugoite-api-client/**/*",
+  "crates/ugoite-storage/**/*",
+  "crates/ugoite-core/**/*",
+  "crates/ugoite-server/**/*",
+  "crates/ugoite-cli/**/*",
+  "vendor/**/*",
+]
+outputs = [
+  "target/rust/release/ugoite",
+  "target/rust/release/ugoite-server",
+]
+run = [
+  "cargo build -p ugoite-server --release --locked",
+  "cargo build -p ugoite-cli --release --locked",
+]
+
+[tasks."build:image"]
+description = "Build the runtime image once for E2E and packaging"
+run = "docker build --tag ${UGOITE_IMAGE_TAG:-ugoite:e2e} ."
+
+[tasks.build]
+description = "Build all reusable release-facing outputs"
+run = [
+  { tasks = ["build:frontend", "build:docsite", "build:rust:release"] },
+  { task = "build:image" },
+]
+
 [tasks.check]
 run = [
   "cargo check --workspace --all-targets --all-features --locked",
@@ -55,11 +182,32 @@ run = [
   "cargo run -p xtask -- docs-current-stack-check",
 ]
 
-[tasks.test]
+[tasks."test:rust"]
+run = "cargo test --workspace --locked"
+
+[tasks."test:tools"]
+run = "deno test -A tools/*_test.ts"
+
+[tasks."test:frontend"]
+depends = ["build:wasm:debug"]
 run = [
-  "cargo test --workspace --locked",
-  "deno task test",
+  "bash scripts/activate-ugoite-wasm.sh debug",
+  "deno task frontend:test",
 ]
+
+[tasks."test:docsite"]
+run = "deno task docsite:test"
+
+[tasks.test]
+run = [{ tasks = ["test:rust", "test:tools", "test:frontend", "test:docsite"] }]
+
+[tasks."test:e2e"]
+depends = ["build:image"]
+run = "E2E_BUILD_IMAGES=false deno task e2e:full"
+
+[tasks."test:e2e:smoke"]
+depends = ["build:image"]
+run = "E2E_BUILD_IMAGES=false deno task e2e:smoke"
 
 [tasks.e2e]
 description = "Run CI-parity E2E tests, preferring Docker Compose and falling back to host processes"
@@ -72,30 +220,68 @@ run = "deno task e2e:smoke"
 [tasks."test:smoke"]
 run = [
   "cargo test -p ugoite-domain -p ugoite-core -p ugoite-server --locked",
-  "deno task frontend:test",
+  { task = "test:frontend" },
 ]
+
+[tasks."package:docsite"]
+description = "Stage the built docsite under target/artifacts"
+run = "deno run -A tools/artifacts.ts package-docsite"
+
+[tasks."package:cli"]
+description = "Package the Linux CLI archive under target/artifacts"
+run = "mkdir -p target/artifacts/cli && test -x target/rust/release/ugoite && tar -C target/rust/release -czf target/artifacts/cli/ugoite-cli-linux-x86_64.tar.gz ugoite"
+
+[tasks."package:helm"]
+description = "Package the Helm chart under target/artifacts"
+run = "mkdir -p target/artifacts/helm && helm package charts/ugoite --destination target/artifacts/helm"
+
+[tasks."package:image"]
+description = "Export the built runtime image under target/artifacts"
+run = "bash -lc 'set -euo pipefail; mkdir -p target/artifacts/image; tmp=target/artifacts/image/ugoite-e2e-docker.tar.gz.tmp; final=target/artifacts/image/ugoite-e2e-docker.tar.gz; rm -f \"$tmp\" \"$final\"; cleanup(){ rm -f \"$tmp\"; }; trap cleanup EXIT; docker save ${UGOITE_IMAGE_TAG:-ugoite:e2e} | gzip -c > \"$tmp\"; mv \"$tmp\" \"$final\"; trap - EXIT'"
+
+[tasks.package]
+description = "Package deployable outputs without rebuilding them"
+run = [
+  "rm -rf target/artifacts && mkdir -p target/artifacts",
+  { tasks = ["package:docsite", "package:cli", "package:helm", "package:image"] },
+  "deno run -A tools/artifacts.ts write-manifest",
+]
+
+[tasks."verify:docsite"]
+run = "deno run -A tools/artifacts.ts verify-docsite"
+
+[tasks."verify:cli"]
+run = "deno run -A tools/artifacts.ts verify-cli"
+
+[tasks."verify:helm"]
+run = "deno run -A tools/artifacts.ts verify-helm"
+
+[tasks."verify:image"]
+run = "deno run -A tools/artifacts.ts verify-image"
+
+[tasks.verify]
+description = "Verify packaged outputs without rebuilding them"
+run = [{ tasks = ["verify:docsite", "verify:cli", "verify:helm", "verify:image"] }]
 
 [tasks.ci]
 run = [
-  "mise run fmt:check",
-  "mise run lint",
-  "mise run check",
-  "mise run test",
+  { task = "fmt:check" },
+  { task = "lint" },
+  { task = "check" },
+  { task = "test" },
 ]
 
 [tasks."ci:merge"]
 run = [
-  "mise run ci",
-  "deno task frontend:build",
-  "deno task docsite:build",
-  "mise run e2e:smoke",
+  { task = "ci" },
+  { task = "build" },
+  { task = "package" },
+  { task = "verify" },
+  { task = "test:e2e:smoke" },
 ]
 
 [tasks."ci:release"]
 run = [
-  "mise run ci:merge",
-  "cargo build -p ugoite-server --release --locked",
-  "cargo build -p ugoite-cli --release --locked",
-  "cargo check -p ugoite-wasm --target wasm32-unknown-unknown --locked",
-  "bash scripts/verify-release-local-image.sh",
+  { task = "ci:merge" },
+  { task = "test:e2e" },
 ]

--- a/scripts/activate-ugoite-wasm.sh
+++ b/scripts/activate-ugoite-wasm.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILE="${1:-debug}"
+
+case "$PROFILE" in
+  debug)
+    SOURCE="$ROOT_DIR/target/wasm/ugoite_wasm.debug.wasm"
+    ;;
+  release)
+    SOURCE="$ROOT_DIR/target/wasm/ugoite_wasm.release.wasm"
+    ;;
+  *)
+    echo "usage: $0 [debug|release]" >&2
+    exit 2
+    ;;
+esac
+
+DESTINATION="$ROOT_DIR/frontend/src/lib/generated/ugoite_wasm.wasm"
+
+if [[ ! -f "$SOURCE" ]]; then
+  echo "WASM build output was not found: $SOURCE" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$DESTINATION")"
+cp "$SOURCE" "$DESTINATION"
+echo "Activated $PROFILE WASM at $DESTINATION"

--- a/scripts/build-ugoite-wasm.sh
+++ b/scripts/build-ugoite-wasm.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROFILE="${1:-debug}"
+DESTINATION="${2:-$ROOT_DIR/frontend/src/lib/generated/ugoite_wasm.wasm}"
 
 case "$PROFILE" in
   debug)
@@ -36,7 +37,6 @@ if [[ "$TARGET_ROOT" != /* ]]; then
   TARGET_ROOT="$ROOT_DIR/$TARGET_ROOT"
 fi
 SOURCE="$TARGET_ROOT/wasm32-unknown-unknown/$PROFILE_DIR/ugoite_wasm.wasm"
-DESTINATION="$ROOT_DIR/frontend/src/lib/generated/ugoite_wasm.wasm"
 
 if [[ ! -f "$SOURCE" ]]; then
   echo "WASM build succeeded but output was not found: $SOURCE" >&2

--- a/tools/artifacts.ts
+++ b/tools/artifacts.ts
@@ -1,0 +1,413 @@
+const decoder = new TextDecoder();
+
+const repoRoot = new URL("../", import.meta.url);
+const artifactRoot = new URL("../target/artifacts/", import.meta.url);
+const docsitePackageDir = new URL("docsite/site/", artifactRoot);
+const cliPackageDir = new URL("cli/", artifactRoot);
+const helmPackageDir = new URL("helm/", artifactRoot);
+const imagePackageDir = new URL("image/", artifactRoot);
+
+const DOCSITE_ARTIFACT_NAME = "ugoite-docsite-pages";
+const CLI_ARTIFACT_NAME = "ugoite-cli-linux";
+const HELM_ARTIFACT_NAME = "ugoite-helm-chart";
+const IMAGE_ARTIFACT_NAME = "ugoite-runtime-image";
+
+type ManifestFile = {
+  path: string;
+  sha256: string;
+  size: number;
+};
+
+type ManifestArtifact = {
+  kind: "docsite" | "cli" | "helm" | "image";
+  logical_name: string;
+  build_profile: string;
+  path: string;
+  files: ManifestFile[];
+  config: Record<string, string>;
+};
+
+type ArtifactManifest = {
+  schema_version: 1;
+  source_sha: string | null;
+  contract_version: 1;
+  generated_at: string;
+  artifacts: ManifestArtifact[];
+};
+
+const command = Deno.args[0];
+
+switch (command) {
+  case "package-docsite":
+    await packageDocsite();
+    break;
+  case "write-manifest":
+    await writeManifest();
+    break;
+  case "verify-docsite":
+    await verifyDocsite();
+    break;
+  case "verify-cli":
+    await verifyCli();
+    break;
+  case "verify-helm":
+    await verifyHelm();
+    break;
+  case "verify-image":
+    await verifyImage();
+    break;
+  default:
+    throw new Error(
+      "usage: deno run -A tools/artifacts.ts <package-docsite|write-manifest|verify-docsite|verify-cli|verify-helm|verify-image>",
+    );
+}
+
+async function packageDocsite(): Promise<void> {
+  const sourceDir = new URL("../docsite/dist/", import.meta.url);
+  await ensureExists(sourceDir, "docsite build output");
+  await Deno.remove(docsitePackageDir, { recursive: true }).catch(() => {});
+  await copyDir(sourceDir, docsitePackageDir);
+}
+
+async function writeManifest(): Promise<void> {
+  await ensureExists(docsitePackageDir, "packaged docsite artifact");
+  await ensureSingleFile(cliPackageDir, /\.tar\.gz$/, "CLI package");
+  await ensureSingleFile(helmPackageDir, /\.tgz$/, "Helm package");
+  await ensureSingleFile(imagePackageDir, /\.tar\.gz$/, "image package");
+
+  const manifest: ArtifactManifest = {
+    schema_version: 1,
+    source_sha: Deno.env.get("UGOITE_SOURCE_SHA") ??
+      Deno.env.get("GITHUB_SHA") ??
+      null,
+    contract_version: 1,
+    generated_at: new Date().toISOString(),
+    artifacts: [
+      {
+        kind: "docsite",
+        logical_name: DOCSITE_ARTIFACT_NAME,
+        build_profile: "release",
+        path: "docsite/site",
+        files: await collectFiles(docsitePackageDir),
+        config: {
+          origin: Deno.env.get("DOCSITE_ORIGIN") ?? "",
+          base: Deno.env.get("DOCSITE_BASE") ?? "/",
+        },
+      },
+      {
+        kind: "cli",
+        logical_name: CLI_ARTIFACT_NAME,
+        build_profile: "release",
+        path: "cli",
+        files: await collectFiles(cliPackageDir),
+        config: {
+          target: Deno.env.get("UGOITE_CLI_TARGET") ?? "linux-amd64",
+          version: await workspaceVersion(),
+        },
+      },
+      {
+        kind: "helm",
+        logical_name: HELM_ARTIFACT_NAME,
+        build_profile: "release",
+        path: "helm",
+        files: await collectFiles(helmPackageDir),
+        config: {
+          chart: "ugoite",
+          version: await chartVersion(),
+        },
+      },
+      {
+        kind: "image",
+        logical_name: IMAGE_ARTIFACT_NAME,
+        build_profile: "release",
+        path: "image",
+        files: await collectFiles(imagePackageDir),
+        config: {
+          tag: Deno.env.get("UGOITE_IMAGE_TAG") ?? "ugoite:e2e",
+        },
+      },
+    ],
+  };
+
+  await Deno.mkdir(artifactRoot, { recursive: true });
+  await Deno.writeTextFile(
+    new URL("manifest.json", artifactRoot),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  const sumLines: string[] = [];
+  for (const artifact of manifest.artifacts) {
+    for (const file of artifact.files) {
+      sumLines.push(`${file.sha256}  ${file.path}`);
+    }
+  }
+  sumLines.sort();
+  await Deno.writeTextFile(
+    new URL("SHA256SUMS", artifactRoot),
+    `${sumLines.join("\n")}\n`,
+  );
+}
+
+async function verifyDocsite(): Promise<void> {
+  const manifest = await readManifest();
+  const artifact = requireArtifact(manifest, "docsite");
+  const indexPath = new URL(`${artifact.path}/index.html`, artifactRoot);
+  const html = await Deno.readTextFile(indexPath);
+  if (html.trim().length === 0) {
+    throw new Error("docsite index.html is empty");
+  }
+  const origin = artifact.config.origin;
+  if (
+    origin && !origin.includes("localhost") && html.includes("http://localhost")
+  ) {
+    throw new Error("production docsite artifact still references localhost");
+  }
+  await verifyManifestFiles(artifact);
+}
+
+async function verifyCli(): Promise<void> {
+  const manifest = await readManifest();
+  const artifact = requireArtifact(manifest, "cli");
+  await verifyManifestFiles(artifact);
+  const archive = artifact.files.find((file) => file.path.endsWith(".tar.gz"));
+  if (!archive) throw new Error("CLI archive is missing from manifest");
+  const tempDir = await Deno.makeTempDir({ prefix: "ugoite-cli-" });
+  await run("tar", [
+    "-xzf",
+    pathFromArtifactRoot(archive.path),
+    "-C",
+    tempDir,
+  ]);
+  const cliPath = `${tempDir}/ugoite`;
+  await Deno.stat(cliPath);
+  await run(cliPath, ["--version"]);
+}
+
+async function verifyHelm(): Promise<void> {
+  const manifest = await readManifest();
+  const artifact = requireArtifact(manifest, "helm");
+  await verifyManifestFiles(artifact);
+  const archive = artifact.files.find((file) => file.path.endsWith(".tgz"));
+  if (!archive) throw new Error("Helm package is missing from manifest");
+  const tempDir = await Deno.makeTempDir({ prefix: "ugoite-helm-" });
+  await run("tar", [
+    "-xzf",
+    pathFromArtifactRoot(archive.path),
+    "-C",
+    tempDir,
+  ]);
+  await run("helm", ["lint", `${tempDir}/ugoite`]);
+}
+
+async function verifyImage(): Promise<void> {
+  const manifest = await readManifest();
+  const artifact = requireArtifact(manifest, "image");
+  await verifyManifestFiles(artifact);
+  const archive = artifact.files.find((file) => file.path.endsWith(".tar.gz"));
+  if (!archive) throw new Error("image archive is missing from manifest");
+  const archivePath = pathFromArtifactRoot(archive.path);
+  await run("gzip", ["-t", archivePath]);
+
+  const imageManifestText = await readTarGzEntry(archivePath, "manifest.json");
+  const imageManifest = JSON.parse(imageManifestText) as Array<
+    { Config?: string }
+  >;
+  const configPath = imageManifest[0]?.Config;
+  if (!configPath) {
+    throw new Error("docker archive manifest is missing Config");
+  }
+
+  const configText = await readTarGzEntry(archivePath, configPath);
+  const config = JSON.parse(configText) as {
+    config?: { Entrypoint?: string[]; User?: string };
+  };
+  const entrypoint = config.config?.Entrypoint ?? [];
+  const user = config.config?.User ?? "";
+  if (JSON.stringify(entrypoint) !== JSON.stringify(["ugoite-server"])) {
+    throw new Error(
+      `unexpected image entrypoint: ${JSON.stringify(entrypoint)}`,
+    );
+  }
+  if (user !== "ugoite") {
+    throw new Error(`unexpected image user: ${JSON.stringify(user)}`);
+  }
+}
+
+async function verifyManifestFiles(artifact: ManifestArtifact): Promise<void> {
+  for (const file of artifact.files) {
+    const actual = await sha256File(new URL(file.path, artifactRoot));
+    if (actual !== file.sha256) {
+      throw new Error(`checksum mismatch for ${file.path}`);
+    }
+  }
+}
+
+async function collectFiles(baseDir: URL): Promise<ManifestFile[]> {
+  const files: ManifestFile[] = [];
+  for await (const fileUrl of walkFiles(baseDir)) {
+    const relative = relativeFromArtifactRoot(fileUrl);
+    files.push({
+      path: relative,
+      sha256: await sha256File(fileUrl),
+      size: (await Deno.stat(fileUrl)).size,
+    });
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return files;
+}
+
+async function* walkFiles(baseDir: URL): AsyncGenerator<URL> {
+  for await (const entry of Deno.readDir(baseDir)) {
+    const childUrl = entry.isDirectory
+      ? new URL(`${entry.name}/`, baseDir)
+      : new URL(entry.name, baseDir);
+    if (entry.isDirectory) {
+      yield* walkFiles(childUrl);
+      continue;
+    }
+    if (entry.isFile) yield childUrl;
+  }
+}
+
+async function copyDir(sourceDir: URL, destinationDir: URL): Promise<void> {
+  await Deno.mkdir(destinationDir, { recursive: true });
+  for await (const entry of Deno.readDir(sourceDir)) {
+    const source = new URL(entry.name, sourceDir);
+    const destination = new URL(entry.name, destinationDir);
+    if (entry.isDirectory) {
+      await copyDir(
+        new URL(`${entry.name}/`, sourceDir),
+        new URL(`${entry.name}/`, destinationDir),
+      );
+      continue;
+    }
+    if (entry.isSymlink) {
+      throw new Error(
+        `unexpected symlink in docsite artifact source: ${source.pathname}`,
+      );
+    }
+    await Deno.copyFile(source, destination);
+  }
+}
+
+async function sha256File(file: URL): Promise<string> {
+  const bytes = await Deno.readFile(file);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((value) =>
+    value.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+function relativeFromArtifactRoot(file: URL): string {
+  const artifactPath = pathFromFileUrl(artifactRoot);
+  const filePath = pathFromFileUrl(file);
+  return filePath.slice(artifactPath.length);
+}
+
+function pathFromArtifactRoot(relativePath: string): string {
+  return pathFromFileUrl(new URL(relativePath, artifactRoot));
+}
+
+function pathFromFileUrl(url: URL): string {
+  return decodeURIComponent(url.pathname);
+}
+
+async function ensureExists(url: URL, label: string): Promise<void> {
+  try {
+    await Deno.stat(url);
+  } catch {
+    throw new Error(`${label} was not found at ${pathFromFileUrl(url)}`);
+  }
+}
+
+async function ensureSingleFile(
+  dir: URL,
+  pattern: RegExp,
+  label: string,
+): Promise<void> {
+  await ensureExists(dir, label);
+  const matches: string[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isFile && pattern.test(entry.name)) matches.push(entry.name);
+  }
+  if (matches.length !== 1) {
+    throw new Error(
+      `${label} expected exactly one matching file in ${pathFromFileUrl(dir)}`,
+    );
+  }
+}
+
+async function readManifest(): Promise<ArtifactManifest> {
+  const manifestText = await Deno.readTextFile(
+    new URL("manifest.json", artifactRoot),
+  );
+  return JSON.parse(manifestText) as ArtifactManifest;
+}
+
+function requireArtifact(
+  manifest: ArtifactManifest,
+  kind: ManifestArtifact["kind"],
+): ManifestArtifact {
+  const artifact = manifest.artifacts.find((entry) => entry.kind === kind);
+  if (!artifact) throw new Error(`manifest is missing ${kind} artifact`);
+  return artifact;
+}
+
+async function workspaceVersion(): Promise<string> {
+  const cargoToml = await Deno.readTextFile(
+    new URL("../Cargo.toml", import.meta.url),
+  );
+  const workspacePackageBlock = cargoToml.match(
+    /\[workspace\.package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/,
+  );
+  const match = workspacePackageBlock ??
+    cargoToml.match(/^\s*version\s*=\s*"([^"]+)"/m);
+  if (!match) throw new Error("workspace version was not found in Cargo.toml");
+  return match[1];
+}
+
+async function chartVersion(): Promise<string> {
+  const chartYaml = await Deno.readTextFile(
+    new URL("../charts/ugoite/Chart.yaml", import.meta.url),
+  );
+  const match = chartYaml.match(/\nversion:\s*([^\n]+)/);
+  if (!match) {
+    throw new Error("chart version was not found in charts/ugoite/Chart.yaml");
+  }
+  return match[1].trim().replace(/^"|"$/g, "");
+}
+
+async function run(
+  cmd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+  const child = new Deno.Command(cmd, {
+    args,
+    cwd: pathFromFileUrl(repoRoot),
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await child.output();
+  const stdout = decoder.decode(output.stdout).trim();
+  const stderr = decoder.decode(output.stderr).trim();
+  if (!output.success) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed\n${stdout}${
+        stdout && stderr ? "\n" : ""
+      }${stderr}`,
+    );
+  }
+  return { stdout, stderr };
+}
+
+async function readTarGzEntry(
+  archivePath: string,
+  entryPath: string,
+): Promise<string> {
+  const result = await run("tar", [
+    "-xOzf",
+    archivePath,
+    entryPath,
+  ]);
+  return result.stdout;
+}


### PR DESCRIPTION
## Summary

- split the root `mise` graph into explicit `build:*`, `test:*`, `package:*`, and `verify:*` contracts
- make WASM/frontend/docsite/package orchestration reuse declared outputs and stage deployable artifacts under `target/artifacts/`
- remove the unused docsite build from the runtime Docker image and document the new artifact contract

## Related Issue (required)

close: #1778

## Testing

- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
- [x] `mise run test`
- [x] `mise run build:docsite`
- [x] `mise run build:frontend`
- [x] `mise run build:rust:release`
- [x] `mise run package:docsite`
- [x] `mise run package:cli`
- [x] `mise run package:helm`
- [x] `deno run -A tools/artifacts.ts verify-docsite`
- [x] `deno run -A tools/artifacts.ts verify-cli`
- [x] `deno run -A tools/artifacts.ts verify-helm`
- [ ] `mise run build:image` (`Docker Desktop is unable to start` locally)
- [ ] `mise run package`
- [ ] `mise run verify`
- [ ] `mise run test:e2e:smoke`
