### PR TITLE
Restore Starlight docsite navigation from docs SSOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,10 @@ jobs:
         id: test-docsite
         run: scripts/measure-step.sh test-docsite mise run test:docsite
 
+      - name: Docsite navigation E2E
+        id: test-docsite-navigation
+        run: scripts/measure-step.sh test-docsite-navigation mise run test:docsite:e2e:navigation
+
       - name: E2E smoke
         id: test-e2e
         run: scripts/measure-step.sh test-e2e mise run test:e2e:smoke

--- a/deno.json
+++ b/deno.json
@@ -16,6 +16,7 @@
     "docsite:dev": "deno task --cwd docsite dev",
     "docsite:build": "deno task --cwd docsite build",
     "docsite:test": "deno task --cwd docsite test",
+    "docsite:e2e:navigation": "deno task --cwd e2e docsite:navigation",
     "e2e:install:browsers": "deno task --cwd e2e install:browsers",
     "e2e:smoke": "bash e2e/scripts/run-e2e-parity.sh smoke",
     "e2e:full": "bash e2e/scripts/run-e2e-parity.sh full",

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 ---
 title: Ugoite
 description: A private, portable knowledge space you can run with Docker, automate from the CLI, and keep on infrastructure you control.
-template: splash
 hero:
   tagline: A private, portable knowledge space built around operator-owned files.
   actions:

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -6,7 +6,7 @@ The required build/test gate is `.github/workflows/ci.yml`. Separate workflows r
 
 | Event | Hosted CI behavior |
 |---|---|
-| pull request to `main` | validation, canonical build/package steps, artifact verification, and E2E smoke |
+| pull request to `main` | validation, canonical build/package steps, a focused docsite-navigation E2E lane, artifact verification, and E2E smoke |
 | merge queue to `main` | same merge gate as pull requests against the queued head |
 | push to `main` | merge gate plus shared-cache refresh and verified artifact upload |
 
@@ -17,12 +17,18 @@ Root task composition:
 - `package:*`: staging under `target/artifacts/` only; packaging must fail if required build outputs are absent;
 - `verify:*`: checks packaged outputs without rebuilding them;
 - `ci`: formatting check, lint, architecture/OpenAPI/type checks, and non-E2E tests;
-- `ci:merge`: `ci`, build/package/verify, and E2E smoke;
+- `ci:merge`: `ci`, build/package/verify, a focused docsite-navigation E2E lane, and E2E smoke;
 - `ci:release`: `ci:merge` plus the full E2E suite.
 
 Hosted CI restores Rust, Deno, and BuildKit caches on every event. Shared project caches are refreshed only after successful pushes to `main`. Successful `main` runs also upload the verified artifact set using the logical names `ugoite-docsite-pages`, `ugoite-runtime-image`, `ugoite-cli-linux`, `ugoite-helm-chart`, and `ugoite-artifact-manifest`.
 
 The hosted runtime image uses Dockerfile's `runtime-prebuilt` target. It copies the canonical frontend and Rust release outputs into the image instead of compiling them again inside Docker. E2E tasks require the already loaded `ugoite:e2e` image and never invoke an image build. The default Dockerfile target remains a portable source build for direct Docker and Compose use.
+
+The focused docsite-navigation lane is intentionally separate from smoke/full
+runtime E2E. It builds the docsite through the canonical `build:docsite`
+inputs, installs Playwright browsers explicitly for that lane, previews the
+static artifact, and verifies Starlight navigation semantics before the heavier
+runtime-backed smoke suite runs.
 
 Deployable artifacts are staged below `target/artifacts/` with a machine-readable `manifest.json` and `SHA256SUMS`. This layout is for promotion by later workflows; deployment workflows must not compile source code again.
 

--- a/docs/spec/testing/strategy.md
+++ b/docs/spec/testing/strategy.md
@@ -7,6 +7,9 @@ Tests are organized around the shared Rust core and thin adapters.
 - Rust unit/integration tests cover domain, storage, core, server, CLI, API protocol, and WASM.
 - Frontend/docsite/tool tests run through Deno and Vitest.
 - Playwright end-to-end tests exercise source/container parity.
