### PR TITLE
docs: define SpaceCatalog architecture

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -9,6 +9,7 @@ These documents describe the current implementation boundaries and the intended
 local-first direction.
 
 - [Architecture North Star](north-star.md)
+- [Space Catalog](../spec/architecture/space-catalog.md)
 - [Authentication and authorization](authentication-authorization.md)
 - [Control surfaces](control-surfaces.md)
 - [Runtime adapters](runtime-adapters.md)

--- a/docs/architecture/north-star.md
+++ b/docs/architecture/north-star.md
@@ -22,6 +22,26 @@ boundary; no hosted database is required to own or recover the content.
 - The WASM crate exposes portable domain/API protocol logic, not a local storage
   engine.
 
+## Persistence architecture
+
+A Space is the complete durable boundary. It maps to one Iceberg namespace and
+is reached only through the configured OpenDAL boundary. A server can expose a
+Space, but it never owns a hidden catalog, relational database, or recovery
+index for that Space.
+
+`_ugoite/catalog/head.json` is the only mutable catalog root. It is published
+with an actual OpenDAL ETag compare-and-swap. Immutable, checksum-protected
+publication records under `_ugoite/catalog/publications/` link each successful
+Head generation to the preceding one. Iceberg metadata, manifests, and data
+files remain Iceberg-owned immutable objects.
+
+Readers pin immutable Head and snapshot coordinates and never lock. Writers can
+prepare immutable objects concurrently, but make a mutation visible only by
+replacing Head with the exact ETag they read. Backends that cannot prove the
+conditional read/create/replace contract are read-only unless an operator
+explicitly selects single-process mode. No lease, heartbeat, TTL, lock file, or
+fencing protocol participates in correctness.
+
 ## Target state
 
 The browser should eventually open a local Space runtime and synchronize only
@@ -31,9 +51,13 @@ not become the mandatory owner of user data.
 ## Invariants
 
 1. Filesystem/object-storage-compatible Space content is the source of truth.
-2. Revisions are append-only; recovery must not depend on a hidden database.
-3. Indexes, projections, and query sessions are derived and replaceable.
-4. Domain and use-case behavior lives in reusable Rust crates.
-5. CLI, server, WASM, and browser transport code remain adapters.
-6. Authentication and authorization do not change ownership of Space data.
-7. Current and planned capabilities are documented separately.
+2. Revisions are append-only Iceberg table data; current state is derived from
+   one table and recovery never depends on a hidden database.
+3. Catalog Head is the only authoritative mutable root. Object listing never
+   establishes catalog state or publication order.
+4. Indexes, projections, health reports, checkpoints, and query sessions are
+   derived or explicitly pinned coordinates, never competing authority.
+5. Domain and use-case behavior lives in reusable Rust crates.
+6. CLI, server, WASM, and browser transport code remain adapters.
+7. Authentication and authorization do not change ownership of Space data.
+8. Current and planned capabilities are documented separately.

--- a/docs/spec/architecture/decisions.md
+++ b/docs/spec/architecture/decisions.md
@@ -61,7 +61,7 @@ two-table commit.
 
 ## ADR-010 — OpenDAL-published SpaceCatalog and DataFusion
 
-**Accepted.** A Space has one OpenDAL-backed `SpaceCatalog` implementing the
+**Accepted target.** A Space has one OpenDAL-backed `SpaceCatalog` implementing the
 current Iceberg `Catalog` trait. Its sole mutable authority is
 `_ugoite/catalog/head.json`; immutable linked publication records beneath
 `_ugoite/catalog/publications/` provide the evidence needed to resolve an

--- a/docs/spec/architecture/decisions.md
+++ b/docs/spec/architecture/decisions.md
@@ -59,21 +59,28 @@ Form table. Current state is the unique greatest `entry_version`; equal maximum
 versions are a conflict. There is no authoritative current-entry table and no
 two-table commit.
 
-## ADR-010 — Catalog and DataFusion are explicit
+## ADR-010 — OpenDAL-published SpaceCatalog and DataFusion
 
-**Accepted.** REST Catalog is the multi-writer production Catalog. Local
-single-process CLI mode uses the explicitly scoped MemoryCatalog plus its
-portable pointer manifest; object listing must not infer metadata pointers.
-MemoryCatalog is not used for shared production deployments.
-DataFusion is the standard structured query engine and receives projection,
-predicate, limit, join, and snapshot work through Iceberg providers.
+**Accepted.** A Space has one OpenDAL-backed `SpaceCatalog` implementing the
+current Iceberg `Catalog` trait. Its sole mutable authority is
+`_ugoite/catalog/head.json`; immutable linked publication records beneath
+`_ugoite/catalog/publications/` provide the evidence needed to resolve an
+ambiguous Head compare-and-swap after later writers publish.
 
