### PR TITLE
feat: coordinate Space Catalog mutations

### DIFF
--- a/crates/ugoite-iceberg/src/entry.rs
+++ b/crates/ugoite-iceberg/src/entry.rs
@@ -506,7 +506,20 @@ async fn append_revision_rows_to_workspace(
         .map(|row| revision_row_to_domain(row, &domain_form))
         .collect::<Result<Vec<_>>>()?;
     let workspace = iceberg_store::native_workspace(op, ws_path).await?;
+    let command = crate::publication_context(
+        format!(
+            "entry-revision-batch:{}",
+            revisions
+                .iter()
+                .map(|revision| revision.revision_id.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        "entry.append",
+        &revisions,
+    )?;
     workspace
+        .commit(command)?
         .append_revisions(domain_form.id, revisions)
         .await?;
     Ok(())

--- a/crates/ugoite-iceberg/src/form.rs
+++ b/crates/ugoite-iceberg/src/form.rs
@@ -75,7 +75,17 @@ pub async fn upsert_form(op: &Operator, ws_path: &str, form_def: &Value) -> Resu
         let changes = form_changes(&current_domain, &desired_domain)?;
         if !changes.is_empty() {
             let workspace = iceberg_store::native_workspace(op, ws_path).await?;
+            let command = crate::publication_context(
+                format!(
+                    "form-evolve:{}:{}",
+                    current_domain.id,
+                    current_domain.version.get()
+                ),
+                "form.evolve",
+                &changes,
+            )?;
             workspace
+                .commit(command)?
                 .evolve_form(&FormChangeSet {
                     form_id: current_domain.id,
                     expected_version: Some(current_domain.version),

--- a/crates/ugoite-iceberg/src/iceberg_store.rs
+++ b/crates/ugoite-iceberg/src/iceberg_store.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Result};
-use iceberg::TableIdent;
 use opendal::Operator;
 use serde_json::Value;
 use std::collections::HashSet;
@@ -49,12 +48,10 @@ pub async fn ensure_form_tables(
 ) -> Result<()> {
     let form = crate::form::to_domain_form(form_definition)?;
     let workspace = native_workspace(operator, workspace_path).await?;
-    let table = TableIdent::new(
-        workspace.namespace().clone(),
-        crate::physical_form_name(form.id),
-    );
-    if !workspace.catalog().table_exists(&table).await? {
-        workspace.create_form(&form).await?;
+    if !workspace.has_form(form.id).await? {
+        let command =
+            crate::publication_context(format!("form-create:{}", form.id), "form.create", &form)?;
+        workspace.commit(command)?.create_form(&form).await?;
     }
     Ok(())
 }

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -28,7 +28,8 @@ pub mod sql_session;
 pub mod storage;
 
 pub use migration::{MigrationFormReport, MigrationManifest, MigrationReport};
-pub use space_catalog::{PublicationContext, SpaceCatalog};
+pub use space_catalog::PublicationContext;
+use space_catalog::SpaceCatalog;
 
 use anyhow::{anyhow, Context, Result};
 use arrow_array::builder::{
@@ -58,6 +59,7 @@ use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
 use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
 use iceberg_datafusion::IcebergCatalogProvider;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use ugoite_domain::entry::{
@@ -107,10 +109,40 @@ impl Default for WriteConfig {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CommitReceipt {
+    pub command_id: String,
+    pub catalog_generation: u64,
     pub snapshot_id: i64,
     pub committed_revision_ids: Vec<RevisionId>,
     pub committed_at_micros: i64,
     pub data_file_count: usize,
+}
+
+/// The only production entry point for changes that publish a Space Catalog
+/// Head.  A coordinator owns one immutable domain command identity.  It
+/// creates a fresh, short-lived `SpaceCatalog` only for the command attempt;
+/// no publication state is ambient or shared between commands.
+#[derive(Debug, Clone)]
+pub struct SpaceCommitCoordinator {
+    workspace: IcebergWorkspace,
+    publication: PublicationContext,
+}
+
+const MAX_PUBLICATION_ATTEMPTS: usize = 3;
+
+/// Builds the immutable identity carried by one domain command. Callers pass
+/// domain values only; canonical JSON is hashed before any physical Iceberg
+/// conversion happens.
+pub fn publication_context<T: Serialize>(
+    command_id: impl Into<String>,
+    command_kind: impl Into<String>,
+    command: &T,
+) -> Result<PublicationContext> {
+    let digest = format!("{:x}", Sha256::digest(serde_json::to_vec(command)?));
+    Ok(PublicationContext::with_command_digest(
+        command_id,
+        command_kind,
+        digest,
+    ))
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -138,26 +170,6 @@ impl IcebergWorkspace {
             write,
         )
         .await
-    }
-
-    pub async fn new(
-        catalog: Arc<dyn Catalog>,
-        space_id: SpaceId,
-        warehouse: impl Into<String>,
-        write: WriteConfig,
-    ) -> Result<Self> {
-        let namespace = namespace_for_space(space_id);
-        if !catalog.namespace_exists(&namespace).await? {
-            catalog.create_namespace(&namespace, HashMap::new()).await?;
-        }
-        Ok(Self {
-            catalog,
-            space_catalog: None,
-            namespace,
-            space_id,
-            warehouse: warehouse.into(),
-            write,
-        })
     }
 
     async fn new_space_catalog(
@@ -197,25 +209,50 @@ impl IcebergWorkspace {
         .await
     }
 
-    pub fn namespace(&self) -> &NamespaceIdent {
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn namespace_for_testing(&self) -> &NamespaceIdent {
         &self.namespace
     }
-    pub fn catalog(&self) -> Arc<dyn Catalog> {
+
+    /// Test-only physical inspection. Release builds expose no Catalog handle,
+    /// so application code cannot bypass `SpaceCommitCoordinator` to commit.
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn catalog_for_testing(&self) -> Arc<dyn Catalog> {
         self.catalog.clone()
     }
 
+    #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn clone_for_testing(&self) -> Self {
+        self.clone()
+    }
+
     fn mutation_catalog(&self) -> Arc<dyn Catalog> {
-        self.space_catalog
-            .as_ref()
-            .map(|catalog| Arc::new(catalog.new_attempt()) as Arc<dyn Catalog>)
-            .unwrap_or_else(|| self.catalog.clone())
+        self.catalog.clone()
+    }
+
+    /// Binds one stable domain command identity to a coordinator.  The
+    /// coordinator is intentionally the only public mutation API; read APIs
+    /// remain on `IcebergWorkspace`.
+    pub fn commit(&self, publication: PublicationContext) -> Result<SpaceCommitCoordinator> {
+        if self.space_catalog.is_none() {
+            return Err(anyhow!(
+                "SpaceCommitCoordinator requires the OpenDAL-backed SpaceCatalog"
+            ));
+        }
+        Ok(SpaceCommitCoordinator {
+            workspace: self.clone(),
+            publication,
+        })
     }
 
     pub fn schema_commit_capability(&self) -> SchemaCommitCapability {
         SchemaCommitCapability::AtomicSchemaEvolution
     }
 
-    pub async fn create_form(&self, form: &FormDefinition) -> Result<()> {
+    async fn create_form(&self, form: &FormDefinition) -> Result<()> {
         form.validate()?;
         validate_field_ids(form)?;
         let ident = self.form_ident(form.id);
@@ -270,6 +307,13 @@ impl IcebergWorkspace {
         Ok(form)
     }
 
+    /// Returns whether the authoritative Catalog Head currently contains this
+    /// Form table. This is a domain read and intentionally exposes neither a
+    /// physical table handle nor a mutation path.
+    pub async fn has_form(&self, form_id: FormId) -> Result<bool> {
+        Ok(self.catalog.table_exists(&self.form_ident(form_id)).await?)
+    }
+
     pub async fn list_forms(&self) -> Result<Vec<FormDefinition>> {
         let mut forms = Vec::new();
         for ident in self.catalog.list_tables(&self.namespace).await? {
@@ -282,7 +326,7 @@ impl IcebergWorkspace {
         Ok(forms)
     }
 
-    pub async fn evolve_form(&self, changes: &FormChangeSet) -> Result<FormDefinition> {
+    async fn evolve_form(&self, changes: &FormChangeSet) -> Result<FormDefinition> {
         let current = self.load_form(changes.form_id).await?;
         if changes.expected_version != Some(current.version) {
             return Err(anyhow!("Form version conflict"));
@@ -364,7 +408,6 @@ impl IcebergWorkspace {
                 .build()?
                 .metadata;
             space_catalog
-                .new_attempt()
                 .replace_table_metadata(table.identifier(), metadata)
                 .await?;
             return self.load_form(changes.form_id).await;
@@ -532,6 +575,8 @@ impl IcebergWorkspace {
             .context("append commit did not create a snapshot")?
             .snapshot_id();
         Ok(CommitReceipt {
+            command_id: String::new(),
+            catalog_generation: 0,
             snapshot_id,
             committed_revision_ids: ids,
             committed_at_micros,
@@ -539,7 +584,7 @@ impl IcebergWorkspace {
         })
     }
 
-    pub async fn append_revisions(
+    async fn append_revisions(
         &self,
         form_id: FormId,
         revisions: Vec<EntryRevision>,
@@ -679,6 +724,144 @@ impl IcebergWorkspace {
             physical_form_name(form_id)
         )
     }
+}
+
+impl SpaceCommitCoordinator {
+    fn attempt_workspace(&self) -> Result<IcebergWorkspace> {
+        let catalog = self
+            .workspace
+            .space_catalog
+            .as_ref()
+            .context("coordinator is missing its SpaceCatalog")?;
+        let catalog = Arc::new(
+            catalog
+                .new_attempt()
+                .with_publication_context(self.publication.clone()),
+        );
+        Ok(IcebergWorkspace {
+            catalog: catalog.clone(),
+            space_catalog: Some(catalog),
+            namespace: self.workspace.namespace.clone(),
+            space_id: self.workspace.space_id,
+            warehouse: self.workspace.warehouse.clone(),
+            write: self.workspace.write,
+        })
+    }
+
+    async fn publication_receipt(&self) -> Result<Option<space_catalog::PublicationReceipt>> {
+        self.workspace
+            .space_catalog
+            .as_ref()
+            .context("coordinator is missing its SpaceCatalog")?
+            .publication_receipt(&self.publication)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn create_form(&self, form: &FormDefinition) -> Result<()> {
+        for _ in 0..MAX_PUBLICATION_ATTEMPTS {
+            if self.publication_receipt().await?.is_some() {
+                return Ok(());
+            }
+            match self.attempt_workspace()?.create_form(form).await {
+                Ok(()) => return Ok(()),
+                Err(error) if is_publication_conflict(&error) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(anyhow!("Catalog Head changed during every create attempt"))
+    }
+
+    pub async fn evolve_form(&self, changes: &FormChangeSet) -> Result<FormDefinition> {
+        for _ in 0..MAX_PUBLICATION_ATTEMPTS {
+            if self.publication_receipt().await?.is_some() {
+                return self.workspace.load_form(changes.form_id).await;
+            }
+            match self.attempt_workspace()?.evolve_form(changes).await {
+                Ok(form) => return Ok(form),
+                Err(error) if is_publication_conflict(&error) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(anyhow!(
+            "Catalog Head changed during every form evolution attempt"
+        ))
+    }
+
+    pub async fn append_revisions(
+        &self,
+        form_id: FormId,
+        revisions: Vec<EntryRevision>,
+    ) -> Result<CommitReceipt> {
+        if let Some(receipt) = self.publication_receipt().await? {
+            return Ok(CommitReceipt {
+                command_id: receipt.command_id,
+                catalog_generation: receipt.catalog_generation,
+                snapshot_id: receipt
+                    .snapshot_id
+                    .context("revision publication did not create an Iceberg snapshot")?,
+                committed_revision_ids: revisions
+                    .iter()
+                    .map(|revision| revision.revision_id)
+                    .collect(),
+                committed_at_micros: revisions
+                    .iter()
+                    .map(|revision| revision.committed_at_micros)
+                    .max()
+                    .unwrap_or_default(),
+                data_file_count: 0,
+            });
+        }
+        for _ in 0..MAX_PUBLICATION_ATTEMPTS {
+            if let Some(receipt) = self.publication_receipt().await? {
+                return Ok(CommitReceipt {
+                    command_id: receipt.command_id,
+                    catalog_generation: receipt.catalog_generation,
+                    snapshot_id: receipt
+                        .snapshot_id
+                        .context("revision publication did not create an Iceberg snapshot")?,
+                    committed_revision_ids: revisions
+                        .iter()
+                        .map(|revision| revision.revision_id)
+                        .collect(),
+                    committed_at_micros: revisions
+                        .iter()
+                        .map(|revision| revision.committed_at_micros)
+                        .max()
+                        .unwrap_or_default(),
+                    data_file_count: 0,
+                });
+            }
+            let mut receipt = match self
+                .attempt_workspace()?
+                .append_revisions(form_id, revisions.clone())
+                .await
+            {
+                Ok(receipt) => receipt,
+                Err(error) if is_publication_conflict(&error) => continue,
+                Err(error) => return Err(error),
+            };
+            let publication = self
+                .publication_receipt()
+                .await?
+                .context("successful append is missing its Catalog publication")?;
+            receipt.command_id = publication.command_id;
+            receipt.catalog_generation = publication.catalog_generation;
+            if publication.snapshot_id != Some(receipt.snapshot_id) {
+                return Err(anyhow!(
+                    "Catalog publication snapshot does not match the append receipt"
+                ));
+            }
+            return Ok(receipt);
+        }
+        Err(anyhow!("Catalog Head changed during every append attempt"))
+    }
+}
+
+fn is_publication_conflict(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().contains("Catalog Head changed"))
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -52,6 +52,16 @@ pub struct PublicationContext {
     pub command_digest: String,
 }
 
+/// Durable outcome of a single command publication.  This deliberately
+/// contains only domain-facing coordinates; Iceberg metadata locations stay
+/// inside the catalog implementation.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct PublicationReceipt {
+    pub command_id: String,
+    pub catalog_generation: u64,
+    pub snapshot_id: Option<i64>,
+}
+
 impl PublicationContext {
     pub fn new(command_id: impl Into<String>, command_kind: impl Into<String>) -> Self {
         let command_id = command_id.into();
@@ -186,7 +196,7 @@ impl SpaceCatalog {
         })
     }
 
-    pub fn with_publication_context(mut self, publication: PublicationContext) -> Self {
+    pub(crate) fn with_publication_context(mut self, publication: PublicationContext) -> Self {
         self.publication = publication;
         self
     }
@@ -194,7 +204,7 @@ impl SpaceCatalog {
     /// Creates a fresh single-command Catalog publication attempt over the
     /// same Space. Reads may share a catalog instance, but a write must never
     /// reuse its immutable publication record or command identifier.
-    pub fn new_attempt(&self) -> Self {
+    pub(crate) fn new_attempt(&self) -> Self {
         Self {
             store: self.store.clone(),
             namespace: self.namespace.clone(),
@@ -206,7 +216,8 @@ impl SpaceCatalog {
         }
     }
 
-    pub fn namespace(&self) -> &NamespaceIdent {
+    #[cfg(test)]
+    fn namespace(&self) -> &NamespaceIdent {
         &self.namespace
     }
 
@@ -224,6 +235,91 @@ impl SpaceCatalog {
         }
         self.validate_head_publication(&head).await?;
         Ok(Some((head, exact)))
+    }
+
+    /// Finds a completed command through the immutable publication chain.
+    /// Reusing an id with a different kind or digest is an invalid idempotency
+    /// key reuse, rather than a request to replay a different mutation.
+    pub(crate) async fn publication_receipt(
+        &self,
+        publication: &PublicationContext,
+    ) -> Result<Option<PublicationReceipt>> {
+        let Some((mut head, _)) = self.exact_head().await? else {
+            return Ok(None);
+        };
+        let mut path = head.publication_location.clone().ok_or_else(|| {
+            Error::new(
+                ErrorKind::DataInvalid,
+                "Catalog Head has no publication record",
+            )
+        })?;
+        let mut visited = BTreeSet::new();
+        loop {
+            if !visited.insert(path.clone()) {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Catalog publication chain contains a cycle",
+                ));
+            }
+            let record = decode_publication(
+                &self
+                    .store
+                    .read_publication(&path)
+                    .await
+                    .map_err(storage_error)?,
+            )?;
+            validate_publication_matches_head(&record, &head)?;
+            if record.command_id == publication.command_id {
+                if record.command_kind != publication.command_kind
+                    || record.command_digest != publication.command_digest
+                {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        "publication command id was reused with different command content",
+                    ));
+                }
+                return Ok(Some(PublicationReceipt {
+                    command_id: record.command_id,
+                    catalog_generation: record.generation,
+                    snapshot_id: record.new_snapshot_id,
+                }));
+            }
+            let (previous_generation, previous_path, previous_checksum) = match (
+                record.previous_generation,
+                record.previous_publication,
+                record.previous_head_checksum,
+            ) {
+                (None, None, None) if record.generation == 0 => return Ok(None),
+                (Some(generation), Some(path), Some(checksum))
+                    if generation + 1 == record.generation =>
+                {
+                    (generation, path, checksum)
+                }
+                _ => {
+                    return Err(Error::new(
+                        ErrorKind::DataInvalid,
+                        "Catalog publication chain is incomplete or corrupt",
+                    ));
+                }
+            };
+            let previous = decode_publication(
+                &self
+                    .store
+                    .read_publication(&previous_path)
+                    .await
+                    .map_err(storage_error)?,
+            )?;
+            if previous.generation != previous_generation
+                || previous.next_head_checksum != previous_checksum
+            {
+                return Err(Error::new(
+                    ErrorKind::DataInvalid,
+                    "Catalog publication predecessor is corrupt",
+                ));
+            }
+            head = previous.next_head.clone();
+            path = previous_path;
+        }
     }
 
     fn table_key(table: &TableIdent) -> String {

--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -7,7 +7,8 @@ use ugoite_domain::form::{
 };
 use ugoite_domain::id::{FieldId, FormId, SpaceId};
 use ugoite_iceberg::{
-    physical_form_name, IcebergWorkspace, MigrationFormReport, MigrationManifest, MigrationReport,
+    physical_form_name, publication_context, IcebergWorkspace, MigrationFormReport,
+    MigrationManifest, MigrationReport,
 };
 use uuid::Uuid;
 
@@ -35,6 +36,43 @@ fn form() -> FormDefinition {
     }
 }
 
+async fn create_form(workspace: &IcebergWorkspace, form: &FormDefinition) -> anyhow::Result<()> {
+    workspace
+        .commit(publication_context(
+            Uuid::new_v4().to_string(),
+            "test.form.create",
+            form,
+        )?)?
+        .create_form(form)
+        .await
+}
+
+async fn evolve_form(
+    workspace: &IcebergWorkspace,
+    changes: &FormChangeSet,
+) -> anyhow::Result<FormDefinition> {
+    workspace
+        .commit(publication_context(
+            Uuid::new_v4().to_string(),
+            "test.form.evolve",
+            changes,
+        )?)?
+        .evolve_form(changes)
+        .await
+}
+
+async fn append_revisions(
+    workspace: &IcebergWorkspace,
+    form_id: FormId,
+    revisions: Vec<EntryRevision>,
+) -> anyhow::Result<ugoite_iceberg::CommitReceipt> {
+    let command = publication_context(Uuid::new_v4().to_string(), "test.entry.append", &revisions)?;
+    workspace
+        .commit(command)?
+        .append_revisions(form_id, revisions)
+        .await
+}
+
 #[tokio::test]
 async fn one_stable_form_id_maps_to_one_catalog_table() -> anyhow::Result<()> {
     let workspace = IcebergWorkspace::memory_for_tests(
@@ -43,13 +81,13 @@ async fn one_stable_form_id_maps_to_one_catalog_table() -> anyhow::Result<()> {
     )
     .await?;
     let form = form();
-    workspace.create_form(&form).await?;
+    create_form(&workspace, &form).await?;
     assert_eq!(workspace.list_forms().await?, vec![form.clone()]);
     assert_eq!(workspace.load_form(form.id).await?, form);
     let table = workspace
-        .catalog()
+        .catalog_for_testing()
         .load_table(&iceberg::TableIdent::new(
-            workspace.namespace().clone(),
+            workspace.namespace_for_testing().clone(),
             physical_form_name(form.id),
         ))
         .await?;
@@ -83,15 +121,15 @@ async fn one_stable_form_id_maps_to_one_catalog_table() -> anyhow::Result<()> {
     ));
     assert_eq!(
         workspace
-            .catalog()
-            .list_tables(workspace.namespace())
+            .catalog_for_testing()
+            .list_tables(workspace.namespace_for_testing())
             .await?
             .len(),
         1
     );
     let sql = format!(
         "SELECT entry_id FROM ugoite.{}.{} LIMIT 1",
-        workspace.namespace().as_ref()[0],
+        workspace.namespace_for_testing().as_ref()[0],
         physical_form_name(form.id)
     );
     assert!(workspace
@@ -124,11 +162,11 @@ async fn nested_fields_have_unique_iceberg_ids_across_form_columns() -> anyhow::
         enum_values: Vec::new(),
         deprecated: false,
     });
-    workspace.create_form(&form).await?;
+    create_form(&workspace, &form).await?;
     let table = workspace
-        .catalog()
+        .catalog_for_testing()
         .load_table(&iceberg::TableIdent::new(
-            workspace.namespace().clone(),
+            workspace.namespace_for_testing().clone(),
             physical_form_name(form.id),
         ))
         .await?;
@@ -185,11 +223,11 @@ async fn native_form_types_are_preserved_in_iceberg_schema() -> anyhow::Result<(
         deprecated: false,
     })
     .collect();
-    workspace.create_form(&form).await?;
+    create_form(&workspace, &form).await?;
     let table = workspace
-        .catalog()
+        .catalog_for_testing()
         .load_table(&iceberg::TableIdent::new(
-            workspace.namespace().clone(),
+            workspace.namespace_for_testing().clone(),
             physical_form_name(form.id),
         ))
         .await?;
@@ -223,22 +261,24 @@ async fn metadata_evolution_keeps_physical_identity() -> anyhow::Result<()> {
     )
     .await?;
     let form = form();
-    workspace.create_form(&form).await?;
-    let evolved = workspace
-        .evolve_form(&FormChangeSet {
+    create_form(&workspace, &form).await?;
+    let evolved = evolve_form(
+        &workspace,
+        &FormChangeSet {
             form_id: form.id,
             expected_version: Some(form.version),
             changes: vec![FormChange::RenameForm {
                 name: "Work item".into(),
             }],
-        })
-        .await?;
+        },
+    )
+    .await?;
     assert_eq!(evolved.id, form.id);
     assert_eq!(evolved.name, "Work item");
     assert_eq!(
         workspace
-            .catalog()
-            .list_tables(workspace.namespace())
+            .catalog_for_testing()
+            .list_tables(workspace.namespace_for_testing())
             .await?
             .len(),
         1
@@ -258,9 +298,10 @@ async fn local_catalog_evolves_schema_bearing_changes() -> anyhow::Result<()> {
         ugoite_iceberg::SchemaCommitCapability::AtomicSchemaEvolution
     );
     let form = form();
-    workspace.create_form(&form).await?;
-    let evolved = workspace
-        .evolve_form(&FormChangeSet {
+    create_form(&workspace, &form).await?;
+    let evolved = evolve_form(
+        &workspace,
+        &FormChangeSet {
             form_id: form.id,
             expected_version: Some(form.version),
             changes: vec![FormChange::AddField(FormField {
@@ -276,13 +317,14 @@ async fn local_catalog_evolves_schema_bearing_changes() -> anyhow::Result<()> {
                 enum_values: Vec::new(),
                 deprecated: false,
             })],
-        })
-        .await?;
+        },
+    )
+    .await?;
     assert!(evolved.fields.iter().any(|field| field.name == "due_at"));
     let table = workspace
-        .catalog()
+        .catalog_for_testing()
         .load_table(&iceberg::TableIdent::new(
-            workspace.namespace().clone(),
+            workspace.namespace_for_testing().clone(),
             physical_form_name(form.id),
         ))
         .await?;
@@ -307,7 +349,7 @@ async fn append_enforces_revision_identity_and_entry_conflicts() -> anyhow::Resu
     )
     .await?;
     let form = form();
-    workspace.create_form(&form).await?;
+    create_form(&workspace, &form).await?;
     let entry_id = Uuid::from_u128(31);
     let revision_id = Uuid::from_u128(32);
     let revision = EntryRevision {
@@ -333,9 +375,7 @@ async fn append_enforces_revision_identity_and_entry_conflicts() -> anyhow::Resu
         FieldId::new(100).unwrap(),
         FieldValue::String("title from revision".into()),
     );
-    let receipt = workspace
-        .append_revisions(form.id, vec![revision.clone()])
-        .await?;
+    let receipt = append_revisions(&workspace, form.id, vec![revision.clone()]).await?;
     assert_eq!(receipt.committed_revision_ids, vec![revision.revision_id]);
     assert!(receipt.data_file_count > 0);
 
@@ -343,11 +383,72 @@ async fn append_enforces_revision_identity_and_entry_conflicts() -> anyhow::Resu
         revision_id: Uuid::from_u128(33).into(),
         ..revision
     };
-    let error = workspace
-        .append_revisions(form.id, vec![conflicting])
+    let error = append_revisions(&workspace, form.id, vec![conflicting])
         .await
         .unwrap_err();
     assert!(error.to_string().contains("conflict"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn coordinator_replays_only_the_same_canonical_command() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(34)),
+        "memory://iceberg-command-idempotency",
+    )
+    .await?;
+    let form = form();
+    create_form(&workspace, &form).await?;
+    let revision = EntryRevision {
+        form_id: form.id,
+        entry_id: Uuid::from_u128(35).into(),
+        revision_id: Uuid::from_u128(36).into(),
+        parent_revision_id: None,
+        entry_version: 1,
+        expected_version: None,
+        operation: EntryOperation::Upsert,
+        committed_at_micros: 1,
+        author_id: "human:owner".into(),
+        form_version: form.version,
+        source_kind: "test".into(),
+        source_id: None,
+        entry: EntryMetadata::default(),
+        values: BTreeMap::from([(
+            FieldId::new(100).unwrap(),
+            FieldValue::String("exactly once".into()),
+        )]),
+        extra_attributes: BTreeMap::new(),
+        extension_metadata: BTreeMap::new(),
+    };
+    let command = publication_context("append-35", "test.entry.append", &vec![revision.clone()])?;
+    let first = workspace
+        .commit(command.clone())?
+        .append_revisions(form.id, vec![revision.clone()])
+        .await?;
+    let replay = workspace
+        .commit(command)?
+        .append_revisions(form.id, vec![revision.clone()])
+        .await?;
+    assert_eq!(replay.command_id, "append-35");
+    assert_eq!(replay.catalog_generation, first.catalog_generation);
+    assert_eq!(replay.snapshot_id, first.snapshot_id);
+    assert_eq!(
+        workspace.read_revisions(form.id).await?,
+        vec![revision.clone()]
+    );
+
+    let mut changed = revision;
+    changed.revision_id = Uuid::from_u128(37).into();
+    let reuse = workspace
+        .commit(publication_context(
+            "append-35",
+            "test.entry.append",
+            &vec![changed.clone()],
+        )?)?
+        .append_revisions(form.id, vec![changed])
+        .await
+        .unwrap_err();
+    assert!(reuse.to_string().contains("reused"));
     Ok(())
 }
 
@@ -359,7 +460,7 @@ async fn one_explicit_form_batch_publishes_one_snapshot_and_receipt() -> anyhow:
     )
     .await?;
     let form = form();
-    workspace.create_form(&form).await?;
+    create_form(&workspace, &form).await?;
     let revisions = [36_u128, 37]
         .into_iter()
         .map(|id| {
@@ -389,9 +490,7 @@ async fn one_explicit_form_batch_publishes_one_snapshot_and_receipt() -> anyhow:
         })
         .collect::<Vec<_>>();
 
-    let receipt = workspace
-        .append_revisions(form.id, revisions.clone())
-        .await?;
+    let receipt = append_revisions(&workspace, form.id, revisions.clone()).await?;
     assert_eq!(
         receipt.committed_revision_ids,
         revisions
@@ -402,9 +501,9 @@ async fn one_explicit_form_batch_publishes_one_snapshot_and_receipt() -> anyhow:
     assert!(receipt.data_file_count > 0);
 
     let table = workspace
-        .catalog()
+        .catalog_for_testing()
         .load_table(&iceberg::TableIdent::new(
-            workspace.namespace().clone(),
+            workspace.namespace_for_testing().clone(),
             physical_form_name(form.id),
         ))
         .await?;
@@ -425,7 +524,7 @@ async fn form_rename_and_optional_addition_read_old_and_new_files_by_stable_id(
     )
     .await?;
     let form = form();
-    workspace.create_form(&form).await?;
+    create_form(&workspace, &form).await?;
     let entry_id = Uuid::from_u128(61).into();
     let first = EntryRevision {
         form_id: form.id,
@@ -448,12 +547,11 @@ async fn form_rename_and_optional_addition_read_old_and_new_files_by_stable_id(
         extra_attributes: BTreeMap::new(),
         extension_metadata: BTreeMap::new(),
     };
-    workspace
-        .append_revisions(form.id, vec![first.clone()])
-        .await?;
+    append_revisions(&workspace, form.id, vec![first.clone()]).await?;
 
-    let evolved = workspace
-        .evolve_form(&FormChangeSet {
+    let evolved = evolve_form(
+        &workspace,
+        &FormChangeSet {
             form_id: form.id,
             expected_version: Some(form.version),
             changes: vec![
@@ -475,12 +573,13 @@ async fn form_rename_and_optional_addition_read_old_and_new_files_by_stable_id(
                     deprecated: false,
                 }),
             ],
-        })
-        .await?;
+        },
+    )
+    .await?;
     let table = workspace
-        .catalog()
+        .catalog_for_testing()
         .load_table(&iceberg::TableIdent::new(
-            workspace.namespace().clone(),
+            workspace.namespace_for_testing().clone(),
             physical_form_name(form.id),
         ))
         .await?;
@@ -520,9 +619,7 @@ async fn form_rename_and_optional_addition_read_old_and_new_files_by_stable_id(
         extra_attributes: BTreeMap::new(),
         extension_metadata: BTreeMap::new(),
     };
-    workspace
-        .append_revisions(form.id, vec![second.clone()])
-        .await?;
+    append_revisions(&workspace, form.id, vec![second.clone()]).await?;
 
     let revisions = workspace.read_revisions(form.id).await?;
     assert_eq!(revisions.len(), 2);
@@ -587,7 +684,7 @@ async fn typed_forms_and_fixed_entry_metadata_round_trip_without_json_payloads(
             deprecated: false,
         },
     ]);
-    workspace.create_form(&form).await?;
+    create_form(&workspace, &form).await?;
     let revision = EntryRevision {
         form_id: form.id,
         entry_id: Uuid::from_u128(71).into(),
@@ -653,9 +750,7 @@ async fn typed_forms_and_fixed_entry_metadata_round_trip_without_json_payloads(
         extra_attributes: BTreeMap::new(),
         extension_metadata: BTreeMap::new(),
     };
-    workspace
-        .append_revisions(form.id, vec![revision.clone()])
-        .await?;
+    append_revisions(&workspace, form.id, vec![revision.clone()]).await?;
     assert_eq!(workspace.read_revisions(form.id).await?, vec![revision]);
     Ok(())
 }
@@ -667,15 +762,9 @@ async fn concurrent_workspace_writers_surface_equal_version_conflicts() -> anyho
         "memory://iceberg-concurrent-writers",
     )
     .await?;
-    let second = IcebergWorkspace::new(
-        first.catalog(),
-        SpaceId::from(Uuid::from_u128(50)),
-        "memory://iceberg-concurrent-writers",
-        Default::default(),
-    )
-    .await?;
+    let second = first.clone_for_testing();
     let form = form();
-    first.create_form(&form).await?;
+    create_form(&first, &form).await?;
     let entry_id = Uuid::from_u128(51).into();
     let mut left = EntryRevision {
         form_id: form.id,
@@ -707,8 +796,8 @@ async fn concurrent_workspace_writers_surface_equal_version_conflicts() -> anyho
         FieldValue::String("right".into()),
     );
     let (left_result, right_result) = tokio::join!(
-        first.append_revisions(form.id, vec![left]),
-        second.append_revisions(form.id, vec![right.clone()]),
+        append_revisions(&first, form.id, vec![left]),
+        append_revisions(&second, form.id, vec![right.clone()]),
     );
     assert!(
         left_result.is_ok() ^ right_result.is_ok(),
@@ -718,8 +807,7 @@ async fn concurrent_workspace_writers_surface_equal_version_conflicts() -> anyho
         revision_id: Uuid::from_u128(54).into(),
         ..right
     };
-    let conflict = first
-        .append_revisions(form.id, vec![probe])
+    let conflict = append_revisions(&first, form.id, vec![probe])
         .await
         .unwrap_err();
     assert!(conflict.to_string().contains("conflict"));

--- a/docs/spec/architecture/overview.md
+++ b/docs/spec/architecture/overview.md
@@ -40,10 +40,10 @@ publication chain instead of blindly repeating the logical mutation. REST,
 Memory, pointer-manifest, external-catalog, and object-list reconstruction modes
 are not production architecture.
 
-The active follow-up issues make this architecture complete: typed Form columns,
-one mutation coordinator, duplicate-head detection, authorization-aware
-DataFusion reads, checkpoints, and read-only health evidence are target work,
-not claims about every current API. One Form table commit is the atomicity
-boundary; Ugoite does not claim cross-Form transactions.
+The active follow-up issues make this architecture complete: duplicate-head
+detection, authorization-aware DataFusion reads, checkpoints, and read-only
+health evidence are target work, not claims about every current API. One Form
+table commit is the atomicity boundary; Ugoite does not claim cross-Form
+transactions.
 
 The current browser is server-backed. The target architecture adds a browser-local runtime and optional synchronization without making the server the mandatory owner of data.

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -7,8 +7,8 @@ intentionally destructive before the first release: the internal pre-release
 Space format version is unchanged, while legacy layouts and catalog modes are
 unsupported rather than migrated.
 
-The Catalog Head layout and upstream physical boundary are implemented by the
-current persistence work. The single mutation coordinator, checkpoint-pinned
+The Catalog Head layout, upstream physical boundary, and single mutation
+coordinator are implemented by the current persistence work. Checkpoint-pinned
 reads, authorization-aware DataFusion context, and health evidence described
 here remain active follow-up work; this document does not advertise them as
 current product APIs.
@@ -52,6 +52,14 @@ rereads Head and walks reachable publication records back to its base
 generation: a matching command identity proves success; reaching base without
 it proves non-publication; missing or corrupt evidence is an explicit
 unknown/corrupt result. Repeating the mutation blindly is forbidden.
+
+`SpaceCommitCoordinator` is the only production mutation entry point. It takes
+a stable command ID, kind, and canonical domain-command digest, constructs one
+short-lived publication-authorized `SpaceCatalog` per attempt, and returns the
+actual command ID, Catalog generation, and Iceberg snapshot ID. Reusing a
+command ID with a different digest fails. Direct physical Catalog and Arrow
+mutation APIs are private to `ugoite-iceberg`; every ETag conflict starts a
+fresh attempt and reruns the domain validation before publishing.
 
 ## Capability and concurrency boundary
 


### PR DESCRIPTION
## Summary

- Route every production Form and Entry mutation through an attempt-scoped `SpaceCommitCoordinator`.
- Make command replay deterministic from the immutable publication chain and include command ID plus Catalog generation in append receipts.
- Remove public production Catalog mutation handles and document the coordinator contract.

## Related Issue (required)

Closes #1814

## Testing

- [x] `cargo clippy -p ugoite-iceberg --all-targets --all-features --offline -- -D warnings`
- [x] `cargo test -p ugoite-iceberg --offline`
- [x] `mise run test:docsite`
