### PR TITLE
fix(frontend): preserve trailing spaces in entry fields

### DIFF
--- a/frontend/src/components/EntryDetailPane.test.tsx
+++ b/frontend/src/components/EntryDetailPane.test.tsx
@@ -99,8 +99,9 @@ describe("EntryDetailPane", () => {
     const form: Form = {
       name: "Meeting",
       version: 1,
-      template: "# Meeting\n\n## Notes\n",
+      template: "# Meeting\n\n## Summary\n\n## Notes\n",
       fields: {
+        Summary: { type: "string", required: false },
         Notes: { type: "markdown", required: false },
       },
     };
@@ -117,13 +118,29 @@ describe("EntryDetailPane", () => {
 
     const title = await screen.findByLabelText("Title");
     expect(title).toHaveValue("Meeting");
-    fireEvent.input(title, { target: { value: "Planning" } });
+    fireEvent.input(title, { target: { value: "Planning " } });
+    expect(title).toHaveValue("Planning ");
+
+    const summary = await screen.findByLabelText("Summary");
+    fireEvent.input(summary, { target: { value: "Project " } });
+    expect(summary).toHaveValue("Project ");
+
+    const notes = await screen.findByLabelText("Notes");
+    fireEvent.input(notes, { target: { value: "Details " } });
+    expect(notes).toHaveValue("Details ");
+
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(entryApi.create).toHaveBeenCalled());
     expect(entryApi.create).toHaveBeenCalledWith("default", {
-      markdown: expect.stringContaining("# Planning"),
+      markdown: expect.stringContaining("# Planning \n"),
     });
+    expect(entryApi.create.mock.calls[0][1].markdown).toContain(
+      "## Summary\nProject ",
+    );
+    expect(entryApi.create.mock.calls[0][1].markdown).toContain(
+      "## Notes\nDetails ",
+    );
     expect(onCreated).toHaveBeenCalledWith("created-entry");
   });
 

--- a/frontend/src/components/EntryDetailPane.test.tsx
+++ b/frontend/src/components/EntryDetailPane.test.tsx
@@ -48,7 +48,7 @@ describe("EntryDetailPane", () => {
       id: "entry-1",
       title: "Test Entry",
       form: "Meeting",
-      content: "---\nform: Meeting\n---\n\n# Test Entry\n\n## Notes\nhello",
+      content: "---\nform: Meeting\n---\n\n# Test Entry\n\n## Notes\nhello ",
       revision_id: "rev-1",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
@@ -77,9 +77,15 @@ describe("EntryDetailPane", () => {
     const dateInput = await screen.findByLabelText("Date");
     expect(dateInput).toHaveValue("");
     expect(screen.getByText("This field is required.")).toBeInTheDocument();
-    expect(screen.getByLabelText("Notes")).toHaveValue("hello");
+    expect(screen.getByLabelText("Notes")).toHaveValue("hello ");
 
+    fireEvent.input(dateInput, { target: { value: " " } });
+    expect(dateInput).toHaveValue(" ");
+    expect(screen.getByText("This field is required.")).toBeInTheDocument();
     fireEvent.input(dateInput, { target: { value: "2026-07-16" } });
+    const notes = screen.getByLabelText("Notes");
+    fireEvent.input(notes, { target: { value: "hello \n" } });
+    expect(notes).toHaveValue("hello \n");
     fireEvent.click(screen.getByRole("tab", { name: "Source" }));
 
     const source = await screen.findByPlaceholderText(
@@ -99,10 +105,11 @@ describe("EntryDetailPane", () => {
     const form: Form = {
       name: "Meeting",
       version: 1,
-      template: "# Meeting\n\n## Summary\n\n## Notes\n",
+      template: "# Meeting\n\n## Summary\n\n## Notes\n\n## Items\n",
       fields: {
         Summary: { type: "string", required: false },
         Notes: { type: "markdown", required: false },
+        Items: { type: "list", required: false },
       },
     };
 
@@ -126,21 +133,20 @@ describe("EntryDetailPane", () => {
     expect(summary).toHaveValue("Project ");
 
     const notes = await screen.findByLabelText("Notes");
-    fireEvent.input(notes, { target: { value: "Details " } });
-    expect(notes).toHaveValue("Details ");
+    fireEvent.input(notes, { target: { value: "Details \n" } });
+    expect(notes).toHaveValue("Details \n");
+
+    const items = await screen.findByLabelText("Items");
+    fireEvent.input(items, { target: { value: "one\ntwo\n" } });
+    expect(items).toHaveValue("one\ntwo\n");
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(entryApi.create).toHaveBeenCalled());
     expect(entryApi.create).toHaveBeenCalledWith("default", {
-      markdown: expect.stringContaining("# Planning \n"),
+      markdown:
+        "---\nform: Meeting\n---\n\n# Planning \n\n## Summary\nProject \n\n## Notes\nDetails \n\n\n## Items\none\ntwo\n\n",
     });
-    expect(entryApi.create.mock.calls[0][1].markdown).toContain(
-      "## Summary\nProject ",
-    );
-    expect(entryApi.create.mock.calls[0][1].markdown).toContain(
-      "## Notes\nDetails ",
-    );
     expect(onCreated).toHaveBeenCalledWith("created-entry");
   });
 
@@ -185,7 +191,7 @@ describe("EntryDetailPane", () => {
       "Start writing in Markdown...",
     );
     expect((source as HTMLTextAreaElement).value).toContain(
-      "## Notes\nupdated\n### Details\nkeep this",
+      "## Notes\nupdated\n\n### Details\nkeep this",
     );
     expect(
       ((source as HTMLTextAreaElement).value.match(/### Details/g) || [])

--- a/frontend/src/components/EntryDetailPane.tsx
+++ b/frontend/src/components/EntryDetailPane.tsx
@@ -125,7 +125,14 @@ function parseMarkdownH2Sections(markdown: string) {
 
   const pushActive = () => {
     if (!activeTitle) return;
-    sections.push({ title: activeTitle, content: buffer.join("\n").trim() });
+    let contentEnd = buffer.length;
+    // Empty lines are Markdown section separators, but whitespace on the last
+    // content line is part of the value being edited and must be preserved.
+    while (contentEnd > 0 && buffer[contentEnd - 1] === "") contentEnd -= 1;
+    sections.push({
+      title: activeTitle,
+      content: buffer.slice(0, contentEnd).join("\n"),
+    });
   };
 
   for (const line of lines) {
@@ -155,7 +162,7 @@ function parseMarkdownH2Sections(markdown: string) {
 function readMarkdownTitle(markdown: string, fallback = "") {
   const heading = markdown.split(/\r?\n/).find((line) => /^#\s+/.test(line));
   if (!heading) return fallback;
-  return heading.replace(/^#\s+/, "").trim();
+  return heading.replace(/^#\s+/, "");
 }
 
 function buildEditorGuidance(form: Form | null, markdown: string) {

--- a/frontend/src/components/EntryDetailPane.tsx
+++ b/frontend/src/components/EntryDetailPane.tsx
@@ -15,6 +15,7 @@ import { AssetUploader } from "~/components/AssetUploader";
 import { locale, t } from "~/lib/i18n";
 import { createResource } from "~/lib/recoverable-resource";
 import {
+  parseMarkdownH2Sections,
   renderMarkdownPreview,
   replaceFirstH1,
   updateH2Section,
@@ -115,48 +116,6 @@ function parseValidationErrorMessage(message: string) {
 
 function normalizeFieldName(fieldName: string) {
   return fieldName.trim().toLowerCase();
-}
-
-function parseMarkdownH2Sections(markdown: string) {
-  const lines = markdown.split(/\r?\n/);
-  const sections: Array<{ title: string; content: string }> = [];
-  let activeTitle: string | null = null;
-  let buffer: string[] = [];
-
-  const pushActive = () => {
-    if (!activeTitle) return;
-    let contentEnd = buffer.length;
-    // Empty lines are Markdown section separators, but whitespace on the last
-    // content line is part of the value being edited and must be preserved.
-    while (contentEnd > 0 && buffer[contentEnd - 1] === "") contentEnd -= 1;
-    sections.push({
-      title: activeTitle,
-      content: buffer.slice(0, contentEnd).join("\n"),
-    });
-  };
-
-  for (const line of lines) {
-    const heading = /^##\s+(.+?)\s*$/.exec(line);
-    if (heading) {
-      pushActive();
-      activeTitle = heading[1];
-      buffer = [];
-      continue;
-    }
-    // The server-side Markdown mapping treats every heading as the end of an
-    // H2 field section. Keep the form editor aligned so nested document
-    // headings remain source content instead of becoming field values.
-    if (line.startsWith("#")) {
-      pushActive();
-      activeTitle = null;
-      buffer = [];
-      continue;
-    }
-    if (activeTitle) buffer.push(line);
-  }
-
-  pushActive();
-  return sections;
 }
 
 function readMarkdownTitle(markdown: string, fallback = "") {

--- a/frontend/src/lib/markdown.test.ts
+++ b/frontend/src/lib/markdown.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ensureFormFrontmatter,
+  parseMarkdownH2Sections,
   renderMarkdownPreview,
   replaceFirstH1,
   updateH2Section,
@@ -55,6 +56,46 @@ describe("markdown utils", () => {
     const md = "# Title\n\n## Section (Special) [Ref]\nOldValue";
     const out = updateH2Section(md, "Section (Special) [Ref]", "NewValue");
     expect(out).toContain("## Section (Special) [Ref]\nNewValue");
+  });
+
+  it("round-trips trailing whitespace through the section boundary", () => {
+    const md = "# Title\n\n## Section\nOldValue\n\n## Next\nKeepMe";
+
+    for (const value of ["NewValue ", "NewValue\n", " "]) {
+      const out = updateH2Section(md, "Section", value);
+      expect(parseMarkdownH2Sections(out)).toContainEqual({
+        title: "Section",
+        content: value,
+      });
+    }
+  });
+
+  it("drops only the generated separator line", () => {
+    const sections = parseMarkdownH2Sections(
+      "# Title\n\n## Section\nNewValue\n\n\n## Next\nKeepMe",
+    );
+
+    expect(sections).toContainEqual({
+      title: "Section",
+      content: "NewValue\n",
+    });
+  });
+
+  it("preserves existing trailing whitespace when appending a section", () => {
+    const out = updateH2Section(
+      "# Title\n\n## Existing\nKeepMe ",
+      "NewSec",
+      "NewValue\n",
+    );
+
+    expect(parseMarkdownH2Sections(out)).toContainEqual({
+      title: "Existing",
+      content: "KeepMe ",
+    });
+    expect(parseMarkdownH2Sections(out)).toContainEqual({
+      title: "NewSec",
+      content: "NewValue\n",
+    });
   });
 
   it("REQ-FE-005: renderMarkdownPreview escapes raw HTML while keeping markdown formatting", () => {

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -101,6 +101,54 @@ export function renderMarkdownPreview(
     .replace(/\n/g, "<br>");
 }
 
+export type MarkdownH2Section = {
+  title: string;
+  content: string;
+};
+
+/**
+ * Read H2 sections while keeping the field value's whitespace intact.
+ *
+ * `updateH2Section` writes exactly one empty line between a section value and
+ * the next heading (or at the end of the document). Remove only that one
+ * structural line here; any additional empty line belongs to the value.
+ */
+export function parseMarkdownH2Sections(markdown: string): MarkdownH2Section[] {
+  const lines = markdown.split(/\r?\n/);
+  const sections: MarkdownH2Section[] = [];
+  let activeTitle: string | null = null;
+  let buffer: string[] = [];
+
+  const pushActive = () => {
+    if (!activeTitle) return;
+    const contentLines = [...buffer];
+    if (contentLines[contentLines.length - 1] === "") contentLines.pop();
+    sections.push({ title: activeTitle, content: contentLines.join("\n") });
+  };
+
+  for (const line of lines) {
+    const heading = /^##\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      pushActive();
+      activeTitle = heading[1];
+      buffer = [];
+      continue;
+    }
+    // Nested Markdown headings remain source content instead of becoming
+    // field values, matching the server-side Markdown mapping.
+    if (line.startsWith("#")) {
+      pushActive();
+      activeTitle = null;
+      buffer = [];
+      continue;
+    }
+    if (activeTitle) buffer.push(line);
+  }
+
+  pushActive();
+  return sections;
+}
+
 /**
  * Helper to escape regex special characters.
  */
@@ -143,11 +191,16 @@ export function updateH2Section(
     const before = lines.slice(0, sectionIdx + 1);
     const after = nextHeaderIdx === -1 ? [] : lines.slice(nextHeaderIdx);
 
-    return [...before, newValue, ...after].join("\n");
+    // Keep one structural empty line separate from the field value so a
+    // trailing newline in newValue survives the next reactive parse.
+    return [...before, newValue, "", ...after].join("\n");
   }
 
   // Append to end if not found
-  return `${markdown.trimEnd()}\n\n## ${sectionTitle}\n${newValue}\n`;
+  let prefix = markdown;
+  if (!prefix.endsWith("\n")) prefix += "\n\n";
+  else if (!prefix.endsWith("\n\n")) prefix += "\n";
+  return `${prefix}## ${sectionTitle}\n${newValue}\n`;
 }
 
 // Named exports only to match project conventions


### PR DESCRIPTION
## Summary

- Preserve trailing spaces and trailing newlines in Entry titles and Form fields during reactive Fields-editor updates.
- Make `updateH2Section()` emit one explicit structural separator line and make the H2 parser remove only that line.
- Move the parser into the Markdown utility layer and add round-trip coverage for text, markdown, whitespace-only, and list values.
- Cover edit-flow whitespace loading, required guidance normalization, and byte-for-byte create payload preservation.

The original bug was caused by the Fields editor parsing each H2 section with broad trimming. That immediately rewrote a controlled input's value after a trailing space or newline was typed. Since Ugoite is pre-v1, this applies the direct internal behavior change without a compatibility path.

## Related Issue (required)

close: #1853

## Testing

- [x] `mise run test`
- [x] `deno task --cwd frontend check`
- [x] `deno lint frontend/src`
- [x] `deno fmt --check frontend/src/lib/markdown.ts frontend/src/lib/markdown.test.ts frontend/src/components/EntryDetailPane.tsx frontend/src/components/EntryDetailPane.test.tsx`