-Schema evolution receives a REST committer from the same typed configuration
-used to construct the REST Catalog. The committer does not re-read a global
-environment variable or construct a second endpoint configuration; Catalog
-config response prefixes, headers, static credentials, and OAuth credential
-exchange are applied to the atomic commit request. Iceberg Rust 0.8 is not
-forked.
+Shared writes require a real Head ETag, exact `if_match` reads, conditional
+initial creation, and conditional whole-object replacement proven by backend
+probes. ETags are opaque tokens. Unsupported backends fail closed for shared
+writes; an explicitly selected single-process mode may serialize in-process
+while retaining every durable byte through OpenDAL. Readers never lock, and no
+lease, heartbeat, TTL, lock file, fencing token, external Catalog, or relational
+database is part of the production architecture.
+
+Iceberg requirement/update application, file locations, filenames, and I/O use
+the current official Iceberg Rust stack and `iceberg-storage-opendal`; Ugoite
+does not supply a second FileIO or infer metadata from listings. DataFusion is
+the standard structured query engine and receives authorization-filtered,
+snapshot-pinned Iceberg providers. One Form-table commit is atomic; cross-Form
+transactions are explicitly unsupported.
 
 ## ADR-011 — Portable logic is not a storage adapter
 

--- a/docs/spec/architecture/future-proofing.md
+++ b/docs/spec/architecture/future-proofing.md
@@ -10,7 +10,9 @@ A future browser adapter may persist a complete Space locally and optionally syn
 
 ## Storage portability
 
-Core behavior uses OpenDAL and Space-relative paths so local files and compatible object stores share one model. Physical Iceberg internals remain owned by the storage layer.
+`ugoite-storage` uses OpenDAL and Space-relative paths so local files and
+compatible object stores share one model. Physical Iceberg internals remain in
+`ugoite-iceberg`; Core consumes domain-facing storage/query contracts only.
 
 ## AI surfaces
 
@@ -18,4 +20,7 @@ MCP may add resources, prompts, and tools only with explicit authorization and u
 
 ## Compatibility
 
-Protocol versions, OpenAPI snapshots, file-schema changes, and release migrations require tests and explicit documentation.
+Protocol versions and OpenAPI snapshots require tests and explicit documentation.
+The current internal pre-release Space format version remains unchanged during
+the destructive architecture transition: superseded layouts fail explicitly
+instead of acquiring migration readers or compatibility flags.

--- a/docs/spec/architecture/overview.md
+++ b/docs/spec/architecture/overview.md
@@ -9,9 +9,11 @@ frontend / CLI / REST / MCP
           ↓ adapters
 ugoite-api-client (remote protocol where applicable)
           ↓
-ugoite-core (use cases and authorization-aware service)
+ugoite-core (domain use cases and authorization policy)
           ↓
