### PR TITLE
feat(frontend): link browser walkthrough from fresh spaces

### DIFF
--- a/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
@@ -1,20 +1,21 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
-import { Show } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setLocale } from "~/lib/i18n";
 import { formApi, spaceApi } from "~/lib/ugoite-client";
 import SpaceDashboardRoute from "./dashboard";
 
 const navigate = vi.fn();
+const { entryStoreMock } = vi.hoisted(() => ({ entryStoreMock: { entries: vi.fn(), loadEntries: vi.fn(), error: vi.fn() } }));
 vi.mock("@solidjs/router", () => ({ useNavigate: () => navigate, useParams: () => ({ space_id: "default" }), A: (props: { href: string; class?: string; children: unknown }) => <a href={props.href} class={props.class}>{props.children}</a> }));
 vi.mock("~/components/SpaceShell", () => ({ SpaceShell: (props: { children: unknown }) => <div>{props.children}</div> }));
 vi.mock("~/components/create-dialogs", () => ({ CreateFormDialog: (props: { open: boolean }) => <Show when={props.open}><div>Create Form Dialog</div></Show> }));
-vi.mock("~/lib/entry-store", () => ({ createEntryStore: () => ({ entries: () => [], loadEntries: vi.fn() }) }));
+vi.mock("~/lib/entry-store", () => ({ createEntryStore: () => entryStoreMock }));
 vi.mock("~/lib/ugoite-client", () => ({ formApi: { list: vi.fn(), listTypes: vi.fn(), create: vi.fn() }, spaceApi: { get: vi.fn() } }));
 
 describe("v5 space Home", () => {
-  beforeEach(() => { navigate.mockReset(); setLocale("en"); vi.mocked(spaceApi.get).mockResolvedValue({ id: "default", name: "Local Knowledge", created_at: "2026-01-01" }); vi.mocked(formApi.listTypes).mockResolvedValue([]); });
+  beforeEach(() => { navigate.mockReset(); setLocale("en"); entryStoreMock.entries.mockReturnValue([]); entryStoreMock.loadEntries.mockResolvedValue(undefined); entryStoreMock.error.mockReturnValue(null); vi.mocked(spaceApi.get).mockResolvedValue({ id: "default", name: "Local Knowledge", created_at: "2026-01-01" }); vi.mocked(formApi.listTypes).mockResolvedValue([]); });
   it("renders Continue, Pinned and Recent without metric cards", async () => {
     vi.mocked(formApi.list).mockResolvedValue([{ name: "Notes", version: 1, template: "", fields: { body: { type: "markdown", required: false } } }]);
     render(() => <SpaceDashboardRoute />);
@@ -31,16 +32,32 @@ describe("v5 space Home", () => {
     fireEvent.click(button);
     expect(navigate).toHaveBeenCalledWith("/spaces/default/entries/new");
   });
-  it("opens Form creation when the Space has no creatable Forms", async () => {
+  it("opens Form creation and shows the walkthrough for a fresh Space", async () => {
     vi.mocked(formApi.list).mockResolvedValue([]);
     render(() => <SpaceDashboardRoute />);
     fireEvent.click((await screen.findAllByRole("button", { name: /Entry/ }))[0]);
     expect(screen.getByText("Create Form Dialog")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Read the browser-first walkthrough" }))
-      .toHaveAttribute(
-        "href",
-        "https://ugoite.github.io/ugoite/docs/guide/browser-first-entry",
-      );
+    expect(await screen.findByRole("link", { name: "Create your first entry with the browser walkthrough" }))
+      .toHaveAttribute("href", "https://ugoite.github.io/ugoite/docs/guide/browser-first-entry");
+  });
+  it("does not show walkthrough guidance while existing entries are loading", async () => {
+    const [mockEntries, setMockEntries] = createSignal<Array<{ id: string; title: string; form: string; updated_at: string; properties: Record<string, never>; tags: never[]; links: never[] }>>([]);
+    let resolveLoad: () => void;
+    entryStoreMock.entries.mockImplementation(mockEntries);
+    entryStoreMock.loadEntries.mockReturnValue(new Promise<void>((resolve) => { resolveLoad = resolve; }));
+    vi.mocked(formApi.list).mockResolvedValue([]);
+    render(() => <SpaceDashboardRoute />);
+    expect(screen.queryByRole("link", { name: /browser walkthrough/ })).not.toBeInTheDocument();
+
+    setMockEntries([{ id: "entry-1", title: "API memo", form: "Notes", updated_at: "2026-01-01", properties: {}, tags: [], links: [] }]);
+    resolveLoad!();
+    await waitFor(() => expect(entryStoreMock.loadEntries).toHaveBeenCalled());
+    expect(screen.queryByRole("link", { name: /browser walkthrough/ })).not.toBeInTheDocument();
+  });
+  it("does not show walkthrough guidance when the entry load fails", async () => {
+    entryStoreMock.error.mockReturnValue("Failed to load entries");
+    render(() => <SpaceDashboardRoute />);
+    await waitFor(() => expect(screen.queryByRole("link", { name: /browser walkthrough/ })).not.toBeInTheDocument());
   });
   it("uses the Japanese v5 copy", async () => {
     setLocale("ja"); vi.mocked(formApi.list).mockResolvedValue([]);

--- a/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
@@ -10,7 +10,7 @@ const navigate = vi.fn();
 vi.mock("@solidjs/router", () => ({ useNavigate: () => navigate, useParams: () => ({ space_id: "default" }), A: (props: { href: string; class?: string; children: unknown }) => <a href={props.href} class={props.class}>{props.children}</a> }));
 vi.mock("~/components/SpaceShell", () => ({ SpaceShell: (props: { children: unknown }) => <div>{props.children}</div> }));
 vi.mock("~/components/create-dialogs", () => ({ CreateFormDialog: (props: { open: boolean }) => <Show when={props.open}><div>Create Form Dialog</div></Show> }));
-vi.mock("~/lib/entry-store", () => ({ createEntryStore: () => ({ entries: () => [{ id: "entry-1", title: "API memo", form: "Notes", updated_at: "2026-01-01", properties: {}, tags: [], links: [] }], loadEntries: vi.fn() }) }));
+vi.mock("~/lib/entry-store", () => ({ createEntryStore: () => ({ entries: () => [], loadEntries: vi.fn() }) }));
 vi.mock("~/lib/ugoite-client", () => ({ formApi: { list: vi.fn(), listTypes: vi.fn(), create: vi.fn() }, spaceApi: { get: vi.fn() } }));
 
 describe("v5 space Home", () => {
@@ -27,15 +27,20 @@ describe("v5 space Home", () => {
   it("starts the dedicated New Entry route when a creatable Form exists", async () => {
     vi.mocked(formApi.list).mockResolvedValue([{ name: "Notes", version: 1, template: "", fields: {} }]);
     render(() => <SpaceDashboardRoute />);
-    const button = await screen.findByRole("button", { name: /Entry/ });
+    const button = (await screen.findAllByRole("button", { name: /Entry/ }))[0];
     fireEvent.click(button);
     expect(navigate).toHaveBeenCalledWith("/spaces/default/entries/new");
   });
   it("opens Form creation when the Space has no creatable Forms", async () => {
     vi.mocked(formApi.list).mockResolvedValue([]);
     render(() => <SpaceDashboardRoute />);
-    fireEvent.click(await screen.findByRole("button", { name: /Entry/ }));
+    fireEvent.click((await screen.findAllByRole("button", { name: /Entry/ }))[0]);
     expect(screen.getByText("Create Form Dialog")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Read the browser-first walkthrough" }))
+      .toHaveAttribute(
+        "href",
+        "https://ugoite.github.io/ugoite/docs/guide/browser-first-entry",
+      );
   });
   it("uses the Japanese v5 copy", async () => {
     setLocale("ja"); vi.mocked(formApi.list).mockResolvedValue([]);

--- a/frontend/src/routes/spaces/[space_id]/dashboard.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.tsx
@@ -11,8 +11,8 @@ import { formApi, spaceApi } from "~/lib/ugoite-client";
 import type { FormCreatePayload } from "~/lib/types";
 
 const copy = {
-  en: { home: "Home", newEntry: "Entry", continue: "Continue", pinned: "Pinned", recent: "Recent", forms: "Forms", search: "Search", assets: "Assets", savedSql: "SQL", noRecent: "Create an entry to start building this Space.", walkthrough: "Read the browser-first walkthrough", form: "Form", entry: "Entry", searchMeta: "Entries · Forms · Assets" },
-  ja: { home: "ホーム", newEntry: "エントリー", continue: "続きから", pinned: "ピン留め", recent: "最近", forms: "フォーム", search: "検索", assets: "アセット", savedSql: "SQL", noRecent: "エントリーを作成して、このスペースを育てましょう。", walkthrough: "ブラウザの使い方を見る", form: "フォーム", entry: "エントリー", searchMeta: "エントリー · フォーム · アセット" },
+  en: { home: "Home", newEntry: "Entry", continue: "Continue", pinned: "Pinned", recent: "Recent", forms: "Forms", search: "Search", assets: "Assets", savedSql: "SQL", noRecent: "Create an entry to start building this Space.", walkthrough: "Create your first entry with the browser walkthrough", form: "Form", entry: "Entry", searchMeta: "Entries · Forms · Assets" },
+  ja: { home: "ホーム", newEntry: "エントリー", continue: "続きから", pinned: "ピン留め", recent: "最近", forms: "フォーム", search: "検索", assets: "アセット", savedSql: "SQL", noRecent: "エントリーを作成して、このスペースを育てましょう。", walkthrough: "ブラウザの使い方で最初のエントリーを作成する", form: "フォーム", entry: "エントリー", searchMeta: "エントリー · フォーム · アセット" },
 } as const;
 
 const browserWalkthroughUrl = getDocsiteHref(
@@ -26,6 +26,7 @@ export default function SpaceDashboardRoute() {
   const spaceId = () => params.space_id;
   const entryStore = createEntryStore(spaceId);
   const [showFormDialog, setShowFormDialog] = createSignal(false);
+  const [entriesLoaded, setEntriesLoaded] = createSignal(false);
   const c = () => copy[locale() === "ja" ? "ja" : "en"];
 
   const [space] = createResource(spaceId, spaceApi.get);
@@ -40,8 +41,11 @@ export default function SpaceDashboardRoute() {
       : (value as ReturnType<typeof entryStore.entries>);
   };
   const recentEntries = createMemo(() => [...storeEntries()].sort((a, b) => String(b.updated_at).localeCompare(String(a.updated_at))).slice(0, 4));
+  const isFreshSpace = createMemo(() => entriesLoaded() && !entryStore.error() && recentEntries().length === 0);
 
-  onMount(() => void entryStore.loadEntries());
+  onMount(() => {
+    void entryStore.loadEntries().then(() => setEntriesLoaded(true));
+  });
 
   const createForm = async (payload: FormCreatePayload) => {
     await formApi.create(spaceId(), payload);
@@ -66,7 +70,9 @@ export default function SpaceDashboardRoute() {
               <button class="cardBtn" type="button" onClick={() => entryForms().length ? navigate(`/spaces/${spaceId()}/entries/new`) : setShowFormDialog(true)}>
                 <span class="glyph active"><UiIcon name="entry" /></span><span><b>{c().newEntry}</b><small>{c().noRecent}</small></span><span class="chev">›</span>
               </button>
-              <a class="ui-muted text-sm hover:underline" href={browserWalkthroughUrl} target="_blank" rel="noopener">{c().walkthrough}</a>
+              <Show when={isFreshSpace()}>
+                <a class="ui-muted text-sm hover:underline" href={browserWalkthroughUrl} target="_blank" rel="noopener">{c().walkthrough}</a>
+              </Show>
             </div>
           }>
             {(entry) => <A class="card cardBtn" href={`/spaces/${spaceId()}/entries/${encodeURIComponent(entry().id)}`}><span class="glyph active"><UiIcon name="entry" /></span><span><b>{entry().title || "Untitled"}</b><small>{entry().form || c().entry}</small></span><span class="chev">›</span></A>}

--- a/frontend/src/routes/spaces/[space_id]/dashboard.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.tsx
@@ -4,15 +4,21 @@ import { CreateFormDialog } from "~/components/create-dialogs";
 import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { createEntryStore } from "~/lib/entry-store";
+import { getDocsiteHref } from "~/lib/docsite-links";
 import { locale } from "~/lib/i18n";
 import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { formApi, spaceApi } from "~/lib/ugoite-client";
 import type { FormCreatePayload } from "~/lib/types";
 
 const copy = {
-  en: { home: "Home", newEntry: "Entry", continue: "Continue", pinned: "Pinned", recent: "Recent", forms: "Forms", search: "Search", assets: "Assets", savedSql: "SQL", noRecent: "Create an entry to start building this Space.", form: "Form", entry: "Entry", searchMeta: "Entries · Forms · Assets" },
-  ja: { home: "ホーム", newEntry: "エントリー", continue: "続きから", pinned: "ピン留め", recent: "最近", forms: "フォーム", search: "検索", assets: "アセット", savedSql: "SQL", noRecent: "エントリーを作成して、このスペースを育てましょう。", form: "フォーム", entry: "エントリー", searchMeta: "エントリー · フォーム · アセット" },
+  en: { home: "Home", newEntry: "Entry", continue: "Continue", pinned: "Pinned", recent: "Recent", forms: "Forms", search: "Search", assets: "Assets", savedSql: "SQL", noRecent: "Create an entry to start building this Space.", walkthrough: "Read the browser-first walkthrough", form: "Form", entry: "Entry", searchMeta: "Entries · Forms · Assets" },
+  ja: { home: "ホーム", newEntry: "エントリー", continue: "続きから", pinned: "ピン留め", recent: "最近", forms: "フォーム", search: "検索", assets: "アセット", savedSql: "SQL", noRecent: "エントリーを作成して、このスペースを育てましょう。", walkthrough: "ブラウザの使い方を見る", form: "フォーム", entry: "エントリー", searchMeta: "エントリー · フォーム · アセット" },
 } as const;
+
+const browserWalkthroughUrl = getDocsiteHref(
+  "/docs/guide/browser-first-entry",
+  "docs/guide/browser-first-entry.md",
+);
 
 export default function SpaceDashboardRoute() {
   const params = useParams<{ space_id: string }>();
@@ -56,9 +62,12 @@ export default function SpaceDashboardRoute() {
         <div class="sectionHead"><h2>{c().continue}</h2></div>
         <div class="grid3">
           <Show when={recentEntries()[0]} fallback={
-            <button class="card cardBtn" type="button" onClick={() => entryForms().length ? navigate(`/spaces/${spaceId()}/entries/new`) : setShowFormDialog(true)}>
-              <span class="glyph active"><UiIcon name="entry" /></span><span><b>{c().newEntry}</b><small>{c().noRecent}</small></span><span class="chev">›</span>
-            </button>
+            <div class="card ui-stack-sm">
+              <button class="cardBtn" type="button" onClick={() => entryForms().length ? navigate(`/spaces/${spaceId()}/entries/new`) : setShowFormDialog(true)}>
+                <span class="glyph active"><UiIcon name="entry" /></span><span><b>{c().newEntry}</b><small>{c().noRecent}</small></span><span class="chev">›</span>
+              </button>
+              <a class="ui-muted text-sm hover:underline" href={browserWalkthroughUrl} target="_blank" rel="noopener">{c().walkthrough}</a>
+            </div>
           }>
             {(entry) => <A class="card cardBtn" href={`/spaces/${spaceId()}/entries/${encodeURIComponent(entry().id)}`}><span class="glyph active"><UiIcon name="entry" /></span><span><b>{entry().title || "Untitled"}</b><small>{entry().form || c().entry}</small></span><span class="chev">›</span></A>}
           </Show>

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -12,6 +12,8 @@ import { spaceApi } from "~/lib/ugoite-client";
 
 const localDevAuthGuideUrl =
   "https://ugoite.github.io/ugoite/docs/guide/local-dev-auth-login";
+const browserWalkthroughUrl =
+  "https://ugoite.github.io/ugoite/docs/guide/browser-first-entry";
 
 const navigateMock = vi.fn();
 
@@ -52,6 +54,9 @@ describe("/spaces", () => {
         "href",
         "/spaces/join",
       );
+    expect(
+      screen.getByRole("link", { name: "Read the browser-first walkthrough" }),
+    ).toHaveAttribute("href", browserWalkthroughUrl);
     expect(spaceApi.create).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -55,7 +55,9 @@ describe("/spaces", () => {
         "/spaces/join",
       );
     expect(
-      screen.getByRole("link", { name: "Read the browser-first walkthrough" }),
+      screen.getByRole("link", {
+        name: "Learn how to create your first entry in the browser",
+      }),
     ).toHaveAttribute("href", browserWalkthroughUrl);
     expect(spaceApi.create).not.toHaveBeenCalled();
   });

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -17,6 +17,10 @@ const localDevAuthGuideUrl = getDocsiteHref(
   "/docs/guide/local-dev-auth-login",
   "docs/guide/local-dev-auth-login.md",
 );
+const browserWalkthroughUrl = getDocsiteHref(
+  "/docs/guide/browser-first-entry",
+  "docs/guide/browser-first-entry.md",
+);
 
 const toMessage = (value: unknown): string => {
   if (value instanceof Error && value.message.trim()) {
@@ -283,6 +287,14 @@ export default function SpacesIndexRoute() {
                   Create space
                 </button>
               </div>
+              <a
+                href={browserWalkthroughUrl}
+                target="_blank"
+                rel="noopener"
+                class="ui-muted text-sm hover:underline"
+              >
+                Read the browser-first walkthrough
+              </a>
             </div>
           </Show>
           <Show when={listedSpaces().length > 0}>

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -293,7 +293,7 @@ export default function SpacesIndexRoute() {
                 rel="noopener"
                 class="ui-muted text-sm hover:underline"
               >
-                Read the browser-first walkthrough
+                Learn how to create your first entry in the browser
               </a>
             </div>
           </Show>


### PR DESCRIPTION
## Summary

- Link the browser-first walkthrough from the authenticated no-Space state.
- Add the same deployment-aware guidance to a fresh Space Home without showing it to returning users.
- Cover local and published docsite URL behavior through existing and route-level tests.

## Related Issue (required)

closes #1389

## Testing

- [x] `cd frontend && deno task test src/routes/spaces/index.test.tsx src/routes/spaces/[space_id]/dashboard.test.tsx src/lib/docsite-links.test.ts`
- [x] `cd frontend && deno task check`
- [x] `mise run fmt:check`
