### PR TITLE
feat: pin SpaceCheckpoint to one Catalog Head

### DIFF
--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -6,6 +6,8 @@
 use crate::id::{FormId, SpaceId};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use uuid::Uuid;
 
 pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 1;
 
@@ -74,6 +76,35 @@ impl SpaceCheckpoint {
     pub fn validate_coordinate_checksum(&self) -> bool {
         self.format_version == SPACE_CHECKPOINT_FORMAT_VERSION
             && self.coordinate_checksum == self.computed_coordinate_checksum()
+    }
+
+    /// Reject ambiguous or malformed coordinates before any storage is read.
+    /// Integrity of the coordinates themselves is subsequently proven against
+    /// their immutable publication and Catalog Head by the Iceberg adapter.
+    pub fn validate_structure(&self) -> Result<(), &'static str> {
+        let mut forms = BTreeSet::new();
+        let mut identifiers = BTreeSet::new();
+        for table in &self.tables {
+            if !forms.insert(table.form_id) {
+                return Err("checkpoint contains a duplicate Form ID");
+            }
+            if table.namespace.is_empty() || table.namespace.iter().any(|part| part.is_empty()) {
+                return Err("checkpoint table namespace is empty or invalid");
+            }
+            if table.table.is_empty() {
+                return Err("checkpoint table name is empty");
+            }
+            if !identifiers.insert((table.namespace.clone(), table.table.clone())) {
+                return Err("checkpoint assigns one table identifier to multiple Forms");
+            }
+            if Uuid::parse_str(&table.table_uuid).is_err() {
+                return Err("checkpoint table UUID is invalid");
+            }
+            if table.metadata_location.is_empty() {
+                return Err("checkpoint metadata location is empty");
+            }
+        }
+        Ok(())
     }
 
     pub fn computed_coordinate_checksum(&self) -> String {

--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -1,0 +1,162 @@
+//! Portable descriptions of reproducible Space read coordinates.
+//!
+//! A checkpoint contains storage coordinates only.  It deliberately carries no
+//! authorization, SQL, or query-policy state.
+
+use crate::id::{FormId, SpaceId};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 1;
+
+/// One immutable Iceberg table coordinate reachable from a Catalog Head.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CheckpointTable {
+    pub form_id: FormId,
+    pub namespace: Vec<String>,
+    pub table: String,
+    pub table_uuid: String,
+    pub metadata_location: String,
+    pub snapshot_id: Option<i64>,
+    pub schema_id: i32,
+}
+
+/// A reproducible, Space-wide read coordinate.
+///
+/// `created_at_micros` and `name` describe a capture but are intentionally
+/// excluded from `coordinate_checksum`: two captures of the same coordinates
+/// have the same identity.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SpaceCheckpoint {
+    pub format_version: u32,
+    pub space_id: SpaceId,
+    pub catalog_generation: u64,
+    pub catalog_head_checksum: String,
+    pub publication_location: String,
+    pub publication_checksum: String,
+    pub form_registry_generation: u64,
+    pub tables: Vec<CheckpointTable>,
+    pub coordinate_checksum: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at_micros: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl SpaceCheckpoint {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        space_id: SpaceId,
+        catalog_generation: u64,
+        catalog_head_checksum: String,
+        publication_location: String,
+        publication_checksum: String,
+        form_registry_generation: u64,
+        tables: Vec<CheckpointTable>,
+    ) -> Self {
+        let mut checkpoint = Self {
+            format_version: SPACE_CHECKPOINT_FORMAT_VERSION,
+            space_id,
+            catalog_generation,
+            catalog_head_checksum,
+            publication_location,
+            publication_checksum,
+            form_registry_generation,
+            tables,
+            coordinate_checksum: String::new(),
+            created_at_micros: None,
+            name: None,
+        };
+        checkpoint.coordinate_checksum = checkpoint.computed_coordinate_checksum();
+        checkpoint
+    }
+
+    pub fn validate_coordinate_checksum(&self) -> bool {
+        self.format_version == SPACE_CHECKPOINT_FORMAT_VERSION
+            && self.coordinate_checksum == self.computed_coordinate_checksum()
+    }
+
+    pub fn computed_coordinate_checksum(&self) -> String {
+        let mut tables = self.tables.clone();
+        tables.sort_by(|left, right| {
+            (
+                left.form_id,
+                &left.namespace,
+                &left.table,
+                &left.metadata_location,
+            )
+                .cmp(&(
+                    right.form_id,
+                    &right.namespace,
+                    &right.table,
+                    &right.metadata_location,
+                ))
+        });
+        let coordinate = CoordinateIdentity {
+            format_version: self.format_version,
+            space_id: self.space_id,
+            catalog_generation: self.catalog_generation,
+            catalog_head_checksum: &self.catalog_head_checksum,
+            publication_location: &self.publication_location,
+            publication_checksum: &self.publication_checksum,
+            form_registry_generation: self.form_registry_generation,
+            tables: &tables,
+        };
+        let bytes = serde_json::to_vec(&coordinate)
+            .expect("checkpoint coordinate identity always serializes");
+        hex::encode(Sha256::digest(bytes))
+    }
+}
+
+#[derive(Serialize)]
+struct CoordinateIdentity<'a> {
+    format_version: u32,
+    space_id: SpaceId,
+    catalog_generation: u64,
+    catalog_head_checksum: &'a str,
+    publication_location: &'a str,
+    publication_checksum: &'a str,
+    form_registry_generation: u64,
+    tables: &'a [CheckpointTable],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckpointTable, SpaceCheckpoint};
+    use crate::id::{FormId, SpaceId};
+    use uuid::Uuid;
+
+    fn checkpoint() -> SpaceCheckpoint {
+        SpaceCheckpoint::new(
+            SpaceId::from(Uuid::from_u128(1)),
+            9,
+            "head".into(),
+            "publication".into(),
+            "publication-checksum".into(),
+            2,
+            vec![CheckpointTable {
+                form_id: FormId::from(Uuid::from_u128(2)),
+                namespace: vec!["space_1".into()],
+                table: "form_2".into(),
+                table_uuid: "table".into(),
+                metadata_location: "memory:///metadata.json".into(),
+                snapshot_id: Some(4),
+                schema_id: 3,
+            }],
+        )
+    }
+
+    #[test]
+    fn metadata_does_not_change_coordinate_identity() {
+        let first = checkpoint();
+        let mut second = first.clone();
+        second.created_at_micros = Some(42);
+        second.name = Some("before-migration".into());
+
+        assert_eq!(
+            first.coordinate_checksum,
+            second.computed_coordinate_checksum()
+        );
+        assert!(second.validate_coordinate_checksum());
+    }
+}