-ugoite-storage + ugoite-iceberg / OpenDAL + Catalog-backed Iceberg tables
+ugoite-iceberg (physical adapter and publication coordinator)
+          ↓
+ugoite-storage (OpenDAL configuration and conditional Head objects)
           ↓
 operator-owned workspace
 ```
@@ -21,22 +23,30 @@ Its portable actions validate Forms and Revisions, preview Form change sets,
 and derive optimistic-concurrency Revision drafts without storage access.
 
 The persistence model is one Iceberg namespace per Space and one append-only
-table per stable Form ID. `ugoite-iceberg` owns Catalog integration,
-Schema/Table Properties mapping, Revision-only batch append, DataFusion
-registration, migration reports, and maintenance planning. Form, Entry,
-Saved SQL, and SQL-session persistence in Core call this boundary; the old
-revision-row writer remains only as migration-reader code and is not a
-production write path.
+revision table per stable Form ID. `ugoite-storage` normalizes backend
+configuration, constructs the Catalog Head operator, probes conditional-object
+behavior, and exposes only the small exact-read/create/replace boundary.
+`ugoite-iceberg` constructs the official `iceberg-storage-opendal` factory,
+owns physical schemas and typed Arrow conversion, implements the one
+OpenDAL-backed `SpaceCatalog`, and is the only production gateway for Iceberg
+table publication and DataFusion providers. `ugoite-core` deals only in domain
+commands, authorization/query policy, checkpoints, receipts, and errors.
 
-Logical Form field IDs are sent as Iceberg field IDs and retained in Form
-metadata. Schema-bearing changes use an explicitly injected REST schema
-committer built from the same typed configuration as the Catalog. It resolves
-the Catalog config response (including endpoint prefix), carries configured
-headers and authentication, and sends `UuidMatch`, current-schema, and
-last-assigned-field requirements together with the schema and Form properties
-in one atomic commit. The local MemoryCatalog fallback is kept for offline
-single-process CLI/test operation. It writes a next Iceberg metadata version
-and then swaps the local catalog pointer, preserving existing data files and
-snapshots while making newly added nullable fields available.
+`_ugoite/catalog/head.json` is the sole mutable catalog authority. Every Head
+generation names the Form tables and their immutable Iceberg metadata. A
+checksum-protected immutable publication record records the complete next Head,
+the previous publication coordinate, and the command identity. Writers read
+Head with its actual ETag, prepare immutable Iceberg objects, and make them
+visible by a conditional Head replacement. A conflict re-runs domain validation
+against an exact fresh Head; a lost response is resolved from the reachable
+publication chain instead of blindly repeating the logical mutation. REST,
+Memory, pointer-manifest, external-catalog, and object-list reconstruction modes
+are not production architecture.
+
+Logical Form field IDs are Iceberg field IDs. Current state is derived once from
+the revision table and fails explicitly on duplicate maximum versions. Reads use
+snapshot-pinned upstream Iceberg/DataFusion providers; query sessions and
+checkpoints are derived/pinned state, not catalog authority. One Form table
+commit is the atomicity boundary: Ugoite does not claim cross-Form transactions.
 
 The current browser is server-backed. The target architecture adds a browser-local runtime and optional synchronization without making the server the mandatory owner of data.

--- a/docs/spec/architecture/overview.md
+++ b/docs/spec/architecture/overview.md
@@ -24,13 +24,10 @@ and derive optimistic-concurrency Revision drafts without storage access.
 
 The persistence model is one Iceberg namespace per Space and one append-only
 revision table per stable Form ID. `ugoite-storage` normalizes backend
-configuration, constructs the Catalog Head operator, probes conditional-object
-behavior, and exposes only the small exact-read/create/replace boundary.
-`ugoite-iceberg` constructs the official `iceberg-storage-opendal` factory,
-owns physical schemas and typed Arrow conversion, implements the one
-OpenDAL-backed `SpaceCatalog`, and is the only production gateway for Iceberg
-table publication and DataFusion providers. `ugoite-core` deals only in domain
-commands, authorization/query policy, checkpoints, receipts, and errors.
+configuration and owns the small Catalog Head object boundary. `ugoite-iceberg`
+constructs the official `iceberg-storage-opendal` factory, owns physical
+schemas, and implements the OpenDAL-backed `SpaceCatalog`. Core receives no
+OpenDAL, Iceberg, Arrow, Parquet, DataFusion, or SQL-parser types.
 
 `_ugoite/catalog/head.json` is the sole mutable catalog authority. Every Head
 generation names the Form tables and their immutable Iceberg metadata. A
@@ -43,10 +40,10 @@ publication chain instead of blindly repeating the logical mutation. REST,
 Memory, pointer-manifest, external-catalog, and object-list reconstruction modes
 are not production architecture.
 
-Logical Form field IDs are Iceberg field IDs. Current state is derived once from
-the revision table and fails explicitly on duplicate maximum versions. Reads use
-snapshot-pinned upstream Iceberg/DataFusion providers; query sessions and
-checkpoints are derived/pinned state, not catalog authority. One Form table
-commit is the atomicity boundary: Ugoite does not claim cross-Form transactions.
+The active follow-up issues make this architecture complete: typed Form columns,
+one mutation coordinator, duplicate-head detection, authorization-aware
+DataFusion reads, checkpoints, and read-only health evidence are target work,
+not claims about every current API. One Form table commit is the atomicity
+boundary; Ugoite does not claim cross-Form transactions.
 
 The current browser is server-backed. The target architecture adds a browser-local runtime and optional synchronization without making the server the mandatory owner of data.

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -64,8 +64,12 @@ serialization but still writes every durable byte through OpenDAL.
 Readers never lock. Writers may prepare immutable files concurrently. Visibility
 changes only through Head. One Form table commit is the mutation atomicity unit;
 Ugoite makes no cross-Form transaction claim. Leases, TTLs, heartbeats, lock
-files, fences, custom FileIO, metadata reconstruction, object-list recovery,
-and custom maintenance engines are outside this architecture.
+files, fences, custom FileIO, independent metadata-history or commit engines,
+object-list recovery, and custom maintenance engines are outside this
+architecture. A narrow physical-schema compatibility adapter is permitted only
+when the upstream Rust API cannot retain an already-assigned Iceberg field ID;
+it must produce standard upstream Iceberg metadata and cannot establish a
+second field-identity authority.
 
 ## Crate boundary
 

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -7,6 +7,12 @@ intentionally destructive before the first release: the internal pre-release
 Space format version is unchanged, while legacy layouts and catalog modes are
 unsupported rather than migrated.
 
+The Catalog Head layout and upstream physical boundary are implemented by the
+current persistence work. The single mutation coordinator, checkpoint-pinned
+reads, authorization-aware DataFusion context, and health evidence described
+here remain active follow-up work; this document does not advertise them as
+current product APIs.
+
 ## Authority and ownership
 
 One Space maps to one Iceberg namespace. One stable Form ID maps to one

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -42,6 +42,11 @@ Head with `if_match` using the exact ETag. No automatic refresh/rebase changes a
 logical mutation. An ETag mismatch reloads exact state and re-runs domain
 validation.
 
+The record stores base/new metadata locations plus the base and resulting
+Iceberg snapshot and schema IDs from upstream table metadata. Snapshot IDs may
+be null for metadata-only changes or a newly created table; schema IDs make the
+schema coordinate explicit without reproducing Iceberg's history locally.
+
 A transport error after Head replacement has an unknown outcome. The writer
 rereads Head and walks reachable publication records back to its base
 generation: a matching command identity proves success; reaching base without

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -1,0 +1,73 @@
+---
+title: 'SpaceCatalog publication contract'
+---
+
+This is the single durable-control-plane contract for a Ugoite Space. It is
+intentionally destructive before the first release: the internal pre-release
+Space format version is unchanged, while legacy layouts and catalog modes are
+unsupported rather than migrated.
+
+## Authority and ownership
+
+One Space maps to one Iceberg namespace. One stable Form ID maps to one
+append-only Iceberg revision table. Iceberg metadata and revision tables are
+authoritative for table history and state derivation.
+
+All durable Ugoite objects are reachable through the configured OpenDAL Space
+boundary. Ugoite does not require PostgreSQL, SQLite, a SQL Catalog, Hive
+Metastore, or any other hosted durable service. The server exposes a Space; it
+does not own one.
+
+The only mutable catalog root is `_ugoite/catalog/head.json`. Immutable
+publication records live at `_ugoite/catalog/publications/<generation>-<command-id>.json`.
+Only records reachable from Head through `previous_publication` are authoritative.
+Object listing never establishes current state or order.
+
+## Exact reads and publication
+
+An exact Head read first obtains a real ETag with `stat`, then reads Head with
+that ETag as `if_match`; a changed object restarts the read. A plain stat plus
+unconditional read is not exact.
+
+A writer reads one exact Head and referenced table metadata, validates its
+domain command, prepares immutable Iceberg data and metadata through the
+official upstream writer, writes one immutable publication record, and replaces
+Head with `if_match` using the exact ETag. No automatic refresh/rebase changes a
+logical mutation. An ETag mismatch reloads exact state and re-runs domain
+validation.
+
+A transport error after Head replacement has an unknown outcome. The writer
+rereads Head and walks reachable publication records back to its base
+generation: a matching command identity proves success; reaching base without
+it proves non-publication; missing or corrupt evidence is an explicit
+unknown/corrupt result. Repeating the mutation blindly is forbidden.
+
+## Capability and concurrency boundary
+
+Shared writes require behavioral probes, not merely capability flags: a real
+changing ETag, exact conditional read, conditional create-if-absent,
+conditional replacement, and stale-ETag rejection. Unsupported backends fail
+closed for shared writes. Explicit single-process mode may use local
+serialization but still writes every durable byte through OpenDAL.
+
+Readers never lock. Writers may prepare immutable files concurrently. Visibility
+changes only through Head. One Form table commit is the mutation atomicity unit;
+Ugoite makes no cross-Form transaction claim. Leases, TTLs, heartbeats, lock
+files, fences, custom FileIO, metadata reconstruction, object-list recovery,
+and custom maintenance engines are outside this architecture.
+
+## Crate boundary
+
+`ugoite-storage` owns normalized storage configuration, the Catalog Head
+operator, capability probes, and the small conditional-object API. It does not
+become a generic OpenDAL wrapper.
+
+`ugoite-iceberg` owns `iceberg-storage-opendal`, `SpaceCatalog`, physical
+schemas, typed Arrow conversion, upstream writers, table commits, snapshots,
+DataFusion, checkpoints, and health evidence. Its physical upstream types do
+not cross into Core.
+
+`ugoite-core` owns domain validation, authorization meaning, use-case
+orchestration, domain commands, receipts, checkpoints, and errors. It neither
+constructs nor inspects OpenDAL, Iceberg, Arrow, Parquet, DataFusion, or SQL
+parser objects.

--- a/docs/spec/data-model/directory-layout.yaml
+++ b/docs/spec/data-model/directory-layout.yaml
@@ -21,19 +21,22 @@ space_layout:
     - path: spaces/{space_id}/settings.json
       kind: file
       schema: space_settings
+    - path: spaces/{space_id}/_ugoite/catalog
+      kind: directory
+      notes:
+      - Catalog Head is the sole mutable catalog authority.
+    - path: spaces/{space_id}/_ugoite/catalog/head.json
+      kind: file
+      schema: iceberg_catalog_head
+    - path_glob: spaces/{space_id}/_ugoite/catalog/publications/{generation}-{command_id}.json
+      kind: file
+      schema: iceberg_catalog_publication
+      notes:
+      - Immutable records are authoritative only when reachable from Head.
     - path: spaces/{space_id}/forms
       kind: directory
       notes:
-      - Iceberg owns all paths below this root.
-    - path: spaces/{space_id}/forms/catalog-pointers.v1.json
-      kind: file
-      schema: iceberg_catalog_pointers
-      notes:
-      - Portable local Catalog pointer manifest; never inferred by listing metadata files.
-    - path: spaces/{space_id}/forms/catalog-instance-id
-      kind: file
-      notes:
-      - Opaque cache isolation identity; it is not a Form or Space identifier.
+      - Iceberg owns table data and metadata locations beneath the Space.
     - path: spaces/{space_id}/assets
       kind: directory
     - path: spaces/{space_id}/materialized_views

--- a/docs/spec/data-model/directory-structure.md
+++ b/docs/spec/data-model/directory-structure.md
@@ -2,7 +2,9 @@
 title: 'Directory structure'
 ---
 
-`directory-layout.yaml` is the machine-readable inventory for repository-owned paths. Apache Iceberg owns the subtree beneath `forms/`; documentation and tests must not depend on its internal filenames.
+`directory-layout.yaml` is the machine-readable inventory for repository-owned
+paths. Apache Iceberg owns table data and metadata locations beneath the Space;
+documentation and tests must not depend on its internal filenames.
 
 ## Workspace layout
 
@@ -11,6 +13,10 @@ spaces/
   {space_id}/
     meta.json
     settings.json
+    _ugoite/
+      catalog/
+        head.json
+        publications/
     forms/
     assets/
     materialized_views/
@@ -59,16 +65,26 @@ Membership operations add `members`, `member_invitations`, and `membership_versi
 | Asset upload | `spaces/{space_id}/assets/{asset_id}_{safe_name}` | binary object |
 | Preference update | `users/{sha256(user_id)}/preferences.json` | portable user UI preferences |
 
