### PR TITLE
feat: pin SQL sessions to checkpoints with bounded pagination

### DIFF
--- a/crates/ugoite-core/src/query.rs
+++ b/crates/ugoite-core/src/query.rs
@@ -31,13 +31,18 @@ pub struct AuthorizedQueryForm {
     pub system_columns: BTreeSet<QuerySystemColumn>,
 }
 
-/// The Entry set that a relation may expose. Local core mode can authorize the
-/// whole Form without first materializing its current Entries into Rust; remote
-/// callers use the explicit ID set supplied by Core authorization.
+/// The Entry set that a relation may expose. Core can authorize the whole Form
+/// without first materializing its current Entries into Rust; remote callers
+/// use either an explicit allow-list or sparse Entry-level exceptions supplied
+/// by the authorization boundary.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EntryScope {
     AllCurrent,
     Only(BTreeSet<EntryId>),
+    /// Exposes the current Form without materializing every permitted Entry
+    /// ID in Core. The trusted DataFusion view removes the listed exceptions
+    /// before it derives each Entry's latest revision.
+    AllExcept(BTreeSet<EntryId>),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]

--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -15,6 +15,11 @@ pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 1;
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CheckpointTable {
     pub form_id: FormId,
+    /// The Form relation captured from immutable Iceberg metadata. It lets a
+    /// query session resolve one requested Form without loading every Form
+    /// definition from the checkpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub form_name: Option<String>,
     pub namespace: Vec<String>,
     pub table: String,
     pub table_uuid: String,
@@ -83,10 +88,19 @@ impl SpaceCheckpoint {
     /// their immutable publication and Catalog Head by the Iceberg adapter.
     pub fn validate_structure(&self) -> Result<(), &'static str> {
         let mut forms = BTreeSet::new();
+        let mut form_names = BTreeSet::new();
         let mut identifiers = BTreeSet::new();
         for table in &self.tables {
             if !forms.insert(table.form_id) {
                 return Err("checkpoint contains a duplicate Form ID");
+            }
+            if let Some(form_name) = &table.form_name {
+                if form_name.trim().is_empty() {
+                    return Err("checkpoint Form relation is empty");
+                }
+                if !form_names.insert(form_name.to_ascii_lowercase()) {
+                    return Err("checkpoint contains duplicate Form relations");
+                }
             }
             if table.namespace.is_empty() || table.namespace.iter().any(|part| part.is_empty()) {
                 return Err("checkpoint table namespace is empty or invalid");
@@ -167,6 +181,7 @@ mod tests {
             2,
             vec![CheckpointTable {
                 form_id: FormId::from(Uuid::from_u128(2)),
+                form_name: Some("form".into()),
                 namespace: vec!["space_1".into()],
                 table: "form_2".into(),
                 table_uuid: "table".into(),

--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -18,8 +18,7 @@ pub struct CheckpointTable {
     /// The Form relation captured from immutable Iceberg metadata. It lets a
     /// query session resolve one requested Form without loading every Form
     /// definition from the checkpoint.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub form_name: Option<String>,
+    pub form_name: String,
     pub namespace: Vec<String>,
     pub table: String,
     pub table_uuid: String,
@@ -94,13 +93,11 @@ impl SpaceCheckpoint {
             if !forms.insert(table.form_id) {
                 return Err("checkpoint contains a duplicate Form ID");
             }
-            if let Some(form_name) = &table.form_name {
-                if form_name.trim().is_empty() {
-                    return Err("checkpoint Form relation is empty");
-                }
-                if !form_names.insert(form_name.to_ascii_lowercase()) {
-                    return Err("checkpoint contains duplicate Form relations");
-                }
+            if table.form_name.trim().is_empty() {
+                return Err("checkpoint Form relation is empty");
+            }
+            if !form_names.insert(table.form_name.to_ascii_lowercase()) {
+                return Err("checkpoint contains duplicate Form relations");
             }
             if table.namespace.is_empty() || table.namespace.iter().any(|part| part.is_empty()) {
                 return Err("checkpoint table namespace is empty or invalid");
@@ -181,7 +178,7 @@ mod tests {
             2,
             vec![CheckpointTable {
                 form_id: FormId::from(Uuid::from_u128(2)),
-                form_name: Some("form".into()),
+                form_name: "form".into(),
                 namespace: vec!["space_1".into()],
                 table: "form_2".into(),
                 table_uuid: "table".into(),

--- a/crates/ugoite-iceberg/src/authorization.rs
+++ b/crates/ugoite-iceberg/src/authorization.rs
@@ -202,74 +202,7 @@ impl Authorizer {
         resource: Option<&ResourceRef>,
     ) -> Result<BTreeSet<Action>> {
         let state = self.state(space_id).await?;
-        let principal = state
-            .principals
-            .get(&principal_id)
-            .filter(|principal| matches!(principal.state, PrincipalState::Active))
-            .ok_or_else(|| AppError::forbidden("principal is not active in this space"))?;
-        if !matches!(principal.kind, PrincipalKind::Human | PrincipalKind::Agent) {
-            return Ok(BTreeSet::new());
-        }
-        let mut effective = if matches!(principal.kind, PrincipalKind::Agent) {
-            let agent = state
-                .agents
-                .get(&principal_id)
-                .filter(|agent| matches!(agent.status, PrincipalState::Active))
-                .ok_or_else(|| AppError::forbidden("agent is not active"))?;
-            if !state
-                .principals
-                .get(&agent.sponsor_principal_id)
-                .is_some_and(|sponsor| {
-                    matches!(sponsor.kind, PrincipalKind::Human)
-                        && matches!(sponsor.state, PrincipalState::Active)
-                })
-            {
-                return Err(AppError::forbidden("agent sponsor is not active").into());
-            }
-            let expires_at = agent
-                .expires_at
-                .as_deref()
-                .ok_or_else(|| AppError::forbidden("agent has no expiry or review deadline"))?;
-            if chrono::DateTime::parse_from_rfc3339(expires_at)
-                .context("invalid agent expiry")?
-                .with_timezone(&Utc)
-                <= Utc::now()
-            {
-                return Err(
-                    AppError::forbidden("agent expiry or review deadline has passed").into(),
-                );
-            }
-            state
-                .agent_grants
-                .get(&principal_id)
-                .cloned()
-                .unwrap_or_default()
-        } else {
-            let membership = state
-                .memberships
-                .get(&principal_id)
-                .ok_or_else(|| AppError::forbidden("principal is not a member of this space"))?;
-            role_actions(&membership.role)
-        };
-        if let Some(resource) = resource {
-            if let Some(parent) = resource.parent.as_deref() {
-                effective =
-                    evaluate_policy(&effective, principal_id, state.policies.get(&parent.key()));
-            }
-            effective = evaluate_policy(
-                &effective,
-                principal_id,
-                state.policies.get(&resource.key()),
-            );
-        }
-        if state
-            .memberships
-            .get(&principal_id)
-            .is_some_and(|membership| matches!(membership.role, SpaceRole::Owner))
-        {
-            effective.extend(role_actions(&SpaceRole::Owner));
-        }
-        Ok(effective)
+        effective_actions_for_state(&state, principal_id, resource)
     }
 
     pub async fn require(
@@ -835,6 +768,82 @@ impl Authorizer {
         }
         Ok(())
     }
+}
+
+/// Evaluates authorization against one already-read state snapshot. Query
+/// session creation uses this to derive its scope and fingerprint from the
+/// same state without an Entry-by-Entry OpenDAL reread.
+pub(crate) fn effective_actions_for_state(
+    state: &AuthorizationState,
+    principal_id: Uuid,
+    resource: Option<&ResourceRef>,
+) -> Result<BTreeSet<Action>> {
+    let principal = state
+        .principals
+        .get(&principal_id)
+        .filter(|principal| matches!(principal.state, PrincipalState::Active))
+        .ok_or_else(|| AppError::forbidden("principal is not active in this space"))?;
+    if !matches!(principal.kind, PrincipalKind::Human | PrincipalKind::Agent) {
+        return Ok(BTreeSet::new());
+    }
+    let mut effective = if matches!(principal.kind, PrincipalKind::Agent) {
+        let agent = state
+            .agents
+            .get(&principal_id)
+            .filter(|agent| matches!(agent.status, PrincipalState::Active))
+            .ok_or_else(|| AppError::forbidden("agent is not active"))?;
+        if !state
+            .principals
+            .get(&agent.sponsor_principal_id)
+            .is_some_and(|sponsor| {
+                matches!(sponsor.kind, PrincipalKind::Human)
+                    && matches!(sponsor.state, PrincipalState::Active)
+            })
+        {
+            return Err(AppError::forbidden("agent sponsor is not active").into());
+        }
+        let expires_at = agent
+            .expires_at
+            .as_deref()
+            .ok_or_else(|| AppError::forbidden("agent has no expiry or review deadline"))?;
+        if chrono::DateTime::parse_from_rfc3339(expires_at)
+            .context("invalid agent expiry")?
+            .with_timezone(&Utc)
+            <= Utc::now()
+        {
+            return Err(AppError::forbidden("agent expiry or review deadline has passed").into());
+        }
+        state
+            .agent_grants
+            .get(&principal_id)
+            .cloned()
+            .unwrap_or_default()
+    } else {
+        let membership = state
+            .memberships
+            .get(&principal_id)
+            .ok_or_else(|| AppError::forbidden("principal is not a member of this space"))?;
+        role_actions(&membership.role)
+    };
+    if let Some(resource) = resource {
+        if let Some(parent) = resource.parent.as_deref() {
+            effective =
+                evaluate_policy(&effective, principal_id, state.policies.get(&parent.key()));
+        }
+        effective = evaluate_policy(
+            &effective,
+            principal_id,
+            state.policies.get(&resource.key()),
+        );
+    }
+    if state
+        .memberships
+        .get(&principal_id)
+        .is_some_and(|membership| matches!(membership.role, SpaceRole::Owner))
+    {
+        effective.extend(role_actions(&SpaceRole::Owner));
+    }
+    Ok(effective)
 }
 
 fn owner_count(state: &AuthorizationState) -> usize {

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -4,10 +4,12 @@ use base64::Engine as _;
 use chrono::{DateTime, NaiveDate, NaiveTime, SecondsFormat, Timelike, Utc};
 use opendal::Operator;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use serde_yaml;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Duration;
+use ugoite_domain::id::FormId;
 pub use ugoite_domain::text::compute_word_count;
 use uuid::Uuid;
 
@@ -31,6 +33,104 @@ pub struct AuthorizedSqlSessionPage {
     pub checkpoint: SpaceCheckpoint,
     pub offset: usize,
     pub limit: usize,
+}
+
+/// Durable, derived authorization policy for one SQL session. It is stored
+/// beside the session metadata rather than in a checkpoint because a
+/// checkpoint intentionally contains only storage coordinates.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqlSessionQueryPolicy {
+    pub forms: Vec<SqlSessionQueryForm>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqlSessionQueryForm {
+    pub form_id: FormId,
+    pub relation: String,
+    pub entry_ids: BTreeSet<String>,
+    pub columns: BTreeSet<String>,
+    pub system_columns: BTreeSet<SqlSessionSystemColumn>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SqlSessionSystemColumn {
+    ExternalId,
+    Title,
+    CreatedAt,
+    UpdatedAt,
+    EntryId,
+    EntryVersion,
+    CommittedAt,
+}
+
+impl SqlSessionQueryPolicy {
+    fn authorized_query_policy(
+        &self,
+        checkpoint: SpaceCheckpoint,
+    ) -> Result<AuthorizedQueryPolicy> {
+        let mut forms = BTreeMap::new();
+        for form in &self.forms {
+            if forms.contains_key(&form.form_id) {
+                return Err(anyhow!("SQL session query policy repeats a Form ID"));
+            }
+            forms.insert(
+                form.form_id,
+                AuthorizedQueryForm {
+                    relation: form.relation.clone(),
+                    entry_scope: EntryScope::Only(entry_scope_from_ids(&form.entry_ids)),
+                    columns: form.columns.clone(),
+                    system_columns: form
+                        .system_columns
+                        .iter()
+                        .copied()
+                        .map(SqlSessionSystemColumn::as_query_system_column)
+                        .collect(),
+                },
+            );
+        }
+        if forms.is_empty() {
+            return Err(anyhow!("SQL session query policy exposes no Forms"));
+        }
+        Ok(AuthorizedQueryPolicy {
+            forms,
+            checkpoint: Some(checkpoint),
+            limits: sql_session_query_limits(),
+        })
+    }
+
+    pub fn readable_entry_ids(&self) -> BTreeSet<String> {
+        self.forms
+            .iter()
+            .flat_map(|form| form.entry_ids.iter().cloned())
+            .collect()
+    }
+}
+
+impl SqlSessionSystemColumn {
+    fn as_query_system_column(self) -> QuerySystemColumn {
+        match self {
+            Self::ExternalId => QuerySystemColumn::ExternalId,
+            Self::Title => QuerySystemColumn::Title,
+            Self::CreatedAt => QuerySystemColumn::CreatedAt,
+            Self::UpdatedAt => QuerySystemColumn::UpdatedAt,
+            Self::EntryId => QuerySystemColumn::EntryId,
+            Self::EntryVersion => QuerySystemColumn::EntryVersion,
+            Self::CommittedAt => QuerySystemColumn::CommittedAt,
+        }
+    }
+}
+
+fn sql_session_query_limits() -> QueryLimits {
+    QueryLimits {
+        max_memory_bytes: SQL_SESSION_MAX_MEMORY_BYTES,
+        max_rows: SQL_SESSION_MAX_ROWS,
+        timeout: SQL_SESSION_TIMEOUT,
+        max_concurrency: 1,
+        allowed_functions: BTreeSet::new(),
+    }
 }
 
 /// Converts transport values to typed DataFusion parameters. A null must carry
@@ -313,67 +413,116 @@ pub async fn execute_sql_query_authorized_by_form_page_at_checkpoint(
     op: &Operator,
     ws_path: &str,
     sql_query: &str,
-    readable_entries_by_form: &BTreeMap<String, HashSet<String>>,
+    policy: &SqlSessionQueryPolicy,
     page: AuthorizedSqlSessionPage,
 ) -> Result<(Vec<Value>, u64)> {
-    validate_sql_session_page_shape(sql_query)?;
-    let relation_scopes = readable_entries_by_form
-        .iter()
-        .map(|(relation, entries)| {
-            (
-                relation.to_ascii_lowercase(),
-                EntryScope::Only(entry_scope(entries)),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-    execute_datafusion_sql_page(
-        op,
-        ws_path,
-        sql_query,
-        EntryScope::AllCurrent,
-        None,
-        Some(&relation_scopes),
-        Some(page.checkpoint),
-        page.offset,
-        page.limit,
-        page.parameters,
-    )
-    .await
+    let context = datafusion_sql_session_context(op, ws_path, policy, page.checkpoint)
+        .await
+        .map_err(map_sql_error)?;
+    let (batches, count) = context
+        .execute_session_page(sql_query, page.parameters, page.offset, page.limit)
+        .await
+        .map_err(map_sql_error)?;
+    Ok((record_batches_to_values(&batches)?, count))
 }
 
-/// Validates a SQL-session query at creation against its frozen checkpoint and
-/// current authorization boundary without materializing any result rows.
+/// Executes a count-only session plan. It shares the frozen policy and
+/// checkpoint used for pages but never materializes a sentinel page row.
+pub async fn execute_sql_query_authorized_by_form_count_at_checkpoint(
+    op: &Operator,
+    ws_path: &str,
+    sql_query: &str,
+    policy: &SqlSessionQueryPolicy,
+    parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    checkpoint: SpaceCheckpoint,
+) -> Result<u64> {
+    let context = datafusion_sql_session_context(op, ws_path, policy, checkpoint)
+        .await
+        .map_err(map_sql_error)?;
+    context
+        .execute_session_count(sql_query, parameters)
+        .await
+        .map_err(map_sql_error)
+}
+
+/// Validates a SQL session query at creation against only frozen policy and
+/// checkpoint inputs. The live Form registry is deliberately absent.
 pub async fn validate_sql_session_query_at_checkpoint(
     op: &Operator,
     ws_path: &str,
     sql_query: &str,
-    readable_entries_by_form: &BTreeMap<String, HashSet<String>>,
+    policy: &SqlSessionQueryPolicy,
     parameters: HashMap<String, datafusion::scalar::ScalarValue>,
     checkpoint: SpaceCheckpoint,
 ) -> Result<()> {
     validate_sql_session_page_shape(sql_query)?;
-    let relation_scopes = readable_entries_by_form
-        .iter()
-        .map(|(relation, entries)| {
-            (
-                relation.to_ascii_lowercase(),
-                EntryScope::Only(entry_scope(entries)),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-    datafusion_sql_context(
-        op,
-        ws_path,
-        EntryScope::AllCurrent,
-        None,
-        Some(&relation_scopes),
-        Some(checkpoint),
-    )
-    .await
-    .map_err(map_sql_error)?
-    .validate_with_parameters(sql_query, parameters)
-    .await
-    .map_err(map_sql_error)
+    let context = datafusion_sql_session_context(op, ws_path, policy, checkpoint)
+        .await
+        .map_err(map_sql_error)?;
+    context
+        .validate_session_with_parameters(sql_query, parameters)
+        .await
+        .map_err(map_sql_error)
+}
+
+/// Derives a serializable SQL-session policy from the Form definitions stored
+/// in a checkpoint. A session policy is derived metadata, never Catalog
+/// authority; it is replayed only together with this checkpoint.
+pub async fn sql_session_query_policy_at_checkpoint(
+    op: &Operator,
+    ws_path: &str,
+    readable_entries_by_form: &BTreeMap<String, HashSet<String>>,
+    checkpoint: &SpaceCheckpoint,
+) -> Result<SqlSessionQueryPolicy> {
+    let workspace = crate::iceberg_store::native_workspace(op, ws_path).await?;
+    let forms = workspace.forms_at_checkpoint(checkpoint).await?;
+    let mut seen_relations = BTreeSet::new();
+    let mut policy_forms = Vec::new();
+    for form in forms {
+        let relation = form.name.to_ascii_lowercase();
+        let Some(entry_ids) = readable_entries_by_form.get(&relation) else {
+            continue;
+        };
+        if !seen_relations.insert(relation.clone()) {
+            return Err(anyhow!(
+                "checkpoint exposes duplicate SQL relation {relation}"
+            ));
+        }
+        policy_forms.push(SqlSessionQueryForm {
+            form_id: form.id,
+            relation,
+            entry_ids: entry_ids.iter().cloned().collect(),
+            columns: form.fields.into_iter().map(|field| field.name).collect(),
+            system_columns: [
+                SqlSessionSystemColumn::ExternalId,
+                SqlSessionSystemColumn::Title,
+                SqlSessionSystemColumn::CreatedAt,
+                SqlSessionSystemColumn::UpdatedAt,
+            ]
+            .into_iter()
+            .collect(),
+        });
+    }
+    if policy_forms.is_empty() {
+        return Err(anyhow!("SQL session has no readable checkpoint Form"));
+    }
+    policy_forms.sort_by(|left, right| left.relation.cmp(&right.relation));
+    Ok(SqlSessionQueryPolicy {
+        forms: policy_forms,
+    })
+}
+
+async fn datafusion_sql_session_context(
+    op: &Operator,
+    ws_path: &str,
+    policy: &SqlSessionQueryPolicy,
+    checkpoint: SpaceCheckpoint,
+) -> Result<crate::query_context::AuthorizedQueryContext> {
+    crate::iceberg_store::native_workspace(op, ws_path)
+        .await?
+        .authorized_query_context(policy.authorized_query_policy(checkpoint)?)
+        .await
+        .context("create frozen DataFusion SQL session context")
 }
 
 /// Validates the deliberately small first SQL-session pagination surface before
@@ -386,9 +535,10 @@ pub async fn validate_sql_session_query_at_checkpoint(
 pub fn validate_sql_session_page_shape(sql: &str) -> Result<()> {
     use datafusion::sql::parser::{DFParser, Statement as DataFusionStatement};
     use datafusion::sql::sqlparser::ast::{
-        Expr, GroupByExpr, LimitClause, OrderByKind, SetExpr, Statement as SqlStatement,
-        TableFactor,
+        visit_expressions, Expr, GroupByExpr, LimitClause, OrderByKind, SetExpr,
+        Statement as SqlStatement, TableFactor,
     };
+    use std::ops::ControlFlow;
 
     let statements = DFParser::parse_sql(sql).context("parse SQL session query with DataFusion")?;
     if statements.len() != 1 {
@@ -403,6 +553,21 @@ pub fn validate_sql_session_page_shape(sql: &str) -> Result<()> {
     let SqlStatement::Query(query) = statement.as_ref() else {
         return Err(anyhow!("SQL session paging requires a SELECT statement"));
     };
+    let mut has_expression_subquery = false;
+    let _ = visit_expressions(statement.as_ref(), |expression| {
+        if matches!(
+            expression,
+            Expr::Exists { .. } | Expr::InSubquery { .. } | Expr::Subquery(_)
+        ) {
+            has_expression_subquery = true;
+        }
+        ControlFlow::<()>::Continue(())
+    });
+    if has_expression_subquery {
+        return Err(anyhow!(
+            "SQL session paging does not support expression subqueries"
+        ));
+    }
     if query.with.is_some()
         || query.fetch.is_some()
         || !query.locks.is_empty()
@@ -583,6 +748,11 @@ pub async fn execute_sql_query_scoped_page(
 }
 
 fn entry_scope(entry_ids: &HashSet<String>) -> BTreeSet<ugoite_domain::id::EntryId> {
+    let entry_ids = entry_ids.iter().cloned().collect::<BTreeSet<_>>();
+    entry_scope_from_ids(&entry_ids)
+}
+
+fn entry_scope_from_ids(entry_ids: &BTreeSet<String>) -> BTreeSet<ugoite_domain::id::EntryId> {
     entry_ids
         .iter()
         .map(|entry_id| {

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -18,9 +18,9 @@ use ugoite_core::query::{
     AuthorizedQueryForm, AuthorizedQueryPolicy, EntryScope, QueryLimits, QuerySystemColumn,
 };
 
-const SQL_MAX_ROWS: usize = 1_000;
-const SQL_MAX_MEMORY_BYTES: usize = 64 * 1024 * 1024;
-const SQL_TIMEOUT: Duration = Duration::from_secs(30);
+pub const SQL_SESSION_MAX_ROWS: usize = 1_000;
+pub const SQL_SESSION_MAX_MEMORY_BYTES: usize = 64 * 1024 * 1024;
+pub const SQL_SESSION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Immutable execution inputs for one authorized SQL-session page.
 ///
@@ -316,6 +316,7 @@ pub async fn execute_sql_query_authorized_by_form_page_at_checkpoint(
     readable_entries_by_form: &BTreeMap<String, HashSet<String>>,
     page: AuthorizedSqlSessionPage,
 ) -> Result<(Vec<Value>, u64)> {
+    validate_sql_session_page_shape(sql_query)?;
     let relation_scopes = readable_entries_by_form
         .iter()
         .map(|(relation, entries)| {
@@ -338,6 +339,155 @@ pub async fn execute_sql_query_authorized_by_form_page_at_checkpoint(
         page.parameters,
     )
     .await
+}
+
+/// Validates a SQL-session query at creation against its frozen checkpoint and
+/// current authorization boundary without materializing any result rows.
+pub async fn validate_sql_session_query_at_checkpoint(
+    op: &Operator,
+    ws_path: &str,
+    sql_query: &str,
+    readable_entries_by_form: &BTreeMap<String, HashSet<String>>,
+    parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    checkpoint: SpaceCheckpoint,
+) -> Result<()> {
+    validate_sql_session_page_shape(sql_query)?;
+    let relation_scopes = readable_entries_by_form
+        .iter()
+        .map(|(relation, entries)| {
+            (
+                relation.to_ascii_lowercase(),
+                EntryScope::Only(entry_scope(entries)),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    datafusion_sql_context(
+        op,
+        ws_path,
+        EntryScope::AllCurrent,
+        None,
+        Some(&relation_scopes),
+        Some(checkpoint),
+    )
+    .await
+    .map_err(map_sql_error)?
+    .validate_with_parameters(sql_query, parameters)
+    .await
+    .map_err(map_sql_error)
+}
+
+/// Validates the deliberately small first SQL-session pagination surface before
+/// planning it against the caller's authorized, checkpoint-pinned relations.
+///
+/// A Form's `_ugoite_id` is unique, so including it in an explicit top-level
+/// order makes offset pagination total for one-Form queries. Joins, aggregates,
+/// DISTINCT, subqueries, and set operations need a separate proof and are
+/// intentionally not part of this initial contract.
+pub fn validate_sql_session_page_shape(sql: &str) -> Result<()> {
+    use datafusion::sql::parser::{DFParser, Statement as DataFusionStatement};
+    use datafusion::sql::sqlparser::ast::{
+        Expr, GroupByExpr, LimitClause, OrderByKind, SetExpr, Statement as SqlStatement,
+        TableFactor,
+    };
+
+    let statements = DFParser::parse_sql(sql).context("parse SQL session query with DataFusion")?;
+    if statements.len() != 1 {
+        return Err(anyhow!(
+            "SQL session paging requires exactly one SELECT statement"
+        ));
+    }
+    let statement = statements.front().expect("one statement was checked above");
+    let DataFusionStatement::Statement(statement) = statement else {
+        return Err(anyhow!("SQL session paging requires a SELECT statement"));
+    };
+    let SqlStatement::Query(query) = statement.as_ref() else {
+        return Err(anyhow!("SQL session paging requires a SELECT statement"));
+    };
+    if query.with.is_some()
+        || query.fetch.is_some()
+        || !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || query.settings.is_some()
+        || query.format_clause.is_some()
+        || !query.pipe_operators.is_empty()
+    {
+        return Err(anyhow!(
+            "SQL session paging supports only a simple single-Form SELECT"
+        ));
+    }
+    let has_sql_offset = match &query.limit_clause {
+        Some(LimitClause::LimitOffset {
+            offset, limit_by, ..
+        }) => offset.is_some() || !limit_by.is_empty(),
+        Some(LimitClause::OffsetCommaLimit { .. }) => true,
+        None => false,
+    };
+    if has_sql_offset {
+        return Err(anyhow!(
+            "SQL session paging does not support an SQL OFFSET or LIMIT BY clause"
+        ));
+    }
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return Err(anyhow!(
+            "SQL session paging does not support set operations or subqueries"
+        ));
+    };
+    if select.distinct.is_some()
+        || select.top.is_some()
+        || select.into.is_some()
+        || !select.lateral_views.is_empty()
+        || select.prewhere.is_some()
+        || !select.connect_by.is_empty()
+        || !matches!(&select.group_by, GroupByExpr::Expressions(expressions, modifiers) if expressions.is_empty() && modifiers.is_empty())
+        || !select.cluster_by.is_empty()
+        || !select.distribute_by.is_empty()
+        || !select.sort_by.is_empty()
+        || select.having.is_some()
+        || !select.named_window.is_empty()
+        || select.qualify.is_some()
+    {
+        return Err(anyhow!(
+            "SQL session paging does not support DISTINCT, aggregation, or window queries"
+        ));
+    }
+    let [from] = select.from.as_slice() else {
+        return Err(anyhow!(
+            "SQL session paging requires exactly one Form relation"
+        ));
+    };
+    if !from.joins.is_empty() || !matches!(&from.relation, TableFactor::Table { args: None, .. }) {
+        return Err(anyhow!(
+            "SQL session paging does not support joins or table functions"
+        ));
+    }
+    let Some(order_by) = &query.order_by else {
+        return Err(anyhow!(
+            "SQL session paging requires ORDER BY ending with _ugoite_id"
+        ));
+    };
+    let OrderByKind::Expressions(ordering) = &order_by.kind else {
+        return Err(anyhow!(
+            "SQL session paging requires ORDER BY ending with _ugoite_id"
+        ));
+    };
+    let Some(last) = ordering.last() else {
+        return Err(anyhow!(
+            "SQL session paging requires ORDER BY ending with _ugoite_id"
+        ));
+    };
+    let is_entry_id = match &last.expr {
+        Expr::Identifier(identifier) => identifier.value.eq_ignore_ascii_case("_ugoite_id"),
+        Expr::CompoundIdentifier(identifiers) => identifiers
+            .last()
+            .is_some_and(|identifier| identifier.value.eq_ignore_ascii_case("_ugoite_id")),
+        _ => false,
+    };
+    if !is_entry_id || last.with_fill.is_some() {
+        return Err(anyhow!(
+            "SQL session paging requires ORDER BY ending with _ugoite_id"
+        ));
+    }
+    Ok(())
 }
 
 pub async fn query_index_authorized(
@@ -541,9 +691,9 @@ async fn datafusion_sql_context(
             forms: policy_forms,
             checkpoint,
             limits: QueryLimits {
-                max_memory_bytes: SQL_MAX_MEMORY_BYTES,
-                max_rows: SQL_MAX_ROWS,
-                timeout: SQL_TIMEOUT,
+                max_memory_bytes: SQL_SESSION_MAX_MEMORY_BYTES,
+                max_rows: SQL_SESSION_MAX_ROWS,
+                timeout: SQL_SESSION_TIMEOUT,
                 max_concurrency: 1,
                 allowed_functions: BTreeSet::new(),
             },

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -21,6 +21,10 @@ use ugoite_core::query::{
 };
 
 pub const SQL_SESSION_MAX_ROWS: usize = 1_000;
+/// A durable SQL-session policy may carry a sparse ID set only up to the same
+/// hard window bound as its rows. Production creation uses `AllExcept`; the
+/// public explicit-ID constructor uses `Only` and is bounded identically.
+pub const SQL_SESSION_MAX_AUTHORIZATION_SCOPE_IDS: usize = SQL_SESSION_MAX_ROWS;
 pub const SQL_SESSION_MAX_MEMORY_BYTES: usize = 64 * 1024 * 1024;
 pub const SQL_SESSION_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -49,9 +53,30 @@ pub struct SqlSessionQueryPolicy {
 pub struct SqlSessionQueryForm {
     pub form_id: FormId,
     pub relation: String,
-    pub entry_ids: BTreeSet<String>,
+    pub entry_scope: SqlSessionEntryScope,
     pub columns: BTreeSet<String>,
     pub system_columns: BTreeSet<SqlSessionSystemColumn>,
+}
+
+/// Serializable authorization boundary for one frozen SQL-session Form. The
+/// `AllExcept` form keeps a sparse set of Entry-level ACL exceptions rather
+/// than serializing every readable Entry in a large Form.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SqlSessionEntryScope {
+    AllCurrent,
+    Only(BTreeSet<String>),
+    AllExcept(BTreeSet<String>),
+}
+
+impl SqlSessionEntryScope {
+    fn as_query_scope(&self) -> EntryScope {
+        match self {
+            Self::AllCurrent => EntryScope::AllCurrent,
+            Self::Only(entry_ids) => EntryScope::Only(entry_scope_from_ids(entry_ids)),
+            Self::AllExcept(entry_ids) => EntryScope::AllExcept(entry_scope_from_ids(entry_ids)),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -71,6 +96,11 @@ impl SqlSessionQueryPolicy {
         &self,
         checkpoint: SpaceCheckpoint,
     ) -> Result<AuthorizedQueryPolicy> {
+        if self.forms.len() != 1 {
+            return Err(anyhow!(
+                "SQL session query policy must expose exactly one Form"
+            ));
+        }
         let mut forms = BTreeMap::new();
         for form in &self.forms {
             if forms.contains_key(&form.form_id) {
@@ -80,7 +110,7 @@ impl SqlSessionQueryPolicy {
                 form.form_id,
                 AuthorizedQueryForm {
                     relation: form.relation.clone(),
-                    entry_scope: EntryScope::Only(entry_scope_from_ids(&form.entry_ids)),
+                    entry_scope: form.entry_scope.as_query_scope(),
                     columns: form.columns.clone(),
                     system_columns: form
                         .system_columns
@@ -99,13 +129,6 @@ impl SqlSessionQueryPolicy {
             checkpoint: Some(checkpoint),
             limits: sql_session_query_limits(),
         })
-    }
-
-    pub fn readable_entry_ids(&self) -> BTreeSet<String> {
-        self.forms
-            .iter()
-            .flat_map(|form| form.entry_ids.iter().cloned())
-            .collect()
     }
 }
 
@@ -471,27 +494,18 @@ pub async fn validate_sql_session_query_at_checkpoint(
 pub async fn sql_session_query_policy_at_checkpoint(
     op: &Operator,
     ws_path: &str,
-    readable_entries_by_form: &BTreeMap<String, HashSet<String>>,
+    relation: &str,
+    entry_scope: SqlSessionEntryScope,
     checkpoint: &SpaceCheckpoint,
 ) -> Result<SqlSessionQueryPolicy> {
     let workspace = crate::iceberg_store::native_workspace(op, ws_path).await?;
-    let forms = workspace.forms_at_checkpoint(checkpoint).await?;
-    let mut seen_relations = BTreeSet::new();
-    let mut policy_forms = Vec::new();
-    for form in forms {
-        let relation = form.name.to_ascii_lowercase();
-        let Some(entry_ids) = readable_entries_by_form.get(&relation) else {
-            continue;
-        };
-        if !seen_relations.insert(relation.clone()) {
-            return Err(anyhow!(
-                "checkpoint exposes duplicate SQL relation {relation}"
-            ));
-        }
-        policy_forms.push(SqlSessionQueryForm {
+    let relation = relation.to_ascii_lowercase();
+    let form = workspace.form_at_checkpoint(checkpoint, &relation).await?;
+    Ok(SqlSessionQueryPolicy {
+        forms: vec![SqlSessionQueryForm {
             form_id: form.id,
             relation,
-            entry_ids: entry_ids.iter().cloned().collect(),
+            entry_scope,
             columns: form.fields.into_iter().map(|field| field.name).collect(),
             system_columns: [
                 SqlSessionSystemColumn::ExternalId,
@@ -501,14 +515,7 @@ pub async fn sql_session_query_policy_at_checkpoint(
             ]
             .into_iter()
             .collect(),
-        });
-    }
-    if policy_forms.is_empty() {
-        return Err(anyhow!("SQL session has no readable checkpoint Form"));
-    }
-    policy_forms.sort_by(|left, right| left.relation.cmp(&right.relation));
-    Ok(SqlSessionQueryPolicy {
-        forms: policy_forms,
+        }],
     })
 }
 
@@ -533,6 +540,13 @@ async fn datafusion_sql_session_context(
 /// DISTINCT, subqueries, and set operations need a separate proof and are
 /// intentionally not part of this initial contract.
 pub fn validate_sql_session_page_shape(sql: &str) -> Result<()> {
+    sql_session_page_relation(sql).map(|_| ())
+}
+
+/// Parses and validates the supported SQL-session subset before any Form or
+/// Entry provider is opened. The returned lower-case relation is the only Form
+/// that creation may resolve from the checkpoint.
+pub fn sql_session_page_relation(sql: &str) -> Result<String> {
     use datafusion::sql::parser::{DFParser, Statement as DataFusionStatement};
     use datafusion::sql::sqlparser::ast::{
         visit_expressions, Expr, GroupByExpr, LimitClause, OrderByKind, SetExpr,
@@ -620,11 +634,19 @@ pub fn validate_sql_session_page_shape(sql: &str) -> Result<()> {
             "SQL session paging requires exactly one Form relation"
         ));
     };
-    if !from.joins.is_empty() || !matches!(&from.relation, TableFactor::Table { args: None, .. }) {
+    if !from.joins.is_empty() {
         return Err(anyhow!(
             "SQL session paging does not support joins or table functions"
         ));
     }
+    let TableFactor::Table {
+        name, args: None, ..
+    } = &from.relation
+    else {
+        return Err(anyhow!(
+            "SQL session paging does not support joins or table functions"
+        ));
+    };
     let Some(order_by) = &query.order_by else {
         return Err(anyhow!(
             "SQL session paging requires ORDER BY ending with _ugoite_id"
@@ -652,7 +674,7 @@ pub fn validate_sql_session_page_shape(sql: &str) -> Result<()> {
             "SQL session paging requires ORDER BY ending with _ugoite_id"
         ));
     }
-    Ok(())
+    Ok(name.to_string().to_ascii_lowercase())
 }
 
 pub async fn query_index_authorized(

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -489,8 +489,9 @@ pub async fn validate_sql_session_query_at_checkpoint(
 }
 
 /// Derives a serializable SQL-session policy from the Form definitions stored
-/// in a checkpoint. A session policy is derived metadata, never Catalog
-/// authority; it is replayed only together with this checkpoint.
+/// in a checkpoint. A persisted session policy is derived metadata, never
+/// Catalog or execution authority; callers recreate and compare it at every
+/// use before executing with the rebuilt value.
 pub async fn sql_session_query_policy_at_checkpoint(
     op: &Operator,
     ws_path: &str,

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -75,7 +75,7 @@ use uuid::Uuid;
 
 const FORM_DEFINITION_PROPERTY: &str = "ugoite.form.definition.v1";
 const FORM_ID_PROPERTY: &str = "ugoite.form.id";
-const FORM_NAME_PROPERTY: &str = "ugoite.form.name";
+pub(crate) const FORM_NAME_PROPERTY: &str = "ugoite.form.name";
 const FORM_VERSION_PROPERTY: &str = "ugoite.form.version";
 const TARGET_FILE_SIZE_PROPERTY: &str = "write.target-file-size-bytes";
 const FIRST_FORM_FIELD_ID: i32 = 100;
@@ -451,6 +451,49 @@ impl IcebergWorkspace {
         }
         forms.sort_by(|left, right| left.name.cmp(&right.name));
         Ok(forms)
+    }
+
+    /// Resolves exactly one Form from immutable checkpoint metadata. SQL
+    /// session creation uses this after parsing the relation, rather than
+    /// loading every Form definition or any Entry rows.
+    pub async fn form_at_checkpoint(
+        &self,
+        checkpoint: &SpaceCheckpoint,
+        relation: &str,
+    ) -> Result<FormDefinition> {
+        self.validate_checkpoint(checkpoint)?;
+        let relation = relation.to_ascii_lowercase();
+        let mut matches = checkpoint.tables.iter().filter(|coordinate| {
+            coordinate
+                .form_name
+                .as_deref()
+                .is_some_and(|name| name.eq_ignore_ascii_case(&relation))
+        });
+        let coordinate = matches
+            .next()
+            .ok_or_else(|| CheckpointUnavailable::new(format!("Form relation {relation}")))?;
+        if matches.next().is_some() {
+            return Err(CheckpointIntegrityError::new(format!(
+                "checkpoint contains multiple Forms for relation {relation}"
+            ))
+            .into());
+        }
+        let table = self
+            .space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?
+            .load_checkpoint_table(checkpoint, coordinate)
+            .await?;
+        let form = form_from_table(&table, coordinate.form_id)?;
+        if !form.name.eq_ignore_ascii_case(&relation)
+            || coordinate.form_name.as_deref() != Some(form.name.as_str())
+        {
+            return Err(CheckpointIntegrityError::new(
+                "checkpoint Form relation does not match immutable Iceberg metadata",
+            )
+            .into());
+        }
+        Ok(form)
     }
 
     fn validate_checkpoint(&self, checkpoint: &SpaceCheckpoint) -> Result<()> {

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -463,12 +463,10 @@ impl IcebergWorkspace {
     ) -> Result<FormDefinition> {
         self.validate_checkpoint(checkpoint)?;
         let relation = relation.to_ascii_lowercase();
-        let mut matches = checkpoint.tables.iter().filter(|coordinate| {
-            coordinate
-                .form_name
-                .as_deref()
-                .is_some_and(|name| name.eq_ignore_ascii_case(&relation))
-        });
+        let mut matches = checkpoint
+            .tables
+            .iter()
+            .filter(|coordinate| coordinate.form_name.eq_ignore_ascii_case(&relation));
         let coordinate = matches
             .next()
             .ok_or_else(|| CheckpointUnavailable::new(format!("Form relation {relation}")))?;
@@ -485,9 +483,7 @@ impl IcebergWorkspace {
             .load_checkpoint_table(checkpoint, coordinate)
             .await?;
         let form = form_from_table(&table, coordinate.form_id)?;
-        if !form.name.eq_ignore_ascii_case(&relation)
-            || coordinate.form_name.as_deref() != Some(form.name.as_str())
-        {
+        if !form.name.eq_ignore_ascii_case(&relation) || coordinate.form_name != form.name {
             return Err(CheckpointIntegrityError::new(
                 "checkpoint Form relation does not match immutable Iceberg metadata",
             )

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -428,6 +428,31 @@ impl IcebergWorkspace {
             .map_err(checkpoint_query_error)
     }
 
+    /// Loads Form definitions from the immutable tables named by one
+    /// checkpoint. This deliberately never consults the live Form registry:
+    /// callers that retain a checkpoint must retain its relation names and
+    /// column surface as well.
+    pub async fn forms_at_checkpoint(
+        &self,
+        checkpoint: &SpaceCheckpoint,
+    ) -> Result<Vec<FormDefinition>> {
+        self.validate_checkpoint(checkpoint)?;
+        let catalog = self
+            .space_catalog
+            .as_ref()
+            .context("SpaceCheckpoint requires the OpenDAL-backed SpaceCatalog")?;
+        catalog.validate_checkpoint_evidence(checkpoint).await?;
+        let mut forms = Vec::with_capacity(checkpoint.tables.len());
+        for coordinate in &checkpoint.tables {
+            let table = catalog
+                .load_checkpoint_table(checkpoint, coordinate)
+                .await?;
+            forms.push(form_from_table(&table, coordinate.form_id)?);
+        }
+        forms.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(forms)
+    }
+
     fn validate_checkpoint(&self, checkpoint: &SpaceCheckpoint) -> Result<()> {
         if checkpoint.space_id != self.space_id {
             return Err(

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -12,7 +12,7 @@ use datafusion::execution::memory_pool::GreedyMemoryPool;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::{SessionStateBuilder, SessionStateDefaults};
 use datafusion::logical_expr::expr_fn::ident;
-use datafusion::logical_expr::LogicalPlan;
+use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::{col, lit, DataFrame, SessionConfig};
 use iceberg_datafusion::IcebergStaticTableProvider;
@@ -387,6 +387,20 @@ impl AuthorizedQueryContext {
         self.prepared_plan(sql, parameters).await.map(|_| ())
     }
 
+    /// Validates the deliberately small SQL-session pagination contract at
+    /// the same bound logical-plan stage used for execution. In particular,
+    /// this is before optimizer rewrites can remove a sort from an empty or
+    /// `LIMIT 0` plan.
+    pub async fn validate_session_with_parameters(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    ) -> Result<()> {
+        self.prepared_session_plan(sql, parameters)
+            .await
+            .map(|_| ())
+    }
+
     /// Plans and executes a read-only statement. User predicates are evaluated
     /// above the trusted Entry filter embedded in every registered view.
     pub async fn execute(&self, sql: &str) -> Result<Vec<arrow_array::RecordBatch>> {
@@ -432,6 +446,48 @@ impl AuthorizedQueryContext {
         tokio::time::timeout(
             self.limits.timeout,
             self.execute_page_with_permit(sql, parameters, offset, limit),
+        )
+        .await
+        .map_err(|_| AuthorizedQueryError::QueryTimedOut)?
+    }
+
+    /// Executes only the requested SQL-session page. The count endpoint uses
+    /// [`Self::execute_session_count`] so it never performs an unrelated page
+    /// execution.
+    pub async fn execute_session_page(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<arrow_array::RecordBatch>, u64)> {
+        let _permit = self
+            .permits
+            .clone()
+            .try_acquire_owned()
+            .map_err(AuthorizedQueryError::resource_limit)?;
+        tokio::time::timeout(
+            self.limits.timeout,
+            self.execute_session_page_with_permit(sql, parameters, offset, limit),
+        )
+        .await
+        .map_err(|_| AuthorizedQueryError::QueryTimedOut)?
+    }
+
+    /// Executes a count-only SQL-session plan from the frozen checkpoint.
+    pub async fn execute_session_count(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    ) -> Result<u64> {
+        let _permit = self
+            .permits
+            .clone()
+            .try_acquire_owned()
+            .map_err(AuthorizedQueryError::resource_limit)?;
+        tokio::time::timeout(
+            self.limits.timeout,
+            self.execute_session_count_with_permit(sql, parameters),
         )
         .await
         .map_err(|_| AuthorizedQueryError::QueryTimedOut)?
@@ -535,7 +591,98 @@ impl AuthorizedQueryContext {
         Ok((batches, total))
     }
 
+    async fn execute_session_page_with_permit(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<arrow_array::RecordBatch>, u64)> {
+        validate_session_page_range(offset, limit, self.limits.max_rows)?;
+        let plan = self.prepared_session_plan(sql, parameters).await?;
+        let validation_plan = plan.clone();
+        let frame = self
+            .context
+            .execute_logical_plan(plan)
+            .await
+            .map_err(AuthorizedQueryError::execution_failed)?;
+        let count_frame = frame
+            .clone()
+            .aggregate(
+                Vec::new(),
+                vec![datafusion::functions_aggregate::expr_fn::count(lit(1))
+                    .alias("ugoite_session_count")],
+            )
+            .map_err(AuthorizedQueryError::execution_failed)?;
+        let count_batches = self.collect_frame(count_frame).await?;
+        let total = count_from_batches(&count_batches)?;
+        let page = frame
+            .limit(offset, Some(limit))
+            .map_err(AuthorizedQueryError::resource_limit)?;
+        let batches = self.collect_frame(page).await?;
+        self.validate_revision_invariants(&validation_plan).await?;
+        Ok((batches, total))
+    }
+
+    async fn execute_session_count_with_permit(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    ) -> Result<u64> {
+        let plan = self.prepared_session_plan(sql, parameters).await?;
+        let validation_plan = plan.clone();
+        let frame = self
+            .context
+            .execute_logical_plan(plan)
+            .await
+            .map_err(AuthorizedQueryError::execution_failed)?;
+        let count_frame = frame
+            .aggregate(
+                Vec::new(),
+                vec![datafusion::functions_aggregate::expr_fn::count(lit(1))
+                    .alias("ugoite_session_count")],
+            )
+            .map_err(AuthorizedQueryError::execution_failed)?;
+        let count_batches = self.collect_frame(count_frame).await?;
+        self.validate_revision_invariants(&validation_plan).await?;
+        count_from_batches(&count_batches)
+    }
+
     async fn prepared_plan(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    ) -> Result<LogicalPlan> {
+        let plan = self.bound_logical_plan(sql, parameters).await?;
+        let optimized = self
+            .context
+            .state()
+            .optimize(&plan)
+            .map_err(AuthorizedQueryError::invalid_query)?;
+        validate_logical_plan(&optimized, &self.authorized_relations)
+            .map_err(AuthorizedQueryError::unauthorized)?;
+        Ok(optimized)
+    }
+
+    async fn prepared_session_plan(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    ) -> Result<LogicalPlan> {
+        let plan = self.bound_logical_plan(sql, parameters).await?;
+        validate_sql_session_logical_plan(&plan, &self.authorized_relations)
+            .map_err(AuthorizedQueryError::invalid_query)?;
+        let optimized = self
+            .context
+            .state()
+            .optimize(&plan)
+            .map_err(AuthorizedQueryError::invalid_query)?;
+        validate_logical_plan(&optimized, &self.authorized_relations)
+            .map_err(AuthorizedQueryError::unauthorized)?;
+        Ok(optimized)
+    }
+
+    async fn bound_logical_plan(
         &self,
         sql: &str,
         parameters: HashMap<String, datafusion::scalar::ScalarValue>,
@@ -564,14 +711,7 @@ impl AuthorizedQueryContext {
             .map_err(AuthorizedQueryError::invalid_query)?;
         validate_logical_plan(&plan, &self.authorized_relations)
             .map_err(AuthorizedQueryError::unauthorized)?;
-        let optimized = self
-            .context
-            .state()
-            .optimize(&plan)
-            .map_err(AuthorizedQueryError::invalid_query)?;
-        validate_logical_plan(&optimized, &self.authorized_relations)
-            .map_err(AuthorizedQueryError::unauthorized)?;
-        Ok(optimized)
+        Ok(plan)
     }
 
     async fn collect_frame(&self, frame: DataFrame) -> Result<Vec<arrow_array::RecordBatch>> {
@@ -626,6 +766,157 @@ fn logical_plan_contains_sort(plan: &LogicalPlan) -> bool {
             .inputs()
             .iter()
             .any(|input| logical_plan_contains_sort(input))
+}
+
+fn validate_session_page_range(offset: usize, limit: usize, max_rows: usize) -> Result<()> {
+    let requested_rows = offset.checked_add(limit).ok_or_else(|| {
+        AuthorizedQueryError::resource_limit(anyhow!("SQL session page range overflows"))
+    })?;
+    if limit == 0 || limit > max_rows || requested_rows > max_rows {
+        return Err(AuthorizedQueryError::resource_limit(anyhow!(
+            "SQL session page exceeds its configured row limit"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+/// Validates the session-only subset after DataFusion has resolved names and
+/// aliases but before optimization. Generic authorized SQL intentionally
+/// supports a broader read-only language; session paging does not.
+fn validate_sql_session_logical_plan(
+    plan: &LogicalPlan,
+    authorized_relations: &BTreeSet<String>,
+) -> Result<()> {
+    let mut sort_count = 0;
+    validate_sql_session_logical_plan_node(plan, authorized_relations, &mut sort_count)?;
+    if sort_count != 1 {
+        bail!("SQL session paging requires exactly one explicit ORDER BY");
+    }
+    Ok(())
+}
+
+fn validate_sql_session_logical_plan_node(
+    plan: &LogicalPlan,
+    authorized_relations: &BTreeSet<String>,
+    sort_count: &mut usize,
+) -> Result<()> {
+    match plan {
+        LogicalPlan::Sort(sort) => {
+            *sort_count += 1;
+            let last = sort.expr.last().ok_or_else(|| {
+                anyhow!("SQL session paging requires ORDER BY ending with _ugoite_id")
+            })?;
+            if !sort_expression_resolves_to_external_id(&last.expr, &sort.input) {
+                bail!("SQL session paging requires ORDER BY ending with the Form external ID");
+            }
+        }
+        LogicalPlan::Subquery(_)
+        | LogicalPlan::Join(_)
+        | LogicalPlan::Aggregate(_)
+        | LogicalPlan::Distinct(_)
+        | LogicalPlan::Union(_)
+        | LogicalPlan::Window(_)
+        | LogicalPlan::Unnest(_)
+        | LogicalPlan::Values(_)
+        | LogicalPlan::EmptyRelation(_) => {
+            bail!("SQL session paging supports only a simple single-Form SELECT")
+        }
+        LogicalPlan::TableScan(scan) => {
+            let relation = scan.table_name.to_string();
+            if !authorized_relations.contains(&relation) {
+                bail!("query plan scans an unauthorized relation {relation}");
+            }
+        }
+        LogicalPlan::SubqueryAlias(alias)
+            if authorized_relations.contains(&alias.alias.to_string()) =>
+        {
+            // A public relation expands to Ugoite's trusted latest-revision
+            // view, which contains an internal aggregate and join. Those
+            // operators are not user SQL and must remain outside this
+            // session-subset check.
+            return Ok(());
+        }
+        LogicalPlan::Projection(_)
+        | LogicalPlan::Filter(_)
+        | LogicalPlan::Repartition(_)
+        | LogicalPlan::SubqueryAlias(_)
+        | LogicalPlan::Limit(_) => {}
+        LogicalPlan::Explain(_)
+        | LogicalPlan::Analyze(_)
+        | LogicalPlan::Dml(_)
+        | LogicalPlan::Ddl(_)
+        | LogicalPlan::Copy(_)
+        | LogicalPlan::Statement(_)
+        | LogicalPlan::DescribeTable(_)
+        | LogicalPlan::Extension(_)
+        | LogicalPlan::RecursiveQuery(_) => {
+            bail!("SQL session paging supports only a SELECT statement")
+        }
+    }
+    for input in plan.inputs() {
+        validate_sql_session_logical_plan_node(input, authorized_relations, sort_count)?;
+    }
+    Ok(())
+}
+
+/// Follows the resolved expression through projections, filters, aliases, and
+/// scans. This rejects an output alias called `_ugoite_id` unless its lineage
+/// reaches the provider's real external-ID column.
+fn sort_expression_resolves_to_external_id(expr: &Expr, input: &LogicalPlan) -> bool {
+    match input {
+        LogicalPlan::Projection(projection) => {
+            let Expr::Column(column) = expr else {
+                return false;
+            };
+            let mut candidates = projection.expr.iter().filter(|candidate| {
+                expression_output_name(candidate) == Some(column.name.as_str())
+            });
+            let Some(candidate) = candidates.next() else {
+                return false;
+            };
+            if candidates.next().is_some() {
+                return false;
+            }
+            if expression_is_external_id_source(candidate) {
+                return true;
+            }
+            sort_expression_resolves_to_external_id(candidate, &projection.input)
+        }
+        LogicalPlan::Filter(filter) => sort_expression_resolves_to_external_id(expr, &filter.input),
+        LogicalPlan::Sort(sort) => sort_expression_resolves_to_external_id(expr, &sort.input),
+        LogicalPlan::Repartition(repartition) => {
+            sort_expression_resolves_to_external_id(expr, &repartition.input)
+        }
+        LogicalPlan::Limit(limit) => sort_expression_resolves_to_external_id(expr, &limit.input),
+        LogicalPlan::SubqueryAlias(alias) => {
+            sort_expression_resolves_to_external_id(expr, &alias.input)
+        }
+        LogicalPlan::TableScan(scan) => matches!(expr, Expr::Column(column)
+            if column.name.eq_ignore_ascii_case("ugoite_entry_external_id")
+                || (column.name.eq_ignore_ascii_case("_ugoite_id")
+                    && !scan.table_name.to_string().starts_with(INTERNAL_RELATION_PREFIX))),
+        _ => false,
+    }
+}
+
+fn expression_is_external_id_source(expr: &Expr) -> bool {
+    match expr {
+        Expr::Column(column) => column.name.eq_ignore_ascii_case("ugoite_entry_external_id"),
+        Expr::Alias(alias) => matches!(
+            alias.expr.as_ref(),
+            Expr::Column(column) if column.name.eq_ignore_ascii_case("ugoite_entry_external_id")
+        ),
+        _ => false,
+    }
+}
+
+fn expression_output_name(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Alias(alias) => Some(alias.name.as_str()),
+        Expr::Column(column) => Some(column.name.as_str()),
+        _ => None,
+    }
 }
 
 fn count_from_batches(batches: &[arrow_array::RecordBatch]) -> Result<u64> {

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -48,6 +48,16 @@ pub(crate) fn latest_revision_dataframe(
                 false,
             ),
         )?,
+        EntryScope::AllExcept(entry_ids) if entry_ids.is_empty() => revisions,
+        EntryScope::AllExcept(entry_ids) => revisions.filter(
+            col("entry_id").in_list(
+                entry_ids
+                    .iter()
+                    .map(|entry_id| lit(entry_id.as_uuid().as_bytes().to_vec()))
+                    .collect::<Vec<_>>(),
+                true,
+            ),
+        )?,
     };
     let maxima = scoped
         .clone()

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -376,6 +376,17 @@ impl AuthorizedQueryContext {
             .collect())
     }
 
+    /// Validates a session query against this closed context without executing
+    /// it. This binds native parameters, resolves only authorized relations,
+    /// and applies the same read-only plan checks used at execution time.
+    pub async fn validate_with_parameters(
+        &self,
+        sql: &str,
+        parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    ) -> Result<()> {
+        self.prepared_plan(sql, parameters).await.map(|_| ())
+    }
+
     /// Plans and executes a read-only statement. User predicates are evaluated
     /// above the trusted Entry filter embedded in every registered view.
     pub async fn execute(&self, sql: &str) -> Result<Vec<arrow_array::RecordBatch>> {
@@ -483,6 +494,16 @@ impl AuthorizedQueryContext {
         offset: usize,
         limit: usize,
     ) -> Result<(Vec<arrow_array::RecordBatch>, u64)> {
+        let requested_rows = offset
+            .checked_add(limit)
+            .ok_or_else(|| anyhow!("SQL session page range overflows"))
+            .map_err(AuthorizedQueryError::resource_limit)?;
+        if limit == 0 || limit > self.limits.max_rows || requested_rows > self.limits.max_rows {
+            return Err(AuthorizedQueryError::resource_limit(anyhow!(
+                "SQL session page exceeds its configured row limit"
+            ))
+            .into());
+        }
         let plan = self.prepared_plan(sql, parameters).await?;
         let validation_plan = plan.clone();
         if !logical_plan_contains_sort(&plan) {

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 use crate::integrity::RealIntegrityProvider;
 use crate::{
     asset,
-    authorization::{AuthorizationState, Authorizer, ResourceKind, ResourceRef},
+    authorization::{
+        effective_actions_for_state, AuthorizationState, Authorizer, ResourceKind, ResourceRef,
+    },
     entry, form, iceberg_store, index, preferences, saved_sql, search, space, sql_session,
     storage::operator_from_uri,
 };
@@ -689,21 +691,37 @@ impl UgoiteService {
         parameter_types: BTreeMap<String, String>,
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
-        let (allowed, authorization_policy_hash) = self
-            .sql_session_authorization(space_id, principal_ids)
+        let workspace =
+            iceberg_store::native_workspace(&self.operator, &self.workspace_path(space_id)).await?;
+        let checkpoint = workspace.capture_checkpoint().await?;
+        let (allowed, state) = self
+            .sql_session_authorization_at_checkpoint(space_id, principal_ids, &checkpoint)
             .await?;
+        let query_policy = index::sql_session_query_policy_at_checkpoint(
+            &self.operator,
+            &self.workspace_path(space_id),
+            &allowed,
+            &checkpoint,
+        )
+        .await?;
+        let authorization_policy_hash =
+            sql_session_policy_hash(&state, principal_ids, &query_policy.readable_entry_ids())?;
         let authorization = sql_session::SqlSessionAuthorization {
             principal_ids,
             policy_hash: &authorization_policy_hash,
             readable_entries_by_form: &allowed,
         };
-        sql_session::create_sql_session_authorized_for_principals_by_form_with_parameters(
+        let bound_parameters = index::datafusion_parameters(&parameters, &parameter_types)?;
+        sql_session::create_sql_session_authorized_for_principals_with_frozen_policy(
             &self.operator,
             &self.workspace_path(space_id),
             sql,
             parameters,
             parameter_types,
             authorization,
+            bound_parameters,
+            checkpoint,
+            query_policy,
         )
         .await
     }
@@ -716,8 +734,14 @@ impl UgoiteService {
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let (_, authorization_policy_hash) = self
-            .sql_session_authorization(space_id, principal_ids)
+        let query_policy = sql_session::get_session_query_policy(
+            &self.operator,
+            &self.workspace_path(space_id),
+            session_id,
+        )
+        .await?;
+        let authorization_policy_hash = self
+            .sql_session_current_policy_hash(space_id, principal_ids, &query_policy)
             .await?;
         sql_session::require_session_authorization(
             &self.operator,
@@ -735,23 +759,69 @@ impl UgoiteService {
         .await
     }
 
-    async fn sql_session_authorization(
+    async fn sql_session_authorization_at_checkpoint(
         &self,
         space_id: &str,
         principal_ids: &[Uuid],
-    ) -> Result<(BTreeMap<String, HashSet<String>>, String)> {
+        checkpoint: &crate::SpaceCheckpoint,
+    ) -> Result<(BTreeMap<String, HashSet<String>>, AuthorizationState)> {
         let authorizer = Authorizer::new(self.operator.clone());
-        let before = authorizer.state(space_id).await?;
-        let allowed = self
-            .authorized_form_entry_ids_for_principals(space_id, principal_ids)
-            .await?;
-        let after = authorizer.state(space_id).await?;
-        if before.space_uid != after.space_uid || before.revision != after.revision {
-            return Err(anyhow!(
-                "authorization changed while resolving the SQL session policy; retry the request"
-            ));
+        let state = authorizer.state(space_id).await?;
+        for principal_id in principal_ids {
+            if !effective_actions_for_state(&state, *principal_id, None)?.contains(&Action::Read) {
+                return Err(AppError::forbidden(
+                    "principal is not currently allowed to read this Space",
+                )
+                .into());
+            }
         }
-        Ok((allowed, sql_session_policy_hash(&after, principal_ids)?))
+        let workspace =
+            iceberg_store::native_workspace(&self.operator, &self.workspace_path(space_id)).await?;
+        let mut allowed = BTreeMap::new();
+        for form in workspace.forms_at_checkpoint(checkpoint).await? {
+            let relation = form.name.to_ascii_lowercase();
+            let revisions = workspace
+                .read_revision_view_at_checkpoint(checkpoint, form.id, crate::RevisionView::Current)
+                .await?;
+            let mut entry_ids = HashSet::new();
+            for revision in revisions {
+                let resource = ResourceRef {
+                    kind: ResourceKind::Entry,
+                    id: revision.entry.external_id.clone(),
+                    parent: None,
+                };
+                if principal_ids.iter().all(|principal_id| {
+                    effective_actions_for_state(&state, *principal_id, Some(&resource))
+                        .is_ok_and(|actions| actions.contains(&Action::Read))
+                }) {
+                    entry_ids.insert(revision.entry.external_id);
+                }
+            }
+            if !entry_ids.is_empty() {
+                allowed.insert(relation, entry_ids);
+            }
+        }
+        Ok((allowed, state))
+    }
+
+    async fn sql_session_current_policy_hash(
+        &self,
+        space_id: &str,
+        principal_ids: &[Uuid],
+        query_policy: &index::SqlSessionQueryPolicy,
+    ) -> Result<String> {
+        let state = Authorizer::new(self.operator.clone())
+            .state(space_id)
+            .await?;
+        for principal_id in principal_ids {
+            if !effective_actions_for_state(&state, *principal_id, None)?.contains(&Action::Read) {
+                return Err(AppError::forbidden(
+                    "principal is not currently allowed to read this Space",
+                )
+                .into());
+            }
+        }
+        sql_session_policy_hash(&state, principal_ids, &query_policy.readable_entry_ids())
     }
 
     async fn asset_parent_entry(&self, space_id: &str, asset_id: &str) -> Result<Option<String>> {
@@ -890,13 +960,20 @@ impl UgoiteService {
     ) -> Result<u64> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let (allowed, authorization_policy_hash) = self
-            .sql_session_authorization(space_id, principal_ids)
+        let query_policy = sql_session::get_session_query_policy(
+            &self.operator,
+            &self.workspace_path(space_id),
+            session_id,
+        )
+        .await?;
+        let authorization_policy_hash = self
+            .sql_session_current_policy_hash(space_id, principal_ids, &query_policy)
             .await?;
+        let no_live_scope = BTreeMap::new();
         let authorization = sql_session::SqlSessionAuthorization {
             principal_ids,
             policy_hash: &authorization_policy_hash,
-            readable_entries_by_form: &allowed,
+            readable_entries_by_form: &no_live_scope,
         };
         sql_session::get_sql_session_count_authorized_by_form(
             &self.operator,
@@ -917,13 +994,20 @@ impl UgoiteService {
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let (allowed, authorization_policy_hash) = self
-            .sql_session_authorization(space_id, principal_ids)
+        let query_policy = sql_session::get_session_query_policy(
+            &self.operator,
+            &self.workspace_path(space_id),
+            session_id,
+        )
+        .await?;
+        let authorization_policy_hash = self
+            .sql_session_current_policy_hash(space_id, principal_ids, &query_policy)
             .await?;
+        let no_live_scope = BTreeMap::new();
         let authorization = sql_session::SqlSessionAuthorization {
             principal_ids,
             policy_hash: &authorization_policy_hash,
-            readable_entries_by_form: &allowed,
+            readable_entries_by_form: &no_live_scope,
         };
         sql_session::get_sql_session_rows_authorized_by_form(
             &self.operator,
@@ -1008,15 +1092,58 @@ impl UgoiteService {
     }
 }
 
-fn sql_session_policy_hash(state: &AuthorizationState, principal_ids: &[Uuid]) -> Result<String> {
+fn sql_session_policy_hash(
+    state: &AuthorizationState,
+    principal_ids: &[Uuid],
+    readable_entry_ids: &std::collections::BTreeSet<String>,
+) -> Result<String> {
     let principal_ids = principal_ids
         .iter()
         .map(Uuid::to_string)
         .collect::<std::collections::BTreeSet<_>>();
+    let membership_roles = principal_ids
+        .iter()
+        .map(|principal_id| {
+            let principal_id = Uuid::parse_str(principal_id)
+                .expect("principal IDs were serialized from UUID values");
+            (
+                principal_id.to_string(),
+                state
+                    .memberships
+                    .get(&principal_id)
+                    .map(|membership| membership.role.clone()),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let agent_grants = principal_ids
+        .iter()
+        .map(|principal_id| {
+            let principal_id = Uuid::parse_str(principal_id)
+                .expect("principal IDs were serialized from UUID values");
+            (
+                principal_id.to_string(),
+                state.agent_grants.get(&principal_id).cloned(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let entry_policies = readable_entry_ids
+        .iter()
+        .map(|entry_id| {
+            let key = ResourceRef {
+                kind: ResourceKind::Entry,
+                id: entry_id.clone(),
+                parent: None,
+            }
+            .key();
+            (key.clone(), state.policies.get(&key).cloned())
+        })
+        .collect::<BTreeMap<_, _>>();
     let canonical = serde_json::to_vec(&json!({
         "space_uid": state.space_uid,
-        "authorization_revision": state.revision,
         "principal_ids": principal_ids,
+        "membership_roles": membership_roles,
+        "agent_grants": agent_grants,
+        "entry_policies": entry_policies,
     }))?;
     Ok(format!("sha256:{}", hex::encode(Sha256::digest(canonical))))
 }

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -45,6 +45,11 @@ pub struct UgoiteService {
     root_uri: String,
 }
 
+struct CurrentSqlSessionExecutionAuthorization {
+    policy_hash: String,
+    query_policy: index::SqlSessionQueryPolicy,
+}
+
 impl UgoiteService {
     pub fn new(root_uri: impl Into<String>) -> Result<Self> {
         let root_uri = root_uri.into();
@@ -741,36 +746,58 @@ impl UgoiteService {
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let authorization_policy_hash = self
-            .sql_session_current_policy_hash(space_id, principal_ids)
+        let current_authorization = self
+            .sql_session_current_execution_authorization(space_id, session_id, principal_ids)
             .await?;
-        sql_session::require_session_authorization(
+        sql_session::get_sql_session_status_authorized(
             &self.operator,
             &self.workspace_path(space_id),
             session_id,
-            principal_ids,
-            &authorization_policy_hash,
-        )
-        .await?;
-        sql_session::get_sql_session_status(
-            &self.operator,
-            &self.workspace_path(space_id),
-            session_id,
+            sql_session::SqlSessionExecutionAuthorization {
+                authorization: sql_session::SqlSessionAuthorization {
+                    principal_ids,
+                    policy_hash: &current_authorization.policy_hash,
+                },
+                query_policy: &current_authorization.query_policy,
+            },
         )
         .await
     }
 
-    async fn sql_session_current_policy_hash(
+    /// Rebuilds the execution policy from immutable checkpoint metadata and
+    /// the current authorization state. Durable session policy JSON is only a
+    /// cache: every use compares it against this independently derived value.
+    async fn sql_session_current_execution_authorization(
         &self,
         space_id: &str,
+        session_id: &str,
         principal_ids: &[Uuid],
-    ) -> Result<String> {
+    ) -> Result<CurrentSqlSessionExecutionAuthorization> {
         require_sql_session_principals(principal_ids)?;
+        let workspace_path = self.workspace_path(space_id);
+        let inputs =
+            sql_session::get_session_execution_inputs(&self.operator, &workspace_path, session_id)
+                .await
+                .map_err(sql_session_metadata_authorization_error)?;
+        let relation = index::sql_session_page_relation(&inputs.sql)
+            .map_err(sql_session_metadata_authorization_error)?;
         let state = Authorizer::new(self.operator.clone())
             .state(space_id)
             .await?;
-        validate_sql_session_principal_access(&state, principal_ids)?;
-        sql_session_policy_hash(&state, principal_ids)
+        let entry_scope = sql_session_entry_scope(&state, principal_ids)?;
+        let query_policy = index::sql_session_query_policy_at_checkpoint(
+            &self.operator,
+            &workspace_path,
+            &relation,
+            entry_scope,
+            &inputs.checkpoint,
+        )
+        .await
+        .map_err(sql_session_metadata_authorization_error)?;
+        Ok(CurrentSqlSessionExecutionAuthorization {
+            policy_hash: sql_session_policy_hash(&state, principal_ids)?,
+            query_policy,
+        })
     }
 
     async fn asset_parent_entry(&self, space_id: &str, asset_id: &str) -> Result<Option<String>> {
@@ -909,12 +936,15 @@ impl UgoiteService {
     ) -> Result<u64> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let authorization_policy_hash = self
-            .sql_session_current_policy_hash(space_id, principal_ids)
+        let current_authorization = self
+            .sql_session_current_execution_authorization(space_id, session_id, principal_ids)
             .await?;
-        let authorization = sql_session::SqlSessionAuthorization {
-            principal_ids,
-            policy_hash: &authorization_policy_hash,
+        let authorization = sql_session::SqlSessionExecutionAuthorization {
+            authorization: sql_session::SqlSessionAuthorization {
+                principal_ids,
+                policy_hash: &current_authorization.policy_hash,
+            },
+            query_policy: &current_authorization.query_policy,
         };
         sql_session::get_sql_session_count_authorized_by_form(
             &self.operator,
@@ -935,12 +965,15 @@ impl UgoiteService {
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let authorization_policy_hash = self
-            .sql_session_current_policy_hash(space_id, principal_ids)
+        let current_authorization = self
+            .sql_session_current_execution_authorization(space_id, session_id, principal_ids)
             .await?;
-        let authorization = sql_session::SqlSessionAuthorization {
-            principal_ids,
-            policy_hash: &authorization_policy_hash,
+        let authorization = sql_session::SqlSessionExecutionAuthorization {
+            authorization: sql_session::SqlSessionAuthorization {
+                principal_ids,
+                policy_hash: &current_authorization.policy_hash,
+            },
+            query_policy: &current_authorization.query_policy,
         };
         sql_session::get_sql_session_rows_authorized_by_form(
             &self.operator,
@@ -1032,6 +1065,14 @@ fn require_sql_session_principals(principal_ids: &[Uuid]) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn sql_session_metadata_authorization_error(error: anyhow::Error) -> anyhow::Error {
+    if error.downcast_ref::<AppError>().is_some() {
+        error
+    } else {
+        AppError::forbidden("SQL session execution metadata is invalid").into()
+    }
 }
 
 /// Builds a sparse provider-side authorization predicate from the authoritative

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -691,25 +691,32 @@ impl UgoiteService {
         parameter_types: BTreeMap<String, String>,
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
+        require_sql_session_principals(principal_ids)?;
+        let relation = index::sql_session_page_relation(sql).map_err(|error| {
+            AppError::invalid_input(
+                ugoite_core::error::ErrorCode::InvalidInput,
+                error.to_string(),
+            )
+        })?;
         let workspace =
             iceberg_store::native_workspace(&self.operator, &self.workspace_path(space_id)).await?;
         let checkpoint = workspace.capture_checkpoint().await?;
-        let (allowed, state) = self
-            .sql_session_authorization_at_checkpoint(space_id, principal_ids, &checkpoint)
+        let state = Authorizer::new(self.operator.clone())
+            .state(space_id)
             .await?;
+        let entry_scope = sql_session_entry_scope(&state, principal_ids)?;
         let query_policy = index::sql_session_query_policy_at_checkpoint(
             &self.operator,
             &self.workspace_path(space_id),
-            &allowed,
+            &relation,
+            entry_scope,
             &checkpoint,
         )
         .await?;
-        let authorization_policy_hash =
-            sql_session_policy_hash(&state, principal_ids, &query_policy.readable_entry_ids())?;
+        let authorization_policy_hash = sql_session_policy_hash(&state, principal_ids)?;
         let authorization = sql_session::SqlSessionAuthorization {
             principal_ids,
             policy_hash: &authorization_policy_hash,
-            readable_entries_by_form: &allowed,
         };
         let bound_parameters = index::datafusion_parameters(&parameters, &parameter_types)?;
         sql_session::create_sql_session_authorized_for_principals_with_frozen_policy(
@@ -734,14 +741,8 @@ impl UgoiteService {
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let query_policy = sql_session::get_session_query_policy(
-            &self.operator,
-            &self.workspace_path(space_id),
-            session_id,
-        )
-        .await?;
         let authorization_policy_hash = self
-            .sql_session_current_policy_hash(space_id, principal_ids, &query_policy)
+            .sql_session_current_policy_hash(space_id, principal_ids)
             .await?;
         sql_session::require_session_authorization(
             &self.operator,
@@ -759,69 +760,17 @@ impl UgoiteService {
         .await
     }
 
-    async fn sql_session_authorization_at_checkpoint(
-        &self,
-        space_id: &str,
-        principal_ids: &[Uuid],
-        checkpoint: &crate::SpaceCheckpoint,
-    ) -> Result<(BTreeMap<String, HashSet<String>>, AuthorizationState)> {
-        let authorizer = Authorizer::new(self.operator.clone());
-        let state = authorizer.state(space_id).await?;
-        for principal_id in principal_ids {
-            if !effective_actions_for_state(&state, *principal_id, None)?.contains(&Action::Read) {
-                return Err(AppError::forbidden(
-                    "principal is not currently allowed to read this Space",
-                )
-                .into());
-            }
-        }
-        let workspace =
-            iceberg_store::native_workspace(&self.operator, &self.workspace_path(space_id)).await?;
-        let mut allowed = BTreeMap::new();
-        for form in workspace.forms_at_checkpoint(checkpoint).await? {
-            let relation = form.name.to_ascii_lowercase();
-            let revisions = workspace
-                .read_revision_view_at_checkpoint(checkpoint, form.id, crate::RevisionView::Current)
-                .await?;
-            let mut entry_ids = HashSet::new();
-            for revision in revisions {
-                let resource = ResourceRef {
-                    kind: ResourceKind::Entry,
-                    id: revision.entry.external_id.clone(),
-                    parent: None,
-                };
-                if principal_ids.iter().all(|principal_id| {
-                    effective_actions_for_state(&state, *principal_id, Some(&resource))
-                        .is_ok_and(|actions| actions.contains(&Action::Read))
-                }) {
-                    entry_ids.insert(revision.entry.external_id);
-                }
-            }
-            if !entry_ids.is_empty() {
-                allowed.insert(relation, entry_ids);
-            }
-        }
-        Ok((allowed, state))
-    }
-
     async fn sql_session_current_policy_hash(
         &self,
         space_id: &str,
         principal_ids: &[Uuid],
-        query_policy: &index::SqlSessionQueryPolicy,
     ) -> Result<String> {
+        require_sql_session_principals(principal_ids)?;
         let state = Authorizer::new(self.operator.clone())
             .state(space_id)
             .await?;
-        for principal_id in principal_ids {
-            if !effective_actions_for_state(&state, *principal_id, None)?.contains(&Action::Read) {
-                return Err(AppError::forbidden(
-                    "principal is not currently allowed to read this Space",
-                )
-                .into());
-            }
-        }
-        sql_session_policy_hash(&state, principal_ids, &query_policy.readable_entry_ids())
+        validate_sql_session_principal_access(&state, principal_ids)?;
+        sql_session_policy_hash(&state, principal_ids)
     }
 
     async fn asset_parent_entry(&self, space_id: &str, asset_id: &str) -> Result<Option<String>> {
@@ -960,20 +909,12 @@ impl UgoiteService {
     ) -> Result<u64> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let query_policy = sql_session::get_session_query_policy(
-            &self.operator,
-            &self.workspace_path(space_id),
-            session_id,
-        )
-        .await?;
         let authorization_policy_hash = self
-            .sql_session_current_policy_hash(space_id, principal_ids, &query_policy)
+            .sql_session_current_policy_hash(space_id, principal_ids)
             .await?;
-        let no_live_scope = BTreeMap::new();
         let authorization = sql_session::SqlSessionAuthorization {
             principal_ids,
             policy_hash: &authorization_policy_hash,
-            readable_entries_by_form: &no_live_scope,
         };
         sql_session::get_sql_session_count_authorized_by_form(
             &self.operator,
@@ -994,20 +935,12 @@ impl UgoiteService {
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let query_policy = sql_session::get_session_query_policy(
-            &self.operator,
-            &self.workspace_path(space_id),
-            session_id,
-        )
-        .await?;
         let authorization_policy_hash = self
-            .sql_session_current_policy_hash(space_id, principal_ids, &query_policy)
+            .sql_session_current_policy_hash(space_id, principal_ids)
             .await?;
-        let no_live_scope = BTreeMap::new();
         let authorization = sql_session::SqlSessionAuthorization {
             principal_ids,
             policy_hash: &authorization_policy_hash,
-            readable_entries_by_form: &no_live_scope,
         };
         sql_session::get_sql_session_rows_authorized_by_form(
             &self.operator,
@@ -1092,11 +1025,75 @@ impl UgoiteService {
     }
 }
 
-fn sql_session_policy_hash(
+fn require_sql_session_principals(principal_ids: &[Uuid]) -> Result<()> {
+    if principal_ids.is_empty() {
+        return Err(
+            AppError::forbidden("SQL session requires at least one authorized principal").into(),
+        );
+    }
+    Ok(())
+}
+
+/// Builds a sparse provider-side authorization predicate from the authoritative
+/// policy state. SQL sessions require every principal to have Space-level
+/// read, so only Entry policies that remove that inherited read need to be
+/// carried into the frozen checkpoint policy.
+fn sql_session_entry_scope(
     state: &AuthorizationState,
     principal_ids: &[Uuid],
-    readable_entry_ids: &std::collections::BTreeSet<String>,
-) -> Result<String> {
+) -> Result<index::SqlSessionEntryScope> {
+    validate_sql_session_principal_access(state, principal_ids)?;
+    let mut denied_entry_ids = std::collections::BTreeSet::new();
+    for resource_key in state.policies.keys() {
+        let Some(entry_id) = resource_key.strip_prefix("entry:") else {
+            continue;
+        };
+        let resource = ResourceRef {
+            kind: ResourceKind::Entry,
+            id: entry_id.to_string(),
+            parent: None,
+        };
+        let mut readable_by_every_principal = true;
+        for principal_id in principal_ids {
+            if !effective_actions_for_state(state, *principal_id, Some(&resource))?
+                .contains(&Action::Read)
+            {
+                readable_by_every_principal = false;
+                break;
+            }
+        }
+        if !readable_by_every_principal {
+            if denied_entry_ids.len() == index::SQL_SESSION_MAX_AUTHORIZATION_SCOPE_IDS {
+                return Err(AppError::invalid_input(
+                    ugoite_core::error::ErrorCode::InvalidInput,
+                    "SQL session authorization scope exceeds the configured maximum",
+                )
+                .into());
+            }
+            denied_entry_ids.insert(entry_id.to_string());
+        }
+    }
+    Ok(index::SqlSessionEntryScope::AllExcept(denied_entry_ids))
+}
+
+fn validate_sql_session_principal_access(
+    state: &AuthorizationState,
+    principal_ids: &[Uuid],
+) -> Result<()> {
+    require_sql_session_principals(principal_ids)?;
+    for principal_id in principal_ids {
+        if !effective_actions_for_state(state, *principal_id, None)?.contains(&Action::Read) {
+            return Err(AppError::forbidden(
+                "principal is not currently allowed to read this Space",
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn sql_session_policy_hash(state: &AuthorizationState, principal_ids: &[Uuid]) -> Result<String> {
+    require_sql_session_principals(principal_ids)?;
     let principal_ids = principal_ids
         .iter()
         .map(Uuid::to_string)
@@ -1126,17 +1123,11 @@ fn sql_session_policy_hash(
             )
         })
         .collect::<BTreeMap<_, _>>();
-    let entry_policies = readable_entry_ids
+    let entry_policies = state
+        .policies
         .iter()
-        .map(|entry_id| {
-            let key = ResourceRef {
-                kind: ResourceKind::Entry,
-                id: entry_id.clone(),
-                parent: None,
-            }
-            .key();
-            (key.clone(), state.policies.get(&key).cloned())
-        })
+        .filter(|(resource_key, _)| resource_key.starts_with("entry:"))
+        .map(|(resource_key, policy)| (resource_key.clone(), policy.clone()))
         .collect::<BTreeMap<_, _>>();
     let canonical = serde_json::to_vec(&json!({
         "space_uid": state.space_uid,

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -1,13 +1,14 @@
 use anyhow::{anyhow, Result};
 use opendal::Operator;
-use serde_json::Value;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashSet};
 use uuid::Uuid;
 
 use crate::integrity::RealIntegrityProvider;
 use crate::{
     asset,
-    authorization::{Authorizer, ResourceKind, ResourceRef},
+    authorization::{AuthorizationState, Authorizer, ResourceKind, ResourceRef},
     entry, form, iceberg_store, index, preferences, saved_sql, search, space, sql_session,
     storage::operator_from_uri,
 };
@@ -688,36 +689,69 @@ impl UgoiteService {
         parameter_types: BTreeMap<String, String>,
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
-        let allowed = self
-            .authorized_form_entry_ids_for_principals(space_id, principal_ids)
+        let (allowed, authorization_policy_hash) = self
+            .sql_session_authorization(space_id, principal_ids)
             .await?;
+        let authorization = sql_session::SqlSessionAuthorization {
+            principal_ids,
+            policy_hash: &authorization_policy_hash,
+            readable_entries_by_form: &allowed,
+        };
         sql_session::create_sql_session_authorized_for_principals_by_form_with_parameters(
             &self.operator,
             &self.workspace_path(space_id),
             sql,
             parameters,
             parameter_types,
-            &allowed,
-            principal_ids,
+            authorization,
         )
         .await
     }
 
-    pub async fn require_sql_session_principals(
+    pub async fn get_sql_session_authorized_for_principals(
         &self,
         space_id: &str,
         session_id: &str,
         principal_ids: &[Uuid],
-    ) -> Result<()> {
+    ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        sql_session::require_session_principals(
+        let (_, authorization_policy_hash) = self
+            .sql_session_authorization(space_id, principal_ids)
+            .await?;
+        sql_session::require_session_authorization(
             &self.operator,
             &self.workspace_path(space_id),
             session_id,
             principal_ids,
+            &authorization_policy_hash,
+        )
+        .await?;
+        sql_session::get_sql_session_status(
+            &self.operator,
+            &self.workspace_path(space_id),
+            session_id,
         )
         .await
+    }
+
+    async fn sql_session_authorization(
+        &self,
+        space_id: &str,
+        principal_ids: &[Uuid],
+    ) -> Result<(BTreeMap<String, HashSet<String>>, String)> {
+        let authorizer = Authorizer::new(self.operator.clone());
+        let before = authorizer.state(space_id).await?;
+        let allowed = self
+            .authorized_form_entry_ids_for_principals(space_id, principal_ids)
+            .await?;
+        let after = authorizer.state(space_id).await?;
+        if before.space_uid != after.space_uid || before.revision != after.revision {
+            return Err(anyhow!(
+                "authorization changed while resolving the SQL session policy; retry the request"
+            ));
+        }
+        Ok((allowed, sql_session_policy_hash(&after, principal_ids)?))
     }
 
     async fn asset_parent_entry(&self, space_id: &str, asset_id: &str) -> Result<Option<String>> {
@@ -848,33 +882,6 @@ impl UgoiteService {
         preferences::patch_user_preferences(&self.operator, user_id, patch).await
     }
 
-    pub async fn create_sql_session(&self, space_id: &str, sql: &str) -> Result<Value> {
-        validate_storage_id(validate_space_id(space_id))?;
-        sql_session::create_sql_session(&self.operator, &self.workspace_path(space_id), sql).await
-    }
-
-    pub async fn get_sql_session(&self, space_id: &str, session_id: &str) -> Result<Value> {
-        validate_storage_id(validate_space_id(space_id))?;
-        validate_storage_id(validate_sql_session_id(session_id))?;
-        sql_session::get_sql_session_status(
-            &self.operator,
-            &self.workspace_path(space_id),
-            session_id,
-        )
-        .await
-    }
-
-    pub async fn get_sql_session_count(&self, space_id: &str, session_id: &str) -> Result<u64> {
-        validate_storage_id(validate_space_id(space_id))?;
-        validate_storage_id(validate_sql_session_id(session_id))?;
-        sql_session::get_sql_session_count(
-            &self.operator,
-            &self.workspace_path(space_id),
-            session_id,
-        )
-        .await
-    }
-
     pub async fn get_sql_session_count_authorized_for_principals(
         &self,
         space_id: &str,
@@ -883,33 +890,19 @@ impl UgoiteService {
     ) -> Result<u64> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let allowed = self
-            .authorized_form_entry_ids_for_principals(space_id, principal_ids)
+        let (allowed, authorization_policy_hash) = self
+            .sql_session_authorization(space_id, principal_ids)
             .await?;
+        let authorization = sql_session::SqlSessionAuthorization {
+            principal_ids,
+            policy_hash: &authorization_policy_hash,
+            readable_entries_by_form: &allowed,
+        };
         sql_session::get_sql_session_count_authorized_by_form(
             &self.operator,
             &self.workspace_path(space_id),
             session_id,
-            &allowed,
-        )
-        .await
-    }
-
-    pub async fn get_sql_session_rows(
-        &self,
-        space_id: &str,
-        session_id: &str,
-        offset: usize,
-        limit: usize,
-    ) -> Result<Value> {
-        validate_storage_id(validate_space_id(space_id))?;
-        validate_storage_id(validate_sql_session_id(session_id))?;
-        sql_session::get_sql_session_rows(
-            &self.operator,
-            &self.workspace_path(space_id),
-            session_id,
-            offset,
-            limit,
+            authorization,
         )
         .await
     }
@@ -924,14 +917,19 @@ impl UgoiteService {
     ) -> Result<Value> {
         validate_storage_id(validate_space_id(space_id))?;
         validate_storage_id(validate_sql_session_id(session_id))?;
-        let allowed = self
-            .authorized_form_entry_ids_for_principals(space_id, principal_ids)
+        let (allowed, authorization_policy_hash) = self
+            .sql_session_authorization(space_id, principal_ids)
             .await?;
+        let authorization = sql_session::SqlSessionAuthorization {
+            principal_ids,
+            policy_hash: &authorization_policy_hash,
+            readable_entries_by_form: &allowed,
+        };
         sql_session::get_sql_session_rows_authorized_by_form(
             &self.operator,
             &self.workspace_path(space_id),
             session_id,
-            &allowed,
+            authorization,
             offset,
             limit,
         )
@@ -1008,6 +1006,19 @@ impl UgoiteService {
     ) -> Result<Value> {
         space::test_storage_connection(config).await
     }
+}
+
+fn sql_session_policy_hash(state: &AuthorizationState, principal_ids: &[Uuid]) -> Result<String> {
+    let principal_ids = principal_ids
+        .iter()
+        .map(Uuid::to_string)
+        .collect::<std::collections::BTreeSet<_>>();
+    let canonical = serde_json::to_vec(&json!({
+        "space_uid": state.space_uid,
+        "authorization_revision": state.revision,
+        "principal_ids": principal_ids,
+    }))?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(canonical))))
 }
 
 fn validate_storage_id(

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -885,7 +885,12 @@ impl SpaceCatalog {
             form_name: metadata
                 .properties()
                 .get(crate::FORM_NAME_PROPERTY)
-                .cloned(),
+                .cloned()
+                .ok_or_else(|| {
+                    crate::CheckpointIntegrityError::new(
+                        "Iceberg table has no immutable Form relation name",
+                    )
+                })?,
             namespace: reference.identifier.namespace.clone(),
             table: reference.identifier.table.clone(),
             table_uuid: reference.table_uuid.clone(),

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -882,6 +882,10 @@ impl SpaceCatalog {
         }
         Ok(CheckpointTable {
             form_id,
+            form_name: metadata
+                .properties()
+                .get(crate::FORM_NAME_PROPERTY)
+                .cloned(),
             namespace: reference.identifier.namespace.clone(),
             table: reference.identifier.table.clone(),
             table_uuid: reference.table_uuid.clone(),

--- a/crates/ugoite-iceberg/src/sql_session.rs
+++ b/crates/ugoite-iceberg/src/sql_session.rs
@@ -87,6 +87,7 @@ async fn load_session_meta(op: &Operator, ws_path: &str, session_id: &str) -> Re
     let mut meta = read_json(op, &meta_path(ws_path, session_id)).await?;
     if is_expired(&meta) {
         meta["status"] = Value::String("expired".to_string());
+        write_json(op, &meta_path(ws_path, session_id), &meta).await?;
     }
     Ok(meta)
 }
@@ -121,6 +122,26 @@ fn session_parameters(meta: &Value) -> Result<HashMap<String, datafusion::scalar
     index::datafusion_parameters(&values, &types)
 }
 
+fn session_query_policy(meta: &Value) -> Result<index::SqlSessionQueryPolicy> {
+    serde_json::from_value(
+        meta.get("query_policy")
+            .cloned()
+            .ok_or_else(|| anyhow!("SQL session is missing its frozen query policy"))?,
+    )
+    .map_err(|error| anyhow!("SQL session query policy is invalid: {error}"))
+}
+
+/// Reads only session metadata and returns its frozen query policy. Service
+/// callers use this before calculating a current policy fingerprint, so a
+/// status request never needs to enumerate live Entries.
+pub async fn get_session_query_policy(
+    op: &Operator,
+    ws_path: &str,
+    session_id: &str,
+) -> Result<index::SqlSessionQueryPolicy> {
+    session_query_policy(&load_session_meta(op, ws_path, session_id).await?)
+}
+
 fn validate_session_authorization(
     meta: &Value,
     principal_ids: &[Uuid],
@@ -131,9 +152,15 @@ fn validate_session_authorization(
         .and_then(Value::as_array)
         .ok_or_else(|| AppError::forbidden("SQL session is not bound to an authorized principal"))?
         .iter()
-        .filter_map(Value::as_str)
-        .filter_map(|value| Uuid::parse_str(value).ok())
-        .collect::<BTreeSet<_>>();
+        .map(|value| {
+            let value = value.as_str().ok_or_else(|| {
+                AppError::forbidden("SQL session authorized principal metadata is malformed")
+            })?;
+            Uuid::parse_str(value).map_err(|_| {
+                AppError::forbidden("SQL session authorized principal metadata is malformed")
+            })
+        })
+        .collect::<std::result::Result<BTreeSet<_>, _>>()?;
     let requested = principal_ids.iter().copied().collect::<BTreeSet<_>>();
     if stored != requested {
         return Err(
@@ -179,7 +206,7 @@ async fn execute_session_page_authorized_by_form(
         op,
         ws_path,
         session_sql(&meta)?,
-        authorization.readable_entries_by_form,
+        &session_query_policy(&meta)?,
         index::AuthorizedSqlSessionPage {
             parameters: session_parameters(&meta)?,
             checkpoint: session_checkpoint(&meta)?,
@@ -221,11 +248,47 @@ pub async fn create_sql_session_authorized_for_principals_by_form_with_parameter
         .await?
         .capture_checkpoint()
         .await?;
+    let query_policy = index::sql_session_query_policy_at_checkpoint(
+        op,
+        ws_path,
+        authorization.readable_entries_by_form,
+        &checkpoint,
+    )
+    .await?;
+    create_sql_session_authorized_for_principals_with_frozen_policy(
+        op,
+        ws_path,
+        sql,
+        parameters,
+        parameter_types,
+        authorization,
+        bound_parameters,
+        checkpoint,
+        query_policy,
+    )
+    .await
+}
+
+/// Creates a session from a checkpoint and derived policy that the service
+/// already bound to the same authorization read. This is the production path;
+/// it never resolves Forms or Entry scope from the live head at later use.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_sql_session_authorized_for_principals_with_frozen_policy(
+    op: &Operator,
+    ws_path: &str,
+    sql: &str,
+    parameters: serde_json::Map<String, Value>,
+    parameter_types: BTreeMap<String, String>,
+    authorization: SqlSessionAuthorization<'_>,
+    bound_parameters: HashMap<String, datafusion::scalar::ScalarValue>,
+    checkpoint: SpaceCheckpoint,
+    query_policy: index::SqlSessionQueryPolicy,
+) -> Result<Value> {
     index::validate_sql_session_query_at_checkpoint(
         op,
         ws_path,
         sql,
-        authorization.readable_entries_by_form,
+        &query_policy,
         bound_parameters,
         checkpoint.clone(),
     )
@@ -262,6 +325,7 @@ pub async fn create_sql_session_authorized_for_principals_by_form_with_parameter
         "expires_at": (now + SESSION_LIFETIME).to_rfc3339(),
         "error": Value::Null,
         "checkpoint": checkpoint,
+        "query_policy": query_policy,
         "pagination": {
             "strategy": "offset",
             "total_order": "ORDER BY ending with _ugoite_id",
@@ -310,10 +374,25 @@ pub async fn get_sql_session_count_authorized_by_form(
     session_id: &str,
     authorization: SqlSessionAuthorization<'_>,
 ) -> Result<u64> {
-    let (_, count) =
-        execute_session_page_authorized_by_form(op, ws_path, session_id, authorization, 0, 1)
-            .await?;
-    Ok(count)
+    let meta = load_session_meta(op, ws_path, session_id).await?;
+    if meta.get("status").and_then(|v| v.as_str()) == Some("expired") {
+        return Err(AppError::expired(ErrorCode::SqlSessionExpired, "SQL session expired").into());
+    }
+    validate_session_authorization(
+        &meta,
+        authorization.principal_ids,
+        authorization.policy_hash,
+    )?;
+    index::execute_sql_query_authorized_by_form_count_at_checkpoint(
+        op,
+        ws_path,
+        session_sql(&meta)?,
+        &session_query_policy(&meta)?,
+        session_parameters(&meta)?,
+        session_checkpoint(&meta)?,
+    )
+    .await
+    .map_err(session_query_error)
 }
 
 pub async fn get_sql_session_rows_authorized_by_form(

--- a/crates/ugoite-iceberg/src/sql_session.rs
+++ b/crates/ugoite-iceberg/src/sql_session.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use chrono::{DateTime, Duration, Utc};
 use opendal::Operator;
 use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use uuid::Uuid;
 
 use crate::index;
@@ -10,6 +11,18 @@ use crate::SpaceCheckpoint;
 use ugoite_core::error::{AppError, ErrorCode};
 
 const SESSION_DIR: &str = "sql_sessions";
+const SESSION_LIFETIME: Duration = Duration::minutes(10);
+pub const DEFAULT_PAGE_SIZE: usize = 50;
+pub const MAX_PAGE_SIZE: usize = index::SQL_SESSION_MAX_ROWS;
+
+pub type ReadableEntriesByForm = BTreeMap<String, HashSet<String>>;
+
+#[derive(Clone, Copy)]
+pub struct SqlSessionAuthorization<'a> {
+    pub principal_ids: &'a [Uuid],
+    pub policy_hash: &'a str,
+    pub readable_entries_by_form: &'a ReadableEntriesByForm,
+}
 
 fn sessions_root(ws_path: &str) -> String {
     format!("{}/{}", ws_path.trim_end_matches('/'), SESSION_DIR)
@@ -84,74 +97,6 @@ fn session_sql(meta: &Value) -> Result<&str> {
         .ok_or_else(|| anyhow!("SQL session missing sql"))
 }
 
-async fn execute_session_page(
-    op: &Operator,
-    ws_path: &str,
-    session_id: &str,
-    offset: usize,
-    limit: usize,
-) -> Result<(Vec<Value>, u64)> {
-    let meta = load_session_meta(op, ws_path, session_id).await?;
-    if meta.get("status").and_then(|v| v.as_str()) == Some("expired") {
-        return Err(AppError::expired(ErrorCode::SqlSessionExpired, "SQL session expired").into());
-    }
-    if let Some(by_form) = meta.get("readable_entries_by_form") {
-        let by_form = serde_json::from_value(by_form.clone())?;
-        return index::execute_sql_query_authorized_by_form_page_at_checkpoint(
-            op,
-            ws_path,
-            session_sql(&meta)?,
-            &by_form,
-            index::AuthorizedSqlSessionPage {
-                parameters: session_parameters(&meta)?,
-                checkpoint: session_checkpoint(&meta)?,
-                offset,
-                limit,
-            },
-        )
-        .await;
-    }
-    index::execute_sql_query_page_with_parameters(
-        op,
-        ws_path,
-        session_sql(&meta)?,
-        session_parameters(&meta)?,
-        offset,
-        limit,
-    )
-    .await
-}
-
-async fn execute_session_page_authorized_by_form(
-    op: &Operator,
-    ws_path: &str,
-    session_id: &str,
-    readable_entries_by_form: &std::collections::BTreeMap<
-        String,
-        std::collections::HashSet<String>,
-    >,
-    offset: usize,
-    limit: usize,
-) -> Result<(Vec<Value>, u64)> {
-    let meta = load_session_meta(op, ws_path, session_id).await?;
-    if meta.get("status").and_then(|v| v.as_str()) == Some("expired") {
-        return Err(AppError::expired(ErrorCode::SqlSessionExpired, "SQL session expired").into());
-    }
-    index::execute_sql_query_authorized_by_form_page_at_checkpoint(
-        op,
-        ws_path,
-        session_sql(&meta)?,
-        readable_entries_by_form,
-        index::AuthorizedSqlSessionPage {
-            parameters: session_parameters(&meta)?,
-            checkpoint: session_checkpoint(&meta)?,
-            offset,
-            limit,
-        },
-    )
-    .await
-}
-
 fn session_checkpoint(meta: &Value) -> Result<SpaceCheckpoint> {
     serde_json::from_value(
         meta.get("checkpoint")
@@ -161,9 +106,7 @@ fn session_checkpoint(meta: &Value) -> Result<SpaceCheckpoint> {
     .map_err(Into::into)
 }
 
-fn session_parameters(
-    meta: &Value,
-) -> Result<std::collections::HashMap<String, datafusion::scalar::ScalarValue>> {
+fn session_parameters(meta: &Value) -> Result<HashMap<String, datafusion::scalar::ScalarValue>> {
     let values = meta
         .get("parameters")
         .and_then(Value::as_object)
@@ -178,24 +121,89 @@ fn session_parameters(
     index::datafusion_parameters(&values, &types)
 }
 
+fn validate_session_authorization(
+    meta: &Value,
+    principal_ids: &[Uuid],
+    authorization_policy_hash: &str,
+) -> Result<()> {
+    let stored = meta
+        .get("authorized_principal_ids")
+        .and_then(Value::as_array)
+        .ok_or_else(|| AppError::forbidden("SQL session is not bound to an authorized principal"))?
+        .iter()
+        .filter_map(Value::as_str)
+        .filter_map(|value| Uuid::parse_str(value).ok())
+        .collect::<BTreeSet<_>>();
+    let requested = principal_ids.iter().copied().collect::<BTreeSet<_>>();
+    if stored != requested {
+        return Err(
+            AppError::forbidden("SQL session belongs to a different principal context").into(),
+        );
+    }
+    if meta
+        .get("authorization_policy_hash")
+        .and_then(Value::as_str)
+        != Some(authorization_policy_hash)
+    {
+        return Err(AppError::forbidden("SQL session authorization policy has changed").into());
+    }
+    Ok(())
+}
+
+fn session_query_error(error: anyhow::Error) -> anyhow::Error {
+    if error.downcast_ref::<AppError>().is_some() {
+        error
+    } else {
+        AppError::invalid_input(ErrorCode::InvalidInput, error.to_string()).into()
+    }
+}
+
+async fn execute_session_page_authorized_by_form(
+    op: &Operator,
+    ws_path: &str,
+    session_id: &str,
+    authorization: SqlSessionAuthorization<'_>,
+    offset: usize,
+    limit: usize,
+) -> Result<(Vec<Value>, u64)> {
+    let meta = load_session_meta(op, ws_path, session_id).await?;
+    if meta.get("status").and_then(|v| v.as_str()) == Some("expired") {
+        return Err(AppError::expired(ErrorCode::SqlSessionExpired, "SQL session expired").into());
+    }
+    validate_session_authorization(
+        &meta,
+        authorization.principal_ids,
+        authorization.policy_hash,
+    )?;
+    index::execute_sql_query_authorized_by_form_page_at_checkpoint(
+        op,
+        ws_path,
+        session_sql(&meta)?,
+        authorization.readable_entries_by_form,
+        index::AuthorizedSqlSessionPage {
+            parameters: session_parameters(&meta)?,
+            checkpoint: session_checkpoint(&meta)?,
+            offset,
+            limit,
+        },
+    )
+    .await
+    .map_err(session_query_error)
+}
+
 pub async fn create_sql_session_authorized_for_principals_by_form(
     op: &Operator,
     ws_path: &str,
     sql: &str,
-    readable_entries_by_form: &std::collections::BTreeMap<
-        String,
-        std::collections::HashSet<String>,
-    >,
-    principal_ids: &[Uuid],
+    authorization: SqlSessionAuthorization<'_>,
 ) -> Result<Value> {
     create_sql_session_authorized_for_principals_by_form_with_parameters(
         op,
         ws_path,
         sql,
         serde_json::Map::new(),
-        std::collections::BTreeMap::new(),
-        readable_entries_by_form,
-        principal_ids,
+        BTreeMap::new(),
+        authorization,
     )
     .await
 }
@@ -205,51 +213,26 @@ pub async fn create_sql_session_authorized_for_principals_by_form_with_parameter
     ws_path: &str,
     sql: &str,
     parameters: serde_json::Map<String, Value>,
-    parameter_types: std::collections::BTreeMap<String, String>,
-    readable_entries_by_form: &std::collections::BTreeMap<
-        String,
-        std::collections::HashSet<String>,
-    >,
-    principal_ids: &[Uuid],
+    parameter_types: BTreeMap<String, String>,
+    authorization: SqlSessionAuthorization<'_>,
 ) -> Result<Value> {
-    let mut meta =
-        create_sql_session_with_parameters(op, ws_path, sql, parameters, parameter_types).await?;
-    meta["readable_entries_by_form"] = serde_json::to_value(readable_entries_by_form)?;
-    meta["authorized_principal_ids"] = serde_json::to_value(principal_ids)?;
-    let session_id = meta
-        .get("id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("SQL session id missing"))?;
-    write_json(op, &meta_path(ws_path, session_id), &meta).await?;
-    Ok(meta)
-}
-
-async fn execute_session_page_scoped(
-    op: &Operator,
-    ws_path: &str,
-    session_id: &str,
-    offset: usize,
-    limit: usize,
-    readable_forms: &[String],
-) -> Result<(Vec<Value>, u64)> {
-    let meta = load_session_meta(op, ws_path, session_id).await?;
-    if meta.get("status").and_then(|v| v.as_str()) == Some("expired") {
-        return Err(AppError::expired(ErrorCode::SqlSessionExpired, "SQL session expired").into());
-    }
-    index::execute_sql_query_scoped_page(
+    let bound_parameters = index::datafusion_parameters(&parameters, &parameter_types)?;
+    let checkpoint = crate::iceberg_store::native_workspace(op, ws_path)
+        .await?
+        .capture_checkpoint()
+        .await?;
+    index::validate_sql_session_query_at_checkpoint(
         op,
         ws_path,
-        session_sql(&meta)?,
-        readable_forms,
-        offset,
-        limit,
+        sql,
+        authorization.readable_entries_by_form,
+        bound_parameters,
+        checkpoint.clone(),
     )
     .await
-}
+    .map_err(session_query_error)?;
 
-pub async fn create_sql_session(op: &Operator, ws_path: &str, sql: &str) -> Result<Value> {
     ensure_sessions_dir(op, ws_path).await?;
-
     let session_id = Uuid::new_v4().to_string();
     let session_dir = format!("{}/", session_path(ws_path, &session_id));
     op.create_dir(&session_dir).await?;
@@ -258,33 +241,39 @@ pub async fn create_sql_session(op: &Operator, ws_path: &str, sql: &str) -> Resu
         Some(existing_id) => existing_id,
         None => Uuid::new_v4().to_string(),
     };
-    let checkpoint = crate::iceberg_store::native_workspace(op, ws_path)
-        .await?
-        .capture_checkpoint()
-        .await?;
-
     let now = Utc::now();
-    let expires_at = (now + Duration::minutes(10)).to_rfc3339();
-    let created_at = now.to_rfc3339();
     let space_id = space_id_from_ws_path(ws_path);
-
+    let authorized_principal_ids = authorization
+        .principal_ids
+        .iter()
+        .map(Uuid::to_string)
+        .collect::<BTreeSet<_>>();
     let meta = json!({
         "id": session_id,
         "space_id": space_id,
         "sql_id": sql_id,
         "sql": sql,
-        "parameters": {},
-        "parameter_types": {},
+        "parameters": parameters,
+        "parameter_types": parameter_types,
+        "authorized_principal_ids": authorized_principal_ids,
+        "authorization_policy_hash": authorization.policy_hash,
         "status": "ready",
-        "created_at": created_at,
-        "expires_at": expires_at,
+        "created_at": now.to_rfc3339(),
+        "expires_at": (now + SESSION_LIFETIME).to_rfc3339(),
         "error": Value::Null,
         "checkpoint": checkpoint,
         "pagination": {
             "strategy": "offset",
-            "order_by": "sql_order_by_required",
-            "default_limit": 50,
-            "max_limit": 1000,
+            "total_order": "ORDER BY ending with _ugoite_id",
+            "default_limit": DEFAULT_PAGE_SIZE,
+            "max_limit": MAX_PAGE_SIZE,
+            "max_offset": MAX_PAGE_SIZE - 1,
+        },
+        "limits": {
+            "max_rows": index::SQL_SESSION_MAX_ROWS,
+            "max_memory_bytes": index::SQL_SESSION_MAX_MEMORY_BYTES,
+            "timeout_ms": index::SQL_SESSION_TIMEOUT.as_millis(),
+            "max_concurrency": 1,
         },
         "count": {
             "mode": "on_demand",
@@ -292,57 +281,19 @@ pub async fn create_sql_session(op: &Operator, ws_path: &str, sql: &str) -> Resu
             "value": Value::Null,
         }
     });
-
     write_json(op, &meta_path(ws_path, &session_id), &meta).await?;
     Ok(meta)
 }
 
-pub async fn create_sql_session_with_parameters(
-    op: &Operator,
-    ws_path: &str,
-    sql: &str,
-    parameters: serde_json::Map<String, Value>,
-    parameter_types: std::collections::BTreeMap<String, String>,
-) -> Result<Value> {
-    // Validate at the API/storage boundary. The executor repeats exact
-    // placeholder matching after parse so missing or extra values fail closed.
-    index::datafusion_parameters(&parameters, &parameter_types)?;
-    let mut meta = create_sql_session(op, ws_path, sql).await?;
-    meta["parameters"] = Value::Object(parameters);
-    meta["parameter_types"] = serde_json::to_value(parameter_types)?;
-    let session_id = meta
-        .get("id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("SQL session id missing"))?;
-    write_json(op, &meta_path(ws_path, session_id), &meta).await?;
-    Ok(meta)
-}
-
-pub async fn require_session_principals(
+pub async fn require_session_authorization(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
     principal_ids: &[Uuid],
+    authorization_policy_hash: &str,
 ) -> Result<()> {
     let meta = load_session_meta(op, ws_path, session_id).await?;
-    let stored = meta
-        .get("authorized_principal_ids")
-        .and_then(Value::as_array)
-        .ok_or_else(|| AppError::forbidden("SQL session is not bound to an authorized principal"))?
-        .iter()
-        .filter_map(Value::as_str)
-        .filter_map(|value| Uuid::parse_str(value).ok())
-        .collect::<std::collections::BTreeSet<_>>();
-    let requested = principal_ids
-        .iter()
-        .copied()
-        .collect::<std::collections::BTreeSet<_>>();
-    if stored != requested {
-        return Err(
-            AppError::forbidden("SQL session belongs to a different principal context").into(),
-        );
-    }
-    Ok(())
+    validate_session_authorization(&meta, principal_ids, authorization_policy_hash)
 }
 
 pub async fn get_sql_session_status(
@@ -353,68 +304,23 @@ pub async fn get_sql_session_status(
     load_session_meta(op, ws_path, session_id).await
 }
 
-pub async fn get_sql_session_count(op: &Operator, ws_path: &str, session_id: &str) -> Result<u64> {
-    let (_, count) = execute_session_page(op, ws_path, session_id, 0, 1).await?;
-    Ok(count)
-}
-
 pub async fn get_sql_session_count_authorized_by_form(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
-    readable_entries_by_form: &std::collections::BTreeMap<
-        String,
-        std::collections::HashSet<String>,
-    >,
-) -> Result<u64> {
-    let (_, count) = execute_session_page_authorized_by_form(
-        op,
-        ws_path,
-        session_id,
-        readable_entries_by_form,
-        0,
-        1,
-    )
-    .await?;
-    Ok(count)
-}
-
-pub async fn get_sql_session_count_scoped(
-    op: &Operator,
-    ws_path: &str,
-    session_id: &str,
-    readable_forms: &[String],
+    authorization: SqlSessionAuthorization<'_>,
 ) -> Result<u64> {
     let (_, count) =
-        execute_session_page_scoped(op, ws_path, session_id, 0, 1, readable_forms).await?;
+        execute_session_page_authorized_by_form(op, ws_path, session_id, authorization, 0, 1)
+            .await?;
     Ok(count)
-}
-
-pub async fn get_sql_session_rows(
-    op: &Operator,
-    ws_path: &str,
-    session_id: &str,
-    offset: usize,
-    limit: usize,
-) -> Result<Value> {
-    let (rows, total) = execute_session_page(op, ws_path, session_id, offset, limit).await?;
-
-    Ok(serde_json::json!({
-        "rows": rows,
-        "offset": offset,
-        "limit": limit,
-        "total_count": total,
-    }))
 }
 
 pub async fn get_sql_session_rows_authorized_by_form(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
-    readable_entries_by_form: &std::collections::BTreeMap<
-        String,
-        std::collections::HashSet<String>,
-    >,
+    authorization: SqlSessionAuthorization<'_>,
     offset: usize,
     limit: usize,
 ) -> Result<Value> {
@@ -422,30 +328,11 @@ pub async fn get_sql_session_rows_authorized_by_form(
         op,
         ws_path,
         session_id,
-        readable_entries_by_form,
+        authorization,
         offset,
         limit,
     )
     .await?;
-    Ok(serde_json::json!({
-        "rows": rows,
-        "offset": offset,
-        "limit": limit,
-        "total_count": total,
-    }))
-}
-
-pub async fn get_sql_session_rows_scoped(
-    op: &Operator,
-    ws_path: &str,
-    session_id: &str,
-    offset: usize,
-    limit: usize,
-    readable_forms: &[String],
-) -> Result<Value> {
-    let (rows, total) =
-        execute_session_page_scoped(op, ws_path, session_id, offset, limit, readable_forms).await?;
-
     Ok(serde_json::json!({
         "rows": rows,
         "offset": offset,

--- a/crates/ugoite-iceberg/src/sql_session.rs
+++ b/crates/ugoite-iceberg/src/sql_session.rs
@@ -23,6 +23,15 @@ pub struct SqlSessionAuthorization<'a> {
     pub policy_hash: &'a str,
 }
 
+/// Use-time authorization inputs. The query policy must be rebuilt from the
+/// immutable checkpoint and current authorization state by the caller; the
+/// persisted policy is compared with it only as derived metadata.
+#[derive(Clone, Copy)]
+pub struct SqlSessionExecutionAuthorization<'a> {
+    pub authorization: SqlSessionAuthorization<'a>,
+    pub query_policy: &'a index::SqlSessionQueryPolicy,
+}
+
 /// Creation-only authorization inputs. The public convenience constructor
 /// accepts an explicit readable-ID map for callers that already have one; the
 /// production service instead supplies a frozen sparse scope directly.
@@ -151,15 +160,24 @@ fn session_query_policy(meta: &Value) -> Result<index::SqlSessionQueryPolicy> {
     .map_err(|error| anyhow!("SQL session query policy is invalid: {error}"))
 }
 
-/// Reads only session metadata and returns its frozen query policy. Service
-/// callers use this before calculating a current policy fingerprint, so a
-/// status request never needs to enumerate live Entries.
-pub async fn get_session_query_policy(
+/// The durable inputs used to recreate an expected execution policy.
+#[derive(Clone)]
+pub struct SqlSessionExecutionInputs {
+    pub sql: String,
+    pub checkpoint: SpaceCheckpoint,
+}
+
+/// Reads the durable query coordinate, not the stored derived policy.
+pub async fn get_session_execution_inputs(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
-) -> Result<index::SqlSessionQueryPolicy> {
-    session_query_policy(&load_session_meta(op, ws_path, session_id).await?)
+) -> Result<SqlSessionExecutionInputs> {
+    let meta = load_session_meta(op, ws_path, session_id).await?;
+    Ok(SqlSessionExecutionInputs {
+        sql: session_sql(&meta)?.to_string(),
+        checkpoint: session_checkpoint(&meta)?,
+    })
 }
 
 fn validate_session_authorization(
@@ -207,6 +225,21 @@ fn validate_session_authorization(
     Ok(())
 }
 
+fn validate_session_execution_authorization(
+    meta: &Value,
+    authorization: SqlSessionExecutionAuthorization<'_>,
+) -> Result<()> {
+    validate_session_authorization(
+        meta,
+        authorization.authorization.principal_ids,
+        authorization.authorization.policy_hash,
+    )?;
+    if session_query_policy(meta)? != *authorization.query_policy {
+        return Err(AppError::forbidden("SQL session query policy has changed").into());
+    }
+    Ok(())
+}
+
 fn session_query_error(error: anyhow::Error) -> anyhow::Error {
     if error.downcast_ref::<AppError>().is_some() {
         error
@@ -219,7 +252,7 @@ async fn execute_session_page_authorized_by_form(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
-    authorization: SqlSessionAuthorization<'_>,
+    authorization: SqlSessionExecutionAuthorization<'_>,
     offset: usize,
     limit: usize,
 ) -> Result<(Vec<Value>, u64)> {
@@ -227,16 +260,12 @@ async fn execute_session_page_authorized_by_form(
     if meta.get("status").and_then(|v| v.as_str()) == Some("expired") {
         return Err(AppError::expired(ErrorCode::SqlSessionExpired, "SQL session expired").into());
     }
-    validate_session_authorization(
-        &meta,
-        authorization.principal_ids,
-        authorization.policy_hash,
-    )?;
+    validate_session_execution_authorization(&meta, authorization)?;
     index::execute_sql_query_authorized_by_form_page_at_checkpoint(
         op,
         ws_path,
         session_sql(&meta)?,
-        &session_query_policy(&meta)?,
+        authorization.query_policy,
         index::AuthorizedSqlSessionPage {
             parameters: session_parameters(&meta)?,
             checkpoint: session_checkpoint(&meta)?,
@@ -394,45 +423,33 @@ pub async fn create_sql_session_authorized_for_principals_with_frozen_policy(
     Ok(meta)
 }
 
-pub async fn require_session_authorization(
+pub async fn get_sql_session_status_authorized(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
-    principal_ids: &[Uuid],
-    authorization_policy_hash: &str,
-) -> Result<()> {
-    let meta = load_session_meta(op, ws_path, session_id).await?;
-    validate_session_authorization(&meta, principal_ids, authorization_policy_hash)
-}
-
-pub async fn get_sql_session_status(
-    op: &Operator,
-    ws_path: &str,
-    session_id: &str,
+    authorization: SqlSessionExecutionAuthorization<'_>,
 ) -> Result<Value> {
-    load_session_meta(op, ws_path, session_id).await
+    let meta = load_session_meta(op, ws_path, session_id).await?;
+    validate_session_execution_authorization(&meta, authorization)?;
+    Ok(meta)
 }
 
 pub async fn get_sql_session_count_authorized_by_form(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
-    authorization: SqlSessionAuthorization<'_>,
+    authorization: SqlSessionExecutionAuthorization<'_>,
 ) -> Result<u64> {
     let meta = load_session_meta(op, ws_path, session_id).await?;
     if meta.get("status").and_then(|v| v.as_str()) == Some("expired") {
         return Err(AppError::expired(ErrorCode::SqlSessionExpired, "SQL session expired").into());
     }
-    validate_session_authorization(
-        &meta,
-        authorization.principal_ids,
-        authorization.policy_hash,
-    )?;
+    validate_session_execution_authorization(&meta, authorization)?;
     index::execute_sql_query_authorized_by_form_count_at_checkpoint(
         op,
         ws_path,
         session_sql(&meta)?,
-        &session_query_policy(&meta)?,
+        authorization.query_policy,
         session_parameters(&meta)?,
         session_checkpoint(&meta)?,
     )
@@ -444,7 +461,7 @@ pub async fn get_sql_session_rows_authorized_by_form(
     op: &Operator,
     ws_path: &str,
     session_id: &str,
-    authorization: SqlSessionAuthorization<'_>,
+    authorization: SqlSessionExecutionAuthorization<'_>,
     offset: usize,
     limit: usize,
 ) -> Result<Value> {

--- a/crates/ugoite-iceberg/src/sql_session.rs
+++ b/crates/ugoite-iceberg/src/sql_session.rs
@@ -21,7 +21,27 @@ pub type ReadableEntriesByForm = BTreeMap<String, HashSet<String>>;
 pub struct SqlSessionAuthorization<'a> {
     pub principal_ids: &'a [Uuid],
     pub policy_hash: &'a str,
+}
+
+/// Creation-only authorization inputs. The public convenience constructor
+/// accepts an explicit readable-ID map for callers that already have one; the
+/// production service instead supplies a frozen sparse scope directly.
+#[derive(Clone, Copy)]
+pub struct SqlSessionCreateAuthorization<'a> {
+    pub authorization: SqlSessionAuthorization<'a>,
     pub readable_entries_by_form: &'a ReadableEntriesByForm,
+}
+
+impl SqlSessionAuthorization<'_> {
+    fn require_principals(self) -> Result<()> {
+        if self.principal_ids.is_empty() {
+            return Err(AppError::forbidden(
+                "SQL session requires at least one authorized principal",
+            )
+            .into());
+        }
+        Ok(())
+    }
 }
 
 fn sessions_root(ws_path: &str) -> String {
@@ -147,6 +167,11 @@ fn validate_session_authorization(
     principal_ids: &[Uuid],
     authorization_policy_hash: &str,
 ) -> Result<()> {
+    if principal_ids.is_empty() {
+        return Err(
+            AppError::forbidden("SQL session requires at least one authorized principal").into(),
+        );
+    }
     let stored = meta
         .get("authorized_principal_ids")
         .and_then(Value::as_array)
@@ -161,6 +186,11 @@ fn validate_session_authorization(
             })
         })
         .collect::<std::result::Result<BTreeSet<_>, _>>()?;
+    if stored.is_empty() {
+        return Err(
+            AppError::forbidden("SQL session is not bound to an authorized principal").into(),
+        );
+    }
     let requested = principal_ids.iter().copied().collect::<BTreeSet<_>>();
     if stored != requested {
         return Err(
@@ -222,7 +252,7 @@ pub async fn create_sql_session_authorized_for_principals_by_form(
     op: &Operator,
     ws_path: &str,
     sql: &str,
-    authorization: SqlSessionAuthorization<'_>,
+    authorization: SqlSessionCreateAuthorization<'_>,
 ) -> Result<Value> {
     create_sql_session_authorized_for_principals_by_form_with_parameters(
         op,
@@ -241,8 +271,21 @@ pub async fn create_sql_session_authorized_for_principals_by_form_with_parameter
     sql: &str,
     parameters: serde_json::Map<String, Value>,
     parameter_types: BTreeMap<String, String>,
-    authorization: SqlSessionAuthorization<'_>,
+    authorization: SqlSessionCreateAuthorization<'_>,
 ) -> Result<Value> {
+    authorization.authorization.require_principals()?;
+    let relation = index::sql_session_page_relation(sql).map_err(session_query_error)?;
+    let readable_entry_ids = authorization
+        .readable_entries_by_form
+        .get(&relation)
+        .ok_or_else(|| anyhow!("SQL session has no readable checkpoint Form {relation}"))?;
+    if readable_entry_ids.len() > index::SQL_SESSION_MAX_AUTHORIZATION_SCOPE_IDS {
+        return Err(AppError::invalid_input(
+            ErrorCode::InvalidInput,
+            "SQL session authorization scope exceeds the configured maximum",
+        )
+        .into());
+    }
     let bound_parameters = index::datafusion_parameters(&parameters, &parameter_types)?;
     let checkpoint = crate::iceberg_store::native_workspace(op, ws_path)
         .await?
@@ -251,7 +294,8 @@ pub async fn create_sql_session_authorized_for_principals_by_form_with_parameter
     let query_policy = index::sql_session_query_policy_at_checkpoint(
         op,
         ws_path,
-        authorization.readable_entries_by_form,
+        &relation,
+        index::SqlSessionEntryScope::Only(readable_entry_ids.iter().cloned().collect()),
         &checkpoint,
     )
     .await?;
@@ -261,7 +305,7 @@ pub async fn create_sql_session_authorized_for_principals_by_form_with_parameter
         sql,
         parameters,
         parameter_types,
-        authorization,
+        authorization.authorization,
         bound_parameters,
         checkpoint,
         query_policy,
@@ -284,6 +328,7 @@ pub async fn create_sql_session_authorized_for_principals_with_frozen_policy(
     checkpoint: SpaceCheckpoint,
     query_policy: index::SqlSessionQueryPolicy,
 ) -> Result<Value> {
+    authorization.require_principals()?;
     index::validate_sql_session_query_at_checkpoint(
         op,
         ws_path,

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -155,8 +155,13 @@ async fn checkpoint_pins_one_head_and_uses_static_iceberg_coordinates() -> anyho
     );
     assert_eq!(checkpoint.tables.len(), 1);
     assert_eq!(checkpoint.tables[0].form_id, form.id);
+    assert_eq!(checkpoint.tables[0].form_name.as_deref(), Some("Task"));
     assert!(checkpoint.tables[0].snapshot_id.is_some());
     assert!(checkpoint.validate_coordinate_checksum());
+    assert_eq!(
+        workspace.form_at_checkpoint(&checkpoint, "task").await?.id,
+        form.id
+    );
 
     workspace
         .save_checkpoint("before-update", &checkpoint)

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -155,7 +155,7 @@ async fn checkpoint_pins_one_head_and_uses_static_iceberg_coordinates() -> anyho
     );
     assert_eq!(checkpoint.tables.len(), 1);
     assert_eq!(checkpoint.tables[0].form_id, form.id);
-    assert_eq!(checkpoint.tables[0].form_name.as_deref(), Some("Task"));
+    assert_eq!(checkpoint.tables[0].form_name, "Task");
     assert!(checkpoint.tables[0].snapshot_id.is_some());
     assert!(checkpoint.validate_coordinate_checksum());
     assert_eq!(

--- a/crates/ugoite-iceberg/tests/test_saved_sql.rs
+++ b/crates/ugoite-iceberg/tests/test_saved_sql.rs
@@ -168,14 +168,23 @@ async fn test_saved_sql_req_api_007_validation_errors() -> anyhow::Result<()> {
         &integrity,
     )
     .await?;
-    let session = sql_session::create_sql_session(&op, ws_path, &invalid_sql.sql).await?;
-    assert!(sql_session::get_sql_session_count(
-        &op,
-        ws_path,
-        session["id"].as_str().expect("session id"),
-    )
-    .await
-    .is_err());
+    let readable_entries_by_form = std::collections::BTreeMap::new();
+    let principal_ids = [uuid::Uuid::from_u128(1)];
+    let authorization = sql_session::SqlSessionAuthorization {
+        principal_ids: &principal_ids,
+        policy_hash: "sha256:test-authorization-policy",
+        readable_entries_by_form: &readable_entries_by_form,
+    };
+    assert!(
+        sql_session::create_sql_session_authorized_for_principals_by_form(
+            &op,
+            ws_path,
+            &invalid_sql.sql,
+            authorization,
+        )
+        .await
+        .is_err()
+    );
 
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/test_saved_sql.rs
+++ b/crates/ugoite-iceberg/tests/test_saved_sql.rs
@@ -173,6 +173,9 @@ async fn test_saved_sql_req_api_007_validation_errors() -> anyhow::Result<()> {
     let authorization = sql_session::SqlSessionAuthorization {
         principal_ids: &principal_ids,
         policy_hash: "sha256:test-authorization-policy",
+    };
+    let create_authorization = sql_session::SqlSessionCreateAuthorization {
+        authorization,
         readable_entries_by_form: &readable_entries_by_form,
     };
     assert!(
@@ -180,7 +183,7 @@ async fn test_saved_sql_req_api_007_validation_errors() -> anyhow::Result<()> {
             &op,
             ws_path,
             &invalid_sql.sql,
-            authorization,
+            create_authorization,
         )
         .await
         .is_err()

--- a/crates/ugoite-iceberg/tests/test_sql_sessions.rs
+++ b/crates/ugoite-iceberg/tests/test_sql_sessions.rs
@@ -162,6 +162,11 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
         serde_json::json!({"title": "string"})
     );
     let session_id = session["id"].as_str().unwrap();
+    let query_policy = serde_json::from_value(session["query_policy"].clone())?;
+    let execution_authorization = sql_session::SqlSessionExecutionAuthorization {
+        authorization,
+        query_policy: &query_policy,
+    };
 
     entry::create_entry(
         &op,
@@ -177,7 +182,7 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
         &op,
         ws_path,
         session_id,
-        authorization,
+        execution_authorization,
     )
     .await?;
     assert_eq!(count, 1);
@@ -186,7 +191,7 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
         &op,
         ws_path,
         session_id,
-        authorization,
+        execution_authorization,
         0,
         10,
     )
@@ -285,12 +290,17 @@ async fn test_sql_sessions_req_api_008_scopes_rows_before_limit() -> anyhow::Res
     )
     .await?;
     let session_id = session["id"].as_str().unwrap();
+    let query_policy = serde_json::from_value(session["query_policy"].clone())?;
+    let execution_authorization = sql_session::SqlSessionExecutionAuthorization {
+        authorization,
+        query_policy: &query_policy,
+    };
 
     let count = sql_session::get_sql_session_count_authorized_by_form(
         &op,
         ws_path,
         session_id,
-        authorization,
+        execution_authorization,
     )
     .await?;
     assert_eq!(count, 2);
@@ -299,7 +309,7 @@ async fn test_sql_sessions_req_api_008_scopes_rows_before_limit() -> anyhow::Res
         &op,
         ws_path,
         session_id,
-        authorization,
+        execution_authorization,
         0,
         10,
     )
@@ -390,11 +400,16 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
     )
     .await?;
     let session_id = session["id"].as_str().expect("session id");
+    let query_policy = serde_json::from_value(session["query_policy"].clone())?;
+    let execution_authorization = sql_session::SqlSessionExecutionAuthorization {
+        authorization,
+        query_policy: &query_policy,
+    };
     assert!(sql_session::get_sql_session_rows_authorized_by_form(
         &op,
         ws_path,
         session_id,
-        authorization,
+        execution_authorization,
         1_000,
         1,
     )
@@ -404,7 +419,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         &op,
         ws_path,
         session_id,
-        authorization,
+        execution_authorization,
         usize::MAX,
         1,
     )
@@ -414,9 +429,12 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         &op,
         ws_path,
         session_id,
-        sql_session::SqlSessionAuthorization {
-            policy_hash: "sha256:changed-policy",
-            ..authorization
+        sql_session::SqlSessionExecutionAuthorization {
+            authorization: sql_session::SqlSessionAuthorization {
+                policy_hash: "sha256:changed-policy",
+                ..authorization
+            },
+            query_policy: &query_policy,
         },
         0,
         1,
@@ -432,12 +450,17 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
     )
     .await?;
     let limit_zero_id = limit_zero["id"].as_str().expect("session id");
+    let limit_zero_query_policy = serde_json::from_value(limit_zero["query_policy"].clone())?;
+    let limit_zero_execution_authorization = sql_session::SqlSessionExecutionAuthorization {
+        authorization,
+        query_policy: &limit_zero_query_policy,
+    };
     assert_eq!(
         sql_session::get_sql_session_count_authorized_by_form(
             &op,
             ws_path,
             limit_zero_id,
-            authorization,
+            limit_zero_execution_authorization,
         )
         .await?,
         0
@@ -447,7 +470,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
             &op,
             ws_path,
             limit_zero_id,
-            authorization,
+            limit_zero_execution_authorization,
             0,
             1,
         )
@@ -463,7 +486,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         &op,
         ws_path,
         limit_zero_id,
-        authorization,
+        limit_zero_execution_authorization,
     )
     .await
     .is_err());
@@ -741,6 +764,86 @@ async fn sql_sessions_apply_sparse_entry_denials_in_the_provider() -> anyhow::Re
             .await?["rows"][0]["_ugoite_id"],
         "task-public"
     );
+
+    // Query policy is durable derived metadata, not execution authority. Each
+    // access must reject a policy that no longer equals the scope, Form, and
+    // projection reconstructed from the immutable checkpoint and current ACL.
+    let meta_path = format!(
+        "{}/sql_sessions/{session_id}/meta.json",
+        service.workspace_path(&space_id)
+    );
+    let original_meta: serde_json::Value =
+        serde_json::from_slice(&service.operator().read(&meta_path).await?.to_vec())?;
+    let original_policy = original_meta["query_policy"].clone();
+    let mut all_current = original_policy.clone();
+    all_current["forms"][0]["entry_scope"] = serde_json::json!("all_current");
+    let mut empty_all_except = original_policy.clone();
+    empty_all_except["forms"][0]["entry_scope"] = serde_json::json!({"all_except": []});
+    let mut extra_system_columns = original_policy.clone();
+    extra_system_columns["forms"][0]["system_columns"] = serde_json::json!([
+        "external_id",
+        "title",
+        "created_at",
+        "updated_at",
+        "entry_id",
+        "entry_version",
+        "committed_at",
+    ]);
+    let mut different_form = original_policy.clone();
+    different_form["forms"][0]["form_id"] = serde_json::json!(Uuid::now_v7().to_string());
+    let mut different_relation = original_policy.clone();
+    different_relation["forms"][0]["relation"] = serde_json::json!("other");
+    let mut different_columns = original_policy.clone();
+    different_columns["forms"][0]["columns"] = serde_json::json!(["other_column"]);
+    let oversized_scope = (0..=ugoite_iceberg::index::SQL_SESSION_MAX_AUTHORIZATION_SCOPE_IDS)
+        .map(|index| format!("injected-{index}"))
+        .collect::<Vec<_>>();
+    let mut oversized_scope_policy = original_policy.clone();
+    oversized_scope_policy["forms"][0]["entry_scope"] =
+        serde_json::json!({"all_except": oversized_scope});
+
+    for (name, query_policy) in [
+        ("all_current scope", all_current),
+        ("empty all_except scope", empty_all_except),
+        ("extra system columns", extra_system_columns),
+        ("different Form ID", different_form),
+        ("different relation", different_relation),
+        ("different columns", different_columns),
+        ("oversized scope", oversized_scope_policy),
+    ] {
+        let mut meta = original_meta.clone();
+        meta["query_policy"] = query_policy;
+        service
+            .operator()
+            .write(&meta_path, serde_json::to_vec(&meta)?)
+            .await?;
+
+        let error = service
+            .get_sql_session_authorized_for_principals(&space_id, session_id, &principals)
+            .await
+            .expect_err(&format!("status must reject a tampered {name}"));
+        assert_forbidden(&error);
+        let error = service
+            .get_sql_session_count_authorized_for_principals(&space_id, session_id, &principals)
+            .await
+            .expect_err(&format!("count must reject a tampered {name}"));
+        assert_forbidden(&error);
+        let error = service
+            .get_sql_session_rows_authorized_for_principals(
+                &space_id,
+                session_id,
+                &principals,
+                0,
+                1,
+            )
+            .await
+            .expect_err(&format!("rows must reject a tampered {name}"));
+        assert_forbidden(&error);
+    }
+    service
+        .operator()
+        .write(&meta_path, serde_json::to_vec(&original_meta)?)
+        .await?;
 
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/test_sql_sessions.rs
+++ b/crates/ugoite-iceberg/tests/test_sql_sessions.rs
@@ -1,8 +1,16 @@
 mod common;
 
+use chrono::{Duration, Utc};
 use common::setup_operator;
+use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashSet};
-use ugoite_iceberg::{entry, form, saved_sql, space, sql_session};
+use ugoite_domain::identity::{AccessPolicy, Action, AgentMode};
+use ugoite_iceberg::{
+    authorization::{Authorizer, CreateAgentRequest, ResourceKind, ResourceRef},
+    entry, form, saved_sql,
+    service::UgoiteService,
+    space, sql_session,
+};
 use uuid::Uuid;
 
 fn authorized_entries(form: &str, entry_ids: &[&str]) -> (Uuid, BTreeMap<String, HashSet<String>>) {
@@ -298,6 +306,10 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         "SELECT * FROM task",
         "SELECT * FROM task ORDER BY _ugoite_updated_at",
         "SELECT DISTINCT _ugoite_id FROM task ORDER BY _ugoite_id",
+        "SELECT _ugoite_title AS _ugoite_id FROM task ORDER BY _ugoite_id",
+        "SELECT * FROM task WHERE EXISTS (SELECT 1 FROM task t2 WHERE t2._ugoite_id = task._ugoite_id) ORDER BY _ugoite_id",
+        "SELECT (SELECT _ugoite_id FROM task LIMIT 1) FROM task ORDER BY _ugoite_id",
+        "SELECT * FROM task WHERE _ugoite_id IN (SELECT _ugoite_id FROM task) ORDER BY _ugoite_id",
         "SELECT * FROM task ORDER BY _ugoite_id LIMIT 1 OFFSET 1000000",
     ] {
         assert!(
@@ -334,6 +346,16 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         &op,
         ws_path,
         session_id,
+        authorization,
+        usize::MAX,
+        1,
+    )
+    .await
+    .is_err());
+    assert!(sql_session::get_sql_session_rows_authorized_by_form(
+        &op,
+        ws_path,
+        session_id,
         sql_session::SqlSessionAuthorization {
             policy_hash: "sha256:changed-policy",
             ..authorization
@@ -343,6 +365,193 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
     )
     .await
     .is_err());
+
+    let limit_zero = sql_session::create_sql_session_authorized_for_principals_by_form(
+        &op,
+        ws_path,
+        "SELECT * FROM task ORDER BY _ugoite_id LIMIT 0",
+        authorization,
+    )
+    .await?;
+    let limit_zero_id = limit_zero["id"].as_str().expect("session id");
+    assert_eq!(
+        sql_session::get_sql_session_count_authorized_by_form(
+            &op,
+            ws_path,
+            limit_zero_id,
+            authorization,
+        )
+        .await?,
+        0
+    );
+    assert_eq!(
+        sql_session::get_sql_session_rows_authorized_by_form(
+            &op,
+            ws_path,
+            limit_zero_id,
+            authorization,
+            0,
+            1,
+        )
+        .await?["rows"],
+        serde_json::json!([])
+    );
+
+    let meta_path = format!("{ws_path}/sql_sessions/{limit_zero_id}/meta.json");
+    let mut meta: serde_json::Value = serde_json::from_slice(&op.read(&meta_path).await?.to_vec())?;
+    meta["authorized_principal_ids"] = serde_json::json!(["not-a-uuid"]);
+    op.write(&meta_path, serde_json::to_vec(&meta)?).await?;
+    assert!(sql_session::get_sql_session_count_authorized_by_form(
+        &op,
+        ws_path,
+        limit_zero_id,
+        authorization,
+    )
+    .await
+    .is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+/// REQ-API-008: production service calls retain a frozen checkpoint policy.
+async fn sql_sessions_service_freezes_checkpoint_scope_and_policy() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    let service = UgoiteService::from_operator(op, "memory://sql-session-service");
+    let owner = Uuid::from_u128(44);
+    let space_id = service
+        .create_space_for_principal("sql-session-service", owner, "Owner")
+        .await?
+        .to_string();
+    service
+        .upsert_form(
+            &space_id,
+            &serde_json::json!({
+                "name": "Task",
+                "template": "# Task\n\n## Summary\n",
+                "fields": {"Summary": {"type": "string"}},
+            }),
+        )
+        .await?;
+    for (id, title) in [("task-1", "One"), ("task-2", "Two")] {
+        service
+            .create_entry(
+                &space_id,
+                id,
+                &format!("---\nform: Task\n---\n# {title}\n\n## Summary\n{title}\n"),
+                "owner",
+            )
+            .await?;
+    }
+
+    // `last_used_at` advances the legacy global authorization revision but
+    // does not affect the owner's effective policy or this session scope.
+    let authorizer = Authorizer::new(service.operator().clone());
+    let agent = authorizer
+        .create_agent(
+            &space_id,
+            owner,
+            CreateAgentRequest {
+                display_name: "Unrelated reader".to_string(),
+                description: String::new(),
+                mode: AgentMode::Autonomous,
+                owner_principal_ids: [owner].into_iter().collect::<BTreeSet<_>>(),
+                granted_actions: [Action::Read].into_iter().collect(),
+                expires_at: Some((Utc::now() + Duration::hours(1)).to_rfc3339()),
+            },
+        )
+        .await?;
+
+    let principals = [owner];
+    let session = service
+        .create_sql_session_authorized_for_principals(
+            &space_id,
+            &principals,
+            "SELECT * FROM task ORDER BY _ugoite_id",
+        )
+        .await?;
+    let session_id = session["id"].as_str().expect("session ID");
+
+    service.delete_entry(&space_id, "task-1", false).await?;
+    service
+        .create_entry(
+            &space_id,
+            "task-3",
+            "---\nform: Task\n---\n# Three\n\n## Summary\nThree\n",
+            "owner",
+        )
+        .await?;
+    service
+        .upsert_form(
+            &space_id,
+            &serde_json::json!({
+                "name": "Task",
+                "template": "# Task\n\n## Summary\n\n## Detail\n",
+                "fields": {
+                    "Summary": {"type": "string"},
+                    "Detail": {"id": 101, "type": "string"},
+                },
+            }),
+        )
+        .await?;
+
+    authorizer
+        .mark_agent_used(&space_id, agent.agent_id)
+        .await?;
+    assert_eq!(
+        service
+            .get_sql_session_authorized_for_principals(&space_id, session_id, &principals)
+            .await?["status"],
+        "ready"
+    );
+    assert_eq!(
+        service
+            .get_sql_session_count_authorized_for_principals(&space_id, session_id, &principals)
+            .await?,
+        2
+    );
+    let rows = service
+        .get_sql_session_rows_authorized_for_principals(&space_id, session_id, &principals, 0, 2)
+        .await?;
+    assert_eq!(rows["total_count"], 2);
+    assert_eq!(
+        rows["rows"]
+            .as_array()
+            .expect("rows")
+            .iter()
+            .map(|row| row["_ugoite_id"].as_str().expect("entry ID"))
+            .collect::<Vec<_>>(),
+        vec!["task-1", "task-2"]
+    );
+
+    authorizer
+        .set_policy(
+            &space_id,
+            owner,
+            &ResourceRef {
+                kind: ResourceKind::Entry,
+                id: "task-1".to_string(),
+                parent: None,
+            },
+            AccessPolicy {
+                policy_id: Uuid::now_v7(),
+                inherit_space_role: false,
+                grants: Vec::new(),
+            },
+        )
+        .await?;
+    assert!(service
+        .get_sql_session_authorized_for_principals(&space_id, session_id, &principals)
+        .await
+        .is_err());
+    assert!(service
+        .get_sql_session_count_authorized_for_principals(&space_id, session_id, &principals)
+        .await
+        .is_err());
+    assert!(service
+        .get_sql_session_rows_authorized_for_principals(&space_id, session_id, &principals, 0, 1)
+        .await
+        .is_err());
 
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/test_sql_sessions.rs
+++ b/crates/ugoite-iceberg/tests/test_sql_sessions.rs
@@ -4,7 +4,10 @@ use chrono::{Duration, Utc};
 use common::setup_operator;
 use std::collections::BTreeSet;
 use std::collections::{BTreeMap, HashSet};
-use ugoite_domain::identity::{AccessPolicy, Action, AgentMode};
+use ugoite_core::error::{AppError, ErrorKind};
+use ugoite_domain::identity::{
+    AccessPolicy, Action, AgentMode, PrincipalKind, PrincipalState, SpacePrincipal, SpaceRole,
+};
 use ugoite_iceberg::{
     authorization::{Authorizer, CreateAgentRequest, ResourceKind, ResourceRef},
     entry, form, saved_sql,
@@ -29,6 +32,13 @@ fn authorized_entries(form: &str, entry_ids: &[&str]) -> (Uuid, BTreeMap<String,
 }
 
 const AUTHORIZATION_POLICY_HASH: &str = "sha256:test-authorization-policy";
+
+fn assert_forbidden(error: &anyhow::Error) {
+    assert_eq!(
+        error.downcast_ref::<AppError>().map(AppError::kind),
+        Some(ErrorKind::Forbidden)
+    );
+}
 
 #[tokio::test]
 /// REQ-API-008
@@ -85,8 +95,50 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
     let authorization = sql_session::SqlSessionAuthorization {
         principal_ids: &principal_ids,
         policy_hash: AUTHORIZATION_POLICY_HASH,
+    };
+    let create_authorization = sql_session::SqlSessionCreateAuthorization {
+        authorization,
         readable_entries_by_form: &readable_entries_by_form,
     };
+
+    let no_principals = [];
+    let error = sql_session::create_sql_session_authorized_for_principals_by_form(
+        &op,
+        ws_path,
+        "SELECT * FROM entry ORDER BY _ugoite_id",
+        sql_session::SqlSessionCreateAuthorization {
+            authorization: sql_session::SqlSessionAuthorization {
+                principal_ids: &no_principals,
+                policy_hash: AUTHORIZATION_POLICY_HASH,
+            },
+            readable_entries_by_form: &readable_entries_by_form,
+        },
+    )
+    .await
+    .expect_err("a public SQL-session constructor must reject an empty principal set");
+    assert_forbidden(&error);
+
+    let oversized_entries = (0..=ugoite_iceberg::index::SQL_SESSION_MAX_AUTHORIZATION_SCOPE_IDS)
+        .map(|index| format!("entry-{index}"))
+        .collect::<HashSet<_>>();
+    let oversized_scope = [("entry".to_string(), oversized_entries)]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let error = sql_session::create_sql_session_authorized_for_principals_by_form(
+        &op,
+        ws_path,
+        "SELECT * FROM entry ORDER BY _ugoite_id",
+        sql_session::SqlSessionCreateAuthorization {
+            authorization,
+            readable_entries_by_form: &oversized_scope,
+        },
+    )
+    .await
+    .expect_err("an explicit authorization scope must be bounded before checkpoint creation");
+    assert!(error
+        .to_string()
+        .contains("authorization scope exceeds the configured maximum"));
+
     let parameters = [("title".to_string(), serde_json::json!("Alpha"))]
         .into_iter()
         .collect();
@@ -100,7 +152,7 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
             &sql_payload.sql,
             parameters,
             parameter_types,
-            authorization,
+            create_authorization,
         )
         .await?;
     assert_eq!(session["status"], "ready");
@@ -220,13 +272,16 @@ async fn test_sql_sessions_req_api_008_scopes_rows_before_limit() -> anyhow::Res
     let authorization = sql_session::SqlSessionAuthorization {
         principal_ids: &principal_ids,
         policy_hash: AUTHORIZATION_POLICY_HASH,
+    };
+    let create_authorization = sql_session::SqlSessionCreateAuthorization {
+        authorization,
         readable_entries_by_form: &readable_entries_by_form,
     };
     let session = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
         "SELECT * FROM publictask ORDER BY _ugoite_id DESC LIMIT 2",
-        authorization,
+        create_authorization,
     )
     .await?;
     let session_id = session["id"].as_str().unwrap();
@@ -299,6 +354,9 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
     let authorization = sql_session::SqlSessionAuthorization {
         principal_ids: &principal_ids,
         policy_hash: AUTHORIZATION_POLICY_HASH,
+    };
+    let create_authorization = sql_session::SqlSessionCreateAuthorization {
+        authorization,
         readable_entries_by_form: &readable_entries_by_form,
     };
 
@@ -317,7 +375,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
                 &op,
                 ws_path,
                 sql,
-                authorization,
+                create_authorization,
             )
             .await
             .is_err()
@@ -328,7 +386,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         &op,
         ws_path,
         "SELECT * FROM task ORDER BY _ugoite_id",
-        authorization,
+        create_authorization,
     )
     .await?;
     let session_id = session["id"].as_str().expect("session id");
@@ -370,7 +428,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         &op,
         ws_path,
         "SELECT * FROM task ORDER BY _ugoite_id LIMIT 0",
-        authorization,
+        create_authorization,
     )
     .await?;
     let limit_zero_id = limit_zero["id"].as_str().expect("session id");
@@ -471,6 +529,39 @@ async fn sql_sessions_service_freezes_checkpoint_scope_and_policy() -> anyhow::R
         )
         .await?;
     let session_id = session["id"].as_str().expect("session ID");
+    assert_eq!(
+        session["query_policy"]["forms"][0]["entry_scope"],
+        serde_json::json!({"all_except": []})
+    );
+    assert!(session["query_policy"]["forms"][0]
+        .get("entry_ids")
+        .is_none());
+
+    let no_principals = [];
+    let error = service
+        .create_sql_session_authorized_for_principals(
+            &space_id,
+            &no_principals,
+            "SELECT * FROM task ORDER BY _ugoite_id",
+        )
+        .await
+        .expect_err("session creation must reject an empty principal set");
+    assert_forbidden(&error);
+    let error = service
+        .get_sql_session_authorized_for_principals(&space_id, session_id, &no_principals)
+        .await
+        .expect_err("session status must reject an empty principal set");
+    assert_forbidden(&error);
+    let error = service
+        .get_sql_session_count_authorized_for_principals(&space_id, session_id, &no_principals)
+        .await
+        .expect_err("session count must reject an empty principal set");
+    assert_forbidden(&error);
+    let error = service
+        .get_sql_session_rows_authorized_for_principals(&space_id, session_id, &no_principals, 0, 1)
+        .await
+        .expect_err("session rows must reject an empty principal set");
+    assert_forbidden(&error);
 
     service.delete_entry(&space_id, "task-1", false).await?;
     service
@@ -553,5 +644,123 @@ async fn sql_sessions_service_freezes_checkpoint_scope_and_policy() -> anyhow::R
         .await
         .is_err());
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_sessions_apply_sparse_entry_denials_in_the_provider() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    let service = UgoiteService::from_operator(op, "memory://sql-session-sparse-scope");
+    let owner = Uuid::from_u128(81);
+    let viewer = Uuid::from_u128(82);
+    let space_id = service
+        .create_space_for_principal("sql-session-sparse-scope", owner, "Owner")
+        .await?
+        .to_string();
+    service
+        .upsert_form(
+            &space_id,
+            &serde_json::json!({
+                "name": "Task",
+                "template": "# Task\n\n## Summary\n",
+                "fields": {"Summary": {"type": "string"}},
+            }),
+        )
+        .await?;
+    for (id, title) in [("task-public", "Public"), ("task-private", "Private")] {
+        service
+            .create_entry(
+                &space_id,
+                id,
+                &format!("---\nform: Task\n---\n# {title}\n\n## Summary\n{title}\n"),
+                "owner",
+            )
+            .await?;
+    }
+
+    let authorizer = Authorizer::new(service.operator().clone());
+    authorizer
+        .add_human_member(
+            &space_id,
+            owner,
+            SpacePrincipal {
+                principal_id: viewer,
+                kind: PrincipalKind::Human,
+                display_name: "Viewer".to_string(),
+                state: PrincipalState::Active,
+                created_at: Utc::now().to_rfc3339(),
+            },
+            SpaceRole::Viewer,
+        )
+        .await?;
+    authorizer
+        .set_policy(
+            &space_id,
+            owner,
+            &ResourceRef {
+                kind: ResourceKind::Entry,
+                id: "task-private".to_string(),
+                parent: None,
+            },
+            AccessPolicy {
+                policy_id: Uuid::now_v7(),
+                inherit_space_role: false,
+                grants: Vec::new(),
+            },
+        )
+        .await?;
+
+    let principals = [viewer];
+    let session = service
+        .create_sql_session_authorized_for_principals(
+            &space_id,
+            &principals,
+            "SELECT * FROM task ORDER BY _ugoite_id",
+        )
+        .await?;
+    assert_eq!(
+        session["query_policy"]["forms"][0]["entry_scope"],
+        serde_json::json!({"all_except": ["task-private"]})
+    );
+    let session_id = session["id"].as_str().expect("session ID");
+    assert_eq!(
+        service
+            .get_sql_session_count_authorized_for_principals(&space_id, session_id, &principals)
+            .await?,
+        1
+    );
+    assert_eq!(
+        service
+            .get_sql_session_rows_authorized_for_principals(
+                &space_id,
+                session_id,
+                &principals,
+                0,
+                1,
+            )
+            .await?["rows"][0]["_ugoite_id"],
+        "task-public"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_session_rejects_unsupported_sql_before_resolving_a_space_scope() -> anyhow::Result<()>
+{
+    let service = UgoiteService::from_operator(
+        setup_operator()?,
+        "memory://sql-session-early-shape-validation",
+    );
+    let principals = [Uuid::from_u128(91)];
+    let error = service
+        .create_sql_session_authorized_for_principals(
+            "missing-space",
+            &principals,
+            "SELECT * FROM task JOIN other ON task._ugoite_id = other._ugoite_id ORDER BY task._ugoite_id",
+        )
+        .await
+        .expect_err("unsupported SQL must fail before the Space is opened");
+    assert!(error.to_string().contains("does not support joins"));
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/test_sql_sessions.rs
+++ b/crates/ugoite-iceberg/tests/test_sql_sessions.rs
@@ -1,7 +1,26 @@
 mod common;
 
 use common::setup_operator;
+use std::collections::{BTreeMap, HashSet};
 use ugoite_iceberg::{entry, form, saved_sql, space, sql_session};
+use uuid::Uuid;
+
+fn authorized_entries(form: &str, entry_ids: &[&str]) -> (Uuid, BTreeMap<String, HashSet<String>>) {
+    (
+        Uuid::from_u128(1),
+        [(
+            form.to_ascii_lowercase(),
+            entry_ids
+                .iter()
+                .map(|entry_id| (*entry_id).to_string())
+                .collect(),
+        )]
+        .into_iter()
+        .collect(),
+    )
+}
+
+const AUTHORIZATION_POLICY_HASH: &str = "sha256:test-authorization-policy";
 
 #[tokio::test]
 /// REQ-API-008
@@ -35,8 +54,12 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
 
     let sql_payload = saved_sql::SqlPayload {
         name: "Alpha Query".to_string(),
-        sql: "SELECT * FROM entry WHERE _ugoite_title = 'Alpha' ORDER BY _ugoite_id".to_string(),
-        variables: serde_json::json!([]),
+        sql: "SELECT * FROM entry WHERE _ugoite_title = $title ORDER BY _ugoite_id".to_string(),
+        variables: serde_json::json!([{
+            "name": "title",
+            "type": "string",
+            "description": "Entry title",
+        }]),
     };
     saved_sql::create_sql(
         &op,
@@ -48,14 +71,66 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
     )
     .await?;
 
-    let session = sql_session::create_sql_session(&op, ws_path, &sql_payload.sql).await?;
+    let (principal_id, readable_entries_by_form) =
+        authorized_entries("Entry", &["entry-1", "entry-2"]);
+    let principal_ids = [principal_id];
+    let authorization = sql_session::SqlSessionAuthorization {
+        principal_ids: &principal_ids,
+        policy_hash: AUTHORIZATION_POLICY_HASH,
+        readable_entries_by_form: &readable_entries_by_form,
+    };
+    let parameters = [("title".to_string(), serde_json::json!("Alpha"))]
+        .into_iter()
+        .collect();
+    let parameter_types = [("title".to_string(), "string".to_string())]
+        .into_iter()
+        .collect();
+    let session =
+        sql_session::create_sql_session_authorized_for_principals_by_form_with_parameters(
+            &op,
+            ws_path,
+            &sql_payload.sql,
+            parameters,
+            parameter_types,
+            authorization,
+        )
+        .await?;
     assert_eq!(session["status"], "ready");
+    assert_eq!(session["parameters"], serde_json::json!({"title": "Alpha"}));
+    assert_eq!(
+        session["parameter_types"],
+        serde_json::json!({"title": "string"})
+    );
     let session_id = session["id"].as_str().unwrap();
 
-    let count = sql_session::get_sql_session_count(&op, ws_path, session_id).await?;
+    entry::create_entry(
+        &op,
+        ws_path,
+        "entry-3",
+        "---\nform: Entry\n---\n# After checkpoint\n\n## Body\nnew",
+        "author",
+        &MockIntegrity,
+    )
+    .await?;
+
+    let count = sql_session::get_sql_session_count_authorized_by_form(
+        &op,
+        ws_path,
+        session_id,
+        authorization,
+    )
+    .await?;
     assert_eq!(count, 1);
 
-    let rows = sql_session::get_sql_session_rows(&op, ws_path, session_id, 0, 10).await?;
+    let rows = sql_session::get_sql_session_rows_authorized_by_form(
+        &op,
+        ws_path,
+        session_id,
+        authorization,
+        0,
+        10,
+    )
+    .await?;
     assert_eq!(rows["total_count"], 1);
     let rows_list = rows["rows"].as_array().unwrap();
     assert_eq!(rows_list.len(), 1);
@@ -131,28 +206,143 @@ async fn test_sql_sessions_req_api_008_scopes_rows_before_limit() -> anyhow::Res
     )
     .await?;
 
-    let session = sql_session::create_sql_session(
+    let (principal_id, readable_entries_by_form) =
+        authorized_entries("PublicTask", &["public-a", "public-b"]);
+    let principal_ids = [principal_id];
+    let authorization = sql_session::SqlSessionAuthorization {
+        principal_ids: &principal_ids,
+        policy_hash: AUTHORIZATION_POLICY_HASH,
+        readable_entries_by_form: &readable_entries_by_form,
+    };
+    let session = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
         "SELECT * FROM publictask ORDER BY _ugoite_id DESC LIMIT 2",
+        authorization,
     )
     .await?;
     let session_id = session["id"].as_str().unwrap();
-    let readable_forms = vec!["PublicTask".to_string()];
 
-    let count =
-        sql_session::get_sql_session_count_scoped(&op, ws_path, session_id, &readable_forms)
-            .await?;
+    let count = sql_session::get_sql_session_count_authorized_by_form(
+        &op,
+        ws_path,
+        session_id,
+        authorization,
+    )
+    .await?;
     assert_eq!(count, 2);
 
-    let rows =
-        sql_session::get_sql_session_rows_scoped(&op, ws_path, session_id, 0, 10, &readable_forms)
-            .await?;
+    let rows = sql_session::get_sql_session_rows_authorized_by_form(
+        &op,
+        ws_path,
+        session_id,
+        authorization,
+        0,
+        10,
+    )
+    .await?;
     assert_eq!(rows["total_count"], 2);
     let rows_list = rows["rows"].as_array().unwrap();
     assert_eq!(rows_list.len(), 2);
     assert_eq!(rows_list[0]["_ugoite_id"], "public-b");
     assert_eq!(rows_list[1]["_ugoite_id"], "public-a");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "test-sql-session-boundaries", "/tmp").await?;
+    let ws_path = "spaces/test-sql-session-boundaries";
+
+    struct MockIntegrity;
+    impl ugoite_iceberg::integrity::IntegrityProvider for MockIntegrity {
+        fn checksum(&self, data: &str) -> String {
+            format!("chk-{}", data.len())
+        }
+
+        fn signature(&self, _data: &str) -> String {
+            "mock-signature".to_string()
+        }
+    }
+
+    form::upsert_form(
+        &op,
+        ws_path,
+        &serde_json::json!({
+            "name": "Task",
+            "template": "# Task\n\n## Summary\n",
+            "fields": {"Summary": {"type": "string"}},
+        }),
+    )
+    .await?;
+    entry::create_entry(
+        &op,
+        ws_path,
+        "task-1",
+        "---\nform: Task\n---\n# Task one\n\n## Summary\nOne\n",
+        "author",
+        &MockIntegrity,
+    )
+    .await?;
+    let (principal_id, readable_entries_by_form) = authorized_entries("Task", &["task-1"]);
+    let principal_ids = [principal_id];
+    let authorization = sql_session::SqlSessionAuthorization {
+        principal_ids: &principal_ids,
+        policy_hash: AUTHORIZATION_POLICY_HASH,
+        readable_entries_by_form: &readable_entries_by_form,
+    };
+
+    for sql in [
+        "SELECT * FROM task",
+        "SELECT * FROM task ORDER BY _ugoite_updated_at",
+        "SELECT DISTINCT _ugoite_id FROM task ORDER BY _ugoite_id",
+        "SELECT * FROM task ORDER BY _ugoite_id LIMIT 1 OFFSET 1000000",
+    ] {
+        assert!(
+            sql_session::create_sql_session_authorized_for_principals_by_form(
+                &op,
+                ws_path,
+                sql,
+                authorization,
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    let session = sql_session::create_sql_session_authorized_for_principals_by_form(
+        &op,
+        ws_path,
+        "SELECT * FROM task ORDER BY _ugoite_id",
+        authorization,
+    )
+    .await?;
+    let session_id = session["id"].as_str().expect("session id");
+    assert!(sql_session::get_sql_session_rows_authorized_by_form(
+        &op,
+        ws_path,
+        session_id,
+        authorization,
+        1_000,
+        1,
+    )
+    .await
+    .is_err());
+    assert!(sql_session::get_sql_session_rows_authorized_by_form(
+        &op,
+        ws_path,
+        session_id,
+        sql_session::SqlSessionAuthorization {
+            policy_hash: "sha256:changed-policy",
+            ..authorization
+        },
+        0,
+        1,
+    )
+    .await
+    .is_err());
 
     Ok(())
 }

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -3384,15 +3384,10 @@ async fn get_sql_session(
     validate_id(&session_id, "session_id")?;
     let principal_id = principal_for_space(&state, &space_id, &identity).await?;
     let principals = authorization_principal_ids(&identity, principal_id);
-    state
-        .service
-        .require_sql_session_principals(&space_id, &session_id, &principals)
-        .await
-        .map_err(ApiError::from_core)?;
     Ok(Json(
         state
             .service
-            .get_sql_session(&space_id, &session_id)
+            .get_sql_session_authorized_for_principals(&space_id, &session_id, &principals)
             .await
             .map_err(ApiError::from_core)?,
     ))
@@ -3407,11 +3402,6 @@ async fn get_sql_session_count(
     validate_id(&session_id, "session_id")?;
     let principal_id = principal_for_space(&state, &space_id, &identity).await?;
     let principals = authorization_principal_ids(&identity, principal_id);
-    state
-        .service
-        .require_sql_session_principals(&space_id, &session_id, &principals)
-        .await
-        .map_err(ApiError::from_core)?;
     Ok(Json(json!({
         "count": state
             .service
@@ -3437,11 +3427,16 @@ async fn get_sql_session_rows(
     validate_id(&session_id, "session_id")?;
     let principal_id = principal_for_space(&state, &space_id, &identity).await?;
     let principals = authorization_principal_ids(&identity, principal_id);
-    state
-        .service
-        .require_sql_session_principals(&space_id, &session_id, &principals)
-        .await
-        .map_err(ApiError::from_core)?;
+    let offset = query.offset.unwrap_or_default();
+    let limit = query
+        .limit
+        .unwrap_or(ugoite_iceberg::sql_session::DEFAULT_PAGE_SIZE);
+    if limit > ugoite_iceberg::sql_session::MAX_PAGE_SIZE {
+        return Err(ApiError::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "SQL session page limit exceeds the configured maximum",
+        ));
+    }
     Ok(Json(
         state
             .service
@@ -3449,8 +3444,8 @@ async fn get_sql_session_rows(
                 &space_id,
                 &session_id,
                 &principals,
-                query.offset.unwrap_or_default(),
-                query.limit.unwrap_or(50).min(1000),
+                offset,
+                limit,
             )
             .await
             .map_err(ApiError::from_core)?,

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -3431,12 +3431,7 @@ async fn get_sql_session_rows(
     let limit = query
         .limit
         .unwrap_or(ugoite_iceberg::sql_session::DEFAULT_PAGE_SIZE);
-    if limit > ugoite_iceberg::sql_session::MAX_PAGE_SIZE {
-        return Err(ApiError::new(
-            StatusCode::UNPROCESSABLE_ENTITY,
-            "SQL session page limit exceeds the configured maximum",
-        ));
-    }
+    validate_sql_session_page_request(offset, limit)?;
     Ok(Json(
         state
             .service
@@ -3450,6 +3445,20 @@ async fn get_sql_session_rows(
             .await
             .map_err(ApiError::from_core)?,
     ))
+}
+
+fn validate_sql_session_page_request(offset: usize, limit: usize) -> ApiResult<()> {
+    let page_end = offset.checked_add(limit);
+    if limit == 0
+        || limit > ugoite_iceberg::sql_session::MAX_PAGE_SIZE
+        || page_end.is_none_or(|end| end > ugoite_iceberg::sql_session::MAX_PAGE_SIZE)
+    {
+        return Err(ApiError::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "SQL session page range exceeds the configured maximum",
+        ));
+    }
+    Ok(())
 }
 
 async fn test_connection(
@@ -4408,5 +4417,18 @@ mod authentication_regression_tests {
         validate_action_names(&defaults).expect("CLI default actions are known");
         validate_access_credential_actions(&defaults)
             .expect("CLI default actions require no unavailable approval flow");
+    }
+
+    #[test]
+    fn sql_session_page_request_rejects_zero_overflow_and_large_windows() {
+        assert!(validate_sql_session_page_request(0, 1).is_ok());
+        assert!(validate_sql_session_page_request(0, 0).is_err());
+        assert!(validate_sql_session_page_request(999, 2).is_err());
+        assert!(validate_sql_session_page_request(usize::MAX, 1).is_err());
+        assert!(validate_sql_session_page_request(
+            0,
+            ugoite_iceberg::sql_session::MAX_PAGE_SIZE + 1
+        )
+        .is_err());
     }
 }

--- a/docs/spec/data-model/file-schemas.yaml
+++ b/docs/spec/data-model/file-schemas.yaml
@@ -281,7 +281,7 @@ schemas:
         checkpoint:
           type: object
         query_policy:
-          description: Derived checkpoint-pinned single-Form, column, and sparse Entry-denial authorization policy. It is session metadata, never Catalog authority and does not list every readable Entry.
+          description: Derived checkpoint-pinned single-Form, column, and sparse Entry-denial policy cache. It is never execution or Catalog authority; every use rebuilds and compares it from the immutable checkpoint and current authorization state, and it does not list every readable Entry.
           type: object
         pagination:
           type: object

--- a/docs/spec/data-model/file-schemas.yaml
+++ b/docs/spec/data-model/file-schemas.yaml
@@ -281,7 +281,7 @@ schemas:
         checkpoint:
           type: object
         query_policy:
-          description: Derived checkpoint-pinned Form, column, and Entry authorization policy. It is session metadata, never Catalog authority.
+          description: Derived checkpoint-pinned single-Form, column, and sparse Entry-denial authorization policy. It is session metadata, never Catalog authority and does not list every readable Entry.
           type: object
         pagination:
           type: object

--- a/docs/spec/data-model/file-schemas.yaml
+++ b/docs/spec/data-model/file-schemas.yaml
@@ -251,6 +251,7 @@ schemas:
       - created_at
       - expires_at
       - checkpoint
+      - query_policy
       - pagination
       - count
       properties:
@@ -278,6 +279,9 @@ schemas:
           - string
           - 'null'
         checkpoint:
+          type: object
+        query_policy:
+          description: Derived checkpoint-pinned Form, column, and Entry authorization policy. It is session metadata, never Catalog authority.
           type: object
         pagination:
           type: object

--- a/docs/spec/data-model/sql-sessions.md
+++ b/docs/spec/data-model/sql-sessions.md
@@ -45,7 +45,7 @@ The file contains:
     "forms": [{
       "form_id": "form-uuid",
       "relation": "note",
-      "entry_ids": ["entry-uuid"],
+      "entry_scope": {"all_except": ["entry-hidden-from-session"]},
       "columns": ["Body"],
       "system_columns": ["external_id", "title", "created_at", "updated_at"]
     }]
@@ -62,15 +62,20 @@ The file contains:
 }
 ```
 
-Rows are not stored in the session directory. Creation freezes a derived
-query policy: checkpoint Form IDs, relation names, columns, system columns,
-and readable Entry scope. Status reads metadata; count and paged-row requests
-rebuild DataFusion only from that frozen policy and the same checkpoint, never
-from the live Form registry or live Entries. The principal set and a canonical
-fingerprint of the policies relevant to that frozen scope must still match the
-session; current principal activity, sponsorship, and expiry are checked
-separately. A relevant policy change is rejected and requires a new session.
-There is no stream endpoint.
+Rows are not stored in the session directory. Creation parses and validates the
+single Form relation before it opens a checkpoint, then freezes that Form's
+checkpoint metadata, columns, system columns, and provider-side Entry scope.
+When every principal has Space read access, the scope records only Entry-level
+denials as `all_except`; it never enumerates every readable Entry in metadata.
+Any explicit or sparse scope is capped at the session's 1,000-row hard limit
+and is rejected before session metadata is written when it exceeds that bound.
+Status reads metadata; count and paged-row requests rebuild DataFusion only
+from that frozen policy and the same checkpoint, never from the live Form
+registry or live Entries. The principal set and a canonical fingerprint of
+Entry access policies must still match the session; current principal activity,
+sponsorship, and expiry are checked separately. A policy change is rejected
+and requires a new session. An empty principal set is forbidden. There is no
+stream endpoint.
 
 The initial page surface accepts only one Form relation and an explicit total
 order ending in `_ugoite_id`. The API rejects joins, aggregates, `DISTINCT`,

--- a/docs/spec/data-model/sql-sessions.md
+++ b/docs/spec/data-model/sql-sessions.md
@@ -41,6 +41,15 @@ The file contains:
     "tables": [],
     "coordinate_checksum": "sha256:…"
   },
+  "query_policy": {
+    "forms": [{
+      "form_id": "form-uuid",
+      "relation": "note",
+      "entry_ids": ["entry-uuid"],
+      "columns": ["Body"],
+      "system_columns": ["external_id", "title", "created_at", "updated_at"]
+    }]
+  },
   "pagination": {
     "strategy": "offset",
     "total_order": "ORDER BY ending with _ugoite_id",
@@ -53,11 +62,15 @@ The file contains:
 }
 ```
 
-Rows are not stored in the session directory. Status reads load the metadata
-file; count and paged-row requests re-run the SQL against the same checkpoint
-and the caller's current readable scope. The principal set and the current
-authorization policy hash must still match the session; a changed policy is
-rejected and requires a new session. There is no stream endpoint.
+Rows are not stored in the session directory. Creation freezes a derived
+query policy: checkpoint Form IDs, relation names, columns, system columns,
+and readable Entry scope. Status reads metadata; count and paged-row requests
+rebuild DataFusion only from that frozen policy and the same checkpoint, never
+from the live Form registry or live Entries. The principal set and a canonical
+fingerprint of the policies relevant to that frozen scope must still match the
+session; current principal activity, sponsorship, and expiry are checked
+separately. A relevant policy change is rejected and requires a new session.
+There is no stream endpoint.
 
 The initial page surface accepts only one Form relation and an explicit total
 order ending in `_ugoite_id`. The API rejects joins, aggregates, `DISTINCT`,
@@ -65,4 +78,8 @@ subqueries, and page ranges beyond the retained 1,000-row session window.
 Counts and pages remain bounded by the same DataFusion memory, timeout, and
 single-query concurrency limits.
 
-Sessions expire after ten minutes by default. Accessing an expired session marks it expired and returns an expiration error. A periodic cleanup worker is not shipped, so operators should not assume automatic background deletion.
+Sessions expire after ten minutes by default. Accessing an expired session
+persists `status: "expired"` and returns an expiration error. Expiry is a
+logical access lifetime only: metadata remains physically retained in OpenDAL
+until an operator performs documented cleanup. A periodic cleanup worker is
+not shipped.

--- a/docs/spec/data-model/sql-sessions.md
+++ b/docs/spec/data-model/sql-sessions.md
@@ -69,13 +69,16 @@ When every principal has Space read access, the scope records only Entry-level
 denials as `all_except`; it never enumerates every readable Entry in metadata.
 Any explicit or sparse scope is capped at the session's 1,000-row hard limit
 and is rejected before session metadata is written when it exceeds that bound.
-Status reads metadata; count and paged-row requests rebuild DataFusion only
-from that frozen policy and the same checkpoint, never from the live Form
-registry or live Entries. The principal set and a canonical fingerprint of
-Entry access policies must still match the session; current principal activity,
-sponsorship, and expiry are checked separately. A policy change is rejected
-and requires a new session. An empty principal set is forbidden. There is no
-stream endpoint.
+`query_policy` is derived metadata, never execution authority. Status, count,
+and paged-row requests reparse the stored SQL, resolve the one Form from the
+checkpoint's immutable metadata, and rebuild its scope, columns, and system
+columns from the current authorization state before comparing that expected
+policy with the stored cache. DataFusion receives the rebuilt policy, never a
+policy accepted solely from OpenDAL metadata. The principal set and a canonical
+fingerprint of Entry access policies must still match the session; current
+principal activity, sponsorship, and expiry are checked separately. A policy
+change is rejected and requires a new session. An empty principal set is
+forbidden. There is no stream endpoint.
 
 The initial page surface accepts only one Form relation and an explicit total
 order ending in `_ugoite_id`. The API rejects joins, aggregates, `DISTINCT`,

--- a/docs/spec/data-model/sql-sessions.md
+++ b/docs/spec/data-model/sql-sessions.md
@@ -21,24 +21,48 @@ The file contains:
   "id": "session-uuid",
   "space_id": "space-main",
   "sql_id": "saved-or-generated-sql-id",
-  "sql": "SELECT * FROM note ORDER BY updated_at, id",
+  "sql": "SELECT * FROM note ORDER BY _ugoite_updated_at, _ugoite_id",
+  "parameters": {},
+  "parameter_types": {},
+  "authorized_principal_ids": ["principal-uuid"],
+  "authorization_policy_hash": "sha256:…",
   "status": "ready",
   "created_at": "2026-03-11T10:10:00Z",
   "expires_at": "2026-03-11T10:20:00Z",
   "error": null,
-  "checkpoint": {"catalog_generation": 42, "tables": []},
+  "checkpoint": {
+    "format_version": 1,
+    "space_id": "space-main",
+    "catalog_generation": 42,
+    "catalog_head_checksum": "sha256:…",
+    "publication_location": "catalog/publications/42.json",
+    "publication_checksum": "sha256:…",
+    "form_registry_generation": 7,
+    "tables": [],
+    "coordinate_checksum": "sha256:…"
+  },
   "pagination": {
     "strategy": "offset",
-    "order_by": ["updated_at", "id"],
+    "total_order": "ORDER BY ending with _ugoite_id",
     "default_limit": 50,
-    "max_limit": 1000
+    "max_limit": 1000,
+    "max_offset": 999
   },
+  "limits": {"max_rows": 1000, "max_memory_bytes": 67108864, "timeout_ms": 30000, "max_concurrency": 1},
   "count": {"mode": "on_demand", "cached_at": null, "value": null}
 }
 ```
 
 Rows are not stored in the session directory. Status reads load the metadata
-file; count and paged-row requests re-run the SQL against the checkpoint and
-the caller's current readable scope. There is no stream endpoint.
+file; count and paged-row requests re-run the SQL against the same checkpoint
+and the caller's current readable scope. The principal set and the current
+authorization policy hash must still match the session; a changed policy is
+rejected and requires a new session. There is no stream endpoint.
+
+The initial page surface accepts only one Form relation and an explicit total
+order ending in `_ugoite_id`. The API rejects joins, aggregates, `DISTINCT`,
+subqueries, and page ranges beyond the retained 1,000-row session window.
+Counts and pages remain bounded by the same DataFusion memory, timeout, and
+single-query concurrency limits.
 
 Sessions expire after ten minutes by default. Accessing an expired session marks it expired and returns an expiration error. A periodic cleanup worker is not shipped, so operators should not assume automatic background deletion.

--- a/docs/spec/features/sql.md
+++ b/docs/spec/features/sql.md
@@ -26,8 +26,10 @@ explicit `ORDER BY` ends in `_ugoite_id`, which is the Form's stable unique tie
 breaker. Joins, aggregates, `DISTINCT`, subqueries, and queries without that
 total order are rejected rather than receiving an unstable cursor protocol.
 
-Each session stores the creating principal set and an authorization-policy
-hash, but not the authorization policy in its checkpoint. Every status, count,
-and page request revalidates the current principal and policy revision. A
-policy change requires a new session; an ordinary data write does not move an
-existing session away from its checkpoint.
+Each session stores the creating principal set, a canonical fingerprint of the
+policies relevant to its frozen scope, and a derived query policy beside (not
+inside) its checkpoint. Every status, count, and page request revalidates the
+current principal contract and that fingerprint without rebuilding Entry scope
+or Form metadata from the live Head. A relevant policy change requires a new
+session; an ordinary data write, Form evolution, or unrelated authorization
+activity does not move an existing session away from its checkpoint.

--- a/docs/spec/features/sql.md
+++ b/docs/spec/features/sql.md
@@ -18,4 +18,16 @@ Parameters use DataFusion's native `$name` syntax and are bound as typed
 DataFusion scalar values before planning. Ugoite never substitutes parameter
 text into SQL.
 
-SQL sessions do not become authoritative data. Their metadata is stored below `sql_sessions/`; result rows are regenerated from current Space tables.
+SQL sessions do not become authoritative data. Their metadata is stored below
+`sql_sessions/`; result rows are regenerated from the session's fixed,
+publication-verified `SpaceCheckpoint`, never from the live Space Head. The
+initial pagination contract accepts only a simple single-Form `SELECT` whose
+explicit `ORDER BY` ends in `_ugoite_id`, which is the Form's stable unique tie
+breaker. Joins, aggregates, `DISTINCT`, subqueries, and queries without that
+total order are rejected rather than receiving an unstable cursor protocol.
+
+Each session stores the creating principal set and an authorization-policy
+hash, but not the authorization policy in its checkpoint. Every status, count,
+and page request revalidates the current principal and policy revision. A
+policy change requires a new session; an ordinary data write does not move an
+existing session away from its checkpoint.

--- a/docs/spec/features/sql.md
+++ b/docs/spec/features/sql.md
@@ -27,9 +27,12 @@ breaker. Joins, aggregates, `DISTINCT`, subqueries, and queries without that
 total order are rejected rather than receiving an unstable cursor protocol.
 
 Each session stores the creating principal set, a canonical fingerprint of the
-policies relevant to its frozen scope, and a derived query policy beside (not
-inside) its checkpoint. Every status, count, and page request revalidates the
-current principal contract and that fingerprint without rebuilding Entry scope
-or Form metadata from the live Head. A relevant policy change requires a new
-session; an ordinary data write, Form evolution, or unrelated authorization
-activity does not move an existing session away from its checkpoint.
+Entry access policies, and a derived query policy beside (not inside) its
+checkpoint. Session creation validates the SQL shape before it resolves the
+one requested Form at that checkpoint. Its provider boundary carries sparse
+Entry denials rather than a Rust-collected list of every readable Entry. Every
+status, count, and page request revalidates the current non-empty principal
+contract and that fingerprint without rebuilding Entry scope or Form metadata
+from the live Head. A policy change requires a new session; an ordinary data
+write, Form evolution, or unrelated authorization activity does not move an
+existing session away from its checkpoint.


### PR DESCRIPTION
## Summary

- Pin SQL sessions to a validated, publication-backed `SpaceCheckpoint`, with typed SQL parameters and creating-principal policy identity.
- Enforce the bounded one-Form pagination contract: explicit total order, 1,000-row window, and rejection of unsafe SQL shapes and page ranges.
- Rebuild the expected Form, columns, system columns, and sparse Entry-denial scope on every status, count, and rows request. `query_policy` in OpenDAL metadata is compared only as a derived cache and is never execution authority.
- Require immutable checkpoint Form relation names so the stored coordinate matches the execution requirement.

## Related Issue (required)

Closes #1823

## Testing

- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
- [x] `mise run test`
