### PR TITLE
[Release]: Fix Docsite Pages run resolver authentication

### DIFF
--- a/.github/workflows/docsite-pages.yml
+++ b/.github/workflows/docsite-pages.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Resolve trusted CI run
         id: resolve-run
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           MANUAL_RUN_ID: ${{ inputs.ci_run_id }}
         run: |
           python3 - <<'PY'
@@ -46,7 +47,6 @@ jobs:
           repo = os.environ["GITHUB_REPOSITORY"]
           event_name = os.environ["GITHUB_EVENT_NAME"]
           event_path = os.environ["GITHUB_EVENT_PATH"]
-          token = os.environ["GITHUB_TOKEN"]
           output_path = os.environ["GITHUB_OUTPUT"]
 
           def fail(message: str) -> None:
@@ -85,6 +85,9 @@ jobs:
               run_id = os.environ.get("MANUAL_RUN_ID", "").strip()
               if not run_id:
                   fail("workflow_dispatch requires ci_run_id")
+              token = os.environ.get("GITHUB_TOKEN", "").strip()
+              if not token:
+                  fail("workflow_dispatch requires GITHUB_TOKEN")
               request = urllib.request.Request(
                   f"https://api.github.com/repos/{repo}/actions/runs/{run_id}",
                   headers={

--- a/tools/workspace_test.ts
+++ b/tools/workspace_test.ts
@@ -194,6 +194,8 @@ Deno.test("Pages promotion consumes trusted artifacts without rebuilding", async
       "id-token: write",
       "environment:",
       "name: github-pages",
+      "GITHUB_TOKEN: ${{ github.token }}",
+      'fail("workflow_dispatch requires GITHUB_TOKEN")',
     ]
   ) {
     assertEquals(workflow.includes(required), true, required);


### PR DESCRIPTION
## Summary

- export `GITHUB_TOKEN` into the `Resolve trusted CI run` step in `Docsite Pages`
- require the token only for `workflow_dispatch`, so trusted `workflow_run` promotion keeps working without an unnecessary env dependency
- add a workspace regression check for the token contract

## Related Issue (required)

close: #1784

## Testing

- [x] `mise run test:tools`
- [x] `mise run fmt:check`
- [x] `python3 - <<'PY'` YAML parse for `.github/workflows/docsite-pages.yml`