-## Iceberg-managed Form storage
+## Catalog and Iceberg-managed Form storage
 
 A Form definition and its single append-only revision table are stored through
 the Catalog-backed Rust Iceberg layer. The table identity is derived from the
 stable Form UUID, not its display name. The repository specifies logical schema
 and table-property keys but leaves Iceberg metadata/data filenames unspecified.
 
-Portable local Spaces keep `forms/catalog-pointers.v1.json` as the explicit
-Catalog pointer manifest. A new process registers tables from this file; it
-never scans metadata filenames or selects the numerically greatest file.
+`_ugoite/catalog/head.json` is the only mutable catalog authority. It carries
+the Space identity, format version, catalog/form-registry generations, Form table
+coordinates, checksum, and current publication coordinate. A process opens a
+Space by reading this Head exactly with its OpenDAL ETag and loading only the
+referenced immutable Iceberg metadata.
+
+`_ugoite/catalog/publications/<generation>-<command-id>.json` records the
+complete next Head, its checksum, the preceding Head and publication
+coordinates, command identity/digest, and affected-table Iceberg coordinates.
+Records are immutable and authoritative only when reachable from Head. Listing
+objects never reconstructs catalog state or publication order. Missing/corrupt
+Head or reachable publication evidence is an explicit failure; old pointer
+manifests and layout readers are unsupported rather than migrated.
 
 Revision rows contain stable entry/revision identity, optimistic version and
 parent lineage, operation/tombstone state, commit time, author and provenance,