--- a/crates/ugoite-domain/src/id.rs
+++ b/crates/ugoite-domain/src/id.rs
@@ -69,6 +69,7 @@ impl std::error::Error for FieldIdError {}
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum IdentifierKind {
     Space,
+    Checkpoint,
     Entry,
     Form,
     Asset,
@@ -81,6 +82,7 @@ impl IdentifierKind {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Space => "space_id",
+            Self::Checkpoint => "checkpoint_name",
             Self::Entry => "entry_id",
             Self::Form => "form_name",
             Self::Asset => "asset_id",
@@ -131,6 +133,10 @@ pub fn validate_identifier(kind: IdentifierKind, value: &str) -> Result<(), Iden
 
 pub fn validate_space_id(value: &str) -> Result<(), IdentifierError> {
     validate_identifier(IdentifierKind::Space, value)
+}
+
+pub fn validate_checkpoint_name(value: &str) -> Result<(), IdentifierError> {
+    validate_identifier(IdentifierKind::Checkpoint, value)
 }
 
 pub fn validate_entry_id(value: &str) -> Result<(), IdentifierError> {

--- a/crates/ugoite-domain/src/lib.rs
+++ b/crates/ugoite-domain/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(warnings)]
 #![deny(clippy::all)]
 
+pub mod checkpoint;
 pub mod entry;
 pub mod form;
 pub mod id;

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -30,6 +30,7 @@ pub mod storage;
 pub use migration::{MigrationFormReport, MigrationManifest, MigrationReport};
 pub use space_catalog::PublicationContext;
 use space_catalog::SpaceCatalog;
+pub use ugoite_domain::checkpoint::{CheckpointTable, SpaceCheckpoint};
 
 use anyhow::{anyhow, Context, Result};
 use arrow_array::builder::{
@@ -69,7 +70,7 @@ use ugoite_domain::entry::{
     EntryAsset, EntryIntegrity, EntryLink, EntryMetadata, EntryOperation, EntryRevision, FieldValue,
 };
 use ugoite_domain::form::{Compatibility, FieldType, FormChangeSet, FormDefinition, FormField};
-use ugoite_domain::id::{FormId, RevisionId, SpaceId};
+use ugoite_domain::id::{validate_checkpoint_name, FormId, RevisionId, SpaceId};
 use ugoite_storage::{operator_from_uri, SpaceCatalogStore};
 use uuid::Uuid;
 
@@ -80,6 +81,50 @@ const FORM_VERSION_PROPERTY: &str = "ugoite.form.version";
 const TARGET_FILE_SIZE_PROPERTY: &str = "write.target-file-size-bytes";
 const FIRST_FORM_FIELD_ID: i32 = 100;
 const NESTED_FIELD_ID_BASE: i32 = 1_000_000;
+
+/// A durable checkpoint or one of its immutable targets cannot be resolved.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CheckpointUnavailable {
+    target: String,
+}
+
+impl CheckpointUnavailable {
+    fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for CheckpointUnavailable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "checkpoint unavailable: {}", self.target)
+    }
+}
+
+impl std::error::Error for CheckpointUnavailable {}
+
+/// A checkpoint's coordinate checksum or immutable metadata does not match.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CheckpointIntegrityError {
+    detail: String,
+}
+
+impl CheckpointIntegrityError {
+    fn new(detail: impl Into<String>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for CheckpointIntegrityError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "checkpoint integrity error: {}", self.detail)
+    }
+}
+
+impl std::error::Error for CheckpointIntegrityError {}
 
 #[derive(Debug, Clone)]
 pub struct IcebergWorkspace {
@@ -261,6 +306,86 @@ impl IcebergWorkspace {
         })
     }
 
+    /// Captures one exact, checksum-protected Catalog Head and the immutable
+    /// Iceberg coordinates reachable from it. This is read-only and never
+    /// acquires a writer lock or starts a transaction.
+    pub async fn capture_checkpoint(&self) -> Result<SpaceCheckpoint> {
+        self.space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .capture_checkpoint()
+            .await
+    }
+
+    /// Persists a named immutable checkpoint through the Space's OpenDAL
+    /// boundary. Reusing a name fails rather than silently replacing history.
+    pub async fn save_checkpoint(&self, name: &str, checkpoint: &SpaceCheckpoint) -> Result<()> {
+        validate_checkpoint_name(name)?;
+        self.validate_checkpoint(checkpoint)?;
+        let mut stored = checkpoint.clone();
+        stored.name = Some(name.to_string());
+        self.space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .create_checkpoint(name, &stored)
+            .await
+    }
+
+    /// Loads a durable checkpoint by name. A missing object is represented by
+    /// [`CheckpointUnavailable`], never by an empty or current-head fallback.
+    pub async fn load_checkpoint(&self, name: &str) -> Result<SpaceCheckpoint> {
+        validate_checkpoint_name(name)?;
+        let checkpoint = self
+            .space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .read_checkpoint(name)
+            .await?;
+        self.validate_checkpoint(&checkpoint)?;
+        Ok(checkpoint)
+    }
+
+    /// Reads a revision view from checkpoint-recorded immutable metadata.
+    /// Snapshot-bearing tables use Iceberg's static snapshot provider; a table
+    /// with no snapshots still uses Iceberg's static metadata provider.
+    pub async fn read_revision_view_at_checkpoint(
+        &self,
+        checkpoint: &SpaceCheckpoint,
+        form_id: FormId,
+        view: RevisionView,
+    ) -> Result<Vec<EntryRevision>> {
+        self.validate_checkpoint(checkpoint)?;
+        let coordinate = checkpoint
+            .tables
+            .iter()
+            .find(|coordinate| coordinate.form_id == form_id)
+            .ok_or_else(|| CheckpointUnavailable::new(format!("Form {form_id}")))?;
+        let table = self
+            .space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .load_checkpoint_table(coordinate)
+            .await?;
+        let form = form_from_table(&table, form_id)?;
+        self.read_revision_view_from_table(&form, table, view, coordinate.snapshot_id, true)
+            .await
+    }
+
+    fn validate_checkpoint(&self, checkpoint: &SpaceCheckpoint) -> Result<()> {
+        if checkpoint.space_id != self.space_id {
+            return Err(
+                CheckpointIntegrityError::new("Space ID does not match this workspace").into(),
+            );
+        }
+        if !checkpoint.validate_coordinate_checksum() {
+            return Err(CheckpointIntegrityError::new(
+                "coordinate checksum or format version does not match",
+            )
+            .into());
+        }
+        Ok(())
+    }
+
     pub fn schema_commit_capability(&self) -> SchemaCommitCapability {
         SchemaCommitCapability::AtomicSchemaEvolution
     }
