### PR TITLE
docs(cli): document current command workflows

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -2,26 +2,143 @@
 title: CLI guide
 ---
 
-Core mode is explicitly operator-local: it opens operator-owned Spaces directly,
-uses OS/storage permissions as its trust boundary, and performs no human login:
+`ugoite` has two endpoint modes. Core mode opens operator-owned Space
+directories directly and does not perform human login. Backend/API mode uses a
+Space ID and the configured remote endpoint.
+
+## Choose an endpoint
+
+Use `config current` to inspect the active mode and `config set` to change it:
 
 ```bash
+# Local-first core mode
 ugoite config set --mode core
+ugoite config current
 ugoite space list /path/to/workspace
-```
 
-Remote mode pairs a terminal by device authorization. The CLI does not require a
-browser on that terminal:
-
-```bash
+# Server-backed mode
 ugoite config set --mode backend --backend-url https://ugoite.example.com
+ugoite config current
 ugoite auth login --device-name workstation --actions read,create,update
 ```
 
-Open the displayed verification URL on a signed-in phone or computer, compare
-the code, Space, device name, and requested actions, then approve. The CLI
-stores a P-256 private key in the OS keychain when available and otherwise in
-`~/.ugoite/cli-credentials.json` with owner-only permissions. Five-minute DPoP
-access tokens refresh using a rotating 30-day credential. `ugoite auth profile`
-shows metadata; `ugoite auth logout` deletes local credentials. Revoke a lost
-device from the browser credential page.
+In core mode, commands that address a Space take its full local path, such as
+`/path/to/workspace/spaces/demo`. In backend/API mode, pass the bare Space ID,
+such as `demo`. `ugoite space list` takes the workspace root only in core mode;
+omit the positional argument in backend/API mode.
+
+## Authentication
+
+Remote login uses device authorization. Open the displayed verification URL on
+any already signed-in browser, compare the code and requested actions, and
+approve the device. The CLI stores the rotating credential in the OS keychain
+when available, or in `~/.ugoite/cli-credentials.json` with owner-only
+permissions:
+
+```bash
+ugoite auth login --device-name workstation --actions read,create,update
+ugoite auth profile
+ugoite auth logout
+```
+
+`auth profile` reports metadata only. `auth logout` removes the local device
+credential. The browser credential page can revoke a device that is lost.
+Core mode does not need `auth login`.
+
+## Spaces and entries
+
+Create and inspect a Space, using the path or ID appropriate for the selected
+mode:
+
+```bash
+ugoite space create /path/to/workspace/spaces/team-notes   # core
+ugoite space create team-notes                              # backend/API
+ugoite space get /path/to/workspace/spaces/team-notes
+ugoite entry list /path/to/workspace/spaces/team-notes
+```
+
+An entry ID is a user-chosen storage-safe slug. It may contain ASCII letters,
+digits, `-`, and `_`, must be 1–128 bytes, and must not contain path
+separators, control characters, or `.`/`..` path segments. `first-note` is
+therefore an example ID, not a reserved name.
+
+The smallest complete first-entry workflow is:
+
+```bash
+ugoite entry create /path/to/workspace/spaces/team-notes first-note \
+  --content '# First note'
+ugoite entry get /path/to/workspace/spaces/team-notes first-note
+ugoite entry list /path/to/workspace/spaces/team-notes
+```
+
+Add Form-backed metadata by including form frontmatter in the Markdown:
+
+```bash
+ugoite entry create /path/to/workspace/spaces/team-notes meeting-2026-07-17 \
+  --content $'---\nform: Meeting\n---\n# Planning\n\n## Notes\n\nAgenda'
+```
+
+Use `entry update`, `entry history`, `entry revision`, and `entry restore` for
+revisions. Updates can include `--parent-revision-id` to enforce optimistic
+conflict checks. `entry delete` is soft-delete by default; pass `--hard-delete`
+only when permanent removal is intended.
+
+## Forms
+
+Forms define the fields and defaults available when creating entries. List
+existing Forms, inspect supported field types, and write a definition from a
+JSON file:
+
+```bash
+ugoite form list /path/to/workspace/spaces/team-notes
+ugoite form list-types
+ugoite form get /path/to/workspace/spaces/team-notes Meeting
+ugoite form update /path/to/workspace/spaces/team-notes meeting.json
+```
+
+Run `ugoite form <command> --help` for the exact JSON shape and flags for the
+installed version.
+
+## Search and SQL
+
+Keyword search and saved SQL work in both endpoint modes:
+
+```bash
+ugoite search keyword /path/to/workspace/spaces/team-notes planning
+ugoite sql lint 'SELECT id, title FROM entries LIMIT 10'
+ugoite sql saved-list /path/to/workspace/spaces/team-notes
+ugoite sql saved-get /path/to/workspace/spaces/team-notes recent-notes
+```
+
+Use `query` for an ad-hoc SQL session over indexed entries:
+
+```bash
+ugoite query /path/to/workspace/spaces/team-notes \
+  --sql 'SELECT id, title FROM entries LIMIT 10'
+```
+
+The queryable table is `entries`; standard columns include `id`, `title`,
+`form`, `updated_at`, `space_id`, `word_count`, and `tags`. Form fields can be
+queried by field name or through `properties.<field>`.
+
+## Indexes and assets
+
+Index maintenance is local-core functionality in this release:
+
+```bash
+ugoite index stats /path/to/workspace/spaces/team-notes
+ugoite index run /path/to/workspace/spaces/team-notes
+```
+
+The CLI reports that these commands are unavailable in backend/API mode. Asset
+commands use the same Space path/ID rules:
+
+```bash
+ugoite asset list /path/to/workspace/spaces/team-notes
+ugoite asset upload /path/to/workspace/spaces/team-notes ./diagram.png
+ugoite asset delete /path/to/workspace/spaces/team-notes asset-id
+```
+
+Every command has exhaustive, version-specific help. Use
+`ugoite <command> --help` or `ugoite <command> <subcommand> --help` before
+copying flags into automation.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -66,12 +66,13 @@ The smallest complete first-entry workflow is:
 
 ```bash
 ugoite entry create /path/to/workspace/spaces/team-notes first-note \
-  --content '# First note'
+  --content $'---\nform: Entry\n---\n# First note\n\n## Body\n\nHello from Ugoite.'
 ugoite entry get /path/to/workspace/spaces/team-notes first-note
 ugoite entry list /path/to/workspace/spaces/team-notes
 ```
 