@@ -77,4 +93,8 @@ latest non-conflicting revision provides current Entry responses.
 
 ## Portability
 
-A complete storage root can be backed up or moved as an operator-controlled unit. Copying only one Space preserves that Space’s content and metadata but not user-scoped preferences stored under `users/`. Storage migration is an operator procedure; PATCHing a Space storage descriptor does not move existing files.
+A complete storage root can be backed up or moved as an operator-controlled
+unit. Object versioning or operator backups protect Catalog Head for disaster
+recovery. Copying only one Space preserves that Space’s content and metadata but
+not user-scoped preferences stored under `users/`. PATCHing a Space storage
+descriptor does not move existing files.

--- a/docs/spec/data-model/file-schemas.yaml
+++ b/docs/spec/data-model/file-schemas.yaml
@@ -172,26 +172,56 @@ schemas:
               target_form:
                 type: string
               default: {}
-  iceberg_catalog_pointers:
-    description: Versioned Catalog pointer manifest used by portable local Spaces; it replaces metadata-directory discovery.
-    path: spaces/{id}/forms/catalog-pointers.v1.json
+  iceberg_catalog_head:
+    description: The sole mutable catalog root, conditionally read and published with an OpenDAL ETag.
+    path: spaces/{id}/_ugoite/catalog/head.json
     schema:
       type: object