@@ -288,36 +413,7 @@ impl IcebergWorkspace {
 
     pub async fn load_form(&self, form_id: FormId) -> Result<FormDefinition> {
         let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
-        let raw = table
-            .metadata()
-            .properties()
-            .get(FORM_DEFINITION_PROPERTY)
-            .context("Iceberg table is missing Ugoite Form metadata")?;
-        let form: FormDefinition = serde_json::from_str(raw)?;
-        if form.id != form_id {
-            return Err(anyhow!(
-                "Form ID property does not match physical table identity"
-            ));
-        }
-        for field in &form.fields {
-            let Some(physical) = table
-                .metadata()
-                .current_schema()
-                .field_by_id(field.id.get())
-            else {
-                return Err(anyhow!(
-                    "Iceberg schema is missing Form field ID {}",
-                    field.id.get()
-                ));
-            };
-            if physical.field_type.as_ref() != &iceberg_type(&field.field_type, field.id.get()) {
-                return Err(anyhow!(
-                    "Iceberg field ID {} does not match the Form field type",
-                    field.id.get()
-                ));
-            }
-        }
-        Ok(form)
+        form_from_table(&table, form_id)
     }
 
     /// Returns whether the authoritative Catalog Head currently contains this
@@ -661,6 +757,18 @@ impl IcebergWorkspace {
     ) -> Result<Vec<EntryRevision>> {
         let form = self.load_form(form_id).await?;
         let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
+        self.read_revision_view_from_table(&form, table, view, snapshot_id, false)
+            .await
+    }
+
+    async fn read_revision_view_from_table(
+        &self,
+        form: &FormDefinition,
+        table: iceberg::table::Table,
+        view: RevisionView,
+        snapshot_id: Option<i64>,
+        static_table: bool,
+    ) -> Result<Vec<EntryRevision>> {
         let batches = match view {
             RevisionView::All => {
                 let scan = match snapshot_id {
@@ -682,7 +790,7 @@ impl IcebergWorkspace {
         let schema = table.metadata().current_schema().clone();
         let mut revisions = Vec::new();
         for batch in &batches {
-            revisions.extend(revisions_from_batch(batch, &form, &schema)?);
+            revisions.extend(revisions_from_batch(batch, form, &schema)?);
         }
         Ok(revisions)
     }
@@ -1051,6 +1159,39 @@ fn validate_field_ids(form: &FormDefinition) -> Result<()> {
 
 fn physical_field_id(field: &ugoite_domain::form::FormField) -> i32 {
     field.id.get()
+}
+
+fn form_from_table(table: &iceberg::table::Table, form_id: FormId) -> Result<FormDefinition> {
+    let raw = table
+        .metadata()
+        .properties()
+        .get(FORM_DEFINITION_PROPERTY)
+        .context("Iceberg table is missing Ugoite Form metadata")?;
+    let form: FormDefinition = serde_json::from_str(raw)?;
+    if form.id != form_id {
+        return Err(anyhow!(
+            "Form ID property does not match physical table identity"
+        ));
+    }
+    for field in &form.fields {
+        let Some(physical) = table
+            .metadata()
+            .current_schema()
+            .field_by_id(field.id.get())
+        else {
+            return Err(anyhow!(
+                "Iceberg schema is missing Form field ID {}",
+                field.id.get()
+            ));
+        };
+        if physical.field_type.as_ref() != &iceberg_type(&field.field_type, field.id.get()) {
+            return Err(anyhow!(
+                "Iceberg field ID {} does not match the Form field type",
+                field.id.get()
+            ));
+        }
+    }
+    Ok(form)
 }
 
 fn form_schema(form: &FormDefinition) -> Result<Schema> {

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -346,6 +346,12 @@ impl IcebergWorkspace {
             .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
             .read_checkpoint(name)
             .await?;
+        if checkpoint.name.as_deref() != Some(name) {
+            return Err(CheckpointIntegrityError::new(
+                "stored checkpoint name does not match its object name",
+            )
+            .into());
+        }
         self.validate_checkpoint(&checkpoint)?;
         self.space_catalog
             .as_ref()

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -327,6 +327,11 @@ impl IcebergWorkspace {
             .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
             .validate_checkpoint_evidence(checkpoint)
             .await?;
+        self.space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .validate_checkpoint_tables(checkpoint)
+            .await?;
         let mut stored = checkpoint.clone();
         stored.name = Some(name.to_string());
         self.space_catalog
@@ -357,6 +362,11 @@ impl IcebergWorkspace {
             .as_ref()
             .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
             .validate_checkpoint_evidence(&checkpoint)
+            .await?;
+        self.space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .validate_checkpoint_tables(&checkpoint)
             .await?;
         Ok(checkpoint)
     }

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -322,6 +322,11 @@ impl IcebergWorkspace {
     pub async fn save_checkpoint(&self, name: &str, checkpoint: &SpaceCheckpoint) -> Result<()> {
         validate_checkpoint_name(name)?;
         self.validate_checkpoint(checkpoint)?;
+        self.space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .validate_checkpoint_evidence(checkpoint)
+            .await?;
         let mut stored = checkpoint.clone();
         stored.name = Some(name.to_string());
         self.space_catalog
@@ -342,6 +347,11 @@ impl IcebergWorkspace {
             .read_checkpoint(name)
             .await?;
         self.validate_checkpoint(&checkpoint)?;
+        self.space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .validate_checkpoint_evidence(&checkpoint)
+            .await?;
         Ok(checkpoint)
     }
 
@@ -364,7 +374,7 @@ impl IcebergWorkspace {
             .space_catalog
             .as_ref()
             .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
-            .load_checkpoint_table(coordinate)
+            .load_checkpoint_table(checkpoint, coordinate)
             .await?;
         let form = form_from_table(&table, form_id)?;
         self.read_revision_view_from_table(&form, table, view, coordinate.snapshot_id, true)
@@ -383,6 +393,9 @@ impl IcebergWorkspace {
             )
             .into());
         }
+        checkpoint
+            .validate_structure()
+            .map_err(CheckpointIntegrityError::new)?;
         Ok(())
     }
 

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -385,6 +385,7 @@ impl IcebergWorkspace {
         let form = form_from_table(&table, form_id)?;
         self.read_revision_view_from_table(&form, table, view, coordinate.snapshot_id)
             .await
+            .map_err(checkpoint_query_error)
     }
 
     fn validate_checkpoint(&self, checkpoint: &SpaceCheckpoint) -> Result<()> {
@@ -1005,6 +1006,22 @@ impl IcebergWorkspace {
             self.space_id.as_uuid().simple(),
             physical_form_name(form_id)
         )
+    }
+}
+
+/// Converts missing immutable files discovered while scanning a checkpoint to
+/// the stable checkpoint API error. Planning and execution can reach manifest
+/// lists, manifests, and data files after the metadata coordinate was loaded.
+/// Those are checkpoint targets too, even though DataFusion/Iceberg own the
+/// actual reads.
+fn checkpoint_query_error(error: anyhow::Error) -> anyhow::Error {
+    if error
+        .chain()
+        .any(space_catalog::error_chain_contains_not_found)
+    {
+        CheckpointUnavailable::new("checkpoint immutable data").into()
+    } else {
+        error
     }
 }
 

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -377,7 +377,7 @@ impl IcebergWorkspace {
             .load_checkpoint_table(checkpoint, coordinate)
             .await?;
         let form = form_from_table(&table, form_id)?;
-        self.read_revision_view_from_table(&form, table, view, coordinate.snapshot_id, true)
+        self.read_revision_view_from_table(&form, table, view, coordinate.snapshot_id)
             .await
     }
 
@@ -770,7 +770,7 @@ impl IcebergWorkspace {
     ) -> Result<Vec<EntryRevision>> {
         let form = self.load_form(form_id).await?;
         let table = self.catalog.load_table(&self.form_ident(form_id)).await?;
-        self.read_revision_view_from_table(&form, table, view, snapshot_id, false)
+        self.read_revision_view_from_table(&form, table, view, snapshot_id)
             .await
     }
 
@@ -780,7 +780,6 @@ impl IcebergWorkspace {
         table: iceberg::table::Table,
         view: RevisionView,
         snapshot_id: Option<i64>,
-        static_table: bool,
     ) -> Result<Vec<EntryRevision>> {
         let batches = match view {
             RevisionView::All => {

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -313,8 +313,16 @@ impl SpaceCatalog {
     /// checkpoint. It deliberately does not reread the mutable Catalog Head.
     pub(crate) async fn load_checkpoint_table(
         &self,
+        checkpoint: &SpaceCheckpoint,
         coordinate: &CheckpointTable,
     ) -> anyhow::Result<iceberg::table::Table> {
+        self.validate_checkpoint_evidence(checkpoint).await?;
+        if !checkpoint.tables.contains(coordinate) {
+            return Err(crate::CheckpointIntegrityError::new(
+                "checkpoint table coordinate is not part of this checkpoint",
+            )
+            .into());
+        }
         let namespace =
             NamespaceIdent::from_vec(coordinate.namespace.clone()).map_err(|error| {
                 crate::CheckpointIntegrityError::new(format!("invalid table namespace: {error}"))
@@ -322,7 +330,7 @@ impl SpaceCatalog {
         let identifier = TableIdent::new(namespace, coordinate.table.clone());
         let metadata = TableMetadata::read_from(&self.file_io, &coordinate.metadata_location)
             .await
-            .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?;
+            .map_err(checkpoint_metadata_error)?;
         if metadata.uuid().to_string() != coordinate.table_uuid {
             return Err(crate::CheckpointIntegrityError::new(
                 "Iceberg table UUID does not match the checkpoint",
@@ -365,9 +373,62 @@ impl SpaceCatalog {
             .store
             .read_checkpoint(name)
             .await
-            .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?;
+            .map_err(checkpoint_target_error)?;
         Ok(serde_json::from_slice(&bytes)
             .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?)
+    }
+
+    /// Re-establishes the immutable publication -> canonical Head chain that
+    /// authorizes checkpoint coordinates. The coordinate checksum detects
+    /// corruption, but only this evidence prevents a rewritten checkpoint
+    /// from selecting arbitrary metadata.
+    pub(crate) async fn validate_checkpoint_evidence(
+        &self,
+        checkpoint: &SpaceCheckpoint,
+    ) -> anyhow::Result<()> {
+        let publication_bytes = self
+            .store
+            .read_publication(&checkpoint.publication_location)
+            .await
+            .map_err(checkpoint_target_error)?;
+        let publication = decode_publication(&publication_bytes)
+            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?;
+        if publication.checksum != checkpoint.publication_checksum {
+            return Err(crate::CheckpointIntegrityError::new(
+                "publication checksum does not match the checkpoint",
+            )
+            .into());
+        }
+        let head = &publication.next_head;
+        if head.checksum != checkpoint.catalog_head_checksum
+            || head.generation != checkpoint.catalog_generation
+            || head.form_registry_generation != checkpoint.form_registry_generation
+            || head.space_id != self.space_id.to_string()
+            || head.namespace != *self.namespace.as_ref()
+            || head.publication_location.as_deref()
+                != Some(checkpoint.publication_location.as_str())
+        {
+            return Err(crate::CheckpointIntegrityError::new(
+                "canonical Catalog Head does not match the checkpoint",
+            )
+            .into());
+        }
+        validate_publication_matches_head(&publication, head)
+            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?;
+        if head.tables.len() != checkpoint.tables.len()
+            || !head.tables.values().all(|reference| {
+                checkpoint
+                    .tables
+                    .iter()
+                    .any(|table| checkpoint_table_matches_reference(table, reference))
+            })
+        {
+            return Err(crate::CheckpointIntegrityError::new(
+                "checkpoint tables do not exactly match the canonical Catalog Head",
+            )
+            .into());
+        }
+        Ok(())
     }
 
     /// Finds a completed command through the immutable publication chain.
@@ -821,6 +882,32 @@ impl SpaceCatalog {
                 "Catalog publication chain is incomplete or corrupt",
             )),
         }
+    }
+}
+
+fn checkpoint_table_matches_reference(
+    coordinate: &CheckpointTable,
+    reference: &TableReference,
+) -> bool {
+    reference.form_id.as_deref() == Some(coordinate.form_id.to_string().as_str())
+        && reference.identifier.namespace == coordinate.namespace
+        && reference.identifier.table == coordinate.table
+        && reference.table_uuid == coordinate.table_uuid
+        && reference.metadata_location == coordinate.metadata_location
+}
+
+fn checkpoint_target_error(error: opendal::Error) -> anyhow::Error {
+    match error.kind() {
+        opendal::ErrorKind::NotFound => crate::CheckpointUnavailable::new(error.to_string()).into(),
+        _ => anyhow::Error::new(error).context("read checkpoint target"),
+    }
+}
+
+fn checkpoint_metadata_error(error: iceberg::Error) -> anyhow::Error {
+    if error.kind() == ErrorKind::DataInvalid {
+        crate::CheckpointIntegrityError::new(error.to_string()).into()
+    } else {
+        anyhow::Error::new(error).context("read checkpoint Iceberg metadata")
     }
 }
 

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -15,7 +15,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::sync::{Mutex, OwnedMutexGuard};
 use ugoite_domain::checkpoint::{CheckpointTable, SpaceCheckpoint};
 use ugoite_domain::id::{FormId, SpaceId};
 use ugoite_storage::{CatalogWriteMode, ExactCatalogHead, SpaceCatalogStore};

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -15,7 +15,9 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use ugoite_domain::id::SpaceId;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+use ugoite_domain::checkpoint::{CheckpointTable, SpaceCheckpoint};
+use ugoite_domain::id::{FormId, SpaceId};
 use ugoite_storage::{CatalogWriteMode, ExactCatalogHead, SpaceCatalogStore};
 use uuid::Uuid;
 
@@ -235,6 +237,137 @@ impl SpaceCatalog {
         }
         self.validate_head_publication(&head).await?;
         Ok(Some((head, exact)))
+    }
+
+    /// Captures the one exact Catalog Head currently visible to this reader.
+    /// This is a read-only operation: it neither claims a mutation nor takes a
+    /// writer serializer or lease.
+    pub(crate) async fn capture_checkpoint(&self) -> anyhow::Result<SpaceCheckpoint> {
+        let (head, _) = self
+            .exact_head()
+            .await?
+            .ok_or_else(|| crate::CheckpointUnavailable::new("Catalog Head"))?;
+        let publication_location = head.publication_location.clone().ok_or_else(|| {
+            crate::CheckpointIntegrityError::new("Catalog Head has no publication location")
+        })?;
+        let publication = decode_publication(
+            &self
+                .store
+                .read_publication(&publication_location)
+                .await
+                .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?,
+        )?;
+        validate_publication_matches_head(&publication, &head)?;
+
+        let mut tables = Vec::with_capacity(head.tables.len());
+        for reference in head.tables.values() {
+            tables.push(self.capture_checkpoint_table(reference).await?);
+        }
+        tables.sort_by(|left, right| left.form_id.cmp(&right.form_id));
+
+        Ok(SpaceCheckpoint::new(
+            self.space_id,
+            head.generation,
+            head.checksum,
+            publication_location,
+            publication.checksum,
+            head.form_registry_generation,
+            tables,
+        ))
+    }
+
+    async fn capture_checkpoint_table(
+        &self,
+        reference: &TableReference,
+    ) -> anyhow::Result<CheckpointTable> {
+        let form_id = reference
+            .form_id
+            .as_deref()
+            .ok_or_else(|| {
+                crate::CheckpointIntegrityError::new("Catalog Head table has no Form ID")
+            })?
+            .parse::<Uuid>()
+            .map(FormId::from)
+            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?;
+        let metadata = TableMetadata::read_from(&self.file_io, &reference.metadata_location)
+            .await
+            .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?;
+        if metadata.uuid().to_string() != reference.table_uuid {
+            return Err(crate::CheckpointIntegrityError::new(
+                "Iceberg table UUID does not match the Catalog Head",
+            )
+            .into());
+        }
+        Ok(CheckpointTable {
+            form_id,
+            namespace: reference.identifier.namespace.clone(),
+            table: reference.identifier.table.clone(),
+            table_uuid: reference.table_uuid.clone(),
+            metadata_location: reference.metadata_location.clone(),
+            snapshot_id: metadata.current_snapshot_id(),
+            schema_id: metadata.current_schema_id(),
+        })
+    }
+
+    /// Resolves a table only from the immutable coordinates recorded in a
+    /// checkpoint. It deliberately does not reread the mutable Catalog Head.
+    pub(crate) async fn load_checkpoint_table(
+        &self,
+        coordinate: &CheckpointTable,
+    ) -> anyhow::Result<iceberg::table::Table> {
+        let namespace =
+            NamespaceIdent::from_vec(coordinate.namespace.clone()).map_err(|error| {
+                crate::CheckpointIntegrityError::new(format!("invalid table namespace: {error}"))
+            })?;
+        let identifier = TableIdent::new(namespace, coordinate.table.clone());
+        let metadata = TableMetadata::read_from(&self.file_io, &coordinate.metadata_location)
+            .await
+            .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?;
+        if metadata.uuid().to_string() != coordinate.table_uuid {
+            return Err(crate::CheckpointIntegrityError::new(
+                "Iceberg table UUID does not match the checkpoint",
+            )
+            .into());
+        }
+        if metadata.current_schema_id() != coordinate.schema_id {
+            return Err(crate::CheckpointIntegrityError::new(
+                "Iceberg schema ID does not match the checkpoint",
+            )
+            .into());
+        }
+        if metadata.current_snapshot_id() != coordinate.snapshot_id {
+            return Err(crate::CheckpointIntegrityError::new(
+                "Iceberg snapshot ID does not match the checkpoint",
+            )
+            .into());
+        }
+        Ok(iceberg::table::Table::builder()
+            .identifier(identifier)
+            .metadata(metadata)
+            .metadata_location(coordinate.metadata_location.clone())
+            .file_io(self.file_io.clone())
+            .runtime(self.runtime.clone())
+            .build()?)
+    }
+
+    pub(crate) async fn create_checkpoint(
+        &self,
+        name: &str,
+        checkpoint: &SpaceCheckpoint,
+    ) -> anyhow::Result<()> {
+        let bytes = serde_json::to_vec(checkpoint)?;
+        self.store.create_checkpoint(name, bytes).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn read_checkpoint(&self, name: &str) -> anyhow::Result<SpaceCheckpoint> {
+        let bytes = self
+            .store
+            .read_checkpoint(name)
+            .await
+            .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?;
+        Ok(serde_json::from_slice(&bytes)
+            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?)
     }
 
     /// Finds a completed command through the immutable publication chain.

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -254,7 +254,7 @@ impl SpaceCatalog {
                 .store
                 .read_publication(&publication_location)
                 .await
-                .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?,
+                .map_err(checkpoint_target_error)?,
         )?;
         validate_publication_matches_head(&publication, &head)?;
 
@@ -290,7 +290,7 @@ impl SpaceCatalog {
             .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?;
         let metadata = TableMetadata::read_from(&self.file_io, &reference.metadata_location)
             .await
-            .map_err(|error| crate::CheckpointUnavailable::new(error.to_string()))?;
+            .map_err(checkpoint_metadata_error)?;
         if metadata.uuid().to_string() != reference.table_uuid {
             return Err(crate::CheckpointIntegrityError::new(
                 "Iceberg table UUID does not match the Catalog Head",
@@ -903,11 +903,32 @@ fn checkpoint_target_error(error: opendal::Error) -> anyhow::Error {
 }
 
 fn checkpoint_metadata_error(error: iceberg::Error) -> anyhow::Error {
-    if error.kind() == ErrorKind::DataInvalid {
+    if error_chain_contains_not_found(&error) {
+        crate::CheckpointUnavailable::new("checkpoint Iceberg metadata").into()
+    } else if error.kind() == ErrorKind::DataInvalid {
         crate::CheckpointIntegrityError::new(error.to_string()).into()
     } else {
         anyhow::Error::new(error).context("read checkpoint Iceberg metadata")
     }
+}
+
+/// Iceberg wraps its OpenDAL I/O errors in an `anyhow::Error`, so inspecting
+/// only Iceberg's top-level `ErrorKind` would turn a missing immutable object
+/// into an indistinguishable operational failure. Keep this check at the
+/// checkpoint boundary: missing targets have a stable public meaning, while
+/// corrupt metadata and transient I/O retain their distinct classifications.
+pub(crate) fn error_chain_contains_not_found(error: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if source
+            .downcast_ref::<opendal::Error>()
+            .is_some_and(|error| error.kind() == opendal::ErrorKind::NotFound)
+        {
+            return true;
+        }
+        current = source.source();
+    }
+    false
 }
 
 #[async_trait]

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -357,6 +357,46 @@ impl SpaceCatalog {
             .build()?)
     }
 
+    /// Validates every immutable Iceberg coordinate before a checkpoint is
+    /// made durable or returned to a caller. Publication evidence establishes
+    /// which metadata locations belong to the Head; this verifies that each
+    /// saved snapshot and schema coordinate still exactly matches that
+    /// metadata rather than deferring discovery until query execution.
+    pub(crate) async fn validate_checkpoint_tables(
+        &self,
+        checkpoint: &SpaceCheckpoint,
+    ) -> anyhow::Result<()> {
+        for coordinate in &checkpoint.tables {
+            self.validate_checkpoint_table(coordinate).await?;
+        }
+        Ok(())
+    }
+
+    async fn validate_checkpoint_table(&self, coordinate: &CheckpointTable) -> anyhow::Result<()> {
+        let metadata = TableMetadata::read_from(&self.file_io, &coordinate.metadata_location)
+            .await
+            .map_err(checkpoint_metadata_error)?;
+        if metadata.uuid().to_string() != coordinate.table_uuid {
+            return Err(crate::CheckpointIntegrityError::new(
+                "Iceberg table UUID does not match the checkpoint",
+            )
+            .into());
+        }
+        if metadata.current_schema_id() != coordinate.schema_id {
+            return Err(crate::CheckpointIntegrityError::new(
+                "Iceberg schema ID does not match the checkpoint",
+            )
+            .into());
+        }
+        if metadata.current_snapshot_id() != coordinate.snapshot_id {
+            return Err(crate::CheckpointIntegrityError::new(
+                "Iceberg snapshot ID does not match the checkpoint",
+            )
+            .into());
+        }
+        Ok(())
+    }
+
     pub(crate) async fn create_checkpoint(
         &self,
         name: &str,

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -161,5 +161,23 @@ async fn checkpoint_reports_missing_and_tampered_coordinates_explicitly() -> any
         .await
         .expect_err("tampered coordinate checksum must fail before query planning");
     assert!(error.downcast_ref::<CheckpointIntegrityError>().is_some());
+
+    let mut rewritten = workspace.capture_checkpoint().await?;
+    rewritten.catalog_head_checksum = "attacker-recomputed-checksum".into();
+    rewritten.coordinate_checksum = rewritten.computed_coordinate_checksum();
+    let error = workspace
+        .read_revision_view_at_checkpoint(&rewritten, form.id, RevisionView::Current)
+        .await
+        .expect_err("a self-consistent checkpoint must still match immutable publication evidence");
+    assert!(error.downcast_ref::<CheckpointIntegrityError>().is_some());
+
+    let mut duplicate_form = workspace.capture_checkpoint().await?;
+    duplicate_form.tables.push(duplicate_form.tables[0].clone());
+    duplicate_form.coordinate_checksum = duplicate_form.computed_coordinate_checksum();
+    let error = workspace
+        .read_revision_view_at_checkpoint(&duplicate_form, form.id, RevisionView::Current)
+        .await
+        .expect_err("ambiguous Form coordinates must fail closed");
+    assert!(error.downcast_ref::<CheckpointIntegrityError>().is_some());
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -262,6 +262,54 @@ async fn checkpoint_reports_missing_and_tampered_coordinates_explicitly() -> any
 }
 
 #[tokio::test]
+async fn checkpoint_rejects_tampered_snapshot_and_schema_before_persistence_or_load(
+) -> anyhow::Result<()> {
+    let warehouse = "memory://checkpoint-coordinate-validation";
+    let (workspace, _, checkpoint) = checkpoint_with_one_revision(warehouse, 29).await?;
+
+    for (name, mutate) in [
+        (
+            "snapshot",
+            (|checkpoint: &mut ugoite_iceberg::SpaceCheckpoint| {
+                checkpoint.tables[0].snapshot_id =
+                    checkpoint.tables[0].snapshot_id.map(|id| id + 1);
+            }) as fn(&mut ugoite_iceberg::SpaceCheckpoint),
+        ),
+        (
+            "schema",
+            (|checkpoint: &mut ugoite_iceberg::SpaceCheckpoint| {
+                checkpoint.tables[0].schema_id += 1;
+            }) as fn(&mut ugoite_iceberg::SpaceCheckpoint),
+        ),
+    ] {
+        let mut tampered = checkpoint.clone();
+        mutate(&mut tampered);
+        tampered.coordinate_checksum = tampered.computed_coordinate_checksum();
+        let error = workspace
+            .save_checkpoint(&format!("tampered-{name}"), &tampered)
+            .await
+            .expect_err("tampered table coordinates must not become durable");
+        assert!(error.downcast_ref::<CheckpointIntegrityError>().is_some());
+
+        let load_name = format!("raw-tampered-{name}");
+        tampered.name = Some(load_name.clone());
+        let space_root = format!("test/space_{}", checkpoint.space_id.as_uuid().simple());
+        operator_from_uri(warehouse)?
+            .write(
+                &format!("{space_root}/_ugoite/checkpoints/{load_name}.json"),
+                serde_json::to_vec(&tampered)?,
+            )
+            .await?;
+        let error = workspace
+            .load_checkpoint(&load_name)
+            .await
+            .expect_err("tampered durable coordinates must fail while loading");
+        assert!(error.downcast_ref::<CheckpointIntegrityError>().is_some());
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn checkpoint_missing_immutable_targets_are_unavailable() -> anyhow::Result<()> {
     assert_checkpoint_unavailable_after_delete(
         "memory://checkpoint-missing-publication",

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -1,0 +1,165 @@
+use std::collections::BTreeMap;
+use ugoite_domain::entry::{EntryMetadata, EntryOperation, EntryRevision, FieldValue};
+use ugoite_domain::form::{FieldType, FormDefinition, FormField, FormVersion};
+use ugoite_domain::id::{FieldId, FormId, SpaceId};
+use ugoite_iceberg::{
+    publication_context, CheckpointIntegrityError, CheckpointUnavailable, IcebergWorkspace,
+    RevisionView,
+};
+use uuid::Uuid;
+
+fn form() -> FormDefinition {
+    FormDefinition {
+        id: FormId::from(Uuid::from_u128(2)),
+        version: FormVersion::new(1).expect("test Form version"),
+        name: "Task".into(),
+        description: None,
+        fields: vec![FormField {
+            id: FieldId::new(100).expect("test field ID"),
+            name: "title".into(),
+            field_type: FieldType::String,
+            required: false,
+            label: None,
+            description: None,
+            semantic_role: None,
+            reference_form: None,
+            validation: None,
+            enum_values: Vec::new(),
+            deprecated: false,
+        }],
+        allow_extra_attributes: false,
+        extension_metadata: BTreeMap::new(),
+    }
+}
+
+fn revision(form: &FormDefinition, version: u64, title: &str) -> EntryRevision {
+    let mut values = BTreeMap::new();
+    values.insert(
+        FieldId::new(100).expect("test field ID"),
+        FieldValue::String(title.into()),
+    );
+    EntryRevision {
+        form_id: form.id,
+        entry_id: Uuid::from_u128(11).into(),
+        revision_id: Uuid::from_u128(20 + u128::from(version)).into(),
+        parent_revision_id: (version > 1)
+            .then(|| Uuid::from_u128(20 + u128::from(version - 1)).into()),
+        entry_version: version,
+        expected_version: (version > 1).then_some(version - 1),
+        operation: EntryOperation::Upsert,
+        committed_at_micros: i64::try_from(version).expect("test version fits i64"),
+        author_id: "human:owner".into(),
+        form_version: form.version,
+        source_kind: "test".into(),
+        source_id: None,
+        entry: EntryMetadata::default(),
+        values,
+        extra_attributes: BTreeMap::new(),
+        extension_metadata: BTreeMap::new(),
+    }
+}
+
+async fn create_form(workspace: &IcebergWorkspace, form: &FormDefinition) -> anyhow::Result<()> {
+    workspace
+        .commit(publication_context(
+            "checkpoint-form",
+            "test.form.create",
+            form,
+        )?)?
+        .create_form(form)
+        .await
+}
+
+async fn append(
+    workspace: &IcebergWorkspace,
+    form: &FormDefinition,
+    revision: EntryRevision,
+) -> anyhow::Result<()> {
+    workspace
+        .commit(publication_context(
+            format!("checkpoint-revision-{}", revision.entry_version),
+            "test.entry.append",
+            &revision,
+        )?)?
+        .append_revisions(form.id, vec![revision])
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn checkpoint_pins_one_head_and_uses_static_iceberg_coordinates() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(1)),
+        "memory://checkpoint-pinned-head",
+    )
+    .await?;
+    let form = form();
+    create_form(&workspace, &form).await?;
+    let first = revision(&form, 1, "before checkpoint");
+    append(&workspace, &form, first.clone()).await?;
+
+    let checkpoint = workspace.capture_checkpoint().await?;
+    let repeated_capture = workspace.capture_checkpoint().await?;
+    assert_eq!(
+        checkpoint.coordinate_checksum, repeated_capture.coordinate_checksum,
+        "capturing the same Head twice must retain one coordinate identity"
+    );
+    assert_eq!(checkpoint.tables.len(), 1);
+    assert_eq!(checkpoint.tables[0].form_id, form.id);
+    assert!(checkpoint.tables[0].snapshot_id.is_some());
+    assert!(checkpoint.validate_coordinate_checksum());
+
+    workspace
+        .save_checkpoint("before-update", &checkpoint)
+        .await?;
+    let stored = workspace.load_checkpoint("before-update").await?;
+    assert_eq!(stored.name.as_deref(), Some("before-update"));
+    assert_eq!(stored.coordinate_checksum, checkpoint.coordinate_checksum);
+
+    let second = revision(&form, 2, "after checkpoint");
+    append(&workspace, &form, second.clone()).await?;
+
+    assert_eq!(
+        workspace
+            .read_revision_view_at_checkpoint(
+                &stored,
+                form.id,
+                RevisionView::LatestIncludingTombstones,
+            )
+            .await?,
+        vec![first]
+    );
+    assert_eq!(
+        workspace
+            .read_revision_view(form.id, RevisionView::LatestIncludingTombstones)
+            .await?,
+        vec![second]
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn checkpoint_reports_missing_and_tampered_coordinates_explicitly() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(3)),
+        "memory://checkpoint-errors",
+    )
+    .await?;
+    let missing = workspace
+        .load_checkpoint("not-saved")
+        .await
+        .expect_err("missing durable checkpoint must not fall back to Head");
+    assert!(missing.downcast_ref::<CheckpointUnavailable>().is_some());
+
+    let form = form();
+    create_form(&workspace, &form).await?;
+    append(&workspace, &form, revision(&form, 1, "immutable")).await?;
+    let mut checkpoint = workspace.capture_checkpoint().await?;
+    checkpoint.coordinate_checksum = "tampered".into();
+    let error = workspace
+        .read_revision_view_at_checkpoint(&checkpoint, form.id, RevisionView::Current)
+        .await
+        .expect_err("tampered coordinate checksum must fail before query planning");
+    assert!(error.downcast_ref::<CheckpointIntegrityError>().is_some());
+    Ok(())
+}

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -139,6 +139,36 @@ async fn checkpoint_pins_one_head_and_uses_static_iceberg_coordinates() -> anyho
 }
 
 #[tokio::test]
+async fn named_checkpoints_are_immutable() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(4)),
+        "memory://checkpoint-immutable-name",
+    )
+    .await?;
+    let form = form();
+    create_form(&workspace, &form).await?;
+    append(&workspace, &form, revision(&form, 1, "first")).await?;
+    let first = workspace.capture_checkpoint().await?;
+    workspace.save_checkpoint("fixed-name", &first).await?;
+
+    workspace
+        .save_checkpoint("fixed-name", &first)
+        .await
+        .expect_err("reusing a checkpoint name must fail");
+
+    append(&workspace, &form, revision(&form, 2, "second")).await?;
+    let second = workspace.capture_checkpoint().await?;
+    workspace
+        .save_checkpoint("fixed-name", &second)
+        .await
+        .expect_err("a different checkpoint must not replace a named checkpoint");
+
+    let stored = workspace.load_checkpoint("fixed-name").await?;
+    assert_eq!(stored.coordinate_checksum, first.coordinate_checksum);
+    Ok(())
+}
+
+#[tokio::test]
 async fn checkpoint_reports_missing_and_tampered_coordinates_explicitly() -> anyhow::Result<()> {
     let workspace = IcebergWorkspace::memory_for_tests(
         SpaceId::from(Uuid::from_u128(3)),

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -1,3 +1,4 @@
+use iceberg::{NamespaceIdent, TableIdent};
 use std::collections::BTreeMap;
 use ugoite_domain::entry::{EntryMetadata, EntryOperation, EntryRevision, FieldValue};
 use ugoite_domain::form::{FieldType, FormDefinition, FormField, FormVersion};
@@ -6,6 +7,7 @@ use ugoite_iceberg::{
     publication_context, CheckpointIntegrityError, CheckpointUnavailable, IcebergWorkspace,
     RevisionView,
 };
+use ugoite_storage::operator_from_uri;
 use uuid::Uuid;
 
 fn form() -> FormDefinition {
@@ -83,6 +85,53 @@ async fn append(
         )?)?
         .append_revisions(form.id, vec![revision])
         .await?;
+    Ok(())
+}
+
+async fn checkpoint_with_one_revision(
+    warehouse: &str,
+    space: u128,
+) -> anyhow::Result<(
+    IcebergWorkspace,
+    FormDefinition,
+    ugoite_iceberg::SpaceCheckpoint,
+)> {
+    let workspace =
+        IcebergWorkspace::memory_for_tests(SpaceId::from(Uuid::from_u128(space)), warehouse)
+            .await?;
+    let form = form();
+    create_form(&workspace, &form).await?;
+    append(&workspace, &form, revision(&form, 1, "immutable")).await?;
+    let checkpoint = workspace.capture_checkpoint().await?;
+    Ok((workspace, form, checkpoint))
+}
+
+fn object_path(location: &str) -> &str {
+    location
+        .strip_prefix("memory:///")
+        .or_else(|| location.strip_prefix("memory:/"))
+        .unwrap_or(location)
+}
+
+async fn assert_checkpoint_unavailable_after_delete(
+    warehouse: &str,
+    space: u128,
+    target: impl FnOnce(
+        &IcebergWorkspace,
+        &FormDefinition,
+        &ugoite_iceberg::SpaceCheckpoint,
+    ) -> anyhow::Result<String>,
+) -> anyhow::Result<()> {
+    let (workspace, form, checkpoint) = checkpoint_with_one_revision(warehouse, space).await?;
+    let path = target(&workspace, &form, &checkpoint)?;
+    operator_from_uri(warehouse)?
+        .delete(object_path(&path))
+        .await?;
+    let error = workspace
+        .read_revision_view_at_checkpoint(&checkpoint, form.id, RevisionView::Current)
+        .await
+        .expect_err("a missing immutable checkpoint target must be explicit");
+    assert!(error.downcast_ref::<CheckpointUnavailable>().is_some());
     Ok(())
 }
 
@@ -209,5 +258,111 @@ async fn checkpoint_reports_missing_and_tampered_coordinates_explicitly() -> any
         .await
         .expect_err("ambiguous Form coordinates must fail closed");
     assert!(error.downcast_ref::<CheckpointIntegrityError>().is_some());
+    Ok(())
+}
+
+#[tokio::test]
+async fn checkpoint_missing_immutable_targets_are_unavailable() -> anyhow::Result<()> {
+    assert_checkpoint_unavailable_after_delete(
+        "memory://checkpoint-missing-publication",
+        30,
+        |_, _, checkpoint| Ok(checkpoint.publication_location.clone()),
+    )
+    .await?;
+    assert_checkpoint_unavailable_after_delete(
+        "memory://checkpoint-missing-metadata",
+        31,
+        |_, _, checkpoint| Ok(checkpoint.tables[0].metadata_location.clone()),
+    )
+    .await?;
+
+    let warehouse = "memory://checkpoint-missing-named";
+    let (workspace, _, checkpoint) = checkpoint_with_one_revision(warehouse, 32).await?;
+    workspace.save_checkpoint("removed", &checkpoint).await?;
+    let space_root = format!("test/space_{}", checkpoint.space_id.as_uuid().simple());
+    operator_from_uri(warehouse)?
+        .delete(&format!("{space_root}/_ugoite/checkpoints/removed.json"))
+        .await?;
+    let error = workspace
+        .load_checkpoint("removed")
+        .await
+        .expect_err("a deleted named checkpoint must be unavailable");
+    assert!(error.downcast_ref::<CheckpointUnavailable>().is_some());
+    Ok(())
+}
+
+async fn manifest_and_data_locations(
+    workspace: &IcebergWorkspace,
+    checkpoint: &ugoite_iceberg::SpaceCheckpoint,
+) -> anyhow::Result<(String, String, String)> {
+    let coordinate = &checkpoint.tables[0];
+    let identifier = TableIdent::new(
+        NamespaceIdent::from_vec(coordinate.namespace.clone())?,
+        coordinate.table.clone(),
+    );
+    let table = workspace
+        .catalog_for_testing()
+        .load_table(&identifier)
+        .await?;
+    let snapshot = table
+        .metadata()
+        .current_snapshot()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("test table has no snapshot"))?;
+    let manifest_list = snapshot.manifest_list().to_owned();
+    let manifests = table.manifest_list_reader(&snapshot).load().await?;
+    let manifest = manifests
+        .entries()
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("test snapshot has no manifest"))?;
+    let manifest_path = manifest.manifest_path.clone();
+    let loaded_manifest = manifest.load_manifest(table.file_io()).await?;
+    let data = loaded_manifest
+        .entries()
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("test manifest has no data file"))?
+        .data_file()
+        .file_path()
+        .to_owned();
+    Ok((manifest_list, manifest_path, data))
+}
+
+#[tokio::test]
+async fn checkpoint_missing_manifest_list_or_data_file_is_unavailable() -> anyhow::Result<()> {
+    let warehouse = "memory://checkpoint-missing-manifest-list";
+    let (workspace, form, checkpoint) = checkpoint_with_one_revision(warehouse, 33).await?;
+    let (manifest_list, _, _) = manifest_and_data_locations(&workspace, &checkpoint).await?;
+    operator_from_uri(warehouse)?
+        .delete(object_path(&manifest_list))
+        .await?;
+    let error = workspace
+        .read_revision_view_at_checkpoint(&checkpoint, form.id, RevisionView::Current)
+        .await
+        .expect_err("a deleted manifest list must be unavailable");
+    assert!(error.downcast_ref::<CheckpointUnavailable>().is_some());
+
+    let warehouse = "memory://checkpoint-missing-manifest";
+    let (workspace, form, checkpoint) = checkpoint_with_one_revision(warehouse, 34).await?;
+    let (_, manifest, _) = manifest_and_data_locations(&workspace, &checkpoint).await?;
+    operator_from_uri(warehouse)?
+        .delete(object_path(&manifest))
+        .await?;
+    let error = workspace
+        .read_revision_view_at_checkpoint(&checkpoint, form.id, RevisionView::Current)
+        .await
+        .expect_err("a deleted manifest must be unavailable");
+    assert!(error.downcast_ref::<CheckpointUnavailable>().is_some());
+
+    let warehouse = "memory://checkpoint-missing-data";
+    let (workspace, form, checkpoint) = checkpoint_with_one_revision(warehouse, 35).await?;
+    let (_, _, data) = manifest_and_data_locations(&workspace, &checkpoint).await?;
+    operator_from_uri(warehouse)?
+        .delete(object_path(&data))
+        .await?;
+    let error = workspace
+        .read_revision_view_at_checkpoint(&checkpoint, form.id, RevisionView::Current)
+        .await
+        .expect_err("a deleted data file must be unavailable");
+    assert!(error.downcast_ref::<CheckpointUnavailable>().is_some());
     Ok(())
 }

--- a/crates/ugoite-storage/src/lib.rs
+++ b/crates/ugoite-storage/src/lib.rs
@@ -392,7 +392,7 @@ impl SpaceCatalogStore {
         Ok(())
     }
 
-    pub async fn read_publication(&self, path: &str) -> Result<Vec<u8>> {
+    pub async fn read_publication(&self, path: &str) -> opendal::Result<Vec<u8>> {
         Ok(self.operator.read(path).await?.to_vec())
     }
 
@@ -410,7 +410,7 @@ impl SpaceCatalogStore {
         Ok(())
     }
 
-    pub async fn read_checkpoint(&self, name: &str) -> Result<Vec<u8>> {
+    pub async fn read_checkpoint(&self, name: &str) -> opendal::Result<Vec<u8>> {
         Ok(self
             .operator
             .read(&self.checkpoint_path(name))

--- a/crates/ugoite-storage/src/lib.rs
+++ b/crates/ugoite-storage/src/lib.rs
@@ -278,6 +278,12 @@ impl SpaceCatalogStore {
         self.catalog_path(&format!("publications/{generation}-{command_id}.json"))
     }
 
+    /// Durable named checkpoints are immutable Space objects. They are not
+    /// Catalog authority and never participate in Head publication.
+    pub fn checkpoint_path(&self, name: &str) -> String {
+        self.space_path(&format!("_ugoite/checkpoints/{name}.json"))
+    }
+
     pub async fn read_exact_head(&self) -> Result<Option<ExactCatalogHead>> {
         let path = self.head_path();
         for attempt in 0..EXACT_HEAD_READ_ATTEMPTS {
@@ -390,6 +396,28 @@ impl SpaceCatalogStore {
         Ok(self.operator.read(path).await?.to_vec())
     }
 
+    pub async fn create_checkpoint(&self, name: &str, bytes: Vec<u8>) -> Result<()> {
+        self.operator
+            .write_options(
+                &self.checkpoint_path(name),
+                bytes,
+                WriteOptions {
+                    if_not_exists: true,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn read_checkpoint(&self, name: &str) -> Result<Vec<u8>> {
+        Ok(self
+            .operator
+            .read(&self.checkpoint_path(name))
+            .await?
+            .to_vec())
+    }
+
     pub fn supports_shared_writes(&self) -> bool {
         let capabilities = self.operator.info().full_capability();
         capabilities.read_with_if_match
@@ -398,12 +426,15 @@ impl SpaceCatalogStore {
     }
 
     fn catalog_path(&self, suffix: &str) -> String {
-        let prefix = if self.space_root.is_empty() {
-            "_ugoite/catalog".to_string()
+        self.space_path(&format!("_ugoite/catalog/{suffix}"))
+    }
+
+    fn space_path(&self, suffix: &str) -> String {
+        if self.space_root.is_empty() {
+            suffix.to_string()
         } else {
-            format!("{}/_ugoite/catalog", self.space_root)
-        };
-        format!("{prefix}/{suffix}")
+            format!("{}/{suffix}", self.space_root)
+        }
     }
 }
 

--- a/crates/ugoite-storage/src/lib.rs
+++ b/crates/ugoite-storage/src/lib.rs
@@ -397,6 +397,16 @@ impl SpaceCatalogStore {
     }
 
     pub async fn create_checkpoint(&self, name: &str, bytes: Vec<u8>) -> Result<()> {
+        if !self
+            .operator
+            .info()
+            .full_capability()
+            .write_with_if_not_exists
+        {
+            return Err(anyhow!(
+                "immutable checkpoint creation requires OpenDAL if_not_exists support"
+            ));
+        }
         self.operator
             .write_options(
                 &self.checkpoint_path(name),

--- a/docs/spec/architecture/overview.md
+++ b/docs/spec/architecture/overview.md
@@ -40,10 +40,10 @@ publication chain instead of blindly repeating the logical mutation. REST,
 Memory, pointer-manifest, external-catalog, and object-list reconstruction modes
 are not production architecture.
 
-The active follow-up issues make this architecture complete: duplicate-head
-detection, authorization-aware DataFusion reads, checkpoints, and read-only
-health evidence are target work, not claims about every current API. One Form
-table commit is the atomicity boundary; Ugoite does not claim cross-Form
-transactions.
+Checkpoint capture is a read-only, reproducible coordinate over one exact
+Head: it pins immutable Iceberg metadata and snapshots without claiming a
+cross-Form transaction. Authorization-aware DataFusion reads and read-only
+health evidence remain target work. One Form table commit is the mutation
+atomicity boundary; Ugoite does not claim cross-Form transactions.
 
 The current browser is server-backed. The target architecture adds a browser-local runtime and optional synchronization without making the server the mandatory owner of data.

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -7,10 +7,10 @@ intentionally destructive before the first release: the internal pre-release
 Space format version is unchanged, while legacy layouts and catalog modes are
 unsupported rather than migrated.
 
-The Catalog Head layout, upstream physical boundary, and single mutation
-coordinator are implemented by the current persistence work. Checkpoint-pinned
-reads, authorization-aware DataFusion context, and health evidence described
-here remain active follow-up work; this document does not advertise them as
+The Catalog Head layout, upstream physical boundary, single mutation
+coordinator, and checkpoint-pinned revision reads are implemented by the
+current persistence work. Authorization-aware DataFusion context and health
+evidence remain follow-up work; this document does not advertise them as
 current product APIs.
 
 ## Authority and ownership
@@ -78,6 +78,26 @@ architecture. A narrow physical-schema compatibility adapter is permitted only
 when the upstream Rust API cannot retain an already-assigned Iceberg field ID;
 it must produce standard upstream Iceberg metadata and cannot establish a
 second field-identity authority.
+
+## Space checkpoints
+
+A `SpaceCheckpoint` is one reproducible Space-wide read coordinate, not a
+transaction, authorization artifact, SQL request, or query policy. Capture
+reads one exact Head, validates its reachable publication checksum and Head
+checksum, then loads every referenced immutable Iceberg metadata file. It
+records the Space ID, format/generation coordinates, publication location and
+checksum, and each Form table's identifier, UUID, metadata location, snapshot
+ID (when the table has one), and schema ID. A deterministic coordinate checksum
+excludes optional capture time and human name.
+
+Checkpoint reads never acquire a writer lock and never refresh from the current
+Head. They construct Iceberg static providers from the recorded metadata and,
+when present, the recorded snapshot ID. A durable named checkpoint is created
+once at `_ugoite/checkpoints/<name>.json` through OpenDAL; a missing durable
+object or immutable target returns an explicit unavailable-checkpoint error.
+There is no snapshot-expiration or custom retention implementation. If upstream
+expiration is adopted later, durable checkpoints must first become retention
+roots in that upstream design.
 
 ## Crate boundary
 

--- a/docs/spec/data-model/directory-structure.md
+++ b/docs/spec/data-model/directory-structure.md
@@ -17,6 +17,7 @@ spaces/
       catalog/
         head.json
         publications/
+      checkpoints/
     forms/
     assets/
     materialized_views/
@@ -85,6 +86,14 @@ Records are immutable and authoritative only when reachable from Head. Listing
 objects never reconstructs catalog state or publication order. Missing/corrupt
 Head or reachable publication evidence is an explicit failure; old pointer
 manifests and layout readers are unsupported rather than migrated.
+
+`_ugoite/checkpoints/<name>.json` is an optional immutable named
+`SpaceCheckpoint`, written through the same OpenDAL Space boundary. It records
+one exact Head generation and the referenced Iceberg metadata/snapshot
+coordinates; it is not Catalog authority and cannot alter the Head. Reusing a
+name fails rather than replacing the saved read coordinate. Missing checkpoint
+objects or referenced immutable metadata are explicit unavailable-checkpoint
+errors. Snapshot expiration and a Ugoite retention engine are not implemented.
 
 Revision rows contain stable entry/revision identity, optimistic version and
 parent lineage, operation/tombstone state, commit time, author and provenance,


### PR DESCRIPTION
## Summary

- Add checksum-protected `SpaceCheckpoint` coordinates captured from one exact Catalog Head and its immutable Iceberg metadata.
- Read checkpoint revision views only through upstream Iceberg static/snapshot-pinned providers, and persist immutable named checkpoints through OpenDAL.
- Document the durable checkpoint layout and add coverage for reproducibility, later Head changes, missing targets, and tampering.

## Related Issue (required)

closes #1822

## Testing

- [x] `cargo test -p ugoite-domain -p ugoite-storage -p ugoite-iceberg`
- [x] `cargo test -p ugoite-iceberg --test checkpoint`
- [x] `mise run test:docsite`
- [x] `mise run check`
- [x] `mise run lint`
