### PR TITLE
feat: plan latest entry revisions with DataFusion

### DIFF
--- a/crates/ugoite-iceberg/src/entry.rs
+++ b/crates/ugoite-iceberg/src/entry.rs
@@ -790,37 +790,15 @@ pub(crate) async fn read_entry_row(
     form_name: &str,
     entry_id: &str,
 ) -> Result<EntryRow> {
-    let (_, rows) = revision_rows_for_form(op, ws_path, form_name).await?;
-    let mut selected: Option<RevisionRow> = None;
-    for revision in rows.iter().cloned() {
-        if revision.entry_id != entry_id || revision.state.is_none() {
-            continue;
-        }
-        let replace = match &selected {
-            Some(existing) => revision.entry_version > existing.entry_version,
-            None => true,
-        };
-        if replace {
-            selected = Some(revision);
-        }
-    }
-    let selected = selected.ok_or_else(|| entry_not_found(entry_id))?;
-    let conflicts = rows
-        .iter()
-        .filter(|revision| {
-            revision.entry_id == entry_id && revision.entry_version == selected.entry_version
-        })
-        .count();
-    if conflicts > 1 {
-        return Err(AppError::conflict(
-            ErrorCode::RevisionConflict,
-            format!(
-                "multiple revisions exist for entry {entry_id} at version {}",
-                selected.entry_version
-            ),
-        )
-        .into());
-    }
+    let (form, revisions) =
+        iceberg_store::latest_revisions_for_entry(op, ws_path, form_name, entry_id).await?;
+    let selected = revisions
+        .into_iter()
+        .map(|revision| revision_row_from_domain(revision, form_name, &form))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .find(|revision| revision.entry_id == entry_id)
+        .ok_or_else(|| entry_not_found(entry_id))?;
     selected
         .state
         .ok_or_else(|| entry_not_found(entry_id).into())
@@ -865,7 +843,12 @@ pub(crate) async fn list_entry_rows(
     let mut latest: std::collections::HashMap<String, (String, RevisionRow)> =
         std::collections::HashMap::new();
     for form_name in list_form_names(op, ws_path).await? {
-        let (_, rows) = revision_rows_for_form(op, ws_path, &form_name).await?;
+        let (form, revisions) =
+            iceberg_store::latest_revisions_for_form(op, ws_path, &form_name).await?;
+        let rows = revisions
+            .into_iter()
+            .map(|revision| revision_row_from_domain(revision, &form_name, &form))
+            .collect::<Result<Vec<_>>>()?;
         for revision in rows {
             let Some(row) = revision.state.as_ref() else {
                 continue;
@@ -903,35 +886,13 @@ pub(crate) async fn list_form_entry_rows(
     form_name: &str,
     _form_def: &Value,
 ) -> Result<Vec<EntryRow>> {
-    let (_, rows) = revision_rows_for_form(op, ws_path, form_name).await?;
-    let mut latest: std::collections::HashMap<String, RevisionRow> =
-        std::collections::HashMap::new();
-    for revision in rows {
-        let Some(row) = revision.state.as_ref() else {
-            continue;
-        };
-        let entry = latest.get(&row.entry_id);
-        if let Some(existing) = entry {
-            if revision.entry_version == existing.entry_version
-                && revision.revision_id != existing.revision_id
-            {
-                return Err(anyhow!(
-                    "multiple revisions exist for entry {} at version {}",
-                    row.entry_id,
-                    revision.entry_version
-                ));
-            }
-        }
-        let should_replace = match entry {
-            Some(existing) => revision.entry_version > existing.entry_version,
-            None => true,
-        };
-        if should_replace {
-            latest.insert(row.entry_id.clone(), revision);
-        }
-    }
-    Ok(latest
-        .into_values()
+    let (form, revisions) =
+        iceberg_store::latest_revisions_for_form(op, ws_path, form_name).await?;
+    Ok(revisions
+        .into_iter()
+        .map(|revision| revision_row_from_domain(revision, form_name, &form))
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
         .filter_map(|revision| revision.state)
         .collect())
 }

--- a/crates/ugoite-iceberg/src/entry.rs
+++ b/crates/ugoite-iceberg/src/entry.rs
@@ -840,8 +840,7 @@ pub(crate) async fn list_entry_rows(
     op: &Operator,
     ws_path: &str,
 ) -> Result<Vec<(String, EntryRow)>> {
-    let mut latest: std::collections::HashMap<String, (String, RevisionRow)> =
-        std::collections::HashMap::new();
+    let mut latest = Vec::<(String, RevisionRow)>::new();
     for form_name in list_form_names(op, ws_path).await? {
         let (form, revisions) =
             iceberg_store::latest_revisions_for_form(op, ws_path, &form_name).await?;
@@ -853,8 +852,10 @@ pub(crate) async fn list_entry_rows(
             let Some(row) = revision.state.as_ref() else {
                 continue;
             };
-            let entry = latest.get(&row.entry_id);
-            if let Some((_, existing)) = entry {
+            if let Some((current_form_name, existing)) = latest
+                .iter_mut()
+                .find(|(_, existing)| existing.entry_id == row.entry_id)
+            {
                 if revision.entry_version == existing.entry_version
                     && revision.revision_id != existing.revision_id
                 {
@@ -864,18 +865,17 @@ pub(crate) async fn list_entry_rows(
                         revision.entry_version
                     ));
                 }
-            }
-            let should_replace = match entry {
-                Some((_, existing)) => revision.entry_version > existing.entry_version,
-                None => true,
-            };
-            if should_replace {
-                latest.insert(row.entry_id.clone(), (form_name.clone(), revision));
+                if revision.entry_version > existing.entry_version {
+                    *existing = revision;
+                    *current_form_name = form_name.clone();
+                }
+            } else {
+                latest.push((form_name.clone(), revision));
             }
         }
     }
     Ok(latest
-        .into_values()
+        .into_iter()
         .filter_map(|(form_name, revision)| revision.state.map(|row| (form_name, row)))
         .collect())
 }

--- a/crates/ugoite-iceberg/src/iceberg_store.rs
+++ b/crates/ugoite-iceberg/src/iceberg_store.rs
@@ -79,7 +79,9 @@ pub async fn revisions_for_form(
     form_name: &str,
 ) -> Result<(FormDefinition, Vec<EntryRevision>)> {
     let (workspace, form) = domain_form_by_name(operator, workspace_path, form_name).await?;
-    let revisions = workspace.read_revisions(form.id).await?;
+    let revisions = workspace
+        .read_revision_view(form.id, crate::RevisionView::All)
+        .await?;
     Ok((form, revisions))
 }
 

--- a/crates/ugoite-iceberg/src/iceberg_store.rs
+++ b/crates/ugoite-iceberg/src/iceberg_store.rs
@@ -83,6 +83,34 @@ pub async fn revisions_for_form(
     Ok((form, revisions))
 }
 
+pub async fn latest_revisions_for_form(
+    operator: &Operator,
+    workspace_path: &str,
+    form_name: &str,
+) -> Result<(FormDefinition, Vec<EntryRevision>)> {
+    let (workspace, form) = domain_form_by_name(operator, workspace_path, form_name).await?;
+    let revisions = workspace
+        .read_revision_view(form.id, crate::RevisionView::LatestIncludingTombstones)
+        .await?;
+    Ok((form, revisions))
+}
+
+pub async fn latest_revisions_for_entry(
+    operator: &Operator,
+    workspace_path: &str,
+    form_name: &str,
+    entry_id: &str,
+) -> Result<(FormDefinition, Vec<EntryRevision>)> {
+    let (workspace, form) = domain_form_by_name(operator, workspace_path, form_name).await?;
+    let entry_id = Uuid::parse_str(entry_id)
+        .unwrap_or_else(|_| Uuid::new_v5(&Uuid::NAMESPACE_URL, entry_id.as_bytes()))
+        .into();
+    let revisions = workspace
+        .read_latest_revisions_for_entry(form.id, entry_id)
+        .await?;
+    Ok((form, revisions))
+}
+
 pub async fn load_form_schema_fields(
     operator: &Operator,
     workspace_path: &str,

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -60,7 +60,7 @@ use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
 use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
 use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
-use iceberg_datafusion::IcebergCatalogProvider;
+use iceberg_datafusion::{IcebergCatalogProvider, IcebergStaticTableProvider};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
@@ -644,11 +644,38 @@ impl IcebergWorkspace {
         form_id: FormId,
         view: RevisionView,
     ) -> Result<Vec<EntryRevision>> {
+        self.read_revision_view_with_snapshot(form_id, view, None)
+            .await
+    }
+
+    /// Reads a canonical revision view from one immutable Iceberg snapshot.
+    /// The latest-state plan is identical to the live provider; only the
+    /// upstream Iceberg table provider is pinned.
+    pub async fn read_revision_view_at_snapshot(
+        &self,
+        form_id: FormId,
+        view: RevisionView,
+        snapshot_id: i64,
+    ) -> Result<Vec<EntryRevision>> {
+        self.read_revision_view_with_snapshot(form_id, view, Some(snapshot_id))
+            .await
+    }
+
+    async fn read_revision_view_with_snapshot(
+        &self,
+        form_id: FormId,
+        view: RevisionView,
+        snapshot_id: Option<i64>,
+    ) -> Result<Vec<EntryRevision>> {
         let form = self.load_form(form_id).await?;
         let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
         let batches = match view {
             RevisionView::All => {
-                let mut stream = table.scan().build()?.to_arrow().await?;
+                let scan = match snapshot_id {
+                    Some(snapshot_id) => table.scan().snapshot_id(snapshot_id),
+                    None => table.scan(),
+                };
+                let mut stream = scan.build()?.to_arrow().await?;
                 let mut batches = Vec::new();
                 while let Some(batch) = futures::TryStreamExt::try_next(&mut stream).await? {
                     batches.push(batch);
@@ -656,7 +683,7 @@ impl IcebergWorkspace {
                 batches
             }
             RevisionView::LatestIncludingTombstones | RevisionView::Current => {
-                self.read_latest_revision_batches(&table, form_id, None)
+                self.read_latest_revision_batches(&table, form_id, None, snapshot_id)
                     .await?
             }
         };
@@ -692,7 +719,7 @@ impl IcebergWorkspace {
         let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
         let schema = table.metadata().current_schema().clone();
         let batches = self
-            .read_latest_revision_batches(&table, form_id, Some(entry_ids))
+            .read_latest_revision_batches(&table, form_id, Some(entry_ids), None)
             .await?;
         let mut revisions = Vec::new();
         for batch in &batches {
@@ -703,17 +730,27 @@ impl IcebergWorkspace {
 
     async fn latest_revision_plan(
         &self,
+        table: &iceberg::table::Table,
         form_id: FormId,
         entry_ids: Option<&[ugoite_domain::id::EntryId]>,
+        snapshot_id: Option<i64>,
     ) -> Result<Vec<RecordBatch>> {
         let context = SessionContext::new();
-        let provider = IcebergCatalogProvider::try_new(self.catalog.clone()).await?;
-        context.register_catalog("ugoite", Arc::new(provider));
-        let table_name = format!(
-            "ugoite.{}.{}",
-            self.namespace.as_ref()[0],
-            physical_form_name(form_id)
-        );
+        let table_name = if let Some(snapshot_id) = snapshot_id {
+            let provider =
+                IcebergStaticTableProvider::try_new_from_table_snapshot(table.clone(), snapshot_id)
+                    .await?;
+            context.register_table("revisions", Arc::new(provider))?;
+            "revisions".to_string()
+        } else {
+            let provider = IcebergCatalogProvider::try_new(self.catalog.clone()).await?;
+            context.register_catalog("ugoite", Arc::new(provider));
+            format!(
+                "ugoite.{}.{}",
+                self.namespace.as_ref()[0],
+                physical_form_name(form_id)
+            )
+        };
         let mut revisions = context.table(table_name).await?;
         if let Some(entry_ids) = entry_ids {
             if entry_ids.is_empty() {
@@ -771,8 +808,11 @@ impl IcebergWorkspace {
         table: &iceberg::table::Table,
         form_id: FormId,
         entry_ids: Option<&[ugoite_domain::id::EntryId]>,
+        snapshot_id: Option<i64>,
     ) -> Result<Vec<RecordBatch>> {
-        let ids = self.latest_revision_plan(form_id, entry_ids).await?;
+        let ids = self
+            .latest_revision_plan(table, form_id, entry_ids, snapshot_id)
+            .await?;
         let mut revision_ids = Vec::new();
         for batch in ids {
             let values = batch
@@ -785,12 +825,16 @@ impl IcebergWorkspace {
         if revision_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let mut stream = table
+        let scan = table
             .scan()
-            .with_filter(Reference::new("revision_id").is_in(revision_ids))
-            .build()?
-            .to_arrow()
-            .await?;
+            .with_filter(Reference::new("revision_id").is_in(revision_ids));
+        let mut stream = match snapshot_id {
+            Some(snapshot_id) => scan.snapshot_id(snapshot_id),
+            None => scan,
+        }
+        .build()?
+        .to_arrow()
+        .await?;
         let mut batches = Vec::new();
         while let Some(batch) = futures::TryStreamExt::try_next(&mut stream).await? {
             batches.push(batch);

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -43,6 +43,9 @@ use arrow_array::{
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use datafusion::execution::context::SessionContext;
+use datafusion::functions_aggregate::expr_fn::{count, max};
+use datafusion::logical_expr::JoinType;
+use datafusion::prelude::{col, lit};
 use iceberg::expr::Reference;
 use iceberg::spec::{DataFileFormat, Datum};
 use iceberg::spec::{
@@ -92,6 +95,16 @@ pub struct IcebergWorkspace {
 pub enum SchemaCommitCapability {
     MetadataOnly,
     AtomicSchemaEvolution,
+}
+
+/// The reusable logical views over one append-only Form revision table.
+/// `LatestIncludingTombstones` deliberately retains delete revisions so a
+/// caller can distinguish an absent Entry from a deleted one.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RevisionView {
+    All,
+    LatestIncludingTombstones,
+    Current,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -613,6 +626,150 @@ impl IcebergWorkspace {
             revisions.extend(revisions_from_batch(&batch, &form, &table_schema)?);
         }
         Ok(revisions)
+    }
+
+    /// Reads one of the canonical revision views through the same DataFusion
+    /// logical-plan builder used for live and future checkpoint providers.
+    /// A duplicate maximum entry version is invariant corruption, never a
+    /// condition resolved by timestamp, revision ID, or file order.
+    pub async fn read_revision_view(
+        &self,
+        form_id: FormId,
+        view: RevisionView,
+    ) -> Result<Vec<EntryRevision>> {
+        let form = self.load_form(form_id).await?;
+        let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
+        let batches = match view {
+            RevisionView::All => {
+                let mut stream = table.scan().build()?.to_arrow().await?;
+                let mut batches = Vec::new();
+                while let Some(batch) = futures::TryStreamExt::try_next(&mut stream).await? {
+                    batches.push(batch);
+                }
+                batches
+            }
+            RevisionView::LatestIncludingTombstones | RevisionView::Current => {
+                self.read_latest_revision_batches(&table, form_id, None)
+                    .await?
+            }
+        };
+        let schema = table.metadata().current_schema().clone();
+        let mut revisions = Vec::new();
+        for batch in &batches {
+            revisions.extend(revisions_from_batch(batch, &form, &schema)?);
+        }
+        if view == RevisionView::Current {
+            revisions.retain(|revision| revision.operation != EntryOperation::Delete);
+        }
+        Ok(revisions)
+    }
+
+    /// Point lookup variant of the latest plan. The entry predicate is applied
+    /// before the max-version aggregation, preserving latest-state semantics
+    /// while avoiding a full Form scan.
+    pub async fn read_latest_revisions_for_entry(
+        &self,
+        form_id: FormId,
+        entry_id: ugoite_domain::id::EntryId,
+    ) -> Result<Vec<EntryRevision>> {
+        let form = self.load_form(form_id).await?;
+        let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
+        let schema = table.metadata().current_schema().clone();
+        let batches = self
+            .read_latest_revision_batches(&table, form_id, Some(entry_id))
+            .await?;
+        let mut revisions = Vec::new();
+        for batch in &batches {
+            revisions.extend(revisions_from_batch(batch, &form, &schema)?);
+        }
+        Ok(revisions)
+    }
+
+    async fn latest_revision_plan(
+        &self,
+        form_id: FormId,
+        entry_id: Option<ugoite_domain::id::EntryId>,
+    ) -> Result<Vec<RecordBatch>> {
+        let context = SessionContext::new();
+        let provider = IcebergCatalogProvider::try_new(self.catalog.clone()).await?;
+        context.register_catalog("ugoite", Arc::new(provider));
+        let table_name = format!(
+            "ugoite.{}.{}",
+            self.namespace.as_ref()[0],
+            physical_form_name(form_id)
+        );
+        let mut revisions = context.table(table_name).await?;
+        if let Some(entry_id) = entry_id {
+            revisions = revisions
+                .filter(col("entry_id").eq(lit(entry_id.as_uuid().as_bytes().to_vec())))?;
+        }
+        let maxima = revisions
+            .clone()
+            .aggregate(
+                vec![col("entry_id")],
+                vec![max(col("entry_version")).alias("latest_entry_version")],
+            )?
+            .select(vec![
+                col("entry_id").alias("latest_entry_id"),
+                col("latest_entry_version"),
+            ])?;
+        let heads = revisions.join(
+            maxima,
+            JoinType::Inner,
+            &["entry_id", "entry_version"],
+            &["latest_entry_id", "latest_entry_version"],
+            None,
+        )?;
+        let duplicates = heads
+            .clone()
+            .aggregate(
+                vec![col("entry_id")],
+                vec![count(lit(1)).alias("head_count")],
+            )?
+            .filter(col("head_count").not_eq(lit(1)))?
+            .collect()
+            .await?;
+        if duplicates.iter().any(|batch| batch.num_rows() > 0) {
+            return Err(anyhow!(
+                "entry revision invariant failed: multiple revisions share a maximum entry_version"
+            ));
+        }
+        Ok(heads
+            .select_columns(&["entry_id", "revision_id", "entry_version"])?
+            .collect()
+            .await?)
+    }
+
+    async fn read_latest_revision_batches(
+        &self,
+        table: &iceberg::table::Table,
+        form_id: FormId,
+        entry_id: Option<ugoite_domain::id::EntryId>,
+    ) -> Result<Vec<RecordBatch>> {
+        let ids = self.latest_revision_plan(form_id, entry_id).await?;
+        let mut revision_ids = Vec::new();
+        for batch in ids {
+            let values = batch
+                .column_by_name("revision_id")
+                .context("latest revision plan is missing revision_id")?;
+            for row in 0..batch.num_rows() {
+                revision_ids.push(Datum::uuid(uuid_at(values, row)?.as_uuid()));
+            }
+        }
+        if revision_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut stream = table
+            .scan()
+            .with_filter(Reference::new("revision_id").is_in(revision_ids))
+            .build()?
+            .to_arrow()
+            .await?;
+        let mut batches = Vec::new();
+        while let Some(batch) = futures::TryStreamExt::try_next(&mut stream).await? {
+            batches.push(batch);
+        }
+        Ok(batches)
     }
 
     async fn latest_revisions(

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -474,11 +474,15 @@ impl IcebergWorkspace {
         }
         let form = self.load_form(form_id).await?;
         let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
-        let entry_ids = revisions
-            .iter()
-            .map(|revision| revision.entry_id)
-            .collect::<std::collections::HashSet<_>>();
-        let mut current = self.latest_revisions(&table, Some(&entry_ids)).await?;
+        let mut entry_ids = Vec::new();
+        for revision in revisions {
+            if !entry_ids.contains(&revision.entry_id) {
+                entry_ids.push(revision.entry_id);
+            }
+        }
+        let mut current = self
+            .read_latest_revisions_for_entries(form_id, &entry_ids)
+            .await?;
         let mut seen = std::collections::HashSet::new();
         for revision in revisions {
             if revision.form_id != form.id || revision.form_version != form.version {
@@ -489,7 +493,9 @@ impl IcebergWorkspace {
             if !seen.insert(revision.revision_id) {
                 return Err(anyhow!("duplicate revision ID in append batch"));
             }
-            let previous = current.get(&revision.entry_id);
+            let previous = current
+                .iter()
+                .find(|current| current.entry_id == revision.entry_id);
             if let Some(previous) = previous {
                 if revision.expected_version != Some(previous.entry_version)
                     || revision.parent_revision_id != Some(previous.revision_id)
@@ -508,13 +514,14 @@ impl IcebergWorkspace {
                 return Err(anyhow!("entry revision conflict"));
             }
             revision.validate_payload(&form)?;
-            current.insert(
-                revision.entry_id,
-                LatestRevision {
-                    revision_id: revision.revision_id,
-                    entry_version: revision.entry_version,
-                },
-            );
+            if let Some(current) = current
+                .iter_mut()
+                .find(|current| current.entry_id == revision.entry_id)
+            {
+                *current = revision.clone();
+            } else {
+                current.push(revision.clone());
+            }
         }
         validate_batch_revision_metadata(&batches, revisions)?;
         let table_arrow_schema = Arc::new(iceberg::arrow::schema_to_arrow_schema(
@@ -672,11 +679,20 @@ impl IcebergWorkspace {
         form_id: FormId,
         entry_id: ugoite_domain::id::EntryId,
     ) -> Result<Vec<EntryRevision>> {
+        self.read_latest_revisions_for_entries(form_id, &[entry_id])
+            .await
+    }
+
+    async fn read_latest_revisions_for_entries(
+        &self,
+        form_id: FormId,
+        entry_ids: &[ugoite_domain::id::EntryId],
+    ) -> Result<Vec<EntryRevision>> {
         let form = self.load_form(form_id).await?;
         let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
         let schema = table.metadata().current_schema().clone();
         let batches = self
-            .read_latest_revision_batches(&table, form_id, Some(entry_id))
+            .read_latest_revision_batches(&table, form_id, Some(entry_ids))
             .await?;
         let mut revisions = Vec::new();
         for batch in &batches {
@@ -688,7 +704,7 @@ impl IcebergWorkspace {
     async fn latest_revision_plan(
         &self,
         form_id: FormId,
-        entry_id: Option<ugoite_domain::id::EntryId>,
+        entry_ids: Option<&[ugoite_domain::id::EntryId]>,
     ) -> Result<Vec<RecordBatch>> {
         let context = SessionContext::new();
         let provider = IcebergCatalogProvider::try_new(self.catalog.clone()).await?;
@@ -699,9 +715,19 @@ impl IcebergWorkspace {
             physical_form_name(form_id)
         );
         let mut revisions = context.table(table_name).await?;
-        if let Some(entry_id) = entry_id {
-            revisions = revisions
-                .filter(col("entry_id").eq(lit(entry_id.as_uuid().as_bytes().to_vec())))?;
+        if let Some(entry_ids) = entry_ids {
+            if entry_ids.is_empty() {
+                return Ok(Vec::new());
+            }
+            revisions = revisions.filter(
+                col("entry_id").in_list(
+                    entry_ids
+                        .iter()
+                        .map(|entry_id| lit(entry_id.as_uuid().as_bytes().to_vec()))
+                        .collect(),
+                    false,
+                ),
+            )?;
         }
         let maxima = revisions
             .clone()
@@ -744,9 +770,9 @@ impl IcebergWorkspace {
         &self,
         table: &iceberg::table::Table,
         form_id: FormId,
-        entry_id: Option<ugoite_domain::id::EntryId>,
+        entry_ids: Option<&[ugoite_domain::id::EntryId]>,
     ) -> Result<Vec<RecordBatch>> {
-        let ids = self.latest_revision_plan(form_id, entry_id).await?;
+        let ids = self.latest_revision_plan(form_id, entry_ids).await?;
         let mut revision_ids = Vec::new();
         for batch in ids {
             let values = batch
@@ -770,68 +796,6 @@ impl IcebergWorkspace {
             batches.push(batch);
         }
         Ok(batches)
-    }
-
-    async fn latest_revisions(
-        &self,
-        table: &iceberg::table::Table,
-        entry_ids: Option<&std::collections::HashSet<ugoite_domain::id::EntryId>>,
-    ) -> Result<std::collections::HashMap<ugoite_domain::id::EntryId, LatestRevision>> {
-        let mut scan = table
-            .scan()
-            .select(vec!["entry_id", "revision_id", "entry_version"]);
-        if let Some(entry_ids) = entry_ids {
-            scan = scan.with_filter(
-                Reference::new("entry_id").is_in(
-                    entry_ids
-                        .iter()
-                        .map(|entry_id| Datum::uuid(entry_id.as_uuid())),
-                ),
-            );
-        }
-        let scan = scan.build()?;
-        let mut stream = scan.to_arrow().await?;
-        let mut latest: std::collections::HashMap<ugoite_domain::id::EntryId, LatestRevision> =
-            std::collections::HashMap::new();
-        while let Some(batch) = futures::TryStreamExt::try_next(&mut stream).await? {
-            let entry_ids = batch
-                .column_by_name("entry_id")
-                .context("Iceberg table is missing entry_id")?;
-            let revision_ids = batch
-                .column_by_name("revision_id")
-                .context("Iceberg table is missing revision_id")?;
-            let versions = batch
-                .column_by_name("entry_version")
-                .and_then(|array| array.as_any().downcast_ref::<Int64Array>())
-                .context("entry_version must be an int64 column")?;
-            for row in 0..batch.num_rows() {
-                let entry_id = uuid_at(entry_ids, row)?;
-                let revision_id =
-                    ugoite_domain::id::RevisionId::from_uuid(uuid_at(revision_ids, row)?.as_uuid());
-                let version = u64::try_from(versions.value(row))
-                    .map_err(|_| anyhow!("entry_version must be non-negative"))?;
-                if let Some(known) = latest.get(&entry_id) {
-                    if version == known.entry_version && revision_id != known.revision_id {
-                        return Err(anyhow!(
-                            "entry revision conflict: entry {entry_id} has multiple revisions at version {version}"
-                        ));
-                    }
-                }
-                if latest
-                    .get(&entry_id)
-                    .is_none_or(|known: &LatestRevision| version > known.entry_version)
-                {
-                    latest.insert(
-                        entry_id,
-                        LatestRevision {
-                            revision_id,
-                            entry_version: version,
-                        },
-                    );
-                }
-            }
-        }
-        Ok(latest)
     }
 
     pub async fn query(&self, sql: &str) -> Result<Vec<RecordBatch>> {
@@ -950,6 +914,13 @@ impl SpaceCommitCoordinator {
         form_id: FormId,
         revisions: Vec<EntryRevision>,
     ) -> Result<CommitReceipt> {
+        let _entry_mutation_guard = self
+            .workspace
+            .space_catalog
+            .as_ref()
+            .context("coordinator is missing its SpaceCatalog")?
+            .serialize_entry_mutation()
+            .await;
         if let Some(receipt) = self.publication_receipt().await? {
             return Ok(CommitReceipt {
                 command_id: receipt.command_id,
@@ -1019,12 +990,6 @@ fn is_publication_conflict(error: &anyhow::Error) -> bool {
     error
         .chain()
         .any(|cause| cause.to_string().contains("Catalog Head changed"))
-}
-
-#[derive(Debug, Clone, Copy)]
-struct LatestRevision {
-    revision_id: ugoite_domain::id::RevisionId,
-    entry_version: u64,
 }
 
 pub fn physical_form_name(form_id: FormId) -> String {

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -15,6 +15,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use ugoite_domain::id::SpaceId;
 use ugoite_storage::{CatalogWriteMode, ExactCatalogHead, SpaceCatalogStore};
 use uuid::Uuid;
@@ -153,6 +154,7 @@ pub struct SpaceCatalog {
     runtime: Runtime,
     publication: PublicationContext,
     mutation_claimed: Arc<AtomicBool>,
+    entry_mutation_serializer: Arc<Mutex<()>>,
 }
 
 impl std::fmt::Debug for SpaceCatalog {
@@ -193,6 +195,7 @@ impl SpaceCatalog {
             runtime: Runtime::current(),
             publication: PublicationContext::generated(),
             mutation_claimed: Arc::new(AtomicBool::new(false)),
+            entry_mutation_serializer: Arc::new(Mutex::new(())),
         })
     }
 
@@ -213,7 +216,15 @@ impl SpaceCatalog {
             runtime: self.runtime.clone(),
             publication: PublicationContext::generated(),
             mutation_claimed: Arc::new(AtomicBool::new(false)),
+            entry_mutation_serializer: self.entry_mutation_serializer.clone(),
         }
+    }
+
+    /// Keeps domain revision validation and its Iceberg append together for
+    /// local writers. Shared writers still rely on the Catalog Head's
+    /// conditional publish and read-time duplicate-head detection.
+    pub(crate) async fn serialize_entry_mutation(&self) -> OwnedMutexGuard<()> {
+        self.entry_mutation_serializer.clone().lock_owned().await
     }
 
     #[cfg(test)]

--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -8,7 +8,7 @@ use ugoite_domain::form::{
 use ugoite_domain::id::{FieldId, FormId, SpaceId};
 use ugoite_iceberg::{
     physical_form_name, publication_context, IcebergWorkspace, MigrationFormReport,
-    MigrationManifest, MigrationReport,
+    MigrationManifest, MigrationReport, RevisionView,
 };
 use uuid::Uuid;
 
@@ -378,6 +378,12 @@ async fn append_enforces_revision_identity_and_entry_conflicts() -> anyhow::Resu
     let receipt = append_revisions(&workspace, form.id, vec![revision.clone()]).await?;
     assert_eq!(receipt.committed_revision_ids, vec![revision.revision_id]);
     assert!(receipt.data_file_count > 0);
+    assert_eq!(
+        workspace
+            .read_revision_view(form.id, RevisionView::LatestIncludingTombstones)
+            .await?,
+        vec![revision.clone()]
+    );
 
     let conflicting = EntryRevision {
         revision_id: Uuid::from_u128(33).into(),

--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -397,6 +397,95 @@ async fn append_enforces_revision_identity_and_entry_conflicts() -> anyhow::Resu
 }
 
 #[tokio::test]
+async fn revision_views_keep_tombstones_and_restore_current_entries() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(60)),
+        "memory://iceberg-revision-views",
+    )
+    .await?;
+    let form = form();
+    create_form(&workspace, &form).await?;
+
+    let first = EntryRevision {
+        form_id: form.id,
+        entry_id: Uuid::from_u128(61).into(),
+        revision_id: Uuid::from_u128(62).into(),
+        parent_revision_id: None,
+        entry_version: 1,
+        expected_version: None,
+        operation: EntryOperation::Upsert,
+        committed_at_micros: 1,
+        author_id: "human:owner".into(),
+        form_version: form.version,
+        source_kind: "test".into(),
+        source_id: None,
+        entry: EntryMetadata::default(),
+        values: BTreeMap::new(),
+        extra_attributes: BTreeMap::new(),
+        extension_metadata: BTreeMap::new(),
+    };
+    append_revisions(&workspace, form.id, vec![first.clone()]).await?;
+
+    let deleted = EntryRevision {
+        revision_id: Uuid::from_u128(63).into(),
+        parent_revision_id: Some(first.revision_id),
+        entry_version: 2,
+        expected_version: Some(1),
+        operation: EntryOperation::Delete,
+        committed_at_micros: 2,
+        entry: EntryMetadata {
+            deleted: true,
+            deleted_at_micros: Some(2),
+            ..EntryMetadata::default()
+        },
+        ..first.clone()
+    };
+    append_revisions(&workspace, form.id, vec![deleted.clone()]).await?;
+    assert_eq!(
+        workspace
+            .read_revision_view(form.id, RevisionView::LatestIncludingTombstones)
+            .await?,
+        vec![deleted.clone()]
+    );
+    assert!(workspace
+        .read_revision_view(form.id, RevisionView::Current)
+        .await?
+        .is_empty());
+    assert_eq!(
+        workspace
+            .read_latest_revisions_for_entry(form.id, first.entry_id)
+            .await?,
+        vec![deleted.clone()]
+    );
+
+    let restored = EntryRevision {
+        revision_id: Uuid::from_u128(64).into(),
+        parent_revision_id: Some(deleted.revision_id),
+        entry_version: 3,
+        expected_version: Some(2),
+        operation: EntryOperation::Restore,
+        committed_at_micros: 3,
+        entry: EntryMetadata {
+            restored_from: Some(deleted.revision_id),
+            ..EntryMetadata::default()
+        },
+        ..first.clone()
+    };
+    append_revisions(&workspace, form.id, vec![restored.clone()]).await?;
+    assert_eq!(
+        workspace
+            .read_revision_view(form.id, RevisionView::Current)
+            .await?,
+        vec![restored.clone()]
+    );
+    assert_eq!(
+        workspace.read_revisions(form.id).await?,
+        vec![first, deleted, restored]
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn coordinator_replays_only_the_same_canonical_command() -> anyhow::Result<()> {
     let workspace = IcebergWorkspace::memory_for_tests(
         SpaceId::from(Uuid::from_u128(34)),

--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -424,7 +424,7 @@ async fn revision_views_keep_tombstones_and_restore_current_entries() -> anyhow:
         extra_attributes: BTreeMap::new(),
         extension_metadata: BTreeMap::new(),
     };
-    append_revisions(&workspace, form.id, vec![first.clone()]).await?;
+    let first_receipt = append_revisions(&workspace, form.id, vec![first.clone()]).await?;
 
     let deleted = EntryRevision {
         revision_id: Uuid::from_u128(63).into(),
@@ -440,7 +440,7 @@ async fn revision_views_keep_tombstones_and_restore_current_entries() -> anyhow:
         },
         ..first.clone()
     };
-    append_revisions(&workspace, form.id, vec![deleted.clone()]).await?;
+    let deleted_receipt = append_revisions(&workspace, form.id, vec![deleted.clone()]).await?;
     assert_eq!(
         workspace
             .read_revision_view(form.id, RevisionView::LatestIncludingTombstones)
@@ -456,6 +456,26 @@ async fn revision_views_keep_tombstones_and_restore_current_entries() -> anyhow:
             .read_latest_revisions_for_entry(form.id, first.entry_id)
             .await?,
         vec![deleted.clone()]
+    );
+    assert_eq!(
+        workspace
+            .read_revision_view_at_snapshot(
+                form.id,
+                RevisionView::LatestIncludingTombstones,
+                first_receipt.snapshot_id,
+            )
+            .await?,
+        vec![first.clone()]
+    );
+    assert!(
+        workspace
+            .read_revision_view_at_snapshot(
+                form.id,
+                RevisionView::Current,
+                deleted_receipt.snapshot_id,
+            )
+            .await?
+            .is_empty()
     );
 
     let restored = EntryRevision {


### PR DESCRIPTION
## Summary

- Define all, latest, current, and point latest revision views with one DataFusion aggregation and join plan.
- Reject duplicate maximum Entry versions and use Iceberg revision-ID filters to fetch canonical payload rows without a Rust full-history state map.
- Preserve Iceberg schema-evolution reads by letting Iceberg scan filtered payload files directly.

## Related Issue (required)

Closes #1819

## Testing

- [x] `cargo clippy -p ugoite-iceberg --all-targets --all-features -- -D warnings`
- [x] `cargo test -p ugoite-iceberg --test test_entry --test workspace`