-      required: [version, tables]
+      required: [format_version, space_id, namespace, generation, form_registry_generation, tables, checksum, publication]
       properties:
-        version:
-          const: 1
+        format_version: {type: integer}
+        space_id: {type: string}
+        namespace:
+          type: array
+          items: {type: string}
+        generation: {type: integer, minimum: 0}
+        form_registry_generation: {type: integer, minimum: 0}
         tables:
           type: array
           items:
             type: object
-            required: [namespace, table, metadata_location]
+            required: [form_id, table, table_uuid, metadata_location]
             properties:
-              namespace:
-                type: array
-                items: {type: string}
+              form_id: {type: string, format: uuid}
               table: {type: string}
+              table_uuid: {type: string, format: uuid}
               metadata_location: {type: string}
+        checksum: {type: string}
+        publication:
+          type: object
+          required: [location, command_id]
+          properties:
+            location: {type: string}
+            command_id: {type: string}
+  iceberg_catalog_publication:
+    description: Immutable Head-publication evidence linked from the current Catalog Head.
+    path: spaces/{id}/_ugoite/catalog/publications/{generation}-{command_id}.json
+    schema:
+      type: object
+      required: [generation, command_id, command_kind, command_digest, next_head_checksum, next_head]
+      properties:
+        generation: {type: integer, minimum: 0}
+        previous_generation: {type: [integer, 'null']}
+        previous_publication: {type: [string, 'null']}
+        previous_head_checksum: {type: [string, 'null']}
+        command_id: {type: string}
+        command_kind: {type: string}
+        command_digest: {type: string}
+        affected_table: {type: [string, 'null']}
+        base_metadata_location: {type: [string, 'null']}
+        new_metadata_location: {type: [string, 'null']}
+        next_head_checksum: {type: string}
+        next_head: {type: object}
   materialized_view_meta:
     description: Metadata-only placeholder; no result rows.
     path: spaces/{id}/materialized_views/{sql_id}/meta.json

--- a/docs/spec/data-model/file-schemas.yaml
+++ b/docs/spec/data-model/file-schemas.yaml
@@ -211,7 +211,7 @@ schemas:
     path: spaces/{id}/_ugoite/catalog/publications/{generation}-{command_id}.json
     schema:
       type: object
-      required: [generation, previous_generation, previous_publication, previous_head_checksum, command_id, command_kind, command_digest, affected_table, base_metadata_location, new_metadata_location, next_head_checksum, next_head, checksum]
+      required: [generation, previous_generation, previous_publication, previous_head_checksum, command_id, command_kind, command_digest, affected_table, base_metadata_location, new_metadata_location, base_snapshot_id, base_schema_id, new_snapshot_id, new_schema_id, next_head_checksum, next_head, checksum]
       properties:
         generation: {type: integer, minimum: 0}
         previous_generation: {type: [integer, 'null']}
@@ -229,7 +229,11 @@ schemas:
               items: {type: string}
             table: {type: string}
         base_metadata_location: {type: [string, 'null']}
