### PR TITLE
Build authorization-aware Iceberg query context

### DIFF
--- a/crates/ugoite-core/src/lib.rs
+++ b/crates/ugoite-core/src/lib.rs
@@ -3,3 +3,4 @@
 
 pub mod error;
 pub mod metadata;
+pub mod query;

--- a/crates/ugoite-core/src/query.rs
+++ b/crates/ugoite-core/src/query.rs
@@ -1,0 +1,81 @@
+//! Domain policy for a closed, authorized analytical query surface.
+//!
+//! Core decides which logical Forms, Entry IDs, columns, functions, snapshots,
+//! and resources a caller may use. Storage adapters translate this DTO into
+//! their query engine without exposing physical provider or catalog types.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+use ugoite_domain::id::{EntryId, FormId};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorizedQueryPolicy {
+    pub forms: BTreeMap<FormId, AuthorizedQueryForm>,
+    pub readable_entry_ids: BTreeSet<EntryId>,
+    pub checkpoint: Option<QueryCheckpoint>,
+    pub limits: QueryLimits,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthorizedQueryForm {
+    /// The sole SQL relation name exposed for this Form.
+    pub relation: String,
+    /// User-defined Form columns which may be resolved or projected.
+    pub columns: BTreeSet<String>,
+    /// System columns which are intentionally part of this query contract.
+    pub system_columns: BTreeSet<QuerySystemColumn>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QueryCheckpoint {
+    /// Every exposed Form must have a snapshot in this map. A partial
+    /// checkpoint is rejected by the physical adapter rather than mixing live
+    /// and historical providers.
+    pub form_snapshots: BTreeMap<FormId, i64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum QuerySystemColumn {
+    EntryId,
+    EntryVersion,
+    CommittedAt,
+}
+
+impl QuerySystemColumn {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EntryId => "entry_id",
+            Self::EntryVersion => "entry_version",
+            Self::CommittedAt => "committed_at",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct QueryLimits {
+    pub max_memory_bytes: usize,
+    pub max_rows: usize,
+    pub timeout: Duration,
+    pub max_concurrency: usize,
+    /// DataFusion built-in function names explicitly admitted by Core. UDFs
+    /// are never registered by the authorized query surface.
+    pub allowed_functions: BTreeSet<String>,
+}
+
+impl QueryLimits {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.max_memory_bytes == 0 {
+            return Err("query memory limit must be positive");
+        }
+        if self.max_rows == 0 {
+            return Err("query row limit must be positive");
+        }
+        if self.timeout.is_zero() {
+            return Err("query timeout must be positive");
+        }
+        if self.max_concurrency == 0 {
+            return Err("query concurrency limit must be positive");
+        }
+        Ok(())
+    }
+}

--- a/crates/ugoite-core/src/query.rs
+++ b/crates/ugoite-core/src/query.rs
@@ -12,7 +12,6 @@ use ugoite_domain::id::{EntryId, FormId};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AuthorizedQueryPolicy {
     pub forms: BTreeMap<FormId, AuthorizedQueryForm>,
-    pub readable_entry_ids: BTreeSet<EntryId>,
     /// When present, every provider is built from this one complete,
     /// publication-verified Space coordinate.
     pub checkpoint: Option<SpaceCheckpoint>,
@@ -23,6 +22,9 @@ pub struct AuthorizedQueryPolicy {
 pub struct AuthorizedQueryForm {
     /// The sole SQL relation name exposed for this Form.
     pub relation: String,
+    /// Entry IDs Core authorizes for this Form. The query adapter embeds this
+    /// relation-specific boundary in the trusted view before SQL is planned.
+    pub readable_entry_ids: BTreeSet<EntryId>,
     /// User-defined Form columns which may be resolved or projected.
     pub columns: BTreeSet<String>,
     /// System columns which are intentionally part of this query contract.

--- a/crates/ugoite-core/src/query.rs
+++ b/crates/ugoite-core/src/query.rs
@@ -6,13 +6,16 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
+use ugoite_domain::checkpoint::SpaceCheckpoint;
 use ugoite_domain::id::{EntryId, FormId};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AuthorizedQueryPolicy {
     pub forms: BTreeMap<FormId, AuthorizedQueryForm>,
     pub readable_entry_ids: BTreeSet<EntryId>,
-    pub checkpoint: Option<QueryCheckpoint>,
+    /// When present, every provider is built from this one complete,
+    /// publication-verified Space coordinate.
+    pub checkpoint: Option<SpaceCheckpoint>,
     pub limits: QueryLimits,
 }
 
@@ -24,14 +27,6 @@ pub struct AuthorizedQueryForm {
     pub columns: BTreeSet<String>,
     /// System columns which are intentionally part of this query contract.
     pub system_columns: BTreeSet<QuerySystemColumn>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct QueryCheckpoint {
-    /// Every exposed Form must have a snapshot in this map. A partial
-    /// checkpoint is rejected by the physical adapter rather than mixing live
-    /// and historical providers.
-    pub form_snapshots: BTreeMap<FormId, i64>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/ugoite-iceberg/Cargo.toml
+++ b/crates/ugoite-iceberg/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.10.1"
 regex = "1.12.3"
 serde_yaml = "0.9.34"
 sqlparser = "0.62.0"
-tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "sync", "time"] }
 typetag = "0.2"
 ugoite-domain = { path = "../ugoite-domain" }
 ugoite-core = { path = "../ugoite-core" }

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -18,6 +18,7 @@ pub mod integrity;
 pub mod link;
 pub mod materialized_view;
 pub mod preferences;
+pub mod query_context;
 pub mod sample_data;
 pub mod saved_sql;
 pub mod search;

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use ugoite_core::query::AuthorizedQueryPolicy;
 
-use crate::IcebergWorkspace;
+use crate::{form_from_table, IcebergWorkspace};
 
 const INTERNAL_RELATION_PREFIX: &str = "__ugoite_authorized_source_";
 
@@ -56,6 +56,24 @@ impl IcebergWorkspace {
         let context = SessionContext::new_with_config_rt(config, runtime);
         let mut relations = BTreeSet::new();
 
+        if let Some(checkpoint) = &policy.checkpoint {
+            self.validate_checkpoint(checkpoint)?;
+            self.space_catalog
+                .as_ref()
+                .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+                .validate_checkpoint_evidence(checkpoint)
+                .await?;
+            let checkpoint_forms = checkpoint
+                .tables
+                .iter()
+                .map(|table| table.form_id)
+                .collect::<BTreeSet<_>>();
+            let authorized_forms = policy.forms.keys().copied().collect::<BTreeSet<_>>();
+            if checkpoint_forms != authorized_forms {
+                bail!("checkpoint Forms must exactly match authorized query Forms");
+            }
+        }
+
         for (form_id, form_policy) in &policy.forms {
             validate_relation(&form_policy.relation)?;
             if !relations.insert(form_policy.relation.clone()) {
@@ -64,19 +82,33 @@ impl IcebergWorkspace {
                     form_policy.relation
                 );
             }
-            let form = self.load_form(*form_id).await?;
-            let table = self.catalog.load_table(&self.form_ident(*form_id)).await?;
-            let snapshot_id = policy
-                .checkpoint
-                .as_ref()
-                .map(|checkpoint| {
-                    checkpoint
-                        .form_snapshots
-                        .get(form_id)
-                        .copied()
-                        .ok_or_else(|| anyhow!("checkpoint is missing authorized Form {}", form_id))
-                })
-                .transpose()?;
+            let (form, table, snapshot_id) = match &policy.checkpoint {
+                Some(checkpoint) => {
+                    let coordinate = checkpoint
+                        .tables
+                        .iter()
+                        .find(|coordinate| coordinate.form_id == *form_id)
+                        .ok_or_else(|| {
+                            anyhow!("checkpoint is missing authorized Form {form_id}")
+                        })?;
+                    let table = self
+                        .space_catalog
+                        .as_ref()
+                        .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+                        .load_checkpoint_table(checkpoint, coordinate)
+                        .await?;
+                    (
+                        form_from_table(&table, *form_id)?,
+                        table,
+                        coordinate.snapshot_id,
+                    )
+                }
+                None => (
+                    self.load_form(*form_id).await?,
+                    self.catalog.load_table(&self.form_ident(*form_id)).await?,
+                    None,
+                ),
+            };
             let provider = match snapshot_id {
                 Some(snapshot_id) => {
                     IcebergStaticTableProvider::try_new_from_table_snapshot(table, snapshot_id)
@@ -127,6 +159,12 @@ impl AuthorizedQueryContext {
             .clone()
             .try_acquire_owned()
             .map_err(|_| anyhow!("authorized query concurrency limit reached"))?;
+        tokio::time::timeout(self.limits.timeout, self.execute_with_permit(sql))
+            .await
+            .map_err(|_| anyhow!("authorized query timed out"))?
+    }
+
+    async fn execute_with_permit(&self, sql: &str) -> Result<Vec<arrow_array::RecordBatch>> {
         let plan = self
             .context
             .state()
@@ -146,12 +184,7 @@ impl AuthorizedQueryContext {
         let task_context = Arc::new(frame.task_ctx());
         let physical = frame.create_physical_plan().await?;
         validate_physical_plan(&physical)?;
-        let batches = tokio::time::timeout(
-            self.limits.timeout,
-            datafusion::physical_plan::collect(physical, task_context),
-        )
-        .await
-        .map_err(|_| anyhow!("authorized query timed out"))??;
+        let batches = datafusion::physical_plan::collect(physical, task_context).await?;
         let rows = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
         if rows > self.limits.max_rows {
             bail!("authorized query row limit exceeded");
@@ -177,6 +210,14 @@ fn visible_columns(
         bail!("authorized query policy exposes unknown Form column {column}");
     }
     let mut visible = policy.columns.iter().cloned().collect::<Vec<_>>();
+    if let Some(column) = policy
+        .system_columns
+        .iter()
+        .map(|column| column.as_str())
+        .find(|column| form_columns.contains(column))
+    {
+        bail!("Form column {column} collides with a query system column");
+    }
     visible.extend(
         policy
             .system_columns

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -29,6 +29,14 @@ pub struct AuthorizedQueryContext {
     context: SessionContext,
     limits: ugoite_core::query::QueryLimits,
     permits: Arc<Semaphore>,
+    authorized_relations: BTreeSet<String>,
+    authorized_scans: BTreeSet<AuthorizedScan>,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct AuthorizedScan {
+    table_uuid: String,
+    snapshot_id: Option<i64>,
 }
 
 impl IcebergWorkspace {
@@ -55,6 +63,7 @@ impl IcebergWorkspace {
             .context("configure bounded DataFusion runtime")?;
         let context = SessionContext::new_with_config_rt(config, runtime);
         let mut relations = BTreeSet::new();
+        let mut authorized_scans = BTreeSet::new();
 
         if let Some(checkpoint) = &policy.checkpoint {
             self.validate_checkpoint(checkpoint)?;
@@ -100,6 +109,10 @@ impl IcebergWorkspace {
                     None,
                 ),
             };
+            let authorized_scan = AuthorizedScan {
+                table_uuid: table.metadata().uuid().to_string(),
+                snapshot_id,
+            };
             let provider = match snapshot_id {
                 Some(snapshot_id) => {
                     IcebergStaticTableProvider::try_new_from_table_snapshot(table, snapshot_id)
@@ -111,10 +124,13 @@ impl IcebergWorkspace {
                     .context("open static Iceberg provider")?,
             };
 
+            authorized_scans.insert(authorized_scan);
+
             let internal = format!("{INTERNAL_RELATION_PREFIX}{}", form_id.as_uuid().simple());
+            relations.insert(internal.clone());
             context.register_table(internal.as_str(), Arc::new(provider))?;
             let visible = visible_columns(&form, form_policy)?;
-            let entry_ids = policy
+            let entry_ids = form_policy
                 .readable_entry_ids
                 .iter()
                 .map(|entry_id| lit(entry_id.as_uuid().as_bytes().to_vec()))
@@ -137,6 +153,8 @@ impl IcebergWorkspace {
             context,
             limits: policy.limits,
             permits: Arc::new(Semaphore::new(max_concurrency)),
+            authorized_relations: relations,
+            authorized_scans,
         })
     }
 }
@@ -162,9 +180,17 @@ impl AuthorizedQueryContext {
             .create_logical_plan(sql)
             .await
             .context("plan authorized query")?;
-        validate_logical_plan(&plan, &self.limits.allowed_functions)?;
+        validate_logical_plan(
+            &plan,
+            &self.limits.allowed_functions,
+            &self.authorized_relations,
+        )?;
         let optimized = self.context.state().optimize(&plan)?;
-        validate_logical_plan(&optimized, &self.limits.allowed_functions)?;
+        validate_logical_plan(
+            &optimized,
+            &self.limits.allowed_functions,
+            &self.authorized_relations,
+        )?;
         let frame = self.context.execute_logical_plan(optimized).await?;
         let max_rows_with_sentinel = self
             .limits
@@ -174,7 +200,7 @@ impl AuthorizedQueryContext {
         let frame = frame.limit(0, Some(max_rows_with_sentinel))?;
         let task_context = Arc::new(frame.task_ctx());
         let physical = frame.create_physical_plan().await?;
-        validate_physical_plan(&physical)?;
+        validate_physical_plan(&physical, &self.authorized_scans)?;
         let batches = datafusion::physical_plan::collect(physical, task_context).await?;
         let rows = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
         if rows > self.limits.max_rows {
@@ -225,6 +251,9 @@ fn visible_columns(
 }
 
 fn validate_relation(relation: &str) -> Result<()> {
+    if relation.starts_with(INTERNAL_RELATION_PREFIX) {
+        bail!("authorized query relation uses a reserved internal prefix");
+    }
     let mut characters = relation.chars();
     let Some(first) = characters.next() else {
         bail!("authorized query relation must not be empty");
@@ -237,7 +266,11 @@ fn validate_relation(relation: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_logical_plan(plan: &LogicalPlan, allowed_functions: &BTreeSet<String>) -> Result<()> {
+fn validate_logical_plan(
+    plan: &LogicalPlan,
+    allowed_functions: &BTreeSet<String>,
+    authorized_relations: &BTreeSet<String>,
+) -> Result<()> {
     match plan {
         LogicalPlan::Explain(_) | LogicalPlan::Analyze(_) => bail!("EXPLAIN is not supported"),
         LogicalPlan::Dml(_)
@@ -247,7 +280,27 @@ fn validate_logical_plan(plan: &LogicalPlan, allowed_functions: &BTreeSet<String
         | LogicalPlan::DescribeTable(_)
         | LogicalPlan::Extension(_)
         | LogicalPlan::RecursiveQuery(_) => bail!("statement kind is not supported"),
-        _ => {}
+        LogicalPlan::TableScan(scan) => {
+            let relation = scan.table_name.to_string();
+            if !authorized_relations.contains(&relation) {
+                bail!("query plan scans an unauthorized relation {relation}");
+            }
+        }
+        LogicalPlan::Projection(_)
+        | LogicalPlan::Filter(_)
+        | LogicalPlan::Window(_)
+        | LogicalPlan::Aggregate(_)
+        | LogicalPlan::Sort(_)
+        | LogicalPlan::Join(_)
+        | LogicalPlan::Repartition(_)
+        | LogicalPlan::Union(_)
+        | LogicalPlan::EmptyRelation(_)
+        | LogicalPlan::Subquery(_)
+        | LogicalPlan::SubqueryAlias(_)
+        | LogicalPlan::Limit(_)
+        | LogicalPlan::Values(_)
+        | LogicalPlan::Distinct(_)
+        | LogicalPlan::Unnest(_) => {}
     }
     for expression in plan.expressions() {
         expression.apply(|expression| {
@@ -268,20 +321,61 @@ fn validate_logical_plan(plan: &LogicalPlan, allowed_functions: &BTreeSet<String
         })?;
     }
     for input in plan.inputs() {
-        validate_logical_plan(input, allowed_functions)?;
+        validate_logical_plan(input, allowed_functions, authorized_relations)?;
     }
     Ok(())
 }
 
-fn validate_physical_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
-    if plan
+fn validate_physical_plan(
+    plan: &Arc<dyn ExecutionPlan>,
+    authorized_scans: &BTreeSet<AuthorizedScan>,
+) -> Result<()> {
+    if let Some(scan) = plan
         .as_any()
-        .is::<datafusion::physical_plan::explain::ExplainExec>()
+        .downcast_ref::<iceberg_datafusion::physical_plan::IcebergTableScan>()
     {
-        bail!("EXPLAIN physical plan is not supported");
+        let authorized = AuthorizedScan {
+            table_uuid: scan.table().metadata().uuid().to_string(),
+            snapshot_id: scan.snapshot_id(),
+        };
+        if !authorized_scans.contains(&authorized) {
+            bail!("physical plan scans an unauthorized Iceberg table");
+        }
+        // The Entry predicate is owned by the Core-built view and may remain
+        // in a FilterExec rather than be pushed into IcebergTableScan. The
+        // optimized logical-plan validation above proves that this scan is
+        // reachable only through an authorized relation/view.
+    } else if !is_authorized_physical_node(plan.name()) {
+        bail!("physical plan node {} is not authorized", plan.name());
     }
     for child in plan.children() {
-        validate_physical_plan(child)?;
+        validate_physical_plan(child, authorized_scans)?;
     }
     Ok(())
+}
+
+fn is_authorized_physical_node(name: &str) -> bool {
+    matches!(
+        name,
+        "AggregateExec"
+            | "CoalesceBatchesExec"
+            | "CoalescePartitionsExec"
+            | "CooperativeExec"
+            | "CrossJoinExec"
+            | "EmptyExec"
+            | "FilterExec"
+            | "GlobalLimitExec"
+            | "HashJoinExec"
+            | "LocalLimitExec"
+            | "NestedLoopJoinExec"
+            | "ProjectionExec"
+            | "RepartitionExec"
+            | "SortExec"
+            | "SortMergeJoinExec"
+            | "SortPreservingMergeExec"
+            | "UnionExec"
+            | "WindowAggExec"
+            | "BoundedWindowAggExec"
+            | "UnnestExec"
+    )
 }

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -63,15 +63,6 @@ impl IcebergWorkspace {
                 .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
                 .validate_checkpoint_evidence(checkpoint)
                 .await?;
-            let checkpoint_forms = checkpoint
-                .tables
-                .iter()
-                .map(|table| table.form_id)
-                .collect::<BTreeSet<_>>();
-            let authorized_forms = policy.forms.keys().copied().collect::<BTreeSet<_>>();
-            if checkpoint_forms != authorized_forms {
-                bail!("checkpoint Forms must exactly match authorized query Forms");
-            }
         }
 
         for (form_id, form_policy) in &policy.forms {

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -5,15 +5,15 @@
 //! unapproved object.
 
 use anyhow::{anyhow, bail, Context, Result};
-use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::memory_pool::GreedyMemoryPool;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-use datafusion::logical_expr::{Expr, LogicalPlan};
+use datafusion::execution::{SessionStateBuilder, SessionStateDefaults};
+use datafusion::logical_expr::LogicalPlan;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::{col, lit, SessionConfig};
 use iceberg_datafusion::IcebergStaticTableProvider;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use ugoite_core::query::AuthorizedQueryPolicy;
@@ -31,20 +31,12 @@ pub struct AuthorizedQueryContext {
     permits: Arc<Semaphore>,
     authorized_relations: BTreeSet<String>,
     authorized_scans: BTreeSet<AuthorizedScan>,
-    trusted_relations: BTreeMap<String, TrustedRelation>,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 struct AuthorizedScan {
     table_uuid: String,
     snapshot_id: Option<i64>,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct TrustedRelation {
-    relation: String,
-    readable_entry_ids: BTreeSet<Vec<u8>>,
-    visible_columns: BTreeSet<String>,
 }
 
 /// Closed public errors for the authorization-aware query surface. Upstream
@@ -141,10 +133,46 @@ impl IcebergWorkspace {
             )))
             .build_arc()
             .context("configure bounded DataFusion runtime")?;
-        let context = SessionContext::new_with_config_rt(config, runtime);
+        // Start from an empty SessionState. Registering only Core-approved
+        // built-ins makes every other scalar, aggregate, window, and table
+        // function unresolvable before plan validation. The empty default
+        // catalog is retained solely for relation registration; no file
+        // formats, table factories, function factory, or table functions are
+        // installed.
+        let allowed_functions = &policy.limits.allowed_functions;
+        let state = SessionStateBuilder::new()
+            .with_config(config)
+            .with_runtime_env(runtime)
+            .with_expr_planners(SessionStateDefaults::default_expr_planners())
+            .with_scalar_functions(
+                SessionStateDefaults::default_scalar_functions()
+                    .into_iter()
+                    .filter(|function| {
+                        allowed_functions.contains(&function.name().to_ascii_lowercase())
+                    })
+                    .collect(),
+            )
+            .with_aggregate_functions(
+                SessionStateDefaults::default_aggregate_functions()
+                    .into_iter()
+                    .filter(|function| {
+                        allowed_functions.contains(&function.name().to_ascii_lowercase())
+                    })
+                    .collect(),
+            )
+            .with_window_functions(
+                SessionStateDefaults::default_window_functions()
+                    .into_iter()
+                    .filter(|function| {
+                        allowed_functions.contains(&function.name().to_ascii_lowercase())
+                    })
+                    .collect(),
+            )
+            .with_table_function_list(Vec::new())
+            .build();
+        let context = SessionContext::new_with_state(state);
         let mut relations = BTreeSet::new();
         let mut authorized_scans = BTreeSet::new();
-        let mut trusted_relations = BTreeMap::new();
 
         if let Some(checkpoint) = &policy.checkpoint {
             self.validate_checkpoint(checkpoint)?;
@@ -216,18 +244,6 @@ impl IcebergWorkspace {
                 .iter()
                 .map(|entry_id| lit(entry_id.as_uuid().as_bytes().to_vec()))
                 .collect::<Vec<_>>();
-            trusted_relations.insert(
-                internal.clone(),
-                TrustedRelation {
-                    relation: form_policy.relation.clone(),
-                    readable_entry_ids: form_policy
-                        .readable_entry_ids
-                        .iter()
-                        .map(|entry_id| entry_id.as_uuid().as_bytes().to_vec())
-                        .collect(),
-                    visible_columns: visible.iter().cloned().collect(),
-                },
-            );
             let visible_refs = visible.iter().map(String::as_str).collect::<Vec<_>>();
             let source = context.table(internal.as_str()).await?;
             let filtered = if entry_ids.is_empty() {
@@ -248,7 +264,6 @@ impl IcebergWorkspace {
             permits: Arc::new(Semaphore::new(max_concurrency)),
             authorized_relations: relations,
             authorized_scans,
-            trusted_relations,
         })
     }
 }
@@ -274,24 +289,14 @@ impl AuthorizedQueryContext {
             .create_logical_plan(sql)
             .await
             .map_err(AuthorizedQueryError::invalid_query)?;
-        validate_logical_plan(
-            &plan,
-            &self.limits.allowed_functions,
-            &self.authorized_relations,
-        )
-        .map_err(AuthorizedQueryError::unauthorized)?;
+        validate_logical_plan(&plan, &self.authorized_relations)
+            .map_err(AuthorizedQueryError::unauthorized)?;
         let optimized = self
             .context
             .state()
             .optimize(&plan)
             .map_err(AuthorizedQueryError::invalid_query)?;
-        validate_logical_plan(
-            &optimized,
-            &self.limits.allowed_functions,
-            &self.authorized_relations,
-        )
-        .map_err(AuthorizedQueryError::unauthorized)?;
-        validate_trusted_entry_filters(&optimized, &self.trusted_relations)
+        validate_logical_plan(&optimized, &self.authorized_relations)
             .map_err(AuthorizedQueryError::unauthorized)?;
         let frame = self
             .context
@@ -386,9 +391,14 @@ fn validate_relation(relation: &str) -> Result<()> {
 
 fn validate_logical_plan(
     plan: &LogicalPlan,
-    allowed_functions: &BTreeSet<String>,
     authorized_relations: &BTreeSet<String>,
 ) -> Result<()> {
+    // The private catalog and view/provider construction are the authorization
+    // boundary: a plan cannot resolve the hidden Iceberg source directly, and
+    // every public relation already contains its Entry predicate and visible
+    // projection. Do not attempt to re-evaluate SQL predicate semantics here;
+    // this defense-in-depth check is deliberately limited to statement kinds
+    // and the relations the planner resolved.
     match plan {
         LogicalPlan::Explain(_) | LogicalPlan::Analyze(_) => bail!("EXPLAIN is not supported"),
         LogicalPlan::Dml(_)
@@ -420,212 +430,10 @@ fn validate_logical_plan(
         | LogicalPlan::Distinct(_)
         | LogicalPlan::Unnest(_) => {}
     }
-    for expression in plan.expressions() {
-        expression.apply(|expression| {
-            validate_expression_function(expression, allowed_functions)?;
-            Ok(TreeNodeRecursion::Continue)
-        })?;
-    }
     for input in plan.inputs() {
-        validate_logical_plan(input, allowed_functions, authorized_relations)?;
+        validate_logical_plan(input, authorized_relations)?;
     }
     Ok(())
-}
-
-/// Keep this match exhaustive. DataFusion represents function calls in several
-/// expression variants, and a future variant must fail compilation here until
-/// its authorization semantics are deliberately reviewed.
-#[allow(deprecated)]
-fn validate_expression_function(
-    expression: &Expr,
-    allowed_functions: &BTreeSet<String>,
-) -> datafusion::error::Result<()> {
-    match expression {
-        Expr::ScalarFunction(function) => authorize_function(function.name(), allowed_functions),
-        Expr::AggregateFunction(function) => {
-            authorize_function(function.func.name(), allowed_functions)
-        }
-        Expr::WindowFunction(function) => {
-            authorize_function(function.fun.name(), allowed_functions)
-        }
-        // DataFusion's UNNEST is a distinct expression/plan form rather than
-        // a ScalarFunction. It remains unavailable unless Core admits it.
-        Expr::Unnest(_) => authorize_function("unnest", allowed_functions),
-        Expr::Alias(_)
-        | Expr::Column(_)
-        | Expr::ScalarVariable(_, _)
-        | Expr::Literal(_, _)
-        | Expr::BinaryExpr(_)
-        | Expr::Like(_)
-        | Expr::SimilarTo(_)
-        | Expr::Not(_)
-        | Expr::IsNotNull(_)
-        | Expr::IsNull(_)
-        | Expr::IsTrue(_)
-        | Expr::IsFalse(_)
-        | Expr::IsUnknown(_)
-        | Expr::IsNotTrue(_)
-        | Expr::IsNotFalse(_)
-        | Expr::IsNotUnknown(_)
-        | Expr::Negative(_)
-        | Expr::Between(_)
-        | Expr::Case(_)
-        | Expr::Cast(_)
-        | Expr::TryCast(_)
-        | Expr::InList(_)
-        | Expr::Exists(_)
-        | Expr::InSubquery(_)
-        | Expr::SetComparison(_)
-        | Expr::ScalarSubquery(_)
-        | Expr::Wildcard { .. }
-        | Expr::GroupingSet(_)
-        | Expr::Placeholder(_)
-        | Expr::OuterReferenceColumn(_, _) => Ok(()),
-    }
-}
-
-fn authorize_function(
-    name: &str,
-    allowed_functions: &BTreeSet<String>,
-) -> datafusion::error::Result<()> {
-    if allowed_functions.contains(&name.to_ascii_lowercase()) {
-        Ok(())
-    } else {
-        Err(datafusion::error::DataFusionError::Plan(format!(
-            "function {name} is not authorized"
-        )))
-    }
-}
-
-/// Verifies that every internal Iceberg relation remains guarded by the Entry
-/// boundary installed while building the trusted view. A user predicate can
-/// only add another filter; it cannot make this filter disappear. This runs on
-/// the optimized plan because predicate pushdown/rewrite happens after the
-/// initial authorization check.
-fn validate_trusted_entry_filters(
-    plan: &LogicalPlan,
-    trusted_relations: &BTreeMap<String, TrustedRelation>,
-) -> Result<()> {
-    let mut seen_scans = BTreeSet::new();
-    let mut guarded_scans = BTreeSet::new();
-    let mut projected_relations = BTreeSet::new();
-    collect_trusted_entry_filters(
-        plan,
-        trusted_relations,
-        &mut seen_scans,
-        &mut guarded_scans,
-        &mut projected_relations,
-    )?;
-    for internal in trusted_relations.keys() {
-        if seen_scans.contains(internal) && !guarded_scans.contains(internal) {
-            bail!("optimized query plan lost the trusted Entry authorization filter");
-        }
-        if seen_scans.contains(internal) && !projected_relations.contains(internal) {
-            bail!("optimized query plan lost the trusted visible-column projection");
-        }
-    }
-    Ok(())
-}
-
-fn collect_trusted_entry_filters(
-    plan: &LogicalPlan,
-    trusted_relations: &BTreeMap<String, TrustedRelation>,
-    seen_scans: &mut BTreeSet<String>,
-    guarded_scans: &mut BTreeSet<String>,
-    projected_relations: &mut BTreeSet<String>,
-) -> Result<BTreeSet<String>> {
-    let mut descendants = BTreeSet::new();
-    for input in plan.inputs() {
-        descendants.extend(collect_trusted_entry_filters(
-            input,
-            trusted_relations,
-            seen_scans,
-            guarded_scans,
-            projected_relations,
-        )?);
-    }
-    if let LogicalPlan::TableScan(scan) = plan {
-        let relation = scan.table_name.to_string();
-        if let Some(trusted) = trusted_relations.get(&relation) {
-            seen_scans.insert(relation.clone());
-            descendants.insert(relation.clone());
-            if scan
-                .filters
-                .iter()
-                .any(|filter| is_trusted_entry_filter(filter, trusted))
-            {
-                guarded_scans.insert(relation);
-            }
-        }
-    }
-    if let LogicalPlan::Filter(filter) = plan {
-        if descendants.len() == 1 {
-            let internal = descendants.iter().next().expect("one relation");
-            if let Some(trusted) = trusted_relations.get(internal) {
-                if is_trusted_entry_filter(&filter.predicate, trusted) {
-                    guarded_scans.insert(internal.clone());
-                }
-            }
-        }
-    }
-    if let LogicalPlan::SubqueryAlias(alias) = plan {
-        let visible = alias
-            .schema
-            .fields()
-            .iter()
-            .map(|field| field.name().to_string())
-            .collect::<BTreeSet<_>>();
-        for (internal, trusted) in trusted_relations {
-            if alias.alias.to_string() == trusted.relation
-                && visible.is_subset(&trusted.visible_columns)
-            {
-                projected_relations.insert(internal.clone());
-            }
-        }
-    }
-    Ok(descendants)
-}
-
-fn is_trusted_entry_filter(expression: &Expr, trusted: &TrustedRelation) -> bool {
-    let mut entry_ids = BTreeSet::new();
-    let _ = expression.apply(|candidate| {
-        if let Expr::InList(list) = candidate {
-            if !list.negated && is_entry_id_column(&list.expr) {
-                entry_ids.extend(list.list.iter().filter_map(literal_binary));
-            }
-        }
-        if let Expr::BinaryExpr(binary) = candidate {
-            if binary.op == datafusion::logical_expr::Operator::Eq {
-                if is_entry_id_column(&binary.left) {
-                    if let Some(value) = literal_binary(&binary.right) {
-                        entry_ids.insert(value);
-                    }
-                } else if is_entry_id_column(&binary.right) {
-                    if let Some(value) = literal_binary(&binary.left) {
-                        entry_ids.insert(value);
-                    }
-                }
-            }
-        }
-        Ok(TreeNodeRecursion::Continue)
-    });
-    entry_ids == trusted.readable_entry_ids
-}
-
-fn is_entry_id_column(expression: &Expr) -> bool {
-    matches!(expression, Expr::Column(column) if column.name == "entry_id")
-}
-
-fn literal_binary(expression: &Expr) -> Option<Vec<u8>> {
-    match expression {
-        Expr::Literal(datafusion::scalar::ScalarValue::Binary(Some(value)), _) => {
-            Some(value.clone())
-        }
-        Expr::Literal(datafusion::scalar::ScalarValue::FixedSizeBinary(_, Some(value)), _) => {
-            Some(value.clone())
-        }
-        _ => None,
-    }
 }
 
 fn validate_physical_plan(
@@ -643,41 +451,14 @@ fn validate_physical_plan(
         if !authorized_scans.contains(&authorized) {
             bail!("physical plan scans an unauthorized Iceberg table");
         }
-        // The Entry predicate is owned by the Core-built view and may remain
-        // in a FilterExec rather than be pushed into IcebergTableScan. The
-        // optimized logical-plan validation above proves that this scan is
-        // reachable only through an authorized relation/view.
-    } else if !is_authorized_physical_node(plan.name()) {
-        bail!("physical plan node {} is not authorized", plan.name());
+    } else if plan.children().is_empty() && plan.name() != "EmptyExec" {
+        // Intermediate DataFusion operators are not an authorization boundary.
+        // A leaf is: permit only an authorized Iceberg scan (or an empty plan)
+        // so a future external provider cannot silently enter the query.
+        bail!("physical plan has an unauthorized data source");
     }
     for child in plan.children() {
         validate_physical_plan(child, authorized_scans)?;
     }
     Ok(())
-}
-
-fn is_authorized_physical_node(name: &str) -> bool {
-    matches!(
-        name,
-        "AggregateExec"
-            | "CoalesceBatchesExec"
-            | "CoalescePartitionsExec"
-            | "CooperativeExec"
-            | "CrossJoinExec"
-            | "EmptyExec"
-            | "FilterExec"
-            | "GlobalLimitExec"
-            | "HashJoinExec"
-            | "LocalLimitExec"
-            | "NestedLoopJoinExec"
-            | "ProjectionExec"
-            | "RepartitionExec"
-            | "SortExec"
-            | "SortMergeJoinExec"
-            | "SortPreservingMergeExec"
-            | "UnionExec"
-            | "WindowAggExec"
-            | "BoundedWindowAggExec"
-            | "UnnestExec"
-    )
 }

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -1,0 +1,255 @@
+//! Closed DataFusion context for authorized Iceberg queries.
+//!
+//! The public type deliberately exposes only `execute`. It never returns a
+//! `SessionContext`, Catalog, provider, or SQL planner that could resolve an
+//! unapproved object.
+
+use anyhow::{anyhow, bail, Context, Result};
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::execution::context::SessionContext;
+use datafusion::execution::memory_pool::GreedyMemoryPool;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::logical_expr::{Expr, LogicalPlan};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::{col, lit, SessionConfig};
+use iceberg_datafusion::IcebergStaticTableProvider;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use ugoite_core::query::AuthorizedQueryPolicy;
+
+use crate::IcebergWorkspace;
+
+const INTERNAL_RELATION_PREFIX: &str = "__ugoite_authorized_source_";
+
+/// A query surface containing only Core-authorized, read-only logical Form
+/// views. The underlying context remains private so callers cannot register a
+/// table, UDF, object store, or provider of their own.
+pub struct AuthorizedQueryContext {
+    context: SessionContext,
+    limits: ugoite_core::query::QueryLimits,
+    permits: Arc<Semaphore>,
+}
+
+impl IcebergWorkspace {
+    /// Translates a Core authorization decision into a closed DataFusion query
+    /// surface. All providers are static Iceberg providers; a requested
+    /// checkpoint requires one snapshot for every exposed Form.
+    pub async fn authorized_query_context(
+        &self,
+        policy: AuthorizedQueryPolicy,
+    ) -> Result<AuthorizedQueryContext> {
+        policy
+            .limits
+            .validate()
+            .map_err(|message| anyhow!(message))?;
+
+        let config = SessionConfig::new()
+            .with_information_schema(false)
+            .with_target_partitions(policy.limits.max_concurrency);
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::new(GreedyMemoryPool::new(
+                policy.limits.max_memory_bytes,
+            )))
+            .build_arc()
+            .context("configure bounded DataFusion runtime")?;
+        let context = SessionContext::new_with_config_rt(config, runtime);
+        let mut relations = BTreeSet::new();
+
+        for (form_id, form_policy) in &policy.forms {
+            validate_relation(&form_policy.relation)?;
+            if !relations.insert(form_policy.relation.clone()) {
+                bail!(
+                    "authorized query policy repeats relation {}",
+                    form_policy.relation
+                );
+            }
+            let form = self.load_form(*form_id).await?;
+            let table = self.catalog.load_table(&self.form_ident(*form_id)).await?;
+            let snapshot_id = policy
+                .checkpoint
+                .as_ref()
+                .map(|checkpoint| {
+                    checkpoint
+                        .form_snapshots
+                        .get(form_id)
+                        .copied()
+                        .ok_or_else(|| anyhow!("checkpoint is missing authorized Form {}", form_id))
+                })
+                .transpose()?;
+            let provider = match snapshot_id {
+                Some(snapshot_id) => {
+                    IcebergStaticTableProvider::try_new_from_table_snapshot(table, snapshot_id)
+                        .await
+                        .context("open checkpoint-pinned Iceberg provider")?
+                }
+                None => IcebergStaticTableProvider::try_new_from_table(table)
+                    .await
+                    .context("open static Iceberg provider")?,
+            };
+
+            let internal = format!("{INTERNAL_RELATION_PREFIX}{}", form_id.as_uuid().simple());
+            context.register_table(internal.as_str(), Arc::new(provider))?;
+            let visible = visible_columns(&form, form_policy)?;
+            let entry_ids = policy
+                .readable_entry_ids
+                .iter()
+                .map(|entry_id| lit(entry_id.as_uuid().as_bytes().to_vec()))
+                .collect::<Vec<_>>();
+            let visible_refs = visible.iter().map(String::as_str).collect::<Vec<_>>();
+            let source = context.table(internal.as_str()).await?;
+            let filtered = if entry_ids.is_empty() {
+                source.filter(lit(false))?
+            } else {
+                source.filter(col("entry_id").in_list(entry_ids, false))?
+            }
+            .select_columns(&visible_refs)?;
+            let view = filtered.into_view();
+            context.deregister_table(internal.as_str())?;
+            context.register_table(form_policy.relation.as_str(), view)?;
+        }
+
+        let max_concurrency = policy.limits.max_concurrency;
+        Ok(AuthorizedQueryContext {
+            context,
+            limits: policy.limits,
+            permits: Arc::new(Semaphore::new(max_concurrency)),
+        })
+    }
+}
+
+impl AuthorizedQueryContext {
+    /// Plans and executes a read-only statement. User predicates are evaluated
+    /// above the trusted Entry filter embedded in every registered view.
+    pub async fn execute(&self, sql: &str) -> Result<Vec<arrow_array::RecordBatch>> {
+        let _permit = self
+            .permits
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| anyhow!("authorized query concurrency limit reached"))?;
+        let plan = self
+            .context
+            .state()
+            .create_logical_plan(sql)
+            .await
+            .context("plan authorized query")?;
+        validate_logical_plan(&plan, &self.limits.allowed_functions)?;
+        let optimized = self.context.state().optimize(&plan)?;
+        validate_logical_plan(&optimized, &self.limits.allowed_functions)?;
+        let frame = self.context.execute_logical_plan(optimized).await?;
+        let max_rows_with_sentinel = self
+            .limits
+            .max_rows
+            .checked_add(1)
+            .context("authorized query row limit is too large")?;
+        let frame = frame.limit(0, Some(max_rows_with_sentinel))?;
+        let task_context = Arc::new(frame.task_ctx());
+        let physical = frame.create_physical_plan().await?;
+        validate_physical_plan(&physical)?;
+        let batches = tokio::time::timeout(
+            self.limits.timeout,
+            datafusion::physical_plan::collect(physical, task_context),
+        )
+        .await
+        .map_err(|_| anyhow!("authorized query timed out"))??;
+        let rows = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
+        if rows > self.limits.max_rows {
+            bail!("authorized query row limit exceeded");
+        }
+        Ok(batches)
+    }
+}
+
+fn visible_columns(
+    form: &ugoite_domain::form::FormDefinition,
+    policy: &ugoite_core::query::AuthorizedQueryForm,
+) -> Result<Vec<String>> {
+    let form_columns = form
+        .fields
+        .iter()
+        .map(|field| field.name.as_str())
+        .collect::<BTreeSet<_>>();
+    if let Some(column) = policy
+        .columns
+        .iter()
+        .find(|column| !form_columns.contains(column.as_str()))
+    {
+        bail!("authorized query policy exposes unknown Form column {column}");
+    }
+    let mut visible = policy.columns.iter().cloned().collect::<Vec<_>>();
+    visible.extend(
+        policy
+            .system_columns
+            .iter()
+            .map(|column| column.as_str().to_string()),
+    );
+    if visible.is_empty() {
+        bail!(
+            "authorized query policy exposes no columns for {}",
+            policy.relation
+        );
+    }
+    Ok(visible)
+}
+
+fn validate_relation(relation: &str) -> Result<()> {
+    let mut characters = relation.chars();
+    let Some(first) = characters.next() else {
+        bail!("authorized query relation must not be empty");
+    };
+    if !(first.is_ascii_alphabetic() || first == '_')
+        || !characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        bail!("authorized query relation must be an ASCII SQL identifier");
+    }
+    Ok(())
+}
+
+fn validate_logical_plan(plan: &LogicalPlan, allowed_functions: &BTreeSet<String>) -> Result<()> {
+    match plan {
+        LogicalPlan::Explain(_) | LogicalPlan::Analyze(_) => bail!("EXPLAIN is not supported"),
+        LogicalPlan::Dml(_)
+        | LogicalPlan::Ddl(_)
+        | LogicalPlan::Copy(_)
+        | LogicalPlan::Statement(_)
+        | LogicalPlan::DescribeTable(_)
+        | LogicalPlan::Extension(_)
+        | LogicalPlan::RecursiveQuery(_) => bail!("statement kind is not supported"),
+        _ => {}
+    }
+    for expression in plan.expressions() {
+        expression.apply(|expression| {
+            let name = match expression {
+                Expr::ScalarFunction(function) => Some(function.name()),
+                Expr::AggregateFunction(function) => Some(function.func.name()),
+                Expr::WindowFunction(function) => Some(function.fun.name()),
+                _ => None,
+            };
+            if let Some(name) = name {
+                if !allowed_functions.contains(&name.to_ascii_lowercase()) {
+                    return Err(datafusion::error::DataFusionError::Plan(format!(
+                        "function {name} is not authorized"
+                    )));
+                }
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+    }
+    for input in plan.inputs() {
+        validate_logical_plan(input, allowed_functions)?;
+    }
+    Ok(())
+}
+
+fn validate_physical_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
+    if plan
+        .as_any()
+        .is::<datafusion::physical_plan::explain::ExplainExec>()
+    {
+        bail!("EXPLAIN physical plan is not supported");
+    }
+    for child in plan.children() {
+        validate_physical_plan(child)?;
+    }
+    Ok(())
+}

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -13,7 +13,7 @@ use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::{col, lit, SessionConfig};
 use iceberg_datafusion::IcebergStaticTableProvider;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use ugoite_core::query::AuthorizedQueryPolicy;
@@ -31,6 +31,7 @@ pub struct AuthorizedQueryContext {
     permits: Arc<Semaphore>,
     authorized_relations: BTreeSet<String>,
     authorized_scans: BTreeSet<AuthorizedScan>,
+    trusted_relations: BTreeMap<String, TrustedRelation>,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -39,11 +40,90 @@ struct AuthorizedScan {
     snapshot_id: Option<i64>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TrustedRelation {
+    relation: String,
+    readable_entry_ids: BTreeSet<Vec<u8>>,
+    visible_columns: BTreeSet<String>,
+}
+
+/// Closed public errors for the authorization-aware query surface. Upstream
+/// DataFusion, Iceberg, and OpenDAL details remain available through the error
+/// source chain for internal diagnostics, but are never included in `Display`.
+#[derive(Debug)]
+pub enum AuthorizedQueryError {
+    InvalidQuery { source: anyhow::Error },
+    UnauthorizedQueryFeature { source: anyhow::Error },
+    ResourceLimitExceeded { source: anyhow::Error },
+    QueryTimedOut,
+    QueryExecutionFailed { source: anyhow::Error },
+}
+
+impl AuthorizedQueryError {
+    fn invalid_query(source: impl Into<anyhow::Error>) -> Self {
+        Self::InvalidQuery {
+            source: source.into(),
+        }
+    }
+
+    fn unauthorized(source: impl Into<anyhow::Error>) -> Self {
+        Self::UnauthorizedQueryFeature {
+            source: source.into(),
+        }
+    }
+
+    fn resource_limit(source: impl Into<anyhow::Error>) -> Self {
+        Self::ResourceLimitExceeded {
+            source: source.into(),
+        }
+    }
+
+    fn execution_failed(source: impl Into<anyhow::Error>) -> Self {
+        Self::QueryExecutionFailed {
+            source: source.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for AuthorizedQueryError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::InvalidQuery { .. } => "invalid authorized query",
+            Self::UnauthorizedQueryFeature { .. } => "unauthorized query feature",
+            Self::ResourceLimitExceeded { .. } => "authorized query resource limit exceeded",
+            Self::QueryTimedOut => "authorized query timed out",
+            Self::QueryExecutionFailed { .. } => "authorized query execution failed",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for AuthorizedQueryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidQuery { source }
+            | Self::UnauthorizedQueryFeature { source }
+            | Self::ResourceLimitExceeded { source }
+            | Self::QueryExecutionFailed { source } => Some(source.as_ref()),
+            Self::QueryTimedOut => None,
+        }
+    }
+}
+
 impl IcebergWorkspace {
     /// Translates a Core authorization decision into a closed DataFusion query
     /// surface. All providers are static Iceberg providers; a requested
     /// checkpoint requires one snapshot for every exposed Form.
     pub async fn authorized_query_context(
+        &self,
+        policy: AuthorizedQueryPolicy,
+    ) -> Result<AuthorizedQueryContext> {
+        self.authorized_query_context_inner(policy)
+            .await
+            .map_err(|error| AuthorizedQueryError::execution_failed(error).into())
+    }
+
+    async fn authorized_query_context_inner(
         &self,
         policy: AuthorizedQueryPolicy,
     ) -> Result<AuthorizedQueryContext> {
@@ -64,6 +144,7 @@ impl IcebergWorkspace {
         let context = SessionContext::new_with_config_rt(config, runtime);
         let mut relations = BTreeSet::new();
         let mut authorized_scans = BTreeSet::new();
+        let mut trusted_relations = BTreeMap::new();
 
         if let Some(checkpoint) = &policy.checkpoint {
             self.validate_checkpoint(checkpoint)?;
@@ -135,6 +216,18 @@ impl IcebergWorkspace {
                 .iter()
                 .map(|entry_id| lit(entry_id.as_uuid().as_bytes().to_vec()))
                 .collect::<Vec<_>>();
+            trusted_relations.insert(
+                internal.clone(),
+                TrustedRelation {
+                    relation: form_policy.relation.clone(),
+                    readable_entry_ids: form_policy
+                        .readable_entry_ids
+                        .iter()
+                        .map(|entry_id| entry_id.as_uuid().as_bytes().to_vec())
+                        .collect(),
+                    visible_columns: visible.iter().cloned().collect(),
+                },
+            );
             let visible_refs = visible.iter().map(String::as_str).collect::<Vec<_>>();
             let source = context.table(internal.as_str()).await?;
             let filtered = if entry_ids.is_empty() {
@@ -155,6 +248,7 @@ impl IcebergWorkspace {
             permits: Arc::new(Semaphore::new(max_concurrency)),
             authorized_relations: relations,
             authorized_scans,
+            trusted_relations,
         })
     }
 }
@@ -167,10 +261,10 @@ impl AuthorizedQueryContext {
             .permits
             .clone()
             .try_acquire_owned()
-            .map_err(|_| anyhow!("authorized query concurrency limit reached"))?;
+            .map_err(AuthorizedQueryError::resource_limit)?;
         tokio::time::timeout(self.limits.timeout, self.execute_with_permit(sql))
             .await
-            .map_err(|_| anyhow!("authorized query timed out"))?
+            .map_err(|_| AuthorizedQueryError::QueryTimedOut)?
     }
 
     async fn execute_with_permit(&self, sql: &str) -> Result<Vec<arrow_array::RecordBatch>> {
@@ -179,32 +273,56 @@ impl AuthorizedQueryContext {
             .state()
             .create_logical_plan(sql)
             .await
-            .context("plan authorized query")?;
+            .map_err(AuthorizedQueryError::invalid_query)?;
         validate_logical_plan(
             &plan,
             &self.limits.allowed_functions,
             &self.authorized_relations,
-        )?;
-        let optimized = self.context.state().optimize(&plan)?;
+        )
+        .map_err(AuthorizedQueryError::unauthorized)?;
+        let optimized = self
+            .context
+            .state()
+            .optimize(&plan)
+            .map_err(AuthorizedQueryError::invalid_query)?;
         validate_logical_plan(
             &optimized,
             &self.limits.allowed_functions,
             &self.authorized_relations,
-        )?;
-        let frame = self.context.execute_logical_plan(optimized).await?;
+        )
+        .map_err(AuthorizedQueryError::unauthorized)?;
+        validate_trusted_entry_filters(&optimized, &self.trusted_relations)
+            .map_err(AuthorizedQueryError::unauthorized)?;
+        let frame = self
+            .context
+            .execute_logical_plan(optimized)
+            .await
+            .map_err(AuthorizedQueryError::execution_failed)?;
         let max_rows_with_sentinel = self
             .limits
             .max_rows
             .checked_add(1)
-            .context("authorized query row limit is too large")?;
-        let frame = frame.limit(0, Some(max_rows_with_sentinel))?;
+            .ok_or_else(|| anyhow!("authorized query row limit is too large"))
+            .map_err(AuthorizedQueryError::resource_limit)?;
+        let frame = frame
+            .limit(0, Some(max_rows_with_sentinel))
+            .map_err(AuthorizedQueryError::resource_limit)?;
         let task_context = Arc::new(frame.task_ctx());
-        let physical = frame.create_physical_plan().await?;
-        validate_physical_plan(&physical, &self.authorized_scans)?;
-        let batches = datafusion::physical_plan::collect(physical, task_context).await?;
+        let physical = frame
+            .create_physical_plan()
+            .await
+            .map_err(AuthorizedQueryError::execution_failed)?;
+        validate_physical_plan(&physical, &self.authorized_scans)
+            .map_err(AuthorizedQueryError::unauthorized)?;
+        let batches = datafusion::physical_plan::collect(physical, task_context)
+            .await
+            .map_err(AuthorizedQueryError::execution_failed)?;
         let rows = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
         if rows > self.limits.max_rows {
-            bail!("authorized query row limit exceeded");
+            return Err(AuthorizedQueryError::resource_limit(anyhow!(
+                "authorized query row limit exceeded"
+            ))
+            .into());
         }
         Ok(batches)
     }
@@ -304,19 +422,7 @@ fn validate_logical_plan(
     }
     for expression in plan.expressions() {
         expression.apply(|expression| {
-            let name = match expression {
-                Expr::ScalarFunction(function) => Some(function.name()),
-                Expr::AggregateFunction(function) => Some(function.func.name()),
-                Expr::WindowFunction(function) => Some(function.fun.name()),
-                _ => None,
-            };
-            if let Some(name) = name {
-                if !allowed_functions.contains(&name.to_ascii_lowercase()) {
-                    return Err(datafusion::error::DataFusionError::Plan(format!(
-                        "function {name} is not authorized"
-                    )));
-                }
-            }
+            validate_expression_function(expression, allowed_functions)?;
             Ok(TreeNodeRecursion::Continue)
         })?;
     }
@@ -324,6 +430,202 @@ fn validate_logical_plan(
         validate_logical_plan(input, allowed_functions, authorized_relations)?;
     }
     Ok(())
+}
+
+/// Keep this match exhaustive. DataFusion represents function calls in several
+/// expression variants, and a future variant must fail compilation here until
+/// its authorization semantics are deliberately reviewed.
+#[allow(deprecated)]
+fn validate_expression_function(
+    expression: &Expr,
+    allowed_functions: &BTreeSet<String>,
+) -> datafusion::error::Result<()> {
+    match expression {
+        Expr::ScalarFunction(function) => authorize_function(function.name(), allowed_functions),
+        Expr::AggregateFunction(function) => {
+            authorize_function(function.func.name(), allowed_functions)
+        }
+        Expr::WindowFunction(function) => {
+            authorize_function(function.fun.name(), allowed_functions)
+        }
+        // DataFusion's UNNEST is a distinct expression/plan form rather than
+        // a ScalarFunction. It remains unavailable unless Core admits it.
+        Expr::Unnest(_) => authorize_function("unnest", allowed_functions),
+        Expr::Alias(_)
+        | Expr::Column(_)
+        | Expr::ScalarVariable(_, _)
+        | Expr::Literal(_, _)
+        | Expr::BinaryExpr(_)
+        | Expr::Like(_)
+        | Expr::SimilarTo(_)
+        | Expr::Not(_)
+        | Expr::IsNotNull(_)
+        | Expr::IsNull(_)
+        | Expr::IsTrue(_)
+        | Expr::IsFalse(_)
+        | Expr::IsUnknown(_)
+        | Expr::IsNotTrue(_)
+        | Expr::IsNotFalse(_)
+        | Expr::IsNotUnknown(_)
+        | Expr::Negative(_)
+        | Expr::Between(_)
+        | Expr::Case(_)
+        | Expr::Cast(_)
+        | Expr::TryCast(_)
+        | Expr::InList(_)
+        | Expr::Exists(_)
+        | Expr::InSubquery(_)
+        | Expr::SetComparison(_)
+        | Expr::ScalarSubquery(_)
+        | Expr::Wildcard { .. }
+        | Expr::GroupingSet(_)
+        | Expr::Placeholder(_)
+        | Expr::OuterReferenceColumn(_, _) => Ok(()),
+    }
+}
+
+fn authorize_function(
+    name: &str,
+    allowed_functions: &BTreeSet<String>,
+) -> datafusion::error::Result<()> {
+    if allowed_functions.contains(&name.to_ascii_lowercase()) {
+        Ok(())
+    } else {
+        Err(datafusion::error::DataFusionError::Plan(format!(
+            "function {name} is not authorized"
+        )))
+    }
+}
+
+/// Verifies that every internal Iceberg relation remains guarded by the Entry
+/// boundary installed while building the trusted view. A user predicate can
+/// only add another filter; it cannot make this filter disappear. This runs on
+/// the optimized plan because predicate pushdown/rewrite happens after the
+/// initial authorization check.
+fn validate_trusted_entry_filters(
+    plan: &LogicalPlan,
+    trusted_relations: &BTreeMap<String, TrustedRelation>,
+) -> Result<()> {
+    let mut seen_scans = BTreeSet::new();
+    let mut guarded_scans = BTreeSet::new();
+    let mut projected_relations = BTreeSet::new();
+    collect_trusted_entry_filters(
+        plan,
+        trusted_relations,
+        &mut seen_scans,
+        &mut guarded_scans,
+        &mut projected_relations,
+    )?;
+    for internal in trusted_relations.keys() {
+        if seen_scans.contains(internal) && !guarded_scans.contains(internal) {
+            bail!("optimized query plan lost the trusted Entry authorization filter");
+        }
+        if seen_scans.contains(internal) && !projected_relations.contains(internal) {
+            bail!("optimized query plan lost the trusted visible-column projection");
+        }
+    }
+    Ok(())
+}
+
+fn collect_trusted_entry_filters(
+    plan: &LogicalPlan,
+    trusted_relations: &BTreeMap<String, TrustedRelation>,
+    seen_scans: &mut BTreeSet<String>,
+    guarded_scans: &mut BTreeSet<String>,
+    projected_relations: &mut BTreeSet<String>,
+) -> Result<BTreeSet<String>> {
+    let mut descendants = BTreeSet::new();
+    for input in plan.inputs() {
+        descendants.extend(collect_trusted_entry_filters(
+            input,
+            trusted_relations,
+            seen_scans,
+            guarded_scans,
+            projected_relations,
+        )?);
+    }
+    if let LogicalPlan::TableScan(scan) = plan {
+        let relation = scan.table_name.to_string();
+        if let Some(trusted) = trusted_relations.get(&relation) {
+            seen_scans.insert(relation.clone());
+            descendants.insert(relation.clone());
+            if scan
+                .filters
+                .iter()
+                .any(|filter| is_trusted_entry_filter(filter, trusted))
+            {
+                guarded_scans.insert(relation);
+            }
+        }
+    }
+    if let LogicalPlan::Filter(filter) = plan {
+        if descendants.len() == 1 {
+            let internal = descendants.iter().next().expect("one relation");
+            if let Some(trusted) = trusted_relations.get(internal) {
+                if is_trusted_entry_filter(&filter.predicate, trusted) {
+                    guarded_scans.insert(internal.clone());
+                }
+            }
+        }
+    }
+    if let LogicalPlan::SubqueryAlias(alias) = plan {
+        let visible = alias
+            .schema
+            .fields()
+            .iter()
+            .map(|field| field.name().to_string())
+            .collect::<BTreeSet<_>>();
+        for (internal, trusted) in trusted_relations {
+            if alias.alias.to_string() == trusted.relation
+                && visible.is_subset(&trusted.visible_columns)
+            {
+                projected_relations.insert(internal.clone());
+            }
+        }
+    }
+    Ok(descendants)
+}
+
+fn is_trusted_entry_filter(expression: &Expr, trusted: &TrustedRelation) -> bool {
+    let mut entry_ids = BTreeSet::new();
+    let _ = expression.apply(|candidate| {
+        if let Expr::InList(list) = candidate {
+            if !list.negated && is_entry_id_column(&list.expr) {
+                entry_ids.extend(list.list.iter().filter_map(literal_binary));
+            }
+        }
+        if let Expr::BinaryExpr(binary) = candidate {
+            if binary.op == datafusion::logical_expr::Operator::Eq {
+                if is_entry_id_column(&binary.left) {
+                    if let Some(value) = literal_binary(&binary.right) {
+                        entry_ids.insert(value);
+                    }
+                } else if is_entry_id_column(&binary.right) {
+                    if let Some(value) = literal_binary(&binary.left) {
+                        entry_ids.insert(value);
+                    }
+                }
+            }
+        }
+        Ok(TreeNodeRecursion::Continue)
+    });
+    entry_ids == trusted.readable_entry_ids
+}
+
+fn is_entry_id_column(expression: &Expr) -> bool {
+    matches!(expression, Expr::Column(column) if column.name == "entry_id")
+}
+
+fn literal_binary(expression: &Expr) -> Option<Vec<u8>> {
+    match expression {
+        Expr::Literal(datafusion::scalar::ScalarValue::Binary(Some(value)), _) => {
+            Some(value.clone())
+        }
+        Expr::Literal(datafusion::scalar::ScalarValue::FixedSizeBinary(_, Some(value)), _) => {
+            Some(value.clone())
+        }
+        _ => None,
+    }
 }
 
 fn validate_physical_plan(

--- a/crates/ugoite-iceberg/tests/authorized_query.rs
+++ b/crates/ugoite-iceberg/tests/authorized_query.rs
@@ -7,7 +7,8 @@ use ugoite_core::query::{
 use ugoite_domain::entry::{EntryMetadata, EntryOperation, EntryRevision, FieldValue};
 use ugoite_domain::form::{FieldType, FormDefinition, FormField, FormVersion};
 use ugoite_domain::id::{EntryId, FieldId, FormId, SpaceId};
-use ugoite_iceberg::{publication_context, IcebergWorkspace};
+use ugoite_iceberg::{publication_context, query_context::AuthorizedQueryError, IcebergWorkspace};
+use ugoite_storage::operator_from_uri;
 use uuid::Uuid;
 
 fn form(id: u128, name: &str) -> FormDefinition {
@@ -147,6 +148,9 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
         "SELECT current_schema()",
         "SELECT current_catalog()",
         "SELECT unregistered_udf(title) FROM tasks",
+        "SELECT UNNEST([1, 2])",
+        "SELECT array_map([1, 2], x -> x + 1)",
+        "SELECT * FROM generate_series(1, 2)",
     ] {
         assert!(
             context.execute(sql).await.is_err(),
@@ -178,6 +182,54 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
         .authorized_query_context(policy(&tasks, &[]))
         .await?;
     assert!(empty.execute("SELECT * FROM tasks").await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn function_variants_and_storage_failures_are_closed_errors() -> anyhow::Result<()> {
+    let warehouse = "memory://authorized-query-closed-errors";
+    let workspace =
+        IcebergWorkspace::memory_for_tests(SpaceId::from(Uuid::from_u128(70)), warehouse).await?;
+    let tasks = form(71, "Tasks");
+    create_form(&workspace, &tasks).await?;
+    append(&workspace, &tasks, 72, 73, "one").await?;
+    let context = workspace
+        .authorized_query_context(policy(&tasks, &[72]))
+        .await?;
+
+    let error = context
+        .execute("SELECT UNNEST([1, 2])")
+        .await
+        .expect_err("UNNEST must be controlled by the function allowlist");
+    assert!(matches!(
+        error.downcast_ref::<AuthorizedQueryError>(),
+        Some(AuthorizedQueryError::UnauthorizedQueryFeature { .. })
+    ));
+
+    let checkpoint = workspace.capture_checkpoint().await?;
+    let mut checkpoint_policy = policy(&tasks, &[72]);
+    checkpoint_policy.checkpoint = Some(checkpoint.clone());
+    let metadata_path = checkpoint.tables[0]
+        .metadata_location
+        .strip_prefix("memory:///")
+        .or_else(|| {
+            checkpoint.tables[0]
+                .metadata_location
+                .strip_prefix("memory:/")
+        })
+        .expect("memory metadata location");
+    operator_from_uri(warehouse)?.delete(metadata_path).await?;
+    let error = match workspace.authorized_query_context(checkpoint_policy).await {
+        Ok(_) => anyhow::bail!("missing checkpoint metadata must not create a query context"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error.downcast_ref::<AuthorizedQueryError>(),
+        Some(AuthorizedQueryError::QueryExecutionFailed { .. })
+    ));
+    let rendered = error.to_string();
+    assert!(!rendered.contains("memory:"));
+    assert!(!rendered.contains("metadata"));
     Ok(())
 }
 

--- a/crates/ugoite-iceberg/tests/authorized_query.rs
+++ b/crates/ugoite-iceberg/tests/authorized_query.rs
@@ -89,16 +89,16 @@ fn policy(form: &FormDefinition, readable: &[u128]) -> AuthorizedQueryPolicy {
             form.id,
             AuthorizedQueryForm {
                 relation: "tasks".into(),
+                readable_entry_ids: readable
+                    .iter()
+                    .map(|id| EntryId::from(Uuid::from_u128(*id)))
+                    .collect(),
                 columns: ["title".into()].into_iter().collect(),
                 system_columns: BTreeSet::new(),
             },
         )]
         .into_iter()
         .collect(),
-        readable_entry_ids: readable
-            .iter()
-            .map(|id| EntryId::from(Uuid::from_u128(*id)))
-            .collect(),
         checkpoint: None,
         limits: QueryLimits {
             max_memory_bytes: 8 * 1024 * 1024,
@@ -139,10 +139,14 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
 
     for sql in [
         "SELECT entry_id FROM tasks",
+        "SELECT t.entry_id FROM tasks AS t",
         "SELECT * FROM secrets",
         "SELECT * FROM information_schema.tables",
         "EXPLAIN SELECT * FROM tasks",
         "SELECT count(*) FROM tasks",
+        "SELECT current_schema()",
+        "SELECT current_catalog()",
+        "SELECT unregistered_udf(title) FROM tasks",
     ] {
         assert!(
             context.execute(sql).await.is_err(),
@@ -152,6 +156,7 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
     for sql in [
         "SELECT * FROM tasks t JOIN tasks other ON t.title = other.title",
         "SELECT * FROM (SELECT * FROM tasks) nested",
+        "SELECT t.title FROM tasks AS t",
     ] {
         let batches = context.execute(sql).await?;
         assert_eq!(
@@ -159,6 +164,16 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
             1
         );
     }
+    assert_eq!(
+        context
+            .execute("SELECT title AS entry_id FROM tasks")
+            .await?
+            .iter()
+            .map(|batch| batch.num_rows())
+            .sum::<usize>(),
+        1,
+        "a user-selected output alias must not resolve the hidden source column"
+    );
     let empty = workspace
         .authorized_query_context(policy(&tasks, &[]))
         .await?;

--- a/crates/ugoite-iceberg/tests/authorized_query.rs
+++ b/crates/ugoite-iceberg/tests/authorized_query.rs
@@ -1,0 +1,225 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use ugoite_core::query::{
+    AuthorizedQueryForm, AuthorizedQueryPolicy, QueryCheckpoint, QueryLimits, QuerySystemColumn,
+};
+use ugoite_domain::entry::{EntryMetadata, EntryOperation, EntryRevision, FieldValue};
+use ugoite_domain::form::{FieldType, FormDefinition, FormField, FormVersion};
+use ugoite_domain::id::{EntryId, FieldId, FormId, SpaceId};
+use ugoite_iceberg::{publication_context, IcebergWorkspace};
+use uuid::Uuid;
+
+fn form(id: u128, name: &str) -> FormDefinition {
+    FormDefinition {
+        id: FormId::from(Uuid::from_u128(id)),
+        version: FormVersion::new(1).unwrap(),
+        name: name.into(),
+        description: None,
+        fields: vec![FormField {
+            id: FieldId::new(100).unwrap(),
+            name: "title".into(),
+            field_type: FieldType::String,
+            required: false,
+            label: None,
+            description: None,
+            semantic_role: None,
+            reference_form: None,
+            validation: None,
+            enum_values: Vec::new(),
+            deprecated: false,
+        }],
+        allow_extra_attributes: false,
+        extension_metadata: BTreeMap::new(),
+    }
+}
+
+async fn create_form(workspace: &IcebergWorkspace, form: &FormDefinition) -> anyhow::Result<()> {
+    workspace
+        .commit(publication_context(
+            Uuid::new_v4().to_string(),
+            "test.form",
+            form,
+        )?)?
+        .create_form(form)
+        .await
+}
+
+async fn append(
+    workspace: &IcebergWorkspace,
+    form: &FormDefinition,
+    entry: u128,
+    revision: u128,
+    title: &str,
+) -> anyhow::Result<i64> {
+    let mut values = BTreeMap::new();
+    values.insert(FieldId::new(100).unwrap(), FieldValue::String(title.into()));
+    let revision = EntryRevision {
+        form_id: form.id,
+        entry_id: EntryId::from(Uuid::from_u128(entry)),
+        revision_id: Uuid::from_u128(revision).into(),
+        parent_revision_id: None,
+        entry_version: 1,
+        expected_version: None,
+        operation: EntryOperation::Upsert,
+        committed_at_micros: 1,
+        author_id: "test".into(),
+        form_version: form.version,
+        source_kind: "test".into(),
+        source_id: None,
+        entry: EntryMetadata::default(),
+        values,
+        extra_attributes: BTreeMap::new(),
+        extension_metadata: BTreeMap::new(),
+    };
+    Ok(workspace
+        .commit(publication_context(
+            Uuid::new_v4().to_string(),
+            "test.entry",
+            &revision,
+        )?)?
+        .append_revisions(form.id, vec![revision])
+        .await?
+        .snapshot_id)
+}
+
+fn policy(form: &FormDefinition, readable: &[u128]) -> AuthorizedQueryPolicy {
+    AuthorizedQueryPolicy {
+        forms: [(
+            form.id,
+            AuthorizedQueryForm {
+                relation: "tasks".into(),
+                columns: ["title".into()].into_iter().collect(),
+                system_columns: BTreeSet::new(),
+            },
+        )]
+        .into_iter()
+        .collect(),
+        readable_entry_ids: readable
+            .iter()
+            .map(|id| EntryId::from(Uuid::from_u128(*id)))
+            .collect(),
+        checkpoint: None,
+        limits: QueryLimits {
+            max_memory_bytes: 8 * 1024 * 1024,
+            max_rows: 10,
+            timeout: Duration::from_secs(5),
+            max_concurrency: 1,
+            allowed_functions: BTreeSet::new(),
+        },
+    }
+}
+
+#[tokio::test]
+async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unresolvable(
+) -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(1)),
+        "memory://authorized-query-boundary",
+    )
+    .await?;
+    let tasks = form(2, "Tasks");
+    let secrets = form(3, "Secrets");
+    create_form(&workspace, &tasks).await?;
+    create_form(&workspace, &secrets).await?;
+    append(&workspace, &tasks, 10, 11, "allowed").await?;
+    append(&workspace, &tasks, 12, 13, "denied").await?;
+    append(&workspace, &secrets, 14, 15, "secret").await?;
+
+    let context = workspace
+        .authorized_query_context(policy(&tasks, &[10]))
+        .await?;
+    let batches = context
+        .execute("SELECT * FROM tasks WHERE title IS NOT NULL")
+        .await?;
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        1
+    );
+
+    for sql in [
+        "SELECT entry_id FROM tasks",
+        "SELECT * FROM secrets",
+        "SELECT * FROM information_schema.tables",
+        "EXPLAIN SELECT * FROM tasks",
+        "SELECT count(*) FROM tasks",
+    ] {
+        assert!(
+            context.execute(sql).await.is_err(),
+            "{sql} must fail closed"
+        );
+    }
+    for sql in [
+        "SELECT * FROM tasks t JOIN tasks other ON t.title = other.title",
+        "SELECT * FROM (SELECT * FROM tasks) nested",
+    ] {
+        let batches = context.execute(sql).await?;
+        assert_eq!(
+            batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+            1
+        );
+    }
+    let empty = workspace
+        .authorized_query_context(policy(&tasks, &[]))
+        .await?;
+    assert!(empty.execute("SELECT * FROM tasks").await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_requires_complete_checkpoint_and_reads_the_requested_snapshot(
+) -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(20)),
+        "memory://authorized-query-checkpoint",
+    )
+    .await?;
+    let tasks = form(21, "Tasks");
+    create_form(&workspace, &tasks).await?;
+    let first_snapshot = append(&workspace, &tasks, 22, 23, "first").await?;
+    append(&workspace, &tasks, 24, 25, "later").await?;
+
+    let mut snapshot_policy = policy(&tasks, &[22, 24]);
+    snapshot_policy.checkpoint = Some(QueryCheckpoint {
+        form_snapshots: [(tasks.id, first_snapshot)].into_iter().collect(),
+    });
+    let context = workspace.authorized_query_context(snapshot_policy).await?;
+    let batches = context.execute("SELECT * FROM tasks").await?;
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        1
+    );
+
+    let mut incomplete = policy(&tasks, &[22]);
+    incomplete.checkpoint = Some(QueryCheckpoint {
+        form_snapshots: BTreeMap::new(),
+    });
+    assert!(workspace
+        .authorized_query_context(incomplete)
+        .await
+        .is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_enforces_the_row_limit() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(30)),
+        "memory://authorized-query-row-limit",
+    )
+    .await?;
+    let tasks = form(31, "Tasks");
+    create_form(&workspace, &tasks).await?;
+    append(&workspace, &tasks, 32, 33, "one").await?;
+    append(&workspace, &tasks, 34, 35, "two").await?;
+    let mut limited = policy(&tasks, &[32, 34]);
+    limited.limits.max_rows = 1;
+    let context = workspace.authorized_query_context(limited).await?;
+    assert!(context.execute("SELECT * FROM tasks").await.is_err());
+    Ok(())
+}
+
+#[test]
+fn system_column_allowlist_is_explicit() {
+    assert_eq!(QuerySystemColumn::EntryId.as_str(), "entry_id");
+}

--- a/crates/ugoite-iceberg/tests/authorized_query.rs
+++ b/crates/ugoite-iceberg/tests/authorized_query.rs
@@ -175,9 +175,13 @@ async fn context_requires_complete_checkpoint_and_reads_the_requested_snapshot(
     )
     .await?;
     let tasks = form(21, "Tasks");
+    let secrets = form(26, "Secrets");
     create_form(&workspace, &tasks).await?;
+    create_form(&workspace, &secrets).await?;
     append(&workspace, &tasks, 22, 23, "first").await?;
+    append(&workspace, &secrets, 27, 28, "secret").await?;
     let checkpoint = workspace.capture_checkpoint().await?;
+    assert_eq!(checkpoint.tables.len(), 2, "checkpoint is Space-wide");
     append(&workspace, &tasks, 24, 25, "later").await?;
 
     let mut snapshot_policy = policy(&tasks, &[22, 24]);
@@ -188,6 +192,7 @@ async fn context_requires_complete_checkpoint_and_reads_the_requested_snapshot(
         batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
         1
     );
+    assert!(context.execute("SELECT * FROM secrets").await.is_err());
 
     let mut incomplete = policy(&tasks, &[22]);
     let mut incomplete_checkpoint = checkpoint;

--- a/crates/ugoite-iceberg/tests/authorized_query.rs
+++ b/crates/ugoite-iceberg/tests/authorized_query.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 use ugoite_core::query::{
-    AuthorizedQueryForm, AuthorizedQueryPolicy, QueryCheckpoint, QueryLimits, QuerySystemColumn,
+    AuthorizedQueryForm, AuthorizedQueryPolicy, QueryLimits, QuerySystemColumn,
 };
 use ugoite_domain::entry::{EntryMetadata, EntryOperation, EntryRevision, FieldValue};
 use ugoite_domain::form::{FieldType, FormDefinition, FormField, FormVersion};
@@ -176,13 +176,12 @@ async fn context_requires_complete_checkpoint_and_reads_the_requested_snapshot(
     .await?;
     let tasks = form(21, "Tasks");
     create_form(&workspace, &tasks).await?;
-    let first_snapshot = append(&workspace, &tasks, 22, 23, "first").await?;
+    append(&workspace, &tasks, 22, 23, "first").await?;
+    let checkpoint = workspace.capture_checkpoint().await?;
     append(&workspace, &tasks, 24, 25, "later").await?;
 
     let mut snapshot_policy = policy(&tasks, &[22, 24]);
-    snapshot_policy.checkpoint = Some(QueryCheckpoint {
-        form_snapshots: [(tasks.id, first_snapshot)].into_iter().collect(),
-    });
+    snapshot_policy.checkpoint = Some(checkpoint.clone());
     let context = workspace.authorized_query_context(snapshot_policy).await?;
     let batches = context.execute("SELECT * FROM tasks").await?;
     assert_eq!(
@@ -191,9 +190,11 @@ async fn context_requires_complete_checkpoint_and_reads_the_requested_snapshot(
     );
 
     let mut incomplete = policy(&tasks, &[22]);
-    incomplete.checkpoint = Some(QueryCheckpoint {
-        form_snapshots: BTreeMap::new(),
-    });
+    let mut incomplete_checkpoint = checkpoint;
+    incomplete_checkpoint.tables.clear();
+    incomplete_checkpoint.coordinate_checksum =
+        incomplete_checkpoint.computed_coordinate_checksum();
+    incomplete.checkpoint = Some(incomplete_checkpoint);
     assert!(workspace
         .authorized_query_context(incomplete)
         .await
@@ -219,7 +220,127 @@ async fn context_enforces_the_row_limit() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn system_column_allowlist_is_explicit() {
-    assert_eq!(QuerySystemColumn::EntryId.as_str(), "entry_id");
+#[tokio::test]
+async fn system_columns_are_queryable_only_when_explicitly_allowlisted() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(40)),
+        "memory://authorized-query-system-columns",
+    )
+    .await?;
+    let tasks = form(41, "Tasks");
+    create_form(&workspace, &tasks).await?;
+    append(&workspace, &tasks, 42, 43, "one").await?;
+
+    for column in [
+        QuerySystemColumn::EntryId,
+        QuerySystemColumn::EntryVersion,
+        QuerySystemColumn::CommittedAt,
+    ] {
+        let mut allowed = policy(&tasks, &[42]);
+        allowed
+            .forms
+            .get_mut(&tasks.id)
+            .unwrap()
+            .system_columns
+            .insert(column);
+        let context = workspace.authorized_query_context(allowed).await?;
+        assert_eq!(
+            context
+                .execute(&format!("SELECT {} FROM tasks", column.as_str()))
+                .await?
+                .len(),
+            1
+        );
+    }
+
+    let mut wildcard = policy(&tasks, &[42]);
+    wildcard
+        .forms
+        .get_mut(&tasks.id)
+        .unwrap()
+        .system_columns
+        .insert(QuerySystemColumn::EntryId);
+    let context = workspace.authorized_query_context(wildcard).await?;
+    let batches = context.execute("SELECT * FROM tasks").await?;
+    assert_eq!(batches[0].schema().field(0).name(), "title");
+    assert_eq!(batches[0].schema().field(1).name(), "entry_id");
+
+    let context = workspace
+        .authorized_query_context(policy(&tasks, &[42]))
+        .await?;
+    assert!(context.execute("SELECT entry_id FROM tasks").await.is_err());
+
+    let mut colliding = form(44, "Colliding");
+    colliding.fields[0].name = "entry_id".into();
+    assert!(create_form(&workspace, &colliding).await.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_releases_concurrency_permits_after_errors() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(50)),
+        "memory://authorized-query-concurrency",
+    )
+    .await?;
+    let tasks = form(51, "Tasks");
+    create_form(&workspace, &tasks).await?;
+    append(&workspace, &tasks, 52, 53, "one").await?;
+    let context = std::sync::Arc::new(
+        workspace
+            .authorized_query_context(policy(&tasks, &[52]))
+            .await?,
+    );
+    assert!(context.execute("SELECT count(*) FROM tasks").await.is_err());
+    assert!(context.execute("SELECT * FROM tasks").await.is_ok());
+
+    for entry in 54..63 {
+        append(&workspace, &tasks, entry, entry + 100, "many").await?;
+    }
+    let mut busy_policy = policy(&tasks, &(52..63).collect::<Vec<_>>());
+    busy_policy.limits.timeout = Duration::from_millis(50);
+    busy_policy.limits.allowed_functions.insert("count".into());
+    let busy = std::sync::Arc::new(workspace.authorized_query_context(busy_policy).await?);
+    let running = busy.clone();
+    let task = tokio::spawn(async move {
+        running
+            .execute(
+                "SELECT count(*) FROM tasks a CROSS JOIN tasks b CROSS JOIN tasks c CROSS JOIN tasks d CROSS JOIN tasks e CROSS JOIN tasks f CROSS JOIN tasks g CROSS JOIN tasks h",
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+    let second = busy.execute("SELECT * FROM tasks").await;
+    let _ = task.await?;
+    assert!(
+        second.is_err(),
+        "the second concurrent query must fail closed"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn context_enforces_memory_and_timeout_limits() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(60)),
+        "memory://authorized-query-resource-limits",
+    )
+    .await?;
+    let tasks = form(61, "Tasks");
+    create_form(&workspace, &tasks).await?;
+    append(&workspace, &tasks, 62, 63, "one").await?;
+
+    let mut memory_limited = policy(&tasks, &[62]);
+    memory_limited.limits.max_memory_bytes = 1;
+    let context = workspace.authorized_query_context(memory_limited).await?;
+    assert!(context
+        .execute("SELECT * FROM tasks ORDER BY title")
+        .await
+        .is_err());
+
+    let mut timed_out = policy(&tasks, &[62]);
+    timed_out.limits.timeout = Duration::from_nanos(1);
+    let context = workspace.authorized_query_context(timed_out).await?;
+    assert!(context.execute("SELECT * FROM tasks").await.is_err());
+    Ok(())
 }

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -8,10 +8,10 @@ Space format version is unchanged, while legacy layouts and catalog modes are
 unsupported rather than migrated.
 
 The Catalog Head layout, upstream physical boundary, single mutation
-coordinator, and checkpoint-pinned revision reads are implemented by the
-current persistence work. Authorization-aware DataFusion context and health
-evidence remain follow-up work; this document does not advertise them as
-current product APIs.
+coordinator, checkpoint-pinned revision reads, and authorization-aware
+DataFusion context are implemented by the current persistence work. Health
+evidence remains follow-up work; this document does not advertise it as a
+current product API.
 
 ## Authority and ownership
 
@@ -91,8 +91,11 @@ ID (when the table has one), and schema ID. A deterministic coordinate checksum
 excludes optional capture time and human name.
 
 Checkpoint reads never acquire a writer lock and never refresh from the current
-Head. They construct Iceberg static providers from the recorded metadata and,
-when present, the recorded snapshot ID. A durable named checkpoint is created
+Head. Each resolution rereads the checkpoint's immutable publication, verifies
+its checksum and canonical Head, and requires that the Head's complete Form
+table coordinates match the checkpoint before it reads Iceberg metadata. They
+construct Iceberg static providers from the recorded metadata and, when
+present, the recorded snapshot ID. A durable named checkpoint is created
 once at `_ugoite/checkpoints/<name>.json` through OpenDAL; a missing durable
 object or immutable target returns an explicit unavailable-checkpoint error.
 There is no snapshot-expiration or custom retention implementation. If upstream


### PR DESCRIPTION
## Summary

- add a Core-owned, physical-type-free authorized query policy DTO;
- expose a closed Iceberg/DataFusion context that registers only authorized Form views, filters Entry IDs before user predicates, and projects only allowlisted columns;
- use static Iceberg providers, requiring a complete snapshot map for checkpointed reads, and enforce memory, row, timeout, and concurrency limits;
- reject unsupported statement kinds, `EXPLAIN`, and unallowlisted functions while validating logical and physical plans.

## Related Issue (required)

closes #1817

## Testing

- [x] `cargo fmt --check`
- [x] `cargo clippy -p ugoite-core -p ugoite-iceberg -- -D warnings`
- [x] `cargo test -p ugoite-core -p ugoite-iceberg`
