### PR TITLE
fix(frontend): show current timestamps for newly created entries

### DIFF
--- a/frontend/src/lib/client.test.ts
+++ b/frontend/src/lib/client.test.ts
@@ -922,6 +922,31 @@ describe("error paths", () => {
     );
   });
 
+  it("REQ-FE-054: searchApi.query normalizes unix-second timestamps", async () => {
+    server.use(
+      http.post(
+        testApiUrl("/spaces/ws-search-timestamps/query"),
+        () =>
+          HttpResponse.json([
+            {
+              id: "entry-1",
+              title: "Timestamp Entry",
+              updated_at: 1772960822.056,
+              properties: {},
+              tags: [],
+              links: [],
+            },
+          ]),
+      ),
+    );
+
+    const entries = await searchApi.query("ws-search-timestamps", {});
+
+    expect(entries[0].updated_at).toBe(
+      new Date(1772960822.056 * 1000).toISOString(),
+    );
+  });
+
   it("spaceApi.create uses fallback message when error response has no detail", async () => {
     server.use(
       http.post(

--- a/frontend/src/lib/date-format.ts
+++ b/frontend/src/lib/date-format.ts
@@ -1,3 +1,5 @@
+import type { EntryRecord } from "./types";
+
 const numericTimestampPattern = /^-?\d+(?:\.\d+)?$/;
 
 const numericTimestampToDate = (value: number): Date | null => {
@@ -32,6 +34,14 @@ export const normalizeTimestamp = (
   }
   return timestampToDate(value)?.toISOString() ?? String(value ?? "");
 };
+
+export const normalizeEntryRecord = (entry: EntryRecord): EntryRecord => ({
+  ...entry,
+  ...(entry.created_at === undefined
+    ? {}
+    : { created_at: normalizeTimestamp(entry.created_at) }),
+  updated_at: normalizeTimestamp(entry.updated_at),
+});
 
 export const formatDateLabel = (
   value: string | number | null | undefined,

--- a/frontend/src/lib/entry-api.ts
+++ b/frontend/src/lib/entry-api.ts
@@ -7,7 +7,7 @@ import type {
   EntryUpdatePayload,
   Form,
 } from "./types";
-import { normalizeTimestamp } from "./date-format";
+import { normalizeEntryRecord, normalizeTimestamp } from "./date-format";
 import { buildEntryMarkdownByMode } from "./entry-input";
 import {
   protocolFetch,
@@ -18,14 +18,6 @@ type EntryResponse = Omit<Entry, "content"> & {
   content?: string;
   markdown?: string;
 };
-
-const normalizeEntryRecord = (entry: EntryRecord): EntryRecord => ({
-  ...entry,
-  ...(entry.created_at === undefined
-    ? {}
-    : { created_at: normalizeTimestamp(entry.created_at) }),
-  updated_at: normalizeTimestamp(entry.updated_at),
-});
 
 const normalizeEntry = (entry: EntryResponse): Entry => ({
   ...entry,

--- a/frontend/src/lib/search-api.ts
+++ b/frontend/src/lib/search-api.ts
@@ -1,4 +1,5 @@
 import type { EntryRecord, SearchResult } from "./types";
+import { normalizeEntryRecord } from "./date-format";
 import { protocolFetch } from "./ugoite-client/protocol";
 
 export type EntrySummary = {
@@ -13,11 +14,12 @@ export const searchApi = {
     spaceId: string,
     filter: Record<string, unknown>,
   ): Promise<EntryRecord[]> {
-    return await protocolFetch<EntryRecord[]>(
+    const entries = await protocolFetch<EntryRecord[]>(
       "search.query",
       { space_id: spaceId },
       { filter },
     );
+    return entries.map(normalizeEntryRecord);
   },
 
   async keyword(spaceId: string, query: string): Promise<SearchResult[]> {


### PR DESCRIPTION
## Summary

Normalize entry timestamps returned by `search.query` before the frontend renders them, sharing the existing entry-list normalization logic. Add regression coverage for Unix-second timestamps so entries created from the Form workspace keep their current date.

## Related Issue (required)

closes #1852

## Testing

- [x] `mise run test:frontend`
- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