-        new_metadata_location: {type: [string, 'null']}
+        new_metadata_location: {type: string}
+        base_snapshot_id: {type: [integer, 'null']}
+        base_schema_id: {type: [integer, 'null']}
+        new_snapshot_id: {type: [integer, 'null']}
+        new_schema_id: {type: integer}
         next_head_checksum: {type: string}
         next_head: {type: object}
         checksum: {type: string}

--- a/docs/spec/data-model/file-schemas.yaml
+++ b/docs/spec/data-model/file-schemas.yaml
@@ -177,7 +177,7 @@ schemas:
     path: spaces/{id}/_ugoite/catalog/head.json
     schema:
       type: object
-      required: [format_version, space_id, namespace, generation, form_registry_generation, tables, checksum, publication]
+      required: [format_version, space_id, namespace, generation, form_registry_generation, tables, publication_location, publication_command_id, checksum]
       properties:
         format_version: {type: integer}
         space_id: {type: string}
@@ -187,28 +187,31 @@ schemas:
         generation: {type: integer, minimum: 0}
         form_registry_generation: {type: integer, minimum: 0}
         tables:
-          type: array
-          items:
+          type: object
+          additionalProperties:
             type: object
-            required: [form_id, table, table_uuid, metadata_location]
+            required: [identifier, form_id, table_uuid, metadata_location]
             properties:
-              form_id: {type: string, format: uuid}
-              table: {type: string}
+              identifier:
+                type: object
+                required: [namespace, table]
+                properties:
+                  namespace:
+                    type: array
+                    items: {type: string}
+                  table: {type: string}
+              form_id: {type: [string, 'null'], format: uuid}
               table_uuid: {type: string, format: uuid}
               metadata_location: {type: string}
+        publication_location: {type: [string, 'null']}
+        publication_command_id: {type: [string, 'null']}
         checksum: {type: string}
-        publication:
-          type: object
-          required: [location, command_id]
-          properties:
-            location: {type: string}
-            command_id: {type: string}
   iceberg_catalog_publication:
     description: Immutable Head-publication evidence linked from the current Catalog Head.
     path: spaces/{id}/_ugoite/catalog/publications/{generation}-{command_id}.json
     schema:
       type: object
-      required: [generation, command_id, command_kind, command_digest, next_head_checksum, next_head]
+      required: [generation, previous_generation, previous_publication, previous_head_checksum, command_id, command_kind, command_digest, affected_table, base_metadata_location, new_metadata_location, next_head_checksum, next_head, checksum]
       properties:
         generation: {type: integer, minimum: 0}
         previous_generation: {type: [integer, 'null']}
@@ -217,11 +220,19 @@ schemas:
         command_id: {type: string}
         command_kind: {type: string}
         command_digest: {type: string}
-        affected_table: {type: [string, 'null']}
+        affected_table:
+          type: object
+          required: [namespace, table]
+          properties:
+            namespace:
+              type: array
+              items: {type: string}
+            table: {type: string}
         base_metadata_location: {type: [string, 'null']}
         new_metadata_location: {type: [string, 'null']}
         next_head_checksum: {type: string}
         next_head: {type: object}
+        checksum: {type: string}
   materialized_view_meta:
     description: Metadata-only placeholder; no result rows.
     path: spaces/{id}/materialized_views/{sql_id}/meta.json

--- a/docs/spec/data-model/overview.md
+++ b/docs/spec/data-model/overview.md
@@ -82,18 +82,22 @@ H2 sections are parsed according to the Form field type. Supported types are exp
 
 ## Search, query, and derived data
 
-Keyword search, structured query, Links, Assets, and Ugoite SQL are DataFusion
-plans over authorized, snapshot-pinned Iceberg data. They do **not** create a
-persistent inverted index, JSON materialization table, or second history store.
+The current keyword search scans non-deleted Entry rows for a case-insensitive
+substring. It does **not** use a persistent inverted index or relevance ranking.
+The target read path is an authorized, snapshot-pinned DataFusion plan over
+Iceberg data; that transition is tracked separately and must not add a JSON
+materialization table or a second history store.
 
 `ugoite index stats` is available in core/local mode. Reindex and per-entry index update return an explicit “not implemented in this release” error, so persistent live-index/watch-loop behavior remains planned.
 
 ## Saved SQL and SQL sessions
 
