### PR TITLE
test: enforce CAS-only entry concurrency

### DIFF
--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -710,7 +710,10 @@ async fn concurrent_workspace_writers_surface_equal_version_conflicts() -> anyho
         first.append_revisions(form.id, vec![left]),
         second.append_revisions(form.id, vec![right.clone()]),
     );
-    left_result.or(right_result)?;
+    assert!(
+        left_result.is_ok() ^ right_result.is_ok(),
+        "same-base mutations for one Entry must have exactly one winner",
+    );
     let probe = EntryRevision {
         revision_id: Uuid::from_u128(54).into(),
         ..right


### PR DESCRIPTION
## Summary

- require same-base mutations for one Entry to have exactly one successful CAS-backed publication
- retain the lease-free concurrency model: immutable files, upstream validation, and Catalog Head CAS only

## Related Issue (required)

Closes #1813

## Testing

- [x] `cargo test -p ugoite-iceberg --test workspace concurrent_workspace_writers_surface_equal_version_conflicts --offline`
