### PR TITLE
chore: isolate local runtime data under data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Ugoite runtime data (created by ugoite during dev)
 hmac.json
 global.json
+/data/
 spaces/
 !frontend/src/routes/spaces/
 !frontend/src/routes/spaces/**

--- a/docker-compose.release.yaml
+++ b/docker-compose.release.yaml
@@ -4,8 +4,7 @@ services:
     ports:
       - "127.0.0.1:${UGOITE_PORT:-8000}:8000"
     volumes:
-      - "${UGOITE_SPACES_DIR:-./spaces}:/data/spaces"
-      - "${UGOITE_NODE_DIR:-./node}:/data/_ugoite"
+      - "${UGOITE_DATA_DIR:-./data}:/data"
     environment:
       - UGOITE_ROOT=/data
       - UGOITE_SERVER_ADDRESS=0.0.0.0:8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,7 @@ services:
         host_ip: 127.0.0.1
         protocol: tcp
     volumes:
-      - ./spaces:/data/spaces
-      - ./node:/data/_ugoite
+      - "${UGOITE_DATA_DIR:-./data}:/data"
     environment:
       - UGOITE_ROOT=/data
       - UGOITE_SERVER_ADDRESS=0.0.0.0:8000

--- a/docs/guide/container-quickstart.md
+++ b/docs/guide/container-quickstart.md
@@ -11,10 +11,8 @@ docker compose -f docker-compose.release.yaml logs ugoite
 
 Open the one-use setup URL shown in the log and register a Passkey. Complete
 setup with a second Passkey or TOTP plus the displayed recovery codes. The URL
-expires after 30 minutes and can be used once. Portable Spaces live in
-`${UGOITE_SPACES_DIR:-./spaces}`. Atomic Node control objects live separately in
-`${UGOITE_NODE_DIR:-./node}`; back up both and the separately managed encryption
-key with owner-only permissions.
+expires after 30 minutes and can be used once. The local runtime data directory
+is `${UGOITE_DATA_DIR:-./data}`.
 
 For a remote hostname, configure the WebAuthn origin before first start:
 

--- a/docs/guide/docker-compose.md
+++ b/docs/guide/docker-compose.md
@@ -10,9 +10,8 @@ docker compose up --build -d
 ```
 
 This builds the image, binds localhost port
-`${UGOITE_PORT:-8000}`, mounts portable Space directories from `./spaces` at
-`/data/spaces`, and keeps atomic Node control objects separately in `./node`. Read the setup URL
-with `docker compose logs ugoite`.
+`${UGOITE_PORT:-8000}`, and mounts the local runtime data directory from
+`./data` at `/data`. Read the setup URL with `docker compose logs ugoite`.
 
 Set `UGOITE_PUBLIC_ORIGIN` and `UGOITE_WEBAUTHN_RP_ID` to the externally visible
 HTTPS origin and host before registering Passkeys. Set `UGOITE_NODE_SECRET_KEY`

--- a/scripts/dev-seed.sh
+++ b/scripts/dev-seed.sh
@@ -9,7 +9,7 @@ Create local sample data with the existing ugoite-cli sample-data command and
 visible terminal progress.
 
 Defaults:
-  --root        .
+  --root        ./data
   --space-id    dev-seed
   --scenario    renewable-ops
   --entry-count 50
@@ -24,7 +24,7 @@ Environment variable overrides:
 EOF
 }
 
-ROOT_PATH="${UGOITE_SEED_ROOT:-${UGOITE_ROOT:-.}}"
+ROOT_PATH="${UGOITE_SEED_ROOT:-${UGOITE_ROOT:-./data}}"
 SPACE_ID="${UGOITE_SEED_SPACE_ID:-dev-seed}"
 SCENARIO="${UGOITE_SEED_SCENARIO:-renewable-ops}"
 ENTRY_COUNT="${UGOITE_SEED_ENTRY_COUNT:-50}"

--- a/scripts/verify-release-cli-quickstart.sh
+++ b/scripts/verify-release-cli-quickstart.sh
@@ -9,7 +9,7 @@ KEEP_WORK_ROOT="${UGOITE_QUICKSTART_KEEP_WORKDIR:-0}"
 QUICKSTART_HOME_INPUT="${UGOITE_QUICKSTART_HOME:-}"
 INSTALL_DIR_INPUT="${UGOITE_INSTALL_DIR:-}"
 SPACE_ID="${UGOITE_SPACE_ID:-demo}"
-SPACE_ROOT="./spaces"
+SPACE_ROOT="./data/spaces"
 
 log() {
   printf '%s\n' "$*" >&2
@@ -132,7 +132,7 @@ help_output="$("$INSTALLED_BINARY" --help 2>&1)"
 assert_help_output "$help_output"
 log "Verified: ugoite --help"
 
-mkdir -p "$WORK_DIR/spaces"
+mkdir -p "$WORK_DIR/data/spaces"
 
 list_before_output="$(
   cd "$WORK_DIR" &&

--- a/scripts/verify-release-container-quickstart.sh
+++ b/scripts/verify-release-container-quickstart.sh
@@ -85,8 +85,8 @@ ASSET_BASE_URL="${ASSET_BASE_URL_INPUT:-https://github.com/ugoite/ugoite/release
 COMPOSE_PROJECT="ugoite-release-quickstart-${VERSION_INPUT//[^A-Za-z0-9]/-}-$$"
 compose_cmd=(docker compose -p "$COMPOSE_PROJECT" -f docker-compose.release.yaml)
 
-mkdir -p "$STACK_DIR/spaces" "$STACK_DIR/node" "$DOWNLOAD_DIR" "$CLI_INSTALL_DIR"
-chmod 0777 "$STACK_DIR/spaces" "$STACK_DIR/node"
+mkdir -p "$STACK_DIR/data" "$DOWNLOAD_DIR" "$CLI_INSTALL_DIR"
+chmod 0777 "$STACK_DIR/data"
 
 cleanup() {
   status=$?
@@ -125,8 +125,7 @@ gzip -dc "$DOWNLOAD_DIR/ugoite-image.tar.gz" | docker load
 
 cat >"$STACK_DIR/.env" <<EOF
 UGOITE_VERSION=${VERSION_INPUT}
-UGOITE_SPACES_DIR=./spaces
-UGOITE_NODE_DIR=./node
+UGOITE_DATA_DIR=./data
 UGOITE_PORT=8000
 UGOITE_PUBLIC_ORIGIN=http://127.0.0.1:8000
 UGOITE_API_BASE_URL=http://127.0.0.1:8000/api

--- a/scripts/verify-release-local-image.sh
+++ b/scripts/verify-release-local-image.sh
@@ -30,7 +30,8 @@ cleanup() {
   trap - EXIT HUP INT TERM
   (
     cd "$WORK_ROOT" &&
-      docker compose -p "$PROJECT" -f "$REPO_ROOT/docker-compose.yaml" down --remove-orphans -v
+      UGOITE_DATA_DIR="$WORK_ROOT/data" \
+        docker compose -p "$PROJECT" -f "$REPO_ROOT/docker-compose.yaml" down --remove-orphans -v
   ) >/dev/null 2>&1 || true
   if [ "$KEEP_WORK_ROOT" != "1" ] && [ -z "${UGOITE_RELEASE_LOCAL_WORKDIR:-}" ]; then
     rm -rf "$WORK_ROOT"
@@ -46,8 +47,8 @@ require_command curl
 require_command deno
 require_command docker
 
-mkdir -p "$WORK_ROOT/spaces" "$WORK_ROOT/node" "$WORK_ROOT/cli-home"
-chmod 0777 "$WORK_ROOT/spaces" "$WORK_ROOT/node"
+mkdir -p "$WORK_ROOT/data" "$WORK_ROOT/cli-home"
+chmod 0777 "$WORK_ROOT/data"
 
 log "Building release CLI binary"
 (
@@ -58,12 +59,14 @@ log "Building release CLI binary"
 log "Building and starting release-like single-image container"
 (
   cd "$WORK_ROOT" &&
-    docker compose -p "$PROJECT" -f "$REPO_ROOT/docker-compose.yaml" up -d --build
+    UGOITE_DATA_DIR="$WORK_ROOT/data" \
+      docker compose -p "$PROJECT" -f "$REPO_ROOT/docker-compose.yaml" up -d --build
 )
 
 HOST_PORT="$(
   cd "$WORK_ROOT" &&
-    docker compose -p "$PROJECT" -f "$REPO_ROOT/docker-compose.yaml" port ugoite 8000 |
+    UGOITE_DATA_DIR="$WORK_ROOT/data" \
+      docker compose -p "$PROJECT" -f "$REPO_ROOT/docker-compose.yaml" port ugoite 8000 |
       awk -F: '{print $NF}'
 )"
 if [ -z "$HOST_PORT" ]; then

--- a/tools/dev.ts
+++ b/tools/dev.ts
@@ -1,4 +1,5 @@
 const repoRoot = new URL("..", import.meta.url).pathname;
+const devDataRoot = `${repoRoot}data`;
 const devSecretPath = `${repoRoot}target/dev-node-secret`;
 
 await Deno.mkdir(`${repoRoot}target`, { recursive: true, mode: 0o700 });
@@ -22,7 +23,7 @@ const commands = [
   new Deno.Command("cargo", {
     cwd: repoRoot,
     env: {
-      UGOITE_ROOT: Deno.env.get("UGOITE_ROOT") ?? repoRoot,
+      UGOITE_ROOT: Deno.env.get("UGOITE_ROOT") ?? devDataRoot,
       UGOITE_PUBLIC_ORIGIN: Deno.env.get("UGOITE_PUBLIC_ORIGIN") ??
         "http://localhost:3000",
       UGOITE_API_BASE_URL: Deno.env.get("UGOITE_API_BASE_URL") ??

--- a/tools/workspace_test.ts
+++ b/tools/workspace_test.ts
@@ -128,6 +128,23 @@ Deno.test("release path does not reference removed runtimes", async () => {
   }
 });
 
+Deno.test("local runtime data uses one ignored repository mount", async () => {
+  const gitignore = await Deno.readTextFile(".gitignore");
+  const dev = await Deno.readTextFile("tools/dev.ts");
+  const sourceCompose = await Deno.readTextFile("docker-compose.yaml");
+  const releaseCompose = await Deno.readTextFile("docker-compose.release.yaml");
+
+  assertEquals(gitignore.includes("/data/"), true);
+  assertEquals(dev.includes("const devDataRoot = `${repoRoot}data`;"), true);
+  assertEquals(dev.includes("?? devDataRoot"), true);
+  assertEquals(sourceCompose.includes("UGOITE_DATA_DIR:-./data}:/data"), true);
+  assertEquals(releaseCompose.includes("UGOITE_DATA_DIR:-./data}:/data"), true);
+  assertEquals(sourceCompose.includes("./spaces:/data/spaces"), false);
+  assertEquals(sourceCompose.includes("./node:/data/_ugoite"), false);
+  assertEquals(releaseCompose.includes("UGOITE_SPACES_DIR"), false);
+  assertEquals(releaseCompose.includes("UGOITE_NODE_DIR"), false);
+});
+
 Deno.test("CI image and E2E tasks preserve the build-once contract", async () => {
   const rootMise = await Deno.readTextFile("mise.toml");
   const workflow = await Deno.readTextFile(".github/workflows/ci.yml");


### PR DESCRIPTION
## Summary

- Use one repository-local `data/` endpoint for Ugoite runtime storage.
- Point maintainer development, source/release Compose, seed, and release verification helpers at that endpoint.
- Ignore the endpoint as a unit and update the local Compose guides.

## Related Issue (required)

close: #1831

## Testing

- [x] `mise run check`
- [x] `mise run fmt:check`
- [x] `mise run test:tools`
- [x] Source and release `docker compose config --quiet`
- [x] Shell syntax checks for changed scripts
