### PR TITLE
Add read-only Space health evidence

### DIFF
--- a/crates/ugoite-api-client/src/lib.rs
+++ b/crates/ugoite-api-client/src/lib.rs
@@ -25,6 +25,7 @@ pub const SUPPORTED_OPERATIONS: &[&str] = &[
     "space.list",
     "space.create",
     "space.get",
+    "space.health",
     "space.patch",
     "space.test_connection",
     "space.members.list",
@@ -296,6 +297,29 @@ pub fn prepare_request(
                 ],
                 vec![],
             ),
+            "space.health" => {
+                let mut query = Vec::new();
+                if let Some(checkpoints) = args.get("checkpoints").and_then(Value::as_array) {
+                    for checkpoint in checkpoints {
+                        let checkpoint = checkpoint.as_str().ok_or_else(|| {
+                            ApiProtocolError::invalid_arguments(
+                                operation,
+                                "checkpoints must be an array of strings",
+                            )
+                        })?;
+                        query.push(("checkpoint".into(), checkpoint.to_string()));
+                    }
+                }
+                (
+                    OperationSpec::get("Failed to inspect Space health"),
+                    vec![
+                        "spaces".into(),
+                        required_string(operation, args, "space_id")?,
+                        "health".into(),
+                    ],
+                    query,
+                )
+            }
             "space.patch" => (
                 OperationSpec::json(HttpMethod::Patch, "Failed to patch space"),
                 vec![
@@ -957,6 +981,11 @@ fn operation_spec(operation: &str) -> Option<OperationSpec> {
             "Failed to get space",
             RequestBodyKind::None,
         ),
+        "space.health" => (
+            HttpMethod::Get,
+            "Failed to inspect Space health",
+            RequestBodyKind::None,
+        ),
         "space.patch" => (
             HttpMethod::Patch,
             "Failed to patch space",
@@ -1442,6 +1471,21 @@ mod tests {
         );
         let decoded: Value = serde_json::from_str(&decoded).unwrap();
         assert_eq!(decoded["value"]["name"], "Meeting Notes");
+    }
+
+    #[test]
+    fn space_health_encodes_only_requested_checkpoint_names() {
+        let request = prepare_request(
+            "space.health",
+            &json!({"space_id": "demo", "checkpoints": ["before-upgrade", "nightly"]}),
+            None,
+        )
+        .expect("health request");
+        assert_eq!(request.method, HttpMethod::Get);
+        assert_eq!(
+            request.path,
+            "/spaces/demo/health?checkpoint=before-upgrade&checkpoint=nightly"
+        );
     }
 
     #[test]

--- a/crates/ugoite-iceberg/src/health.rs
+++ b/crates/ugoite-iceberg/src/health.rs
@@ -1,0 +1,72 @@
+//! Read-only Catalog Head and Iceberg metadata health evidence.
+
+use serde::Serialize;
+
+/// A read-only Space health report. Physical storage locations are deliberately
+/// omitted so this value is safe to return from the normal REST API.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpaceHealthReport {
+    pub status: HealthStatus,
+    pub catalog_head: CatalogHeadHealth,
+    pub tables: Vec<TableHealth>,
+    pub checkpoints: Vec<CheckpointHealth>,
+    pub unreachable_failed_attempts: Vec<FailedAttemptCandidate>,
+    pub unavailable_capabilities: Vec<&'static str>,
+    pub recommendations: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CatalogHeadHealth {
+    pub readable: bool,
+    pub checksum: Option<String>,
+    pub etag: Option<String>,
+    pub generation: Option<u64>,
+    pub form_registry_generation: Option<u64>,
+    pub issue: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TableHealth {
+    pub status: HealthStatus,
+    pub identifier: TableIdentifierHealth,
+    pub form_id: Option<String>,
+    pub table_uuid: String,
+    pub metadata_location_redacted: bool,
+    pub schema_id: Option<i32>,
+    pub snapshot_id: Option<i64>,
+    pub snapshot_count: Option<usize>,
+    pub manifest_count: Option<usize>,
+    pub manifest_size_bytes: Option<i64>,
+    pub total_record_count: Option<u64>,
+    pub total_data_file_count: Option<u64>,
+    pub total_data_file_size_bytes: Option<u64>,
+    pub issue: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TableIdentifierHealth {
+    pub namespace: Vec<String>,
+    pub table: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CheckpointHealth {
+    pub name: String,
+    pub status: HealthStatus,
+    pub issue: Option<String>,
+}
+
+/// The publication protocol currently records no failed-attempt coordinates.
+/// This type makes the empty evidence set explicit rather than inferring
+/// candidates from an object listing.
+#[derive(Debug, Clone, Serialize)]
+pub struct FailedAttemptCandidate {
+    pub evidence: String,
+}

--- a/crates/ugoite-iceberg/src/health.rs
+++ b/crates/ugoite-iceberg/src/health.rs
@@ -10,8 +10,9 @@ pub struct SpaceHealthReport {
     pub catalog_head: CatalogHeadHealth,
     pub tables: Vec<TableHealth>,
     pub checkpoints: Vec<CheckpointHealth>,
+    pub backend: BackendHealth,
     pub unreachable_failed_attempts: Vec<FailedAttemptCandidate>,
-    pub unavailable_capabilities: Vec<&'static str>,
+    pub unavailable_capabilities: Vec<UnavailableCapability>,
     pub recommendations: Vec<&'static str>,
 }
 
@@ -29,7 +30,16 @@ pub struct CatalogHeadHealth {
     pub etag: Option<String>,
     pub generation: Option<u64>,
     pub form_registry_generation: Option<u64>,
-    pub issue: Option<String>,
+    pub issue: Option<HealthIssue>,
+}
+
+/// Stable, redacted evidence classification. `code` is intended for operator
+/// automation; `target` says which immutable evidence kind failed without
+/// disclosing a physical storage location or backend error text.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct HealthIssue {
+    pub code: &'static str,
+    pub target: &'static str,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -47,7 +57,17 @@ pub struct TableHealth {
     pub total_record_count: Option<u64>,
     pub total_data_file_count: Option<u64>,
     pub total_data_file_size_bytes: Option<u64>,
-    pub issue: Option<String>,
+    pub file_size_distribution: Option<FileSizeDistribution>,
+    pub issue: Option<HealthIssue>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileSizeDistribution {
+    pub min_bytes: Option<u64>,
+    pub max_bytes: Option<u64>,
+    pub average_bytes: Option<u64>,
+    pub small_file_count: u64,
+    pub small_file_threshold_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -60,7 +80,44 @@ pub struct TableIdentifierHealth {
 pub struct CheckpointHealth {
     pub name: String,
     pub status: HealthStatus,
-    pub issue: Option<String>,
+    pub issue: Option<HealthIssue>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UnavailableCapability {
+    pub capability: &'static str,
+    pub reason: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BackendHealth {
+    pub mode: BackendMode,
+    pub etag: bool,
+    pub read_with_if_match: bool,
+    pub write_with_if_match: bool,
+    pub write_with_if_not_exists: bool,
+    pub shared_write_contract: bool,
+    pub probe_status: BackendProbeStatus,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendMode {
+    SingleProcess,
+    Shared,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendProbeStatus {
+    /// Capabilities are known, but no durable active integration-probe result
+    /// is retained for this single-process store.
+    CapabilityDeclaration,
+    /// Shared mode is enabled only after the active conditional-write probe
+    /// completed successfully.
+    ActiveProbeVerified,
+    /// Health is read-only and never runs a write probe itself.
+    ActiveProbeUnavailable,
 }
 
 /// The publication protocol currently records no failed-attempt coordinates.

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -12,6 +12,7 @@ pub mod audit;
 pub mod authorization;
 pub mod entry;
 pub mod form;
+pub mod health;
 pub mod iceberg_store;
 pub mod index;
 pub mod integrity;
@@ -28,6 +29,7 @@ pub mod sql;
 pub mod sql_session;
 pub mod storage;
 
+pub use health::SpaceHealthReport;
 pub use migration::{MigrationFormReport, MigrationManifest, MigrationReport};
 pub use space_catalog::PublicationContext;
 use space_catalog::SpaceCatalog;
@@ -315,6 +317,20 @@ impl IcebergWorkspace {
             .as_ref()
             .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
             .capture_checkpoint()
+            .await
+    }
+
+    /// Collects read-only evidence from the exact Catalog Head and the Iceberg
+    /// metadata it references. It never scans table rows, lists objects, or
+    /// performs a Catalog mutation.
+    pub async fn health_report(&self, checkpoint_names: &[String]) -> Result<SpaceHealthReport> {
+        for name in checkpoint_names {
+            validate_checkpoint_name(name)?;
+        }
+        self.space_catalog
+            .as_ref()
+            .context("Space health requires the OpenDAL-backed SpaceCatalog")?
+            .health_report(checkpoint_names)
             .await
     }
 

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -8,7 +8,7 @@ use crate::integrity::RealIntegrityProvider;
 use crate::{
     asset,
     authorization::{Authorizer, ResourceKind, ResourceRef},
-    entry, form, index, preferences, saved_sql, search, space, sql_session,
+    entry, form, iceberg_store, index, preferences, saved_sql, search, space, sql_session,
     storage::operator_from_uri,
 };
 use ugoite_core::error::AppError;
@@ -137,6 +137,18 @@ impl UgoiteService {
     pub async fn get_space(&self, space_id: &str) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         space::get_space_raw(&self.operator, space_id).await
+    }
+
+    /// Returns read-only Catalog Head and Iceberg metadata evidence for one
+    /// Space. Checkpoint names are caller-supplied because listing storage is
+    /// not a source of Catalog or orphan authority.
+    pub async fn space_health(&self, space_id: &str, checkpoint_names: &[String]) -> Result<Value> {
+        validate_storage_id(validate_space_id(space_id))?;
+        let workspace =
+            iceberg_store::native_workspace(&self.operator, &self.workspace_path(space_id)).await?;
+        Ok(serde_json::to_value(
+            workspace.health_report(checkpoint_names).await?,
+        )?)
     }
 
     pub async fn patch_space(&self, space_id: &str, patch: &Value) -> Result<Value> {

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -20,6 +20,11 @@ use ugoite_domain::id::{FormId, SpaceId};
 use ugoite_storage::{CatalogWriteMode, ExactCatalogHead, SpaceCatalogStore};
 use uuid::Uuid;
 
+use crate::health::{
+    CatalogHeadHealth, CheckpointHealth, HealthStatus, SpaceHealthReport, TableHealth,
+    TableIdentifierHealth,
+};
+
 const SPACE_FORMAT_VERSION: u32 = 1;
 const MAX_HEAD_BYTES: usize = 1 << 20;
 
@@ -273,6 +278,231 @@ impl SpaceCatalog {
             head.form_registry_generation,
             tables,
         ))
+    }
+
+    /// Reads only the authoritative Head, its reachable metadata, and named
+    /// checkpoint targets. It deliberately never lists storage or scans table
+    /// rows: neither can establish Catalog authority or orphan evidence.
+    pub(crate) async fn health_report(
+        &self,
+        checkpoint_names: &[String],
+    ) -> anyhow::Result<SpaceHealthReport> {
+        let (head, exact) = match self.exact_head().await {
+            Ok(Some(head)) => head,
+            Ok(None) => return Ok(self.unavailable_head_health(checkpoint_names)),
+            Err(_) => return Ok(self.unavailable_head_health(checkpoint_names)),
+        };
+        let mut tables = Vec::with_capacity(head.tables.len());
+        for reference in head.tables.values() {
+            tables.push(self.table_health(reference).await);
+        }
+        tables.sort_by(|left, right| {
+            left.identifier
+                .namespace
+                .cmp(&right.identifier.namespace)
+                .then(left.identifier.table.cmp(&right.identifier.table))
+        });
+
+        let mut checkpoints = Vec::with_capacity(checkpoint_names.len());
+        for name in checkpoint_names {
+            checkpoints.push(self.checkpoint_health(name).await);
+        }
+
+        let status = if tables
+            .iter()
+            .any(|table| table.status == HealthStatus::Degraded)
+            || checkpoints
+                .iter()
+                .any(|checkpoint| checkpoint.status == HealthStatus::Degraded)
+        {
+            HealthStatus::Degraded
+        } else {
+            HealthStatus::Healthy
+        };
+        Ok(SpaceHealthReport {
+            status,
+            catalog_head: CatalogHeadHealth {
+                readable: true,
+                checksum: Some(head.checksum),
+                etag: exact.etag,
+                generation: Some(head.generation),
+                form_registry_generation: Some(head.form_registry_generation),
+                issue: None,
+            },
+            tables,
+            checkpoints,
+            unreachable_failed_attempts: Vec::new(),
+            unavailable_capabilities: vec![
+                "file-size distribution: Iceberg Rust exposes snapshots and manifests, not a files metadata table",
+                "orphan discovery: object listing is intentionally not used as Catalog evidence",
+                "failed-attempt candidates: no failed-attempt coordinates are durably recorded",
+            ],
+            recommendations: vec![
+                "Enable object versioning or maintain operator backups for the Catalog Head.",
+            ],
+        })
+    }
+
+    fn unavailable_head_health(&self, checkpoint_names: &[String]) -> SpaceHealthReport {
+        SpaceHealthReport {
+            status: HealthStatus::Degraded,
+            catalog_head: CatalogHeadHealth {
+                readable: false,
+                checksum: None,
+                etag: None,
+                generation: None,
+                form_registry_generation: None,
+                issue: Some("Catalog Head is missing, unreadable, or has invalid evidence".into()),
+            },
+            tables: Vec::new(),
+            checkpoints: checkpoint_names
+                .iter()
+                .map(|name| CheckpointHealth {
+                    name: name.clone(),
+                    status: HealthStatus::Degraded,
+                    issue: Some("Catalog Head evidence is unavailable".into()),
+                })
+                .collect(),
+            unreachable_failed_attempts: Vec::new(),
+            unavailable_capabilities: vec![
+                "file-size distribution: Iceberg Rust exposes snapshots and manifests, not a files metadata table",
+                "orphan discovery: object listing is intentionally not used as Catalog evidence",
+                "failed-attempt candidates: no failed-attempt coordinates are durably recorded",
+            ],
+            recommendations: vec![
+                "Restore the Catalog Head from object versioning or an operator backup before taking action.",
+            ],
+        }
+    }
+
+    async fn table_health(&self, reference: &TableReference) -> TableHealth {
+        let identifier = TableIdentifierHealth {
+            namespace: reference.identifier.namespace.clone(),
+            table: reference.identifier.table.clone(),
+        };
+        let mut report = TableHealth {
+            status: HealthStatus::Healthy,
+            identifier,
+            form_id: reference.form_id.clone(),
+            table_uuid: reference.table_uuid.clone(),
+            metadata_location_redacted: true,
+            schema_id: None,
+            snapshot_id: None,
+            snapshot_count: None,
+            manifest_count: None,
+            manifest_size_bytes: None,
+            total_record_count: None,
+            total_data_file_count: None,
+            total_data_file_size_bytes: None,
+            issue: None,
+        };
+        let metadata = match TableMetadata::read_from(&self.file_io, &reference.metadata_location)
+            .await
+        {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                report.status = HealthStatus::Degraded;
+                report.issue = Some("referenced Iceberg metadata is unavailable or invalid".into());
+                return report;
+            }
+        };
+        if metadata.uuid().to_string() != reference.table_uuid {
+            report.status = HealthStatus::Degraded;
+            report.issue = Some("Iceberg table UUID does not match the Catalog Head".into());
+            return report;
+        }
+        if metadata.properties().get(FORM_ID_PROPERTY) != reference.form_id.as_ref() {
+            report.status = HealthStatus::Degraded;
+            report.issue = Some("Iceberg Form ID does not match the Catalog Head".into());
+            return report;
+        }
+        report.schema_id = Some(metadata.current_schema_id());
+        report.snapshot_id = metadata.current_snapshot_id();
+        report.snapshot_count = Some(metadata.snapshots().len());
+        if let Some(snapshot) = metadata.current_snapshot() {
+            let summary = &snapshot.summary().additional_properties;
+            report.total_record_count = summary
+                .get("total-records")
+                .and_then(|value| value.parse().ok());
+            report.total_data_file_count = summary
+                .get("total-data-files")
+                .and_then(|value| value.parse().ok());
+            report.total_data_file_size_bytes = summary
+                .get("total-file-size-in-bytes")
+                .and_then(|value| value.parse().ok());
+            let snapshot_id = snapshot.snapshot_id();
+            let table = iceberg::table::Table::builder()
+                .identifier(reference.identifier.to_table_ident())
+                .metadata(metadata)
+                .metadata_location(reference.metadata_location.clone())
+                .file_io(self.file_io.clone())
+                .runtime(self.runtime.clone())
+                .build();
+            match table {
+                Ok(table) => {
+                    let snapshot = table
+                        .metadata()
+                        .snapshot_by_id(snapshot_id)
+                        .expect("current snapshot remains in its metadata");
+                    match table.manifest_list_reader(snapshot).load().await {
+                        Ok(manifests) => {
+                            report.manifest_count = Some(manifests.entries().len());
+                            report.manifest_size_bytes = Some(
+                                manifests
+                                    .entries()
+                                    .iter()
+                                    .map(|manifest| manifest.manifest_length)
+                                    .sum(),
+                            );
+                        }
+                        Err(_) => {
+                            report.status = HealthStatus::Degraded;
+                            report.issue = Some(
+                                "current Iceberg manifest list is unavailable or invalid".into(),
+                            );
+                        }
+                    }
+                }
+                Err(_) => {
+                    report.status = HealthStatus::Degraded;
+                    report.issue = Some("referenced Iceberg metadata is invalid".into());
+                }
+            }
+        }
+        report
+    }
+
+    async fn checkpoint_health(&self, name: &str) -> CheckpointHealth {
+        let status = match self.read_checkpoint(name).await {
+            Ok(checkpoint) => match self.validate_checkpoint_evidence(&checkpoint).await {
+                Ok(()) => self.validate_checkpoint_tables(&checkpoint).await,
+                Err(error) => Err(error),
+            },
+            Err(error) => Err(error),
+        };
+        match status {
+            Ok(()) => CheckpointHealth {
+                name: name.to_string(),
+                status: HealthStatus::Healthy,
+                issue: None,
+            },
+            Err(error)
+                if error
+                    .downcast_ref::<crate::CheckpointUnavailable>()
+                    .is_some() =>
+            {
+                CheckpointHealth {
+                    name: name.to_string(),
+                    status: HealthStatus::Degraded,
+                    issue: Some("checkpoint or a referenced immutable target is missing".into()),
+                }
+            }
+            Err(_) => CheckpointHealth {
+                name: name.to_string(),
+                status: HealthStatus::Degraded,
+                issue: Some("checkpoint evidence is invalid or unavailable".into()),
+            },
+        }
     }
 
     async fn capture_checkpoint_table(

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -21,12 +21,15 @@ use ugoite_storage::{CatalogWriteMode, ExactCatalogHead, SpaceCatalogStore};
 use uuid::Uuid;
 
 use crate::health::{
-    CatalogHeadHealth, CheckpointHealth, HealthStatus, SpaceHealthReport, TableHealth,
-    TableIdentifierHealth,
+    BackendHealth, BackendMode, BackendProbeStatus, CatalogHeadHealth, CheckpointHealth,
+    FileSizeDistribution, HealthIssue, HealthStatus, SpaceHealthReport, TableHealth,
+    TableIdentifierHealth, UnavailableCapability,
 };
+use crate::FORM_ID_PROPERTY;
 
 const SPACE_FORMAT_VERSION: u32 = 1;
 const MAX_HEAD_BYTES: usize = 1 << 20;
+const SMALL_FILE_THRESHOLD_BYTES: u64 = 128 * 1024 * 1024;
 
 /// Holds the official OpenDAL Iceberg storage instance for test-only memory
 /// spaces. It adds no I/O behavior; it merely keeps Iceberg metadata and
@@ -287,11 +290,32 @@ impl SpaceCatalog {
         &self,
         checkpoint_names: &[String],
     ) -> anyhow::Result<SpaceHealthReport> {
-        let (head, exact) = match self.exact_head().await {
-            Ok(Some(head)) => head,
-            Ok(None) => return Ok(self.unavailable_head_health(checkpoint_names)),
-            Err(_) => return Ok(self.unavailable_head_health(checkpoint_names)),
+        // Do not use `exact_head` here: normal opens deliberately collapse
+        // integrity errors into one failure, while doctor must retain their
+        // stable classifications. This reads the same exact authoritative
+        // bytes and never reconstructs Catalog state from a listing.
+        let exact = match self.store.read_exact_head().await {
+            Ok(Some(exact)) => exact,
+            Ok(None) => {
+                return Ok(self.unavailable_head_health(checkpoint_names, "catalog_head_missing"))
+            }
+            Err(_) => {
+                return Ok(self.unavailable_head_health(checkpoint_names, "catalog_head_unreadable"))
+            }
         };
+        let head = match decode_head_for_health(&exact.bytes) {
+            Ok(head) => head,
+            Err(code) => return Ok(self.unavailable_head_health(checkpoint_names, code)),
+        };
+        if head.space_id != self.space_id.to_string() || head.namespace != *self.namespace.as_ref()
+        {
+            return Ok(
+                self.unavailable_head_health(checkpoint_names, "catalog_head_identity_mismatch")
+            );
+        }
+        if let Err(issue) = self.validate_publication_chain_for_health(&head).await {
+            return Ok(self.unavailable_head_health(checkpoint_names, issue));
+        }
         let mut tables = Vec::with_capacity(head.tables.len());
         for reference in head.tables.values() {
             tables.push(self.table_health(reference).await);
@@ -331,19 +355,20 @@ impl SpaceCatalog {
             },
             tables,
             checkpoints,
+            backend: self.backend_health(),
             unreachable_failed_attempts: Vec::new(),
-            unavailable_capabilities: vec![
-                "file-size distribution: Iceberg Rust exposes snapshots and manifests, not a files metadata table",
-                "orphan discovery: object listing is intentionally not used as Catalog evidence",
-                "failed-attempt candidates: no failed-attempt coordinates are durably recorded",
-            ],
+            unavailable_capabilities: self.unavailable_capabilities(),
             recommendations: vec![
                 "Enable object versioning or maintain operator backups for the Catalog Head.",
             ],
         })
     }
 
-    fn unavailable_head_health(&self, checkpoint_names: &[String]) -> SpaceHealthReport {
+    fn unavailable_head_health(
+        &self,
+        checkpoint_names: &[String],
+        code: &'static str,
+    ) -> SpaceHealthReport {
         SpaceHealthReport {
             status: HealthStatus::Degraded,
             catalog_head: CatalogHeadHealth {
@@ -352,7 +377,7 @@ impl SpaceCatalog {
                 etag: None,
                 generation: None,
                 form_registry_generation: None,
-                issue: Some("Catalog Head is missing, unreadable, or has invalid evidence".into()),
+                issue: Some(health_issue(code, "catalog_head")),
             },
             tables: Vec::new(),
             checkpoints: checkpoint_names
@@ -360,18 +385,130 @@ impl SpaceCatalog {
                 .map(|name| CheckpointHealth {
                     name: name.clone(),
                     status: HealthStatus::Degraded,
-                    issue: Some("Catalog Head evidence is unavailable".into()),
+                    issue: Some(health_issue("catalog_head_unavailable", "catalog_head")),
                 })
                 .collect(),
+            backend: self.backend_health(),
             unreachable_failed_attempts: Vec::new(),
-            unavailable_capabilities: vec![
-                "file-size distribution: Iceberg Rust exposes snapshots and manifests, not a files metadata table",
-                "orphan discovery: object listing is intentionally not used as Catalog evidence",
-                "failed-attempt candidates: no failed-attempt coordinates are durably recorded",
-            ],
+            unavailable_capabilities: self.unavailable_capabilities(),
             recommendations: vec![
                 "Restore the Catalog Head from object versioning or an operator backup before taking action.",
             ],
+        }
+    }
+
+    fn backend_health(&self) -> BackendHealth {
+        let capability = self.store.backend_capabilities();
+        let mode = match self.store.write_mode() {
+            CatalogWriteMode::SingleProcess => BackendMode::SingleProcess,
+            CatalogWriteMode::Shared => BackendMode::Shared,
+        };
+        BackendHealth {
+            mode,
+            etag: capability.etag,
+            read_with_if_match: capability.read_with_if_match,
+            write_with_if_match: capability.write_with_if_match,
+            write_with_if_not_exists: capability.write_with_if_not_exists,
+            shared_write_contract: capability.shared_write_contract,
+            probe_status: match mode {
+                BackendMode::Shared => BackendProbeStatus::ActiveProbeVerified,
+                // No durable per-store probe history exists for the
+                // single-process contract, and health intentionally does not
+                // write one merely to answer this request.
+                BackendMode::SingleProcess => BackendProbeStatus::ActiveProbeUnavailable,
+            },
+        }
+    }
+
+    fn unavailable_capabilities(&self) -> Vec<UnavailableCapability> {
+        vec![
+            UnavailableCapability {
+                capability: "orphan_discovery",
+                reason: "object_listing_is_not_catalog_evidence",
+            },
+            UnavailableCapability {
+                capability: "failed_attempt_candidates",
+                reason: "no_durable_failed_attempt_coordinates",
+            },
+        ]
+    }
+
+    /// Doctor-only traversal of every immutable publication reachable from
+    /// the exact Head. Normal Space opening intentionally remains constant
+    /// work; this path exists solely to give an operator enough evidence to
+    /// decide whether restoration is required.
+    async fn validate_publication_chain_for_health(
+        &self,
+        head: &CatalogHead,
+    ) -> std::result::Result<(), &'static str> {
+        let Some(mut path) = head.publication_location.clone() else {
+            return Err("publication_missing");
+        };
+        let mut expected_head = head.clone();
+        let mut visited = BTreeSet::new();
+        loop {
+            if !visited.insert(path.clone()) {
+                return Err("publication_chain_corrupt");
+            }
+            let bytes = match self.store.read_publication(&path).await {
+                Ok(bytes) => bytes,
+                Err(error) if error.kind() == opendal::ErrorKind::NotFound => {
+                    return Err(if expected_head == *head {
+                        "publication_missing"
+                    } else {
+                        "publication_predecessor_missing"
+                    });
+                }
+                Err(_) => return Err("publication_unreadable"),
+            };
+            let publication = decode_publication_for_health(&bytes)?;
+            if publication.generation != expected_head.generation
+                || publication.next_head_checksum != expected_head.checksum
+                || publication.next_head != expected_head
+                || expected_head.publication_command_id.as_deref()
+                    != Some(publication.command_id.as_str())
+            {
+                return Err(if expected_head == *head {
+                    "publication_head_mismatch"
+                } else {
+                    "publication_chain_corrupt"
+                });
+            }
+            match (
+                publication.previous_generation,
+                publication.previous_publication,
+                publication.previous_head_checksum,
+            ) {
+                (None, None, None) if publication.generation == 0 => return Ok(()),
+                (Some(previous_generation), Some(previous_path), Some(previous_checksum))
+                    if previous_generation + 1 == publication.generation =>
+                {
+                    path = previous_path;
+                    // A predecessor's `next_head` is the Head we must match
+                    // before taking its own predecessor link.
+                    let bytes = match self.store.read_publication(&path).await {
+                        Ok(bytes) => bytes,
+                        Err(error) if error.kind() == opendal::ErrorKind::NotFound => {
+                            return Err("publication_predecessor_missing");
+                        }
+                        Err(_) => return Err("publication_unreadable"),
+                    };
+                    let predecessor = decode_publication_for_health(&bytes)?;
+                    if predecessor.generation != previous_generation
+                        || predecessor.next_head_checksum != previous_checksum
+                    {
+                        return Err("publication_chain_gap");
+                    }
+                    expected_head = predecessor.next_head.clone();
+                    // Re-read is deliberately avoided on the next iteration
+                    // only when traversal state is simple; validating the
+                    // predecessor as `expected_head` still requires its full
+                    // immutable record, which this loop obtains below.
+                    // Store it nowhere: doctor must not construct a shadow
+                    // Catalog from history.
+                }
+                _ => return Err("publication_chain_gap"),
+            }
         }
     }
 
@@ -394,6 +531,7 @@ impl SpaceCatalog {
             total_record_count: None,
             total_data_file_count: None,
             total_data_file_size_bytes: None,
+            file_size_distribution: None,
             issue: None,
         };
         let metadata = match TableMetadata::read_from(&self.file_io, &reference.metadata_location)
@@ -402,18 +540,46 @@ impl SpaceCatalog {
             Ok(metadata) => metadata,
             Err(_) => {
                 report.status = HealthStatus::Degraded;
-                report.issue = Some("referenced Iceberg metadata is unavailable or invalid".into());
+                report.issue = Some(health_issue("table_metadata_unavailable", "table_metadata"));
                 return report;
             }
         };
         if metadata.uuid().to_string() != reference.table_uuid {
             report.status = HealthStatus::Degraded;
-            report.issue = Some("Iceberg table UUID does not match the Catalog Head".into());
+            report.issue = Some(health_issue("table_uuid_mismatch", "table_metadata"));
             return report;
         }
-        if metadata.properties().get(FORM_ID_PROPERTY) != reference.form_id.as_ref() {
+        let Some(head_form_id) = reference.form_id.as_deref() else {
             report.status = HealthStatus::Degraded;
-            report.issue = Some("Iceberg Form ID does not match the Catalog Head".into());
+            report.issue = Some(health_issue("head_form_id_missing", "catalog_head"));
+            return report;
+        };
+        let Ok(head_form_id) = head_form_id.parse::<Uuid>() else {
+            report.status = HealthStatus::Degraded;
+            report.issue = Some(health_issue("head_form_id_malformed", "catalog_head"));
+            return report;
+        };
+        if reference.identifier.table != crate::physical_form_name(FormId::from(head_form_id)) {
+            report.status = HealthStatus::Degraded;
+            report.issue = Some(health_issue(
+                "form_table_identifier_mismatch",
+                "catalog_head",
+            ));
+            return report;
+        }
+        let Some(metadata_form_id) = metadata.properties().get(FORM_ID_PROPERTY) else {
+            report.status = HealthStatus::Degraded;
+            report.issue = Some(health_issue("table_form_id_missing", "table_metadata"));
+            return report;
+        };
+        let Ok(metadata_form_id) = metadata_form_id.parse::<Uuid>() else {
+            report.status = HealthStatus::Degraded;
+            report.issue = Some(health_issue("table_form_id_malformed", "table_metadata"));
+            return report;
+        };
+        if metadata_form_id != head_form_id {
+            report.status = HealthStatus::Degraded;
+            report.issue = Some(health_issue("form_id_mismatch", "table_metadata"));
             return report;
         }
         report.schema_id = Some(metadata.current_schema_id());
@@ -454,18 +620,74 @@ impl SpaceCatalog {
                                     .map(|manifest| manifest.manifest_length)
                                     .sum(),
                             );
+                            let mut record_count = 0_u64;
+                            let mut data_file_count = 0_u64;
+                            let mut data_file_size = 0_u64;
+                            let mut min_file_size = None;
+                            let mut max_file_size = None;
+                            let mut small_file_count = 0_u64;
+                            for manifest_file in manifests.entries() {
+                                let manifest = match manifest_file
+                                    .load_manifest(&self.file_io)
+                                    .await
+                                {
+                                    Ok(manifest) => manifest,
+                                    Err(_) => {
+                                        report.status = HealthStatus::Degraded;
+                                        report.issue =
+                                            Some(health_issue("manifest_unavailable", "manifest"));
+                                        return report;
+                                    }
+                                };
+                                for entry in
+                                    manifest.entries().iter().filter(|entry| entry.is_alive())
+                                {
+                                    // Only data files describe current table data. Delete
+                                    // manifests are nevertheless loaded above as integrity
+                                    // evidence, but are not mixed into data-file metrics.
+                                    if entry.content_type() != iceberg::spec::DataContentType::Data
+                                    {
+                                        continue;
+                                    }
+                                    let size = entry.file_size_in_bytes();
+                                    data_file_count += 1;
+                                    record_count += entry.record_count();
+                                    data_file_size += size;
+                                    min_file_size = Some(
+                                        min_file_size
+                                            .map_or(size, |current: u64| current.min(size)),
+                                    );
+                                    max_file_size = Some(
+                                        max_file_size
+                                            .map_or(size, |current: u64| current.max(size)),
+                                    );
+                                    if size < SMALL_FILE_THRESHOLD_BYTES {
+                                        small_file_count += 1;
+                                    }
+                                }
+                            }
+                            report.total_record_count = Some(record_count);
+                            report.total_data_file_count = Some(data_file_count);
+                            report.total_data_file_size_bytes = Some(data_file_size);
+                            report.file_size_distribution = Some(FileSizeDistribution {
+                                min_bytes: min_file_size,
+                                max_bytes: max_file_size,
+                                average_bytes: (data_file_count > 0)
+                                    .then_some(data_file_size / data_file_count),
+                                small_file_count,
+                                small_file_threshold_bytes: SMALL_FILE_THRESHOLD_BYTES,
+                            });
                         }
                         Err(_) => {
                             report.status = HealthStatus::Degraded;
-                            report.issue = Some(
-                                "current Iceberg manifest list is unavailable or invalid".into(),
-                            );
+                            report.issue =
+                                Some(health_issue("manifest_list_unavailable", "manifest_list"));
                         }
                     }
                 }
                 Err(_) => {
                     report.status = HealthStatus::Degraded;
-                    report.issue = Some("referenced Iceberg metadata is invalid".into());
+                    report.issue = Some(health_issue("table_metadata_invalid", "table_metadata"));
                 }
             }
         }
@@ -473,35 +695,180 @@ impl SpaceCatalog {
     }
 
     async fn checkpoint_health(&self, name: &str) -> CheckpointHealth {
-        let status = match self.read_checkpoint(name).await {
-            Ok(checkpoint) => match self.validate_checkpoint_evidence(&checkpoint).await {
-                Ok(()) => self.validate_checkpoint_tables(&checkpoint).await,
-                Err(error) => Err(error),
-            },
-            Err(error) => Err(error),
+        let bytes = match self.store.read_checkpoint(name).await {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == opendal::ErrorKind::NotFound => {
+                return checkpoint_issue(name, "checkpoint_object_missing", "checkpoint")
+            }
+            Err(_) => return checkpoint_issue(name, "checkpoint_unreadable", "checkpoint"),
         };
-        match status {
-            Ok(()) => CheckpointHealth {
-                name: name.to_string(),
-                status: HealthStatus::Healthy,
-                issue: None,
-            },
-            Err(error)
-                if error
-                    .downcast_ref::<crate::CheckpointUnavailable>()
-                    .is_some() =>
+        let checkpoint: SpaceCheckpoint = match serde_json::from_slice(&bytes) {
+            Ok(checkpoint) => checkpoint,
+            Err(_) => return checkpoint_issue(name, "checkpoint_decode_failure", "checkpoint"),
+        };
+        if !checkpoint.validate_coordinate_checksum() {
+            return checkpoint_issue(
+                name,
+                "checkpoint_coordinate_checksum_mismatch",
+                "checkpoint",
+            );
+        }
+        if checkpoint.validate_structure().is_err() {
+            return checkpoint_issue(name, "checkpoint_coordinate_invalid", "checkpoint");
+        }
+        if checkpoint.space_id != self.space_id {
+            return checkpoint_issue(name, "checkpoint_space_id_mismatch", "checkpoint");
+        }
+        let publication_bytes = match self
+            .store
+            .read_publication(&checkpoint.publication_location)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == opendal::ErrorKind::NotFound => {
+                return checkpoint_issue(name, "checkpoint_publication_missing", "publication")
+            }
+            Err(_) => {
+                return checkpoint_issue(name, "checkpoint_publication_unreadable", "publication")
+            }
+        };
+        let publication = match decode_publication_for_health(&publication_bytes) {
+            Ok(publication) => publication,
+            Err(code) => return checkpoint_issue(name, code, "publication"),
+        };
+        if publication.checksum != checkpoint.publication_checksum {
+            return checkpoint_issue(
+                name,
+                "checkpoint_publication_checksum_mismatch",
+                "publication",
+            );
+        }
+        let head = &publication.next_head;
+        if head.generation != checkpoint.catalog_generation
+            || head.checksum != checkpoint.catalog_head_checksum
+            || head.form_registry_generation != checkpoint.form_registry_generation
+        {
+            return checkpoint_issue(
+                name,
+                "checkpoint_catalog_generation_mismatch",
+                "publication",
+            );
+        }
+        if head.tables.len() != checkpoint.tables.len()
+            || !head.tables.values().all(|reference| {
+                checkpoint
+                    .tables
+                    .iter()
+                    .any(|coordinate| checkpoint_table_matches_reference(coordinate, reference))
+            })
+        {
+            return checkpoint_issue(name, "checkpoint_table_coordinate_missing", "checkpoint");
+        }
+        for coordinate in &checkpoint.tables {
+            let metadata = match TableMetadata::read_from(
+                &self.file_io,
+                &coordinate.metadata_location,
+            )
+            .await
             {
-                CheckpointHealth {
-                    name: name.to_string(),
-                    status: HealthStatus::Degraded,
-                    issue: Some("checkpoint or a referenced immutable target is missing".into()),
+                Ok(metadata) => metadata,
+                Err(_) => {
+                    return checkpoint_issue(name, "checkpoint_metadata_missing", "table_metadata")
+                }
+            };
+            if metadata.uuid().to_string() != coordinate.table_uuid {
+                return checkpoint_issue(name, "checkpoint_table_uuid_mismatch", "table_metadata");
+            }
+            if metadata.current_schema_id() != coordinate.schema_id {
+                return checkpoint_issue(name, "checkpoint_schema_id_mismatch", "table_metadata");
+            }
+            if metadata.current_snapshot_id() != coordinate.snapshot_id {
+                return checkpoint_issue(name, "checkpoint_snapshot_id_mismatch", "table_metadata");
+            }
+            let namespace = match NamespaceIdent::from_vec(coordinate.namespace.clone()) {
+                Ok(namespace) => namespace,
+                Err(_) => {
+                    return checkpoint_issue(
+                        name,
+                        "checkpoint_table_coordinate_invalid",
+                        "checkpoint",
+                    )
+                }
+            };
+            let table = match iceberg::table::Table::builder()
+                .identifier(TableIdent::new(namespace, coordinate.table.clone()))
+                .metadata(metadata)
+                .metadata_location(coordinate.metadata_location.clone())
+                .file_io(self.file_io.clone())
+                .runtime(self.runtime.clone())
+                .build()
+            {
+                Ok(table) => table,
+                Err(_) => {
+                    return checkpoint_issue(name, "checkpoint_metadata_invalid", "table_metadata")
+                }
+            };
+            if let Some(snapshot_id) = coordinate.snapshot_id {
+                let Some(snapshot) = table.metadata().snapshot_by_id(snapshot_id) else {
+                    return checkpoint_issue(name, "checkpoint_snapshot_missing", "table_metadata");
+                };
+                let manifests = match table.manifest_list_reader(snapshot).load().await {
+                    Ok(manifests) => manifests,
+                    Err(_) => {
+                        return checkpoint_issue(
+                            name,
+                            "checkpoint_manifest_list_missing",
+                            "manifest_list",
+                        )
+                    }
+                };
+                for manifest_file in manifests.entries() {
+                    let manifest = match manifest_file.load_manifest(&self.file_io).await {
+                        Ok(manifest) => manifest,
+                        Err(_) => {
+                            return checkpoint_issue(
+                                name,
+                                "checkpoint_manifest_missing",
+                                "manifest",
+                            )
+                        }
+                    };
+                    for entry in manifest.entries().iter().filter(|entry| entry.is_alive()) {
+                        let file = match self.file_io.new_input(entry.file_path()) {
+                            Ok(file) => file,
+                            Err(_) => {
+                                return checkpoint_issue(
+                                    name,
+                                    "checkpoint_data_file_unreadable",
+                                    "data_file",
+                                )
+                            }
+                        };
+                        match file.exists().await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                return checkpoint_issue(
+                                    name,
+                                    "checkpoint_data_file_missing",
+                                    "data_file",
+                                )
+                            }
+                            Err(_) => {
+                                return checkpoint_issue(
+                                    name,
+                                    "checkpoint_data_file_unreadable",
+                                    "data_file",
+                                )
+                            }
+                        }
+                    }
                 }
             }
-            Err(_) => CheckpointHealth {
-                name: name.to_string(),
-                status: HealthStatus::Degraded,
-                issue: Some("checkpoint evidence is invalid or unavailable".into()),
-            },
+        }
+        CheckpointHealth {
+            name: name.to_string(),
+            status: HealthStatus::Healthy,
+            issue: None,
         }
     }
 
@@ -1595,6 +1962,18 @@ fn decode_head(bytes: &[u8]) -> Result<CatalogHead> {
     Ok(head)
 }
 
+fn decode_head_for_health(bytes: &[u8]) -> std::result::Result<CatalogHead, &'static str> {
+    let head: CatalogHead =
+        serde_json::from_slice(bytes).map_err(|_| "catalog_head_decode_failure")?;
+    if head.format_version != SPACE_FORMAT_VERSION {
+        return Err("catalog_head_decode_failure");
+    }
+    if head.checksum != head_checksum(&head).map_err(|_| "catalog_head_decode_failure")? {
+        return Err("catalog_head_checksum_mismatch");
+    }
+    Ok(head)
+}
+
 fn encode_publication(publication: &PublicationRecord) -> Result<Vec<u8>> {
     let mut publication = publication.clone();
     publication.checksum = publication_checksum(&publication)?;
@@ -1616,6 +1995,34 @@ fn decode_publication(bytes: &[u8]) -> Result<PublicationRecord> {
         ));
     }
     Ok(publication)
+}
+
+fn decode_publication_for_health(
+    bytes: &[u8],
+) -> std::result::Result<PublicationRecord, &'static str> {
+    let publication: PublicationRecord =
+        serde_json::from_slice(bytes).map_err(|_| "publication_decode_failure")?;
+    if publication.checksum
+        != publication_checksum(&publication).map_err(|_| "publication_decode_failure")?
+    {
+        return Err("publication_checksum_mismatch");
+    }
+    if publication.next_head.checksum != publication.next_head_checksum {
+        return Err("publication_head_mismatch");
+    }
+    Ok(publication)
+}
+
+fn health_issue(code: &'static str, target: &'static str) -> HealthIssue {
+    HealthIssue { code, target }
+}
+
+fn checkpoint_issue(name: &str, code: &'static str, target: &'static str) -> CheckpointHealth {
+    CheckpointHealth {
+        name: name.to_string(),
+        status: HealthStatus::Degraded,
+        issue: Some(health_issue(code, target)),
+    }
 }
 
 fn preserve_schema_field_ids(

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -313,9 +313,10 @@ impl SpaceCatalog {
                 self.unavailable_head_health(checkpoint_names, "catalog_head_identity_mismatch")
             );
         }
-        if let Err(issue) = self.validate_publication_chain_for_health(&head).await {
-            return Ok(self.unavailable_head_health(checkpoint_names, issue));
-        }
+        let publication_issue = self
+            .validate_publication_chain_for_health(&head)
+            .await
+            .err();
         let mut tables = Vec::with_capacity(head.tables.len());
         for reference in head.tables.values() {
             tables.push(self.table_health(reference).await);
@@ -332,9 +333,10 @@ impl SpaceCatalog {
             checkpoints.push(self.checkpoint_health(name).await);
         }
 
-        let status = if tables
-            .iter()
-            .any(|table| table.status == HealthStatus::Degraded)
+        let status = if publication_issue.is_some()
+            || tables
+                .iter()
+                .any(|table| table.status == HealthStatus::Degraded)
             || checkpoints
                 .iter()
                 .any(|checkpoint| checkpoint.status == HealthStatus::Degraded)
@@ -351,7 +353,7 @@ impl SpaceCatalog {
                 etag: exact.etag,
                 generation: Some(head.generation),
                 form_registry_generation: Some(head.form_registry_generation),
-                issue: None,
+                issue: publication_issue.map(|code| health_issue(code, "publication")),
             },
             tables,
             checkpoints,
@@ -444,7 +446,9 @@ impl SpaceCatalog {
         let Some(mut path) = head.publication_location.clone() else {
             return Err("publication_missing");
         };
-        let mut expected_head = head.clone();
+        let mut expected_generation = head.generation;
+        let mut expected_checksum = head.checksum.clone();
+        let mut is_head_publication = true;
         let mut visited = BTreeSet::new();
         loop {
             if !visited.insert(path.clone()) {
@@ -453,7 +457,7 @@ impl SpaceCatalog {
             let bytes = match self.store.read_publication(&path).await {
                 Ok(bytes) => bytes,
                 Err(error) if error.kind() == opendal::ErrorKind::NotFound => {
-                    return Err(if expected_head == *head {
+                    return Err(if is_head_publication {
                         "publication_missing"
                     } else {
                         "publication_predecessor_missing"
@@ -462,13 +466,14 @@ impl SpaceCatalog {
                 Err(_) => return Err("publication_unreadable"),
             };
             let publication = decode_publication_for_health(&bytes)?;
-            if publication.generation != expected_head.generation
-                || publication.next_head_checksum != expected_head.checksum
-                || publication.next_head != expected_head
-                || expected_head.publication_command_id.as_deref()
-                    != Some(publication.command_id.as_str())
+            if publication.generation != expected_generation
+                || publication.next_head_checksum != expected_checksum
+                || (is_head_publication && publication.next_head != *head)
+                || (is_head_publication
+                    && head.publication_command_id.as_deref()
+                        != Some(publication.command_id.as_str()))
             {
-                return Err(if expected_head == *head {
+                return Err(if is_head_publication {
                     "publication_head_mismatch"
                 } else {
                     "publication_chain_corrupt"
@@ -484,28 +489,9 @@ impl SpaceCatalog {
                     if previous_generation + 1 == publication.generation =>
                 {
                     path = previous_path;
-                    // A predecessor's `next_head` is the Head we must match
-                    // before taking its own predecessor link.
-                    let bytes = match self.store.read_publication(&path).await {
-                        Ok(bytes) => bytes,
-                        Err(error) if error.kind() == opendal::ErrorKind::NotFound => {
-                            return Err("publication_predecessor_missing");
-                        }
-                        Err(_) => return Err("publication_unreadable"),
-                    };
-                    let predecessor = decode_publication_for_health(&bytes)?;
-                    if predecessor.generation != previous_generation
-                        || predecessor.next_head_checksum != previous_checksum
-                    {
-                        return Err("publication_chain_gap");
-                    }
-                    expected_head = predecessor.next_head.clone();
-                    // Re-read is deliberately avoided on the next iteration
-                    // only when traversal state is simple; validating the
-                    // predecessor as `expected_head` still requires its full
-                    // immutable record, which this loop obtains below.
-                    // Store it nowhere: doctor must not construct a shadow
-                    // Catalog from history.
+                    expected_generation = previous_generation;
+                    expected_checksum = previous_checksum;
+                    is_head_publication = false;
                 }
                 _ => return Err("publication_chain_gap"),
             }

--- a/crates/ugoite-iceberg/tests/health.rs
+++ b/crates/ugoite-iceberg/tests/health.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeMap;
+
+use ugoite_domain::entry::{EntryMetadata, EntryOperation, EntryRevision, FieldValue};
+use ugoite_domain::form::{FieldType, FormDefinition, FormField, FormVersion};
+use ugoite_domain::id::{FieldId, FormId, SpaceId};
+use ugoite_iceberg::{health::HealthStatus, publication_context, IcebergWorkspace};
+use ugoite_storage::operator_from_uri;
+use uuid::Uuid;
+
+fn form() -> FormDefinition {
+    FormDefinition {
+        id: FormId::from(Uuid::from_u128(200)),
+        version: FormVersion::new(1).expect("test Form version"),
+        name: "Health".into(),
+        description: None,
+        fields: vec![FormField {
+            id: FieldId::new(100).expect("test field ID"),
+            name: "title".into(),
+            field_type: FieldType::String,
+            required: false,
+            label: None,
+            description: None,
+            semantic_role: None,
+            reference_form: None,
+            validation: None,
+            enum_values: Vec::new(),
+            deprecated: false,
+        }],
+        allow_extra_attributes: false,
+        extension_metadata: BTreeMap::new(),
+    }
+}
+
+fn revision(form: &FormDefinition) -> EntryRevision {
+    EntryRevision {
+        form_id: form.id,
+        entry_id: Uuid::from_u128(201).into(),
+        revision_id: Uuid::from_u128(202).into(),
+        parent_revision_id: None,
+        entry_version: 1,
+        expected_version: None,
+        operation: EntryOperation::Upsert,
+        committed_at_micros: 1,
+        author_id: "human:owner".into(),
+        form_version: form.version,
+        source_kind: "test".into(),
+        source_id: None,
+        entry: EntryMetadata::default(),
+        values: [(
+            FieldId::new(100).expect("test field ID"),
+            FieldValue::String("safe".into()),
+        )]
+        .into_iter()
+        .collect(),
+        extra_attributes: BTreeMap::new(),
+        extension_metadata: BTreeMap::new(),
+    }
+}
+
+#[tokio::test]
+async fn health_uses_only_reachable_metadata_and_redacts_locations() -> anyhow::Result<()> {
+    let warehouse = "memory://health-evidence";
+    let space_id = SpaceId::from(Uuid::from_u128(203));
+    let workspace = IcebergWorkspace::memory_for_tests(space_id, warehouse).await?;
+    let form = form();
+    workspace
+        .commit(publication_context(
+            "health-form",
+            "test.form.create",
+            &form,
+        )?)?
+        .create_form(&form)
+        .await?;
+    workspace
+        .commit(publication_context(
+            "health-entry",
+            "test.entry.append",
+            &revision(&form),
+        )?)?
+        .append_revisions(form.id, vec![revision(&form)])
+        .await?;
+    let checkpoint = workspace.capture_checkpoint().await?;
+    workspace.save_checkpoint("healthy", &checkpoint).await?;
+
+    let head_path = format!(
+        "test/space_{}/_ugoite/catalog/head.json",
+        space_id.as_uuid().simple()
+    );
+    let operator = operator_from_uri(warehouse)?;
+    let before = operator.read(&head_path).await?.to_vec();
+    let report = workspace
+        .health_report(&["healthy".into(), "missing".into()])
+        .await?;
+    let after = operator.read(&head_path).await?.to_vec();
+
+    assert_eq!(before, after, "health must not mutate Catalog Head");
+    assert_eq!(report.status, HealthStatus::Degraded);
+    assert!(report.catalog_head.readable);
+    assert!(report.catalog_head.checksum.is_some());
+    assert_eq!(report.tables.len(), 1);
+    assert_eq!(report.tables[0].status, HealthStatus::Healthy);
+    assert_eq!(
+        report.tables[0].form_id.as_deref(),
+        Some(form.id.to_string().as_str())
+    );
+    assert!(report.tables[0].snapshot_count.unwrap_or_default() >= 1);
+    assert!(report.tables[0].manifest_count.unwrap_or_default() >= 1);
+    assert!(report.tables[0].metadata_location_redacted);
+    assert_eq!(report.checkpoints[0].status, HealthStatus::Healthy);
+    assert_eq!(report.checkpoints[1].status, HealthStatus::Degraded);
+    let json = serde_json::to_string(&report)?;
+    let value: serde_json::Value = serde_json::from_str(&json)?;
+    assert!(value.pointer("/tables/0/metadata_location").is_none());
+    assert!(!json.contains("memory://"));
+    assert!(report.unreachable_failed_attempts.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_reports_an_unreadable_catalog_head_without_storage_inference() -> anyhow::Result<()>
+{
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(204)),
+        "memory://health-missing-head",
+    )
+    .await?;
+
+    let report = workspace
+        .health_report(&["known-checkpoint".into()])
+        .await?;
+
+    assert_eq!(report.status, HealthStatus::Degraded);
+    assert!(!report.catalog_head.readable);
+    assert!(report.catalog_head.checksum.is_none());
+    assert!(report.tables.is_empty());
+    assert_eq!(report.checkpoints[0].status, HealthStatus::Degraded);
+    Ok(())
+}

--- a/crates/ugoite-iceberg/tests/health.rs
+++ b/crates/ugoite-iceberg/tests/health.rs
@@ -105,6 +105,9 @@ async fn health_uses_only_reachable_metadata_and_redacts_locations() -> anyhow::
     );
     assert!(report.tables[0].snapshot_count.unwrap_or_default() >= 1);
     assert!(report.tables[0].manifest_count.unwrap_or_default() >= 1);
+    assert!(report.tables[0].total_data_file_count.unwrap_or_default() >= 1);
+    assert!(report.tables[0].total_record_count.unwrap_or_default() >= 1);
+    assert!(report.tables[0].file_size_distribution.is_some());
     assert!(report.tables[0].metadata_location_redacted);
     assert_eq!(report.checkpoints[0].status, HealthStatus::Healthy);
     assert_eq!(report.checkpoints[1].status, HealthStatus::Degraded);
@@ -113,6 +116,11 @@ async fn health_uses_only_reachable_metadata_and_redacts_locations() -> anyhow::
     assert!(value.pointer("/tables/0/metadata_location").is_none());
     assert!(!json.contains("memory://"));
     assert!(report.unreachable_failed_attempts.is_empty());
+    assert!(!report.backend.shared_write_contract);
+    assert_eq!(
+        serde_json::to_value(&report.backend)?["probe_status"],
+        "active_probe_unavailable"
+    );
     Ok(())
 }
 
@@ -132,7 +140,45 @@ async fn health_reports_an_unreadable_catalog_head_without_storage_inference() -
     assert_eq!(report.status, HealthStatus::Degraded);
     assert!(!report.catalog_head.readable);
     assert!(report.catalog_head.checksum.is_none());
+    assert_eq!(
+        report.catalog_head.issue.as_ref().map(|issue| issue.code),
+        Some("catalog_head_missing")
+    );
     assert!(report.tables.is_empty());
     assert_eq!(report.checkpoints[0].status, HealthStatus::Degraded);
+    Ok(())
+}
+
+#[tokio::test]
+async fn health_classifies_a_corrupt_exact_head_without_disclosing_location() -> anyhow::Result<()>
+{
+    let warehouse = "memory://health-corrupt-head";
+    let space_id = SpaceId::from(Uuid::from_u128(205));
+    let workspace = IcebergWorkspace::memory_for_tests(space_id, warehouse).await?;
+    let definition = form();
+    workspace
+        .commit(publication_context(
+            "health-form",
+            "test.form.create",
+            &definition,
+        )?)?
+        .create_form(&definition)
+        .await?;
+
+    let head_path = format!(
+        "test/space_{}/_ugoite/catalog/head.json",
+        space_id.as_uuid().simple()
+    );
+    operator_from_uri(warehouse)?
+        .write(&head_path, b"not-json".to_vec())
+        .await?;
+
+    let report = workspace.health_report(&[]).await?;
+    assert_eq!(report.status, HealthStatus::Degraded);
+    assert_eq!(
+        report.catalog_head.issue.as_ref().map(|issue| issue.code),
+        Some("catalog_head_decode_failure")
+    );
+    assert!(!serde_json::to_string(&report)?.contains("memory://"));
     Ok(())
 }

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -253,6 +253,7 @@ fn protected_routes(state: AppState) -> Router<AppState> {
         )
         .route("/spaces", get(list_spaces).post(create_space))
         .route("/spaces/{space_id}", get(get_space).patch(patch_space))
+        .route("/spaces/{space_id}/health", get(space_health))
         .route("/spaces/{space_id}/audit", get(list_audit_events))
         .route("/spaces/{space_id}/test-connection", post(test_connection))
         .route(
@@ -3104,6 +3105,32 @@ async fn get_space(
             .map_err(ApiError::from_core)?,
     );
     Ok(Json(value))
+}
+
+#[derive(Default, Deserialize)]
+struct SpaceHealthQuery {
+    #[serde(default)]
+    checkpoint: Vec<String>,
+}
+
+async fn space_health(
+    State(state): State<AppState>,
+    Extension(identity): Extension<RequestIdentityContext>,
+    Path(space_id): Path<String>,
+    Query(query): Query<SpaceHealthQuery>,
+) -> ApiResult<Json<Value>> {
+    require_space_permission(&state, &space_id, &identity, SpacePermission::ManageSpace).await?;
+    state
+        .service
+        .space_health(&space_id, &query.checkpoint)
+        .await
+        .map(Json)
+        .map_err(|_| {
+            ApiError::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Space health evidence is unavailable",
+            )
+        })
 }
 
 async fn patch_space(

--- a/crates/ugoite-server/src/openapi.json
+++ b/crates/ugoite-server/src/openapi.json
@@ -874,6 +874,26 @@
         }
       }
     },
+    "/spaces/{space_id}/health": {
+      "get": {
+        "summary": "Read-only Catalog Head and Iceberg metadata health evidence",
+        "parameters": [
+          {"$ref": "#/components/parameters/SpaceId"},
+          {
+            "name": "checkpoint",
+            "in": "query",
+            "required": false,
+            "description": "A named durable checkpoint to validate. Repeat for multiple checkpoints; storage is never listed.",
+            "schema": {"type": "string"}
+          }
+        ],
+        "responses": {
+          "200": {"description": "Read-only health evidence with redacted physical locations", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/JsonValue"}}}},
+          "403": {"description": "Space management permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
+          "422": {"description": "Invalid checkpoint name or unavailable Catalog evidence", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+        }
+      }
+    },
     "/spaces/{space_id}": {
       "get": {
         "summary": "Get a space",

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -93,3 +93,19 @@ fn openapi_does_not_publish_removed_credentials() {
     assert!(snapshot.pointer("/paths/~1auth~1passkey~1start").is_some());
     assert!(snapshot.pointer("/paths/~1oauth~1token").is_some());
 }
+
+#[test]
+fn openapi_publishes_read_only_space_health() {
+    let snapshot = ugoite_server::openapi_snapshot();
+    let health = snapshot
+        .pointer("/paths/~1spaces~1{space_id}~1health/get")
+        .expect("Space health endpoint");
+    assert!(health["summary"]
+        .as_str()
+        .expect("summary")
+        .contains("Read-only"));
+    assert_eq!(
+        health["parameters"][1]["name"], "checkpoint",
+        "health validates only caller-named checkpoints"
+    );
+}

--- a/crates/ugoite-storage/src/lib.rs
+++ b/crates/ugoite-storage/src/lib.rs
@@ -64,6 +64,18 @@ pub enum CatalogWriteMode {
     SingleProcess,
 }
 
+/// Read-only declaration of the OpenDAL contract backing a Space Catalog.
+/// It deliberately reports only capability bits and whether shared mode was
+/// previously admitted; it never triggers a write probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CatalogBackendCapabilities {
+    pub etag: bool,
+    pub read_with_if_match: bool,
+    pub write_with_if_match: bool,
+    pub write_with_if_not_exists: bool,
+    pub shared_write_contract: bool,
+}
+
 const EXACT_HEAD_READ_ATTEMPTS: usize = 3;
 
 /// Narrow OpenDAL boundary for the Space Catalog root and immutable
@@ -433,6 +445,21 @@ impl SpaceCatalogStore {
         capabilities.read_with_if_match
             && capabilities.write_with_if_match
             && capabilities.write_with_if_not_exists
+    }
+
+    pub fn backend_capabilities(&self) -> CatalogBackendCapabilities {
+        let capabilities = self.operator.info().full_capability();
+        let shared_write_contract = self.supports_shared_writes();
+        CatalogBackendCapabilities {
+            // OpenDAL exposes ETags through stat metadata rather than a
+            // separate capability bit. Exact shared Head reads additionally
+            // require the conditional-read contract.
+            etag: capabilities.stat && capabilities.read_with_if_match,
+            read_with_if_match: capabilities.read_with_if_match,
+            write_with_if_match: capabilities.write_with_if_match,
+            write_with_if_not_exists: capabilities.write_with_if_not_exists,
+            shared_write_contract,
+        }
     }
 
     fn catalog_path(&self, suffix: &str) -> String {

--- a/crates/ugoite-storage/src/lib.rs
+++ b/crates/ugoite-storage/src/lib.rs
@@ -308,8 +308,8 @@ impl SpaceCatalogStore {
                 .etag()
                 .filter(|etag| !etag.is_empty())
                 .map(str::to_owned);
-            let read = match (self.write_mode, etag.as_deref()) {
-                (CatalogWriteMode::Shared, Some(etag)) => self
+            let read = match etag.as_deref() {
+                Some(etag) => self
                     .operator
                     .read_options(
                         &path,
@@ -320,18 +320,15 @@ impl SpaceCatalogStore {
                     )
                     .await
                     .map(|bytes| bytes.to_vec()),
-                (CatalogWriteMode::Shared, None) => {
+                None if self.write_mode == CatalogWriteMode::Shared => {
                     return Err(anyhow!("Catalog Head stat did not return an ETag"));
                 }
-                (CatalogWriteMode::SingleProcess, _) => {
-                    self.operator.read(&path).await.map(|bytes| bytes.to_vec())
-                }
+                None => self.operator.read(&path).await.map(|bytes| bytes.to_vec()),
             };
             match read {
                 Ok(bytes) => return Ok(Some(ExactCatalogHead { bytes, etag })),
                 Err(error)
-                    if self.write_mode == CatalogWriteMode::Shared
-                        && error.kind() == ErrorKind::ConditionNotMatch
+                    if error.kind() == ErrorKind::ConditionNotMatch
                         && attempt + 1 < EXACT_HEAD_READ_ATTEMPTS =>
                 {
                     continue;

--- a/docs/spec/api/openapi.yaml
+++ b/docs/spec/api/openapi.yaml
@@ -874,6 +874,26 @@
         }
       }
     },
+    "/spaces/{space_id}/health": {
+      "get": {
+        "summary": "Read-only Catalog Head and Iceberg metadata health evidence",
+        "parameters": [
+          {"$ref": "#/components/parameters/SpaceId"},
+          {
+            "name": "checkpoint",
+            "in": "query",
+            "required": false,
+            "description": "A named durable checkpoint to validate. Repeat for multiple checkpoints; storage is never listed.",
+            "schema": {"type": "string"}
+          }
+        ],
+        "responses": {
+          "200": {"description": "Read-only health evidence with redacted physical locations", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/JsonValue"}}}},
+          "403": {"description": "Space management permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
+          "422": {"description": "Invalid checkpoint name or unavailable Catalog evidence", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+        }
+      }
+    },
     "/spaces/{space_id}": {
       "get": {
         "summary": "Get a space",

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -41,10 +41,11 @@ for `entry` or `asset`.
 `POST /spaces/{space_id}/bindings/rebind-owner` binds an imported Space owner to
 the current Node administrator after migration.
 `GET /spaces/{space_id}/health` is a Space-management read-only doctor report.
-It follows only the exact Catalog Head, reachable Iceberg metadata, upstream
-manifest lists, and caller-named checkpoints. It never scans Entry rows, lists
-objects to infer authority or orphans, or repairs storage; physical locations
-are redacted from its normal response.
+It follows only the exact Catalog Head, its reachable immutable publication
+chain, Iceberg metadata, manifest lists/manifests, and caller-named
+checkpoints. It never scans Entry rows, lists objects to infer authority or
+orphans, or repairs storage; physical locations are redacted from its normal
+response.
 
 Errors are structured JSON. Authentication failures use 401; valid identities
 lacking Space/token/resource permission use 403; stale/used one-time credentials

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -40,6 +40,11 @@ sessions, MCP, agents, and resource policies are represented in OpenAPI.
 for `entry` or `asset`.
 `POST /spaces/{space_id}/bindings/rebind-owner` binds an imported Space owner to
 the current Node administrator after migration.
+`GET /spaces/{space_id}/health` is a Space-management read-only doctor report.
+It follows only the exact Catalog Head, reachable Iceberg metadata, upstream
+manifest lists, and caller-named checkpoints. It never scans Entry rows, lists
+objects to infer authority or orphans, or repairs storage; physical locations
+are redacted from its normal response.
 
 Errors are structured JSON. Authentication failures use 401; valid identities
 lacking Space/token/resource permission use 403; stale/used one-time credentials

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -8,10 +8,9 @@ Space format version is unchanged, while legacy layouts and catalog modes are
 unsupported rather than migrated.
 
 The Catalog Head layout, upstream physical boundary, single mutation
-coordinator, checkpoint-pinned revision reads, and authorization-aware
-DataFusion context are implemented by the current persistence work. Health
-evidence remains follow-up work; this document does not advertise it as a
-current product API.
+coordinator, checkpoint-pinned revision reads, authorization-aware DataFusion
+context, and read-only health evidence are implemented by the current
+persistence work.
 
 ## Authority and ownership
 
@@ -112,6 +111,21 @@ become a generic OpenDAL wrapper.
 schemas, typed Arrow conversion, upstream writers, table commits, snapshots,
 DataFusion, checkpoints, and health evidence. Its physical upstream types do
 not cross into Core.
+
+## Read-only health evidence
+
+The health endpoint starts from one exact Catalog Head and reads only the
+referenced Iceberg metadata and upstream manifest list. It reports the Head
+checksum, generation, Form registry generation, table identifiers, Form IDs,
+UUIDs, schemas, snapshots, snapshot-summary counts, and manifest counts/size.
+Physical locations are redacted from the normal API response.
+
+Named checkpoints are caller-supplied and validated through their immutable
+publication and metadata targets; health never lists checkpoint storage. The
+current upstream Rust Iceberg metadata tables expose snapshots and manifests,
+but not a files table for a size distribution, so that capability is explicit
+as unavailable. Failed-attempt and orphan candidates remain empty unless
+durable attempt coordinates exist: object-list inference is forbidden.
 
 `ugoite-core` owns domain validation, authorization meaning, use-case
 orchestration, domain commands, receipts, checkpoints, and errors. It neither

--- a/docs/spec/architecture/space-catalog.md
+++ b/docs/spec/architecture/space-catalog.md
@@ -114,18 +114,21 @@ not cross into Core.
 
 ## Read-only health evidence
 
-The health endpoint starts from one exact Catalog Head and reads only the
-referenced Iceberg metadata and upstream manifest list. It reports the Head
-checksum, generation, Form registry generation, table identifiers, Form IDs,
-UUIDs, schemas, snapshots, snapshot-summary counts, and manifest counts/size.
-Physical locations are redacted from the normal API response.
+The health endpoint starts from one exact Catalog Head, verifies its whole
+reachable immutable publication chain, and reads only referenced Iceberg
+metadata plus upstream manifest lists and manifests. It reports stable,
+redacted issue codes, the Head checksum/generation/Form registry generation,
+table identifiers/Form IDs/UUIDs/schemas/snapshots, and live data-file
+count/record/size distribution evidence. Physical locations are redacted from
+the normal API response.
 
-Named checkpoints are caller-supplied and validated through their immutable
-publication and metadata targets; health never lists checkpoint storage. The
-current upstream Rust Iceberg metadata tables expose snapshots and manifests,
-but not a files table for a size distribution, so that capability is explicit
-as unavailable. Failed-attempt and orphan candidates remain empty unless
-durable attempt coordinates exist: object-list inference is forbidden.
+Named checkpoints are caller-supplied and validated through immutable
+publication, metadata, manifest, and data-file targets; health never lists
+checkpoint storage. File evidence comes from upstream manifest entries, not a
+metadata-table scan. Backend conditional-write capabilities and the durable
+probe status are returned separately from unavailable orphan/failed-attempt
+evidence. Failed-attempt and orphan candidates remain empty unless durable
+attempt coordinates exist: object-list inference is forbidden.
 
 `ugoite-core` owns domain validation, authorization meaning, use-case
 orchestration, domain commands, receipts, checkpoints, and errors. It neither

--- a/frontend/src/lib/generated/openapi-types.ts
+++ b/frontend/src/lib/generated/openapi-types.ts
@@ -85,6 +85,7 @@ export const OPENAPI_PATHS = [
   "/spaces/{space_id}/forms",
   "/spaces/{space_id}/forms/types",
   "/spaces/{space_id}/forms/{form_name}",
+  "/spaces/{space_id}/health",
   "/spaces/{space_id}/members",
   "/spaces/{space_id}/members/invitations",
   "/spaces/{space_id}/members/{principal_id}",

--- a/frontend/src/lib/ugoite-client/protocol.ts
+++ b/frontend/src/lib/ugoite-client/protocol.ts
@@ -13,6 +13,7 @@ export const UGOITE_API_OPERATIONS = [
   "space.list",
   "space.create",
   "space.get",
+  "space.health",
   "space.patch",
   "space.test_connection",
   "space.members.list",


### PR DESCRIPTION
## Summary

- add a read-only Space health endpoint backed only by exact Catalog Head, reachable Iceberg metadata, and upstream manifest-list reads
- report degraded Head/table/checkpoint evidence without row scans, object listing, repairs, or physical-location disclosure
- expose the portable `space.health` operation and synchronize OpenAPI/docs

## Related Issue (required)

closes #1826

## Testing

- [x] `cargo test -p ugoite-iceberg --test health`
- [x] `cargo test -p ugoite-api-client`
- [x] `cargo run -p xtask -- openapi-check`
- [x] `cargo fmt --all -- --check`
- [ ] Server contract test and clippy were attempted but the local volume ran out of space while compiling the server dependency graph.
