### PR TITLE
Fix entry created date normalization

### DIFF
--- a/frontend/src/lib/client.test.ts
+++ b/frontend/src/lib/client.test.ts
@@ -159,6 +159,7 @@ describe("entryApi", () => {
               {
                 id: "entry-1",
                 title: "Test Entry",
+                created_at: 1772960822.056,
                 updated_at: 1772960822.056,
                 properties: {},
                 tags: [],
@@ -169,6 +170,9 @@ describe("entryApi", () => {
       );
 
       const entries = await entryApi.list("test-ws");
+      expect(entries[0].created_at).toBe(
+        new Date(1772960822.056 * 1000).toISOString(),
+      );
       expect(entries[0].updated_at).toBe(
         new Date(1772960822.056 * 1000).toISOString(),
       );

--- a/frontend/src/lib/entry-api.ts
+++ b/frontend/src/lib/entry-api.ts
@@ -20,6 +20,9 @@ type EntryResponse = Omit<Entry, "content"> & {
 
 const normalizeEntryRecord = (entry: EntryRecord): EntryRecord => ({
   ...entry,
+  ...(entry.created_at === undefined
+    ? {}
+    : { created_at: normalizeTimestamp(entry.created_at) }),
   updated_at: normalizeTimestamp(entry.updated_at),
 });
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -116,6 +116,7 @@ export interface EntryRecord {
   id: string;
   title: string;
   form?: string;
+  created_at?: string;
   updated_at: string;
   properties: Record<string, unknown>;
   tags: string[];


### PR DESCRIPTION
## Summary

- Normalize entry-list `created_at` values alongside `updated_at` at the frontend client boundary.
- Preserve missing `created_at` values for compatibility with older payloads.
- Cover Unix-second creation timestamps with a regression test.

## Related Issue (required)

closes #1808

## Testing

- [x] `mise run test:frontend`
- [x] `mise run lint`