-Saved SQL is represented through the reserved SQL metadata Form. A query session
-pins one reproducible Space checkpoint, validates authorization on every use,
-and applies bounded deterministic pagination. Session metadata is derived state,
-not an alternate Catalog or result store. See [sql-sessions.md](sql-sessions.md).
+Saved SQL is represented through the reserved SQL metadata Form. The current
+query session writes `sql_sessions/{session_id}/meta.json`; row and count
+requests re-run SQL against current readable data. The target session model pins
+one reproducible checkpoint and uses bounded deterministic pagination. Session
+metadata remains derived state, not an alternate Catalog or result store. See
+[sql-sessions.md](sql-sessions.md).
 
 ## Assets, links, and integrity
 

--- a/docs/spec/data-model/overview.md
+++ b/docs/spec/data-model/overview.md
@@ -8,7 +8,9 @@ Ugoite treats operator-controlled files as the persistence boundary. A **Space**
 
 - **Authoring:** people and agents edit Markdown.
 - **Domain contract:** a Form defines the typed H2 fields accepted for an Entry.
-- **Persistence:** Iceberg tables and the JSON metadata files listed below are authoritative on disk.
+- **Persistence:** Catalog Head, its reachable immutable publication records,
+  Iceberg metadata, and Iceberg revision tables are authoritative through the
+  configured OpenDAL Space boundary.
 
 The browser is currently server-backed. It does not own an independent local Space database; the Rust server and core write to the configured OpenDAL operator.
 
@@ -18,7 +20,8 @@ The browser is currently server-backed. It does not own an independent local Spa
 spaces/{space_id}/
   meta.json
   settings.json
-  forms/                  # Iceberg-owned subtree
+  _ugoite/catalog/        # Head plus immutable publication records
+  forms/                  # Iceberg-owned table locations
   assets/
   materialized_views/
   sql_sessions/
@@ -56,7 +59,8 @@ The table is an append-only revision log. Common columns include `entry_id`,
 `committed_at`, `author_id`, `form_version`, `source_kind`, and `source_id`,
 followed by Form fields. Delete is a tombstone and restore is another revision.
 Current state is derived from the unique greatest version and is never a second
-source-of-truth table.
+source-of-truth table. Equal greatest versions are a visible corruption/conflict
+and never resolved by iteration order.
 
 Date, time, timestamp, UUID, and binary Form fields use their corresponding
 Iceberg primitive types. Markdown, SQL, row references, and ordinary strings
@@ -78,13 +82,18 @@ H2 sections are parsed according to the Form field type. Supported types are exp
 
 ## Search, query, and derived data
 
-The current keyword search scans non-deleted Entry rows for a case-insensitive substring. It does **not** use a persistent inverted index or relevance ranking. Structured query and Ugoite SQL execute against current Entry data.
+Keyword search, structured query, Links, Assets, and Ugoite SQL are DataFusion
+plans over authorized, snapshot-pinned Iceberg data. They do **not** create a
+persistent inverted index, JSON materialization table, or second history store.
 
 `ugoite index stats` is available in core/local mode. Reindex and per-entry index update return an explicit “not implemented in this release” error, so persistent live-index/watch-loop behavior remains planned.
 
 ## Saved SQL and SQL sessions
 
-Saved SQL is represented through the reserved SQL metadata Form. A query session writes only `sql_sessions/{session_id}/meta.json`; row and count requests re-run the SQL against current readable data. Materialized-view records are metadata placeholders, not persisted result tables. See [sql-sessions.md](sql-sessions.md).
+Saved SQL is represented through the reserved SQL metadata Form. A query session
+pins one reproducible Space checkpoint, validates authorization on every use,
+and applies bounded deterministic pagination. Session metadata is derived state,
+not an alternate Catalog or result store. See [sql-sessions.md](sql-sessions.md).
 
 ## Assets, links, and integrity
 

--- a/docs/spec/specifications.yaml
+++ b/docs/spec/specifications.yaml
@@ -20,6 +20,13 @@
   linked_requirements:
   - REQCAT-API
   - REQCAT-STORAGE
+- id: SPEC-ARCH-SPACE-CATALOG
+  source_file: architecture/space-catalog.md
+  linked_policies:
+  - POL-001
+  - POL-014
+  linked_requirements:
+  - REQCAT-STORAGE
 - id: SPEC-ARCH-INTERFACE
   source_file: architecture/frontend-backend-interface.md
   linked_policies:


### PR DESCRIPTION
## Summary

- define the destructive pre-release SpaceCatalog, Catalog Head, and immutable publication-record contract
- replace pointer-manifest documentation with OpenDAL exact-read/CAS and upstream Iceberg ownership
- record snapshot/schema publication coordinates and the narrow upstream field-ID compatibility boundary

## Related Issue (required)

Closes #1810

## Testing

- [x] `mise run test:docsite`