+- A focused docsite-navigation Playwright lane validates the built Starlight
+  artifact, repository-level docs SSOT wiring, and GitHub Pages base-path
+  navigation without paying the full backend/runtime-image startup cost.
 - `xtask` checks OpenAPI drift, architectural dependency rules, and stale current-stack documentation.
 
 Requirement IDs embedded in test names/source provide traceability. A requirement without a current test reference is labeled `untraced`; deleted paths are not retained as evidence.

--- a/docsite/astro.config.mjs
+++ b/docsite/astro.config.mjs
@@ -1,6 +1,7 @@
 import { satteri } from "@astrojs/markdown-satteri";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import { docsSidebarDirectory, docsSourceDirectory } from "./src/docs-ssot.mjs";
 import satteriDocLinks from "./src/satteri-doc-links.mjs";
 
 const configuredBase = process.env.DOCSITE_BASE ?? "/";
@@ -37,17 +38,19 @@ export default defineConfig({
       markdown: {
         // `docs/` is intentionally outside Starlight's conventional collection
         // directory so the repository and the website share one source tree.
-        processedDirs: ["../docs"],
+        processedDirs: [docsSourceDirectory],
       },
       sidebar: [
         { slug: "index" },
         {
           label: "Guides",
-          items: [{ autogenerate: { directory: "docs/guide" } }],
+          items: [{ autogenerate: { directory: docsSidebarDirectory("guide") } }],
         },
         {
           label: "Architecture",
-          items: [{ autogenerate: { directory: "docs/architecture" } }],
+          items: [
+            { autogenerate: { directory: docsSidebarDirectory("architecture") } },
+          ],
         },
         {
           label: "Specification",
@@ -55,7 +58,7 @@ export default defineConfig({
           items: [
             {
               autogenerate: {
-                directory: "docs/spec",
+                directory: docsSidebarDirectory("spec"),
                 collapsed: true,
               },
             },

--- a/docsite/deno.json
+++ b/docsite/deno.json
@@ -2,6 +2,7 @@
   "tasks": {
     "dev": "deno run -A npm:astro@7.0.2 dev --host 127.0.0.1 --strictPort --port 4321",
     "build": "deno run -A npm:astro@7.0.2 build",
+    "preview:e2e": "deno run -A npm:astro@7.0.2 preview --host 127.0.0.1 --strictPort --port 4321",
     "check": "deno run -A npm:astro@7.0.2 check",
     "test": "deno run -A npm:vitest@4.1.8 run"
   },

--- a/docsite/src/content.config.ts
+++ b/docsite/src/content.config.ts
@@ -1,6 +1,7 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
+import { docsSourceDirectory } from "./docs-ssot.mjs";
 
 function documentationId(entry: string): string {
   const id = entry.replace(/\.mdx?$/, "");
@@ -10,7 +11,7 @@ function documentationId(entry: string): string {
 export const collections = {
   docs: defineCollection({
     loader: glob({
-      base: "../docs",
+      base: docsSourceDirectory,
       pattern: "**/*.{md,mdx}",
       generateId: ({ entry }) => documentationId(entry),
     }),

--- a/docsite/src/docs-ssot.mjs
+++ b/docsite/src/docs-ssot.mjs
@@ -1,0 +1,5 @@
+export const docsSourceDirectory = "../docs";
+
+export function docsSidebarDirectory(section) {
+  return `${docsSourceDirectory}/${section}`;
+}

--- a/docsite/src/ssot.test.ts
+++ b/docsite/src/ssot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { docsSidebarDirectory, docsSourceDirectory } from "./docs-ssot.mjs";
 import { rewriteDocLink } from "./satteri-doc-links.mjs";
 
 const repoRoot = path.resolve(process.cwd(), "..");
@@ -12,7 +13,8 @@ describe("documentation single source of truth", () => {
       path.join(process.cwd(), "src/content.config.ts"),
       "utf8",
     );
-    expect(config).toContain('base: "../docs"');
+    expect(config).toContain('import { docsSourceDirectory } from "./docs-ssot.mjs"');
+    expect(config).toContain("base: docsSourceDirectory");
     expect(config).toContain("docsSchema()");
   });
 
@@ -27,10 +29,23 @@ describe("documentation single source of truth", () => {
     expect(config).toContain(
       "processor: satteri({ mdastPlugins: [satteriDocLinks] })",
     );
-    expect(config).toContain('processedDirs: ["../docs"]');
+    expect(config).toContain(
+      'import { docsSidebarDirectory, docsSourceDirectory } from "./src/docs-ssot.mjs"',
+    );
+    expect(config).toContain("processedDirs: [docsSourceDirectory]");
+    expect(config).toContain('docsSidebarDirectory("guide")');
+    expect(config).toContain('docsSidebarDirectory("architecture")');
+    expect(config).toContain('docsSidebarDirectory("spec")');
     expect(config).not.toContain("@astrojs/markdown-remark");
     expect(config).not.toContain("GITHUB_ACTIONS");
     expect(config).not.toContain("http://localhost");
+  });
+
+  test("shared docs path helpers keep loader and sidebar namespaces aligned", () => {
+    expect(docsSourceDirectory).toBe("../docs");
+    expect(docsSidebarDirectory("guide")).toBe("../docs/guide");
+    expect(docsSidebarDirectory("architecture")).toBe("../docs/architecture");
+    expect(docsSidebarDirectory("spec")).toBe("../docs/spec");
   });
 
   test("docsite contains no hand-authored route tree", async () => {

--- a/e2e/deno.json
+++ b/e2e/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
     "install:browsers": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 install --with-deps chromium",
+    "docsite:navigation": "E2E_AUTH_BEARER_TOKEN=docsite-nav-token deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test docsite-mobile-nav.test.ts docsite-links.test.ts",
     "smoke": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test smoke.test.ts",
     "entries": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test entries.test.ts",
     "forms": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test forms.test.ts",

--- a/e2e/deno.json
+++ b/e2e/deno.json
@@ -1,7 +1,8 @@
 {
   "tasks": {
     "install:browsers": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 install --with-deps chromium",
-    "docsite:navigation": "E2E_AUTH_BEARER_TOKEN=docsite-nav-token deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test docsite-mobile-nav.test.ts docsite-links.test.ts",
+    "docsite:navigation:raw": "E2E_AUTH_BEARER_TOKEN=docsite-nav-token deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test docsite-mobile-nav.test.ts docsite-links.test.ts",
+    "docsite:navigation": "bash scripts/run-docsite-navigation.sh",
     "smoke": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test smoke.test.ts",
     "entries": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test entries.test.ts",
     "forms": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test forms.test.ts",

--- a/e2e/docsite-mobile-nav.test.ts
+++ b/e2e/docsite-mobile-nav.test.ts
@@ -1,10 +1,12 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import {
   type DocsiteServer,
   startDocsiteServer,
 } from "./support/docsite-server.ts";
 
 const docPath = "/docs/spec/";
+const editLinkDocPath = "/docs/guide/cli/";
+const homepagePath = "/";
 
 let docsiteServer: DocsiteServer | undefined;
 
@@ -23,23 +25,18 @@ test.describe("Docsite navigation layout", () => {
     await page.goto(buildDocsiteUrl(docPath), { waitUntil: "networkidle" });
 
     const menuButton = page.getByRole("button", { name: "Menu" });
-    const menuHost = page.locator("starlight-menu-button");
     const sidebar = page.locator("#starlight__sidebar");
 
     await expect(menuButton).toBeVisible();
-    await expect(menuHost).toHaveAttribute("aria-expanded", "false");
     await expect(sidebar).toBeHidden();
 
     await menuButton.click();
-    await expect(menuHost).toHaveAttribute("aria-expanded", "true");
     await expect(sidebar).toBeVisible();
     await expect(page.locator("body")).toHaveAttribute(
       "data-mobile-menu-expanded",
       "",
     );
-    await expect(
-      page.locator('#starlight__sidebar nav[aria-label="Main"]'),
-    ).toBeVisible();
+    await expectSidebarToContainLinks(page, { expectSpecificationLink: true });
   });
 
   test("REQ-E2E-005: the mobile menu closes with Escape", async ({ page }) => {
@@ -47,12 +44,12 @@ test.describe("Docsite navigation layout", () => {
     await page.goto(buildDocsiteUrl(docPath), { waitUntil: "networkidle" });
 
     const menuButton = page.getByRole("button", { name: "Menu" });
-    const menuHost = page.locator("starlight-menu-button");
+    const sidebar = page.locator("#starlight__sidebar");
     await menuButton.click();
-    await expect(menuHost).toHaveAttribute("aria-expanded", "true");
+    await expect(sidebar).toBeVisible();
 
     await menuButton.press("Escape");
-    await expect(menuHost).toHaveAttribute("aria-expanded", "false");
+    await expect(sidebar).toBeHidden();
     await expect(page.locator("body")).not.toHaveAttribute(
       "data-mobile-menu-expanded",
       /.+/,
@@ -65,8 +62,30 @@ test.describe("Docsite navigation layout", () => {
 
     await expect(page.getByRole("button", { name: "Menu" })).toBeHidden();
     await expect(page.locator("#starlight__sidebar")).toBeVisible();
-    await expect(page.locator('nav.sidebar[aria-label="Main"]')).toBeVisible();
     await expect(page.locator(".right-sidebar-container")).toBeVisible();
+    await expectSidebarToContainLinks(page, { expectSpecificationLink: true });
+
+    await page.goto(buildDocsiteUrl(editLinkDocPath), { waitUntil: "networkidle" });
+    await expect(
+      page.getByRole("link", { name: "Edit page" }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/ugoite/ugoite/edit/main/docs/guide/cli.md",
+    );
+  });
+
+  test("REQ-E2E-005: the homepage keeps the hero and Starlight navigation", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(buildDocsiteUrl(homepagePath), { waitUntil: "networkidle" });
+
+    await expect(page.getByText("A private, portable knowledge space")).toBeVisible();
+    await page.getByRole("button", { name: "Menu" }).click();
+    await expectSidebarToContainLinks(page, { expectSpecificationLink: false });
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(buildDocsiteUrl(homepagePath), { waitUntil: "networkidle" });
+    await expect(page.locator("#starlight__sidebar")).toBeVisible();
+    await expectSidebarToContainLinks(page, { expectSpecificationLink: false });
   });
 });
 
@@ -75,4 +94,29 @@ function buildDocsiteUrl(path: string): string {
     throw new Error("Docsite server is unavailable");
   }
   return docsiteServer.buildUrl(path);
+}
+
+async function expectSidebarToContainLinks(
+  page: Page,
+  options: { expectSpecificationLink: boolean },
+): Promise<void> {
+  const sidebar = page.locator("#starlight__sidebar");
+
+  await expect(sidebar.getByRole("link", { name: "CLI guide" })).toHaveAttribute(
+    "href",
+    /\/docs\/guide\/cli\/$/,
+  );
+  await expect(
+    sidebar.getByRole("link", { name: "Container quick start" }),
+  ).toBeVisible();
+  await expect(
+    sidebar.getByRole("link", { name: "Architecture North Star" }),
+  ).toBeVisible();
+  await expect(sidebar.getByText("Specification", { exact: true }).first())
+    .toBeVisible();
+  if (options.expectSpecificationLink) {
+    await expect(
+      sidebar.getByRole("link", { name: "Ugoite specification index" }),
+    ).toBeVisible();
+  }
 }

--- a/e2e/scripts/run-docsite-navigation.sh
+++ b/e2e/scripts/run-docsite-navigation.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Focused docsite-navigation E2E runner.
+# This lane verifies the built Starlight artifact without starting the full
+# backend/frontend stack, but it still prepares Playwright browsers and enforces
+# the same non-zero/non-skipped expectations as the broader E2E runners.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ensure_playwright_browsers() {
+  if [ "${UGOITE_SKIP_PLAYWRIGHT_DEPS:-}" = "1" ]; then
+    echo "Skipping Playwright browser install because UGOITE_SKIP_PLAYWRIGHT_DEPS=1"
+    return
+  fi
+  echo "Installing Playwright browsers..."
+  (cd "$ROOT_DIR/e2e" && deno task install:browsers)
+}
+
+ensure_playwright_browsers
+
+export PLAYWRIGHT_CI_REPORTER="${PLAYWRIGHT_CI_REPORTER:-junit}"
+export PLAYWRIGHT_JUNIT_OUTPUT_FILE="${PLAYWRIGHT_JUNIT_OUTPUT_FILE:-test-results/docsite-navigation-junit.xml}"
+
+cd "$ROOT_DIR/e2e"
+mkdir -p "$(dirname "$PLAYWRIGHT_JUNIT_OUTPUT_FILE")"
+rm -f "$PLAYWRIGHT_JUNIT_OUTPUT_FILE"
+
+cmd=(deno task docsite:navigation:raw --)
+if [ -n "${E2E_TEST_TIMEOUT_MS:-}" ]; then
+  cmd+=(--timeout "$E2E_TEST_TIMEOUT_MS")
+fi
+"${cmd[@]}"
+
+deno eval '
+  const report = Deno.env.get("PLAYWRIGHT_JUNIT_OUTPUT_FILE");
+  if (!report) throw new Error("PLAYWRIGHT_JUNIT_OUTPUT_FILE is required");
+  const xml = await Deno.readTextFile(report);
+  const suites = [...xml.matchAll(/<testsuite\b[^>]*>/g)].map((match) => match[0]);
+  const attr = (text, name) => Number(text.match(new RegExp(`${name}="([^"]*)"`))?.[1] ?? 0);
+  const tests = suites.reduce((sum, suite) => sum + attr(suite, "tests"), 0);
+  const skipped = suites.reduce((sum, suite) => sum + attr(suite, "skipped"), 0);
+  if (tests === 0) throw new Error("docsite navigation e2e: zero executed tests");
+  if (skipped > 0) throw new Error(`docsite navigation e2e: skipped=${skipped} is not allowed`);
+  console.log(`docsite navigation e2e OK: tests=${tests}, skipped=${skipped}`);
+'

--- a/e2e/support/docsite-server.ts
+++ b/e2e/support/docsite-server.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const docsiteDir = fileURLToPath(new URL("../../docsite", import.meta.url));
@@ -27,26 +27,38 @@ export async function startDocsiteServer(options?: {
 
   if (!configuredDocsiteUrl || options?.basePath) {
     resolvedDocsiteUrl = undefined;
+    const docsiteEnv = {
+      ...process.env,
+      ...(options?.basePath ? { DOCSITE_BASE: options.basePath } : {}),
+    };
+    const buildResult = spawnSync(
+      "deno",
+      ["task", "--cwd", docsiteDir, "build"],
+      {
+        cwd: fileURLToPath(new URL("../..", import.meta.url)),
+        env: docsiteEnv,
+        encoding: "utf8",
+      },
+    );
+    if (buildResult.status !== 0) {
+      throw new Error(
+        `Docsite build failed before preview startup.\n${
+          buildResult.stdout ?? ""
+        }${buildResult.stderr ?? ""}`,
+      );
+    }
     docsiteProcess = spawn(
       "deno",
       [
-        "run",
-        "-A",
-        "npm:astro@6.4.8",
-        "dev",
-        "--host",
-        "127.0.0.1",
-        "--strictPort",
-        "--port",
-        "0",
+        "task",
+        "--cwd",
+        docsiteDir,
+        "preview:e2e",
       ],
       {
-        cwd: docsiteDir,
+        cwd: fileURLToPath(new URL("../..", import.meta.url)),
         stdio: "pipe",
-        env: {
-          ...process.env,
-          ...(options?.basePath ? { DOCSITE_BASE: options.basePath } : {}),
-        },
+        env: docsiteEnv,
       },
     );
 

--- a/mise.toml
+++ b/mise.toml
@@ -221,6 +221,9 @@ run = [
 [tasks."test:docsite"]
 run = "deno task docsite:test"
 
+[tasks."test:docsite:e2e:navigation"]
+run = "deno task docsite:e2e:navigation"
+
 [tasks.test]
 run = [{ tasks = ["test:rust", "test:tools", "test:frontend", "test:docsite"] }]
 


### PR DESCRIPTION
## Summary

- restore the docsite homepage to the standard Starlight document layout so the hero and global navigation render together
- align the external `docs/` loader base and sidebar autogeneration directories through one shared docsite SSOT module
- add a dedicated docsite navigation E2E gate and switch the helper to build plus preview with the canonical pinned docsite tasks

## Related Issue (required)

closes #1786

## Testing

- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
- [x] `mise run test:docsite`
- [x] `mise run test:docsite:e2e:navigation`
- [x] `mise run test:frontend`
- [ ] `mise run test`
  note: one repo-wide run hit an unrelated intermittent frontend `src/lib/i18n.test.ts` failure under parallel task execution, but the isolated frontend lane passed on rerun
