### PR TITLE
Cache CI work and publish verified artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,16 @@
 target
 spaces
 wt
+
+# The runtime-prebuilt target consumes only canonical release outputs.
+!frontend/.output/
+!frontend/.output/public/
+!frontend/.output/public/**
+!target/
+target/*
+!target/rust/
+target/rust/*
+!target/rust/release/
+target/rust/release/*
+!target/rust/release/ugoite
+!target/rust/release/ugoite-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   required:
     name: ci-required
@@ -151,6 +155,7 @@ jobs:
       - name: Build runtime image
         id: build-image
         env:
+          UGOITE_IMAGE_PREBUILT: "true"
           UGOITE_IMAGE_USE_BUILDX: "true"
           UGOITE_IMAGE_CACHE_FROM: ${{ steps.ci-config.outputs.docker_cache_from }}
           UGOITE_IMAGE_CACHE_TO: ${{ steps.ci-config.outputs.docker_cache_to }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,29 +18,377 @@ jobs:
   required:
     name: ci-required
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 75
+    env:
+      UGOITE_IMAGE_TAG: ugoite:e2e
+      UGOITE_IMAGE_PLATFORM: linux/amd64
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
+      - name: Record workflow start
+        id: workflow-start
+        run: |
+          echo "epoch=$(date +%s)" >>"$GITHUB_OUTPUT"
+          echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >>"$GITHUB_ENV"
 
       - name: Free runner disk space
         run: |
           sudo rm -rf /opt/ghc /usr/local/.ghcup /usr/local/lib/android /usr/share/dotnet
           sudo docker system prune --all --force
           df -h
+
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
           cache: true
 
       - name: Install Rust CI components
-        run: rustup component add rustfmt clippy && rustup target add wasm32-unknown-unknown
+        run: |
+          rustup component add rustfmt clippy
+          rustup target add wasm32-unknown-unknown
+          rustc --version --verbose
+          cargo clippy -V
+          rustfmt --version
+          rustup target list --installed
 
-      - name: Run pull request gate
-        if: github.event_name == 'pull_request'
-        run: mise run ci
+      - name: Resolve Deno version
+        id: deno-version
+        run: echo "version=$(deno --version | awk 'NR==1 { print $2 }')" >>"$GITHUB_OUTPUT"
 
-      - name: Run merge gate
-        if: github.event_name == 'merge_group' || github.event_name == 'push'
-        run: mise run ci:merge
+      - name: Restore Rust cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: ". -> target/rust"
+          cache-bin: "false"
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Restore Deno cache
+        id: deno-cache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/deno-cache
+          key: deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Resolve production Pages metadata
+        id: pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Resolve CI build configuration
+        id: ci-config
+        env:
+          PAGE_ORIGIN: ${{ steps.pages.outputs.origin }}
+          PAGE_BASE_PATH: ${{ steps.pages.outputs.base_path }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            docsite_origin="${PAGE_ORIGIN}"
+            if [[ -n "${PAGE_BASE_PATH}" ]]; then
+              docsite_base="${PAGE_BASE_PATH%/}/"
+            else
+              docsite_base="/"
+            fi
+            cache_save_allowed="true"
+            docker_cache_to="type=gha,scope=ugoite-runtime,mode=min"
+          else
+            docsite_origin="https://example.invalid"
+            docsite_base="/"
+            cache_save_allowed="false"
+            docker_cache_to=""
+          fi
+
+          {
+            echo "docsite_origin=${docsite_origin}"
+            echo "docsite_base=${docsite_base}"
+            echo "cache_save_allowed=${cache_save_allowed}"
+            echo "docker_cache_scope=ugoite-runtime"
+            echo "docker_cache_mode=min"
+            echo "docker_cache_from=type=gha,scope=ugoite-runtime"
+            echo "docker_cache_to=${docker_cache_to}"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Prepare artifact staging
+        run: rm -rf target/artifacts && mkdir -p target/artifacts
+
+      - name: Formatting check
+        id: fmt-check
+        run: scripts/measure-step.sh fmt-check mise run fmt:check
+
+      - name: Lint
+        id: lint
+        run: scripts/measure-step.sh lint mise run lint
+
+      - name: Source checks
+        id: check
+        run: scripts/measure-step.sh check mise run check
+
+      - name: Build WASM release
+        id: build-wasm
+        run: scripts/measure-step.sh build-wasm mise run build:wasm:release
+
+      - name: Build frontend
+        id: build-frontend
+        run: scripts/measure-step.sh build-frontend mise run build:frontend
+
+      - name: Build docsite
+        id: build-docsite
+        env:
+          DOCSITE_ORIGIN: ${{ steps.ci-config.outputs.docsite_origin }}
+          DOCSITE_BASE: ${{ steps.ci-config.outputs.docsite_base }}
+        run: scripts/measure-step.sh build-docsite mise run build:docsite
+
+      - name: Build Rust release binaries
+        id: build-rust
+        run: scripts/measure-step.sh build-rust mise run build:rust:release
+
+      - name: Build runtime image
+        id: build-image
+        env:
+          UGOITE_IMAGE_USE_BUILDX: "true"
+          UGOITE_IMAGE_CACHE_FROM: ${{ steps.ci-config.outputs.docker_cache_from }}
+          UGOITE_IMAGE_CACHE_TO: ${{ steps.ci-config.outputs.docker_cache_to }}
+        run: scripts/measure-step.sh build-image mise run build:image
+
+      - name: Package docsite artifact
+        id: package-docsite
+        env:
+          DOCSITE_ORIGIN: ${{ steps.ci-config.outputs.docsite_origin }}
+          DOCSITE_BASE: ${{ steps.ci-config.outputs.docsite_base }}
+        run: scripts/measure-step.sh package-docsite mise run package:docsite
+
+      - name: Package CLI artifact
+        id: package-cli
+        run: scripts/measure-step.sh package-cli mise run package:cli
+
+      - name: Package Helm artifact
+        id: package-helm
+        run: scripts/measure-step.sh package-helm mise run package:helm
+
+      - name: Rust tests
+        id: test-rust
+        run: scripts/measure-step.sh test-rust mise run test:rust
+
+      - name: Tool tests
+        id: test-tools
+        run: scripts/measure-step.sh test-tools mise run test:tools
+
+      - name: Frontend tests
+        id: test-frontend
+        run: scripts/measure-step.sh test-frontend mise run test:frontend
+
+      - name: Docsite tests
+        id: test-docsite
+        run: scripts/measure-step.sh test-docsite mise run test:docsite
+
+      - name: E2E smoke
+        id: test-e2e
+        run: scripts/measure-step.sh test-e2e mise run test:e2e:smoke
+
+      - name: Package runtime image artifact
+        id: package-image
+        run: scripts/measure-step.sh package-image mise run package:image
+
+      - name: Write artifact manifest
+        id: package-manifest
+        env:
+          DOCSITE_ORIGIN: ${{ steps.ci-config.outputs.docsite_origin }}
+          DOCSITE_BASE: ${{ steps.ci-config.outputs.docsite_base }}
+          UGOITE_CI_RUN_ID: ${{ github.run_id }}
+        run: scripts/measure-step.sh package-manifest mise run package:manifest
+
+      - name: Verify docsite artifact
+        id: verify-docsite
+        run: scripts/measure-step.sh verify-docsite mise run verify:docsite
+
+      - name: Verify CLI artifact
+        id: verify-cli
+        run: scripts/measure-step.sh verify-cli mise run verify:cli
+
+      - name: Verify Helm artifact
+        id: verify-helm
+        run: scripts/measure-step.sh verify-helm mise run verify:helm
+
+      - name: Verify image artifact
+        id: verify-image
+        run: scripts/measure-step.sh verify-image mise run verify:image
+
+      - name: Upload docsite artifact
+        id: upload-docsite
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ugoite-docsite-pages
+          path: target/artifacts/docsite/site
+          if-no-files-found: error
+
+      - name: Upload runtime image artifact
+        id: upload-image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ugoite-runtime-image
+          path: target/artifacts/image/ugoite-e2e-docker.tar.gz
+          if-no-files-found: error
+          compression-level: 0
+
+      - name: Upload CLI artifact
+        id: upload-cli
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ugoite-cli-linux
+          path: target/artifacts/cli/ugoite-cli-linux-x86_64.tar.gz
+          if-no-files-found: error
+          compression-level: 0
+
+      - name: Upload Helm artifact
+        id: upload-helm
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ugoite-helm-chart
+          path: target/artifacts/helm/ugoite-0.0.1.tgz
+          if-no-files-found: error
+          compression-level: 0
+
+      - name: Upload artifact manifest
+        id: upload-manifest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ugoite-artifact-manifest
+          path: |
+            target/artifacts/manifest.json
+            target/artifacts/SHA256SUMS
+          if-no-files-found: error
+          compression-level: 0
+
+      - name: Save Deno cache
+        id: deno-cache-save
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/deno-cache
+          key: ${{ steps.deno-cache-restore.outputs.cache-primary-key }}
+
+      - name: Summarize CI cache and artifact state
+        if: always()
+        env:
+          DOCSITE_ORIGIN: ${{ steps.ci-config.outputs.docsite_origin }}
+          DOCSITE_BASE: ${{ steps.ci-config.outputs.docsite_base }}
+          CACHE_SAVE_ALLOWED: ${{ steps.ci-config.outputs.cache_save_allowed }}
+          DOCKER_CACHE_SCOPE: ${{ steps.ci-config.outputs.docker_cache_scope }}
+          DOCKER_CACHE_MODE: ${{ steps.ci-config.outputs.docker_cache_mode }}
+          DOCKER_CACHE_FROM: ${{ steps.ci-config.outputs.docker_cache_from }}
+          DOCKER_CACHE_TO: ${{ steps.ci-config.outputs.docker_cache_to }}
+          RUST_CACHE_HIT: ${{ steps.rust-cache.outputs.cache-hit }}
+          DENO_CACHE_HIT: ${{ steps.deno-cache-restore.outputs.cache-hit }}
+          DENO_CACHE_PRIMARY_KEY: ${{ steps.deno-cache-restore.outputs.cache-primary-key }}
+          DENO_CACHE_MATCHED_KEY: ${{ steps.deno-cache-restore.outputs.cache-matched-key }}
+          DOCSITE_ARTIFACT_DIGEST: ${{ steps.upload-docsite.outputs.artifact-digest }}
+          IMAGE_ARTIFACT_DIGEST: ${{ steps.upload-image.outputs.artifact-digest }}
+          CLI_ARTIFACT_DIGEST: ${{ steps.upload-cli.outputs.artifact-digest }}
+          HELM_ARTIFACT_DIGEST: ${{ steps.upload-helm.outputs.artifact-digest }}
+          MANIFEST_ARTIFACT_DIGEST: ${{ steps.upload-manifest.outputs.artifact-digest }}
+          WORKFLOW_START_EPOCH: ${{ steps.workflow-start.outputs.epoch }}
+          DENO_DIR_PATH: ${{ runner.temp }}/deno-cache
+        run: |
+          deno_cache_fallback="false"
+          if [[ -n "${DENO_CACHE_MATCHED_KEY}" && "${DENO_CACHE_MATCHED_KEY}" != "${DENO_CACHE_PRIMARY_KEY}" ]]; then
+            deno_cache_fallback="true"
+          fi
+
+          total_duration_seconds="n/a"
+          if [[ -n "${WORKFLOW_START_EPOCH}" ]]; then
+            total_duration_seconds="$(( $(date +%s) - WORKFLOW_START_EPOCH ))"
+          fi
+
+          artifact_size_bytes="0"
+          if [[ -d target/artifacts ]]; then
+            artifact_size_bytes="$(du -sk target/artifacts | awk '{print $1 * 1024}')"
+          fi
+
+          deno_cache_size_bytes="0"
+          if [[ -d "${DENO_DIR_PATH}" ]]; then
+            deno_cache_size_bytes="$(du -sk "${DENO_DIR_PATH}" | awk '{print $1 * 1024}')"
+          fi
+
+          rust_target_size_bytes="0"
+          if [[ -d target/rust ]]; then
+            rust_target_size_bytes="$(du -sk target/rust | awk '{print $1 * 1024}')"
+          fi
+
+          buildx_cache_size_bytes="n/a"
+
+          {
+            echo "## CI Summary"
+            echo
+            echo "- Event: \`${GITHUB_EVENT_NAME}\`"
+            echo "- Ref: \`${GITHUB_REF}\`"
+            echo "- Source SHA: \`${GITHUB_SHA}\`"
+            echo "- Rust cache exact hit: \`${RUST_CACHE_HIT:-}\`"
+            echo "- Rust cache fallback restore: \`n/a (rust-cache exposes exact-hit only)\`"
+            echo "- Deno cache exact hit: \`${DENO_CACHE_HIT:-}\`"
+            echo "- Deno cache fallback restore: \`${deno_cache_fallback}\`"
+            echo "- Saving shared caches allowed: \`${CACHE_SAVE_ALLOWED}\`"
+            echo "- Docker cache scope: \`${DOCKER_CACHE_SCOPE}\`"
+            echo "- Docker cache export mode: \`${DOCKER_CACHE_MODE}\`"
+            echo "- DOCSITE_ORIGIN: \`${DOCSITE_ORIGIN}\`"
+            echo "- DOCSITE_BASE: \`${DOCSITE_BASE}\`"
+            echo
+            echo "### Timings"
+            echo
+            echo "- fmt:check: ${{ steps.fmt-check.outputs.duration_seconds }}s"
+            echo "- lint: ${{ steps.lint.outputs.duration_seconds }}s"
+            echo "- check: ${{ steps.check.outputs.duration_seconds }}s"
+            echo "- build:wasm:release: ${{ steps.build-wasm.outputs.duration_seconds }}s"
+            echo "- build:frontend: ${{ steps.build-frontend.outputs.duration_seconds }}s"
+            echo "- build:docsite: ${{ steps.build-docsite.outputs.duration_seconds }}s"
+            echo "- build:rust:release: ${{ steps.build-rust.outputs.duration_seconds }}s"
+            echo "- build:image: ${{ steps.build-image.outputs.duration_seconds }}s"
+            echo "- test:rust: ${{ steps.test-rust.outputs.duration_seconds }}s"
+            echo "- test:tools: ${{ steps.test-tools.outputs.duration_seconds }}s"
+            echo "- test:frontend: ${{ steps.test-frontend.outputs.duration_seconds }}s"
+            echo "- test:docsite: ${{ steps.test-docsite.outputs.duration_seconds }}s"
+            echo "- test:e2e:smoke: ${{ steps.test-e2e.outputs.duration_seconds }}s"
+            echo "- package:docsite: ${{ steps.package-docsite.outputs.duration_seconds }}s"
+            echo "- package:cli: ${{ steps.package-cli.outputs.duration_seconds }}s"
+            echo "- package:helm: ${{ steps.package-helm.outputs.duration_seconds }}s"
+            echo "- package:image: ${{ steps.package-image.outputs.duration_seconds }}s"
+            echo "- package:manifest: ${{ steps.package-manifest.outputs.duration_seconds }}s"
+            echo "- verify:docsite: ${{ steps.verify-docsite.outputs.duration_seconds }}s"
+            echo "- verify:cli: ${{ steps.verify-cli.outputs.duration_seconds }}s"
+            echo "- verify:helm: ${{ steps.verify-helm.outputs.duration_seconds }}s"
+            echo "- verify:image: ${{ steps.verify-image.outputs.duration_seconds }}s"
+            echo "- total workflow duration: ${total_duration_seconds}s"
+            echo
+            echo "### Artifact Digests"
+            echo
+            echo "- ugoite-docsite-pages: \`${DOCSITE_ARTIFACT_DIGEST:-not-uploaded}\`"
+            echo "- ugoite-runtime-image: \`${IMAGE_ARTIFACT_DIGEST:-not-uploaded}\`"
+            echo "- ugoite-cli-linux: \`${CLI_ARTIFACT_DIGEST:-not-uploaded}\`"
+            echo "- ugoite-helm-chart: \`${HELM_ARTIFACT_DIGEST:-not-uploaded}\`"
+            echo "- ugoite-artifact-manifest: \`${MANIFEST_ARTIFACT_DIGEST:-not-uploaded}\`"
+            echo
+            echo "### Packaged Checksums"
+            echo
+            if [[ -f target/artifacts/SHA256SUMS ]]; then
+              cat target/artifacts/SHA256SUMS
+            else
+              echo "_SHA256SUMS not available_"
+            fi
+            echo
+            echo "### Cache and Artifact Sizes"
+            echo
+            echo "- target/rust: \`${rust_target_size_bytes}\` bytes"
+            echo "- DENO_DIR: \`${deno_cache_size_bytes}\` bytes"
+            echo "- BuildKit cache: \`${buildx_cache_size_bytes}\`"
+            echo "- target/artifacts: \`${artifact_size_bytes}\` bytes"
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY vendor ./vendor
 RUN cargo build -p ugoite-server --release --locked
 RUN cargo build -p ugoite-cli --release --locked
 
-FROM debian:bookworm-slim AS runtime
+FROM ubuntu:24.04 AS runtime-base
 WORKDIR /app
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates \
@@ -40,12 +40,22 @@ RUN apt-get update \
   && useradd --system --create-home --home-dir /nonexistent --shell /usr/sbin/nologin ugoite \
   && mkdir -p /data /app/static \
   && chown -R ugoite:ugoite /data /app
-COPY --from=rust-build /repo/target/release/ugoite-server /usr/local/bin/ugoite-server
-COPY --from=rust-build /repo/target/release/ugoite /usr/local/bin/ugoite
-COPY --from=frontend-build /repo/frontend/.output/public /app/static
 ENV UGOITE_STATIC_DIR=/app/static
 ENV UGOITE_ROOT=/data
 ENV UGOITE_SERVER_ADDRESS=0.0.0.0:8000
 EXPOSE 8000
 USER ugoite
 ENTRYPOINT ["ugoite-server"]
+
+FROM runtime-base AS runtime-source
+COPY --from=rust-build /repo/target/release/ugoite-server /usr/local/bin/ugoite-server
+COPY --from=rust-build /repo/target/release/ugoite /usr/local/bin/ugoite
+COPY --from=frontend-build /repo/frontend/.output/public /app/static
+
+FROM runtime-base AS runtime-prebuilt
+COPY target/rust/release/ugoite-server /usr/local/bin/ugoite-server
+COPY target/rust/release/ugoite /usr/local/bin/ugoite
+COPY frontend/.output/public /app/static
+
+# Keep the portable source-build image as the default Dockerfile target.
+FROM runtime-source AS runtime

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ mise run verify
 mise run e2e:smoke
 ```
 
-CI mappings:
+Local CI-parity entrypoints:
 
-- pull requests: `mise run ci`
-- merge queue and pushes to `main`: `mise run ci:merge`
-- local release candidate validation: `mise run ci:release`
+- `mise run ci`: formatting, lint, source checks, and non-E2E tests
+- `mise run ci:merge`: `ci`, canonical build/package/verify tasks, and E2E smoke
+- `mise run ci:release`: `ci:merge` plus the full E2E suite
 
 Tasks are defined at the repository root; package-scoped `mise run //...` commands are not supported. `build:*` tasks may be skipped locally when declared outputs are newer than their inputs, but test tasks remain authoritative and are never satisfied by cached success markers.
 

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -22,6 +22,8 @@ Root task composition:
 
 Hosted CI restores Rust, Deno, and BuildKit caches on every event. Shared project caches are refreshed only after successful pushes to `main`. Successful `main` runs also upload the verified artifact set using the logical names `ugoite-docsite-pages`, `ugoite-runtime-image`, `ugoite-cli-linux`, `ugoite-helm-chart`, and `ugoite-artifact-manifest`.
 
+The hosted runtime image uses Dockerfile's `runtime-prebuilt` target. It copies the canonical frontend and Rust release outputs into the image instead of compiling them again inside Docker. E2E tasks require the already loaded `ugoite:e2e` image and never invoke an image build. The default Dockerfile target remains a portable source build for direct Docker and Compose use.
+
 Deployable artifacts are staged below `target/artifacts/` with a machine-readable `manifest.json` and `SHA256SUMS`. This layout is for promotion by later workflows; deployment workflows must not compile source code again.
 
 Build reuse and test-result caching are different concepts. `sources`/`outputs` may skip deterministic `build:*` work when inputs are unchanged, but they are never evidence that a test passed.

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -4,10 +4,11 @@ title: 'CI and release gates'
 
 The required build/test gate is `.github/workflows/ci.yml`. Separate workflows run CodeQL and validate required pull-request body sections/issue links.
 
-| Event | Command |
+| Event | Hosted CI behavior |
 |---|---|
-| pull request to `main` | `mise run ci` |
-| merge queue or push to `main` | `mise run ci:merge` |
+| pull request to `main` | validation, canonical build/package steps, artifact verification, and E2E smoke |
+| merge queue to `main` | same merge gate as pull requests against the queued head |
+| push to `main` | merge gate plus shared-cache refresh and verified artifact upload |
 
 Root task composition:
 
@@ -18,6 +19,8 @@ Root task composition:
 - `ci`: formatting check, lint, architecture/OpenAPI/type checks, and non-E2E tests;
 - `ci:merge`: `ci`, build/package/verify, and E2E smoke;
 - `ci:release`: `ci:merge` plus the full E2E suite.
+
+Hosted CI restores Rust, Deno, and BuildKit caches on every event. Shared project caches are refreshed only after successful pushes to `main`. Successful `main` runs also upload the verified artifact set using the logical names `ugoite-docsite-pages`, `ugoite-runtime-image`, `ugoite-cli-linux`, `ugoite-helm-chart`, and `ugoite-artifact-manifest`.
 
 Deployable artifacts are staged below `target/artifacts/` with a machine-readable `manifest.json` and `SHA256SUMS`. This layout is for promotion by later workflows; deployment workflows must not compile source code again.
 

--- a/mise.toml
+++ b/mise.toml
@@ -161,7 +161,24 @@ run = [
 
 [tasks."build:image"]
 description = "Build the runtime image once for E2E and packaging"
-run = "docker build --tag ${UGOITE_IMAGE_TAG:-ugoite:e2e} ."
+run = """bash -lc 'set -euo pipefail
+tag="${UGOITE_IMAGE_TAG:-ugoite:e2e}"
+if [[ "${UGOITE_IMAGE_USE_BUILDX:-false}" == "true" || -n "${UGOITE_IMAGE_CACHE_FROM:-}" || -n "${UGOITE_IMAGE_CACHE_TO:-}" ]]; then
+  cmd=(docker buildx build --tag "$tag" --load)
+  if [[ -n "${UGOITE_IMAGE_PLATFORM:-}" ]]; then
+    cmd+=(--platform "${UGOITE_IMAGE_PLATFORM}")
+  fi
+  if [[ -n "${UGOITE_IMAGE_CACHE_FROM:-}" ]]; then
+    cmd+=(--cache-from "${UGOITE_IMAGE_CACHE_FROM}")
+  fi
+  if [[ -n "${UGOITE_IMAGE_CACHE_TO:-}" ]]; then
+    cmd+=(--cache-to "${UGOITE_IMAGE_CACHE_TO}")
+  fi
+  cmd+=(.)
+  "${cmd[@]}"
+else
+  docker build --tag "$tag" .
+fi'"""
 
 [tasks.build]
 description = "Build all reusable release-facing outputs"
@@ -239,12 +256,16 @@ run = "mkdir -p target/artifacts/helm && helm package charts/ugoite --destinatio
 description = "Export the built runtime image under target/artifacts"
 run = "bash -lc 'set -euo pipefail; mkdir -p target/artifacts/image; tmp=target/artifacts/image/ugoite-e2e-docker.tar.gz.tmp; final=target/artifacts/image/ugoite-e2e-docker.tar.gz; rm -f \"$tmp\" \"$final\"; cleanup(){ rm -f \"$tmp\"; }; trap cleanup EXIT; docker save ${UGOITE_IMAGE_TAG:-ugoite:e2e} | gzip -c > \"$tmp\"; mv \"$tmp\" \"$final\"; trap - EXIT'"
 
+[tasks."package:manifest"]
+description = "Write the artifact manifest and checksums under target/artifacts"
+run = "deno run -A tools/artifacts.ts write-manifest"
+
 [tasks.package]
 description = "Package deployable outputs without rebuilding them"
 run = [
   "rm -rf target/artifacts && mkdir -p target/artifacts",
   { tasks = ["package:docsite", "package:cli", "package:helm", "package:image"] },
-  "deno run -A tools/artifacts.ts write-manifest",
+  { task = "package:manifest" },
 ]
 
 [tasks."verify:docsite"]

--- a/mise.toml
+++ b/mise.toml
@@ -127,15 +127,13 @@ sources = [
   "target/build-metadata/docsite-inputs.txt",
 ]
 outputs = ["docsite/dist/index.html"]
-env = { DOCSITE_ORIGIN = "http://localhost:4321", DOCSITE_BASE = "/" }
-run = "deno task docsite:build"
+run = "DOCSITE_ORIGIN=\"${DOCSITE_ORIGIN:-http://localhost:4321}\" DOCSITE_BASE=\"${DOCSITE_BASE:-/}\" deno task docsite:build"
 
 [tasks."prepare:docsite:inputs"]
 description = "Record docsite build identity inputs"
-env = { DOCSITE_ORIGIN = "http://localhost:4321", DOCSITE_BASE = "/" }
 run = [
   "mkdir -p target/build-metadata",
-  "tmpfile=\"$(mktemp)\" && printf 'DOCSITE_ORIGIN=%s\\nDOCSITE_BASE=%s\\n' \"$DOCSITE_ORIGIN\" \"$DOCSITE_BASE\" > \"$tmpfile\" && if ! cmp -s \"$tmpfile\" target/build-metadata/docsite-inputs.txt 2>/dev/null; then mv \"$tmpfile\" target/build-metadata/docsite-inputs.txt; else rm -f \"$tmpfile\"; fi",
+  "tmpfile=\"$(mktemp)\" && printf 'DOCSITE_ORIGIN=%s\\nDOCSITE_BASE=%s\\n' \"${DOCSITE_ORIGIN:-http://localhost:4321}\" \"${DOCSITE_BASE:-/}\" > \"$tmpfile\" && if ! cmp -s \"$tmpfile\" target/build-metadata/docsite-inputs.txt 2>/dev/null; then mv \"$tmpfile\" target/build-metadata/docsite-inputs.txt; else rm -f \"$tmpfile\"; fi",
 ]
 
 [tasks."build:rust:release"]

--- a/mise.toml
+++ b/mise.toml
@@ -105,7 +105,8 @@ sources = [
 outputs = ["frontend/.output/public/index.html"]
 run = [
   "bash scripts/activate-ugoite-wasm.sh release",
-  "deno task frontend:build",
+  "UGOITE_STATIC_SPA=true deno task frontend:build",
+  "deno run -A frontend/scripts/generate-static-index.ts frontend/.output/public/_build/.vite/manifest.json frontend/.output/public/index.html",
 ]
 
 [tasks."build:docsite"]
@@ -163,8 +164,15 @@ run = [
 description = "Build the runtime image once for E2E and packaging"
 run = """bash -lc 'set -euo pipefail
 tag="${UGOITE_IMAGE_TAG:-ugoite:e2e}"
+target_args=()
+if [[ "${UGOITE_IMAGE_PREBUILT:-false}" == "true" ]]; then
+  test -x target/rust/release/ugoite
+  test -x target/rust/release/ugoite-server
+  test -s frontend/.output/public/index.html
+  target_args=(--target runtime-prebuilt)
+fi
 if [[ "${UGOITE_IMAGE_USE_BUILDX:-false}" == "true" || -n "${UGOITE_IMAGE_CACHE_FROM:-}" || -n "${UGOITE_IMAGE_CACHE_TO:-}" ]]; then
-  cmd=(docker buildx build --tag "$tag" --load)
+  cmd=(docker buildx build --tag "$tag" --load "${target_args[@]}")
   if [[ -n "${UGOITE_IMAGE_PLATFORM:-}" ]]; then
     cmd+=(--platform "${UGOITE_IMAGE_PLATFORM}")
   fi
@@ -177,14 +185,14 @@ if [[ "${UGOITE_IMAGE_USE_BUILDX:-false}" == "true" || -n "${UGOITE_IMAGE_CACHE_
   cmd+=(.)
   "${cmd[@]}"
 else
-  docker build --tag "$tag" .
+  docker build --tag "$tag" "${target_args[@]}" .
 fi'"""
 
 [tasks.build]
 description = "Build all reusable release-facing outputs"
 run = [
   { tasks = ["build:frontend", "build:docsite", "build:rust:release"] },
-  { task = "build:image" },
+  { task = "build:image", env = { UGOITE_IMAGE_PREBUILT = "true" } },
 ]
 
 [tasks.check]
@@ -219,12 +227,10 @@ run = "deno task docsite:test"
 run = [{ tasks = ["test:rust", "test:tools", "test:frontend", "test:docsite"] }]
 
 [tasks."test:e2e"]
-depends = ["build:image"]
-run = "E2E_BUILD_IMAGES=false deno task e2e:full"
+run = "docker image inspect \"${UGOITE_IMAGE_TAG:-ugoite:e2e}\" >/dev/null && E2E_BUILD_IMAGES=false deno task e2e:full"
 
 [tasks."test:e2e:smoke"]
-depends = ["build:image"]
-run = "E2E_BUILD_IMAGES=false deno task e2e:smoke"
+run = "docker image inspect \"${UGOITE_IMAGE_TAG:-ugoite:e2e}\" >/dev/null && E2E_BUILD_IMAGES=false deno task e2e:smoke"
 
 [tasks.e2e]
 description = "Run CI-parity E2E tests, preferring Docker Compose and falling back to host processes"

--- a/scripts/measure-step.sh
+++ b/scripts/measure-step.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <label> <command> [args...]" >&2
+  exit 1
+fi
+
+label="$1"
+shift
+
+start_epoch="$(date +%s)"
+"$@"
+end_epoch="$(date +%s)"
+duration_seconds="$((end_epoch - start_epoch))"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  printf 'duration_seconds=%s\n' "$duration_seconds" >>"$GITHUB_OUTPUT"
+fi
+
+printf '%s completed in %ss\n' "$label" "$duration_seconds"

--- a/tools/artifacts.ts
+++ b/tools/artifacts.ts
@@ -30,6 +30,7 @@ type ManifestArtifact = {
 type ArtifactManifest = {
   schema_version: 1;
   source_sha: string | null;
+  ci_run_id: string | null;
   contract_version: 1;
   generated_at: string;
   artifacts: ManifestArtifact[];
@@ -80,6 +81,9 @@ async function writeManifest(): Promise<void> {
     source_sha: Deno.env.get("UGOITE_SOURCE_SHA") ??
       Deno.env.get("GITHUB_SHA") ??
       null,
+    ci_run_id: Deno.env.get("UGOITE_CI_RUN_ID") ??
+      Deno.env.get("GITHUB_RUN_ID") ??
+      null,
     contract_version: 1,
     generated_at: new Date().toISOString(),
     artifacts: [
@@ -122,9 +126,7 @@ async function writeManifest(): Promise<void> {
         build_profile: "release",
         path: "image",
         files: await collectFiles(imagePackageDir),
-        config: {
-          tag: Deno.env.get("UGOITE_IMAGE_TAG") ?? "ugoite:e2e",
-        },
+        config: await imageConfig(),
       },
     ],
   };
@@ -375,6 +377,30 @@ async function chartVersion(): Promise<string> {
     throw new Error("chart version was not found in charts/ugoite/Chart.yaml");
   }
   return match[1].trim().replace(/^"|"$/g, "");
+}
+
+async function imageConfig(): Promise<Record<string, string>> {
+  const tag = Deno.env.get("UGOITE_IMAGE_TAG") ?? "ugoite:e2e";
+  const config: Record<string, string> = {
+    tag,
+    platform: Deno.env.get("UGOITE_IMAGE_PLATFORM") ?? "linux/amd64",
+  };
+  try {
+    const inspect = await run("docker", [
+      "image",
+      "inspect",
+      tag,
+      "--format",
+      '{{.Id}}|{{join .RepoDigests ","}}',
+    ]);
+    const [imageId, repoDigests] = inspect.stdout.split("|", 2);
+    if (imageId) config.image_id = imageId;
+    if (repoDigests) config.repo_digests = repoDigests;
+  } catch {
+    // Packaging may be inspected outside CI; keep the manifest usable even if the
+    // local daemon is unavailable.
+  }
+  return config;
 }
 
 async function run(

--- a/tools/workspace_test.ts
+++ b/tools/workspace_test.ts
@@ -156,4 +156,14 @@ Deno.test("CI image and E2E tasks preserve the build-once contract", async () =>
     rootMise.match(/docker image inspect/g)?.length,
     2,
   );
+  assertEquals(
+    rootMise.includes(
+      'env = { DOCSITE_ORIGIN = "http://localhost:4321", DOCSITE_BASE = "/" }',
+    ),
+    false,
+  );
+  assertEquals(
+    rootMise.includes("${DOCSITE_ORIGIN:-http://localhost:4321}"),
+    true,
+  );
 });

--- a/tools/workspace_test.ts
+++ b/tools/workspace_test.ts
@@ -127,3 +127,33 @@ Deno.test("release path does not reference removed runtimes", async () => {
     }
   }
 });
+
+Deno.test("CI image and E2E tasks preserve the build-once contract", async () => {
+  const rootMise = await Deno.readTextFile("mise.toml");
+  const workflow = await Deno.readTextFile(".github/workflows/ci.yml");
+
+  assertEquals(
+    workflow.includes('UGOITE_IMAGE_PREBUILT: "true"'),
+    true,
+  );
+  assertEquals(
+    workflow.includes("cancel-in-progress: true"),
+    true,
+  );
+  assertEquals(
+    rootMise.includes(
+      '[tasks."test:e2e"]\ndepends = ["build:image"]',
+    ),
+    false,
+  );
+  assertEquals(
+    rootMise.includes(
+      '[tasks."test:e2e:smoke"]\ndepends = ["build:image"]',
+    ),
+    false,
+  );
+  assertEquals(
+    rootMise.match(/docker image inspect/g)?.length,
+    2,
+  );
+});


### PR DESCRIPTION
## Summary

- restore Rust, Deno, and BuildKit cache inputs in `.github/workflows/ci.yml` while keeping `ci-required` as the single required job
- build, test, package, verify, and upload the canonical artifact set from the root `mise` task surface without reintroducing hidden package-level orchestration
- record artifact metadata and CI timings in the manifest/summary so successful `main` runs leave behind one verified artifact set per commit

## Related Issue (required)

close: #1779

## Testing

- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- [x] `bash -n scripts/measure-step.sh`
- [x] `deno check tools/artifacts.ts`
- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
- [x] `mise run test:tools`
- [ ] hosted GitHub Actions validation for `.github/workflows/ci.yml`