-Add Form-backed metadata by including form frontmatter in the Markdown:
+After creating a `Meeting` Form as described below, add Form-backed metadata by
+including its name in the frontmatter:
 
 ```bash
 ugoite entry create /path/to/workspace/spaces/team-notes meeting-2026-07-17 \

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -80,8 +80,9 @@ ugoite entry create /path/to/workspace/spaces/team-notes meeting-2026-07-17 \
 
 Use `entry update`, `entry history`, `entry revision`, and `entry restore` for
 revisions. Updates can include `--parent-revision-id` to enforce optimistic
-conflict checks. `entry delete` is soft-delete by default; pass `--hard-delete`
-only when permanent removal is intended.
+conflict checks. `entry delete` appends a deletion tombstone to the revision
+history. The currently accepted `--hard-delete` flag also writes a tombstone;
+permanent removal is not available in this release.
 
 ## Forms
 
@@ -130,14 +131,17 @@ ugoite index stats /path/to/workspace/spaces/team-notes
 ugoite index run /path/to/workspace/spaces/team-notes
 ```
 
-The CLI reports that these commands are unavailable in backend/API mode. Asset
-commands use the same Space path/ID rules:
+The CLI reports that these commands are unavailable in backend/API mode. In core
+mode, asset list, upload, and delete take a local Space path:
 
 ```bash
 ugoite asset list /path/to/workspace/spaces/team-notes
 ugoite asset upload /path/to/workspace/spaces/team-notes ./diagram.png
 ugoite asset delete /path/to/workspace/spaces/team-notes asset-id
 ```
+
+In backend/API mode, `asset list` and `asset delete` accept a bare Space ID.
+Remote CLI asset upload is not available in this release.
 
 Every command has exhaustive, version-specific help. Use
 `ugoite <command> --help` or `ugoite <command> <subcommand> --help` before


### PR DESCRIPTION
## Summary

- Document the current CLI command families and mode-specific Space arguments.
- Add a complete first-entry workflow and explain entry ID constraints.
- Describe saved remote credentials, logout, SQL, search, index, and asset commands.

## Related Issue (required)

close: #1492
closes #1479

## Testing

- [x] `cargo run -p ugoite-cli -- --help` and subcommand help were checked against the examples.
- [x] `mise run fmt:check`
- [x] `mise run check`
- [x] `mise run test:docsite`
