### PR TITLE
Fix frontend search SQL session queries

### DIFF
--- a/crates/ugoite-cli/src/main.rs
+++ b/crates/ugoite-cli/src/main.rs
@@ -69,13 +69,13 @@ enum Commands {
     ///
     /// Examples:
     ///   # List all entries in a space (core mode)
-    ///   ugoite query /root/spaces/my-space --sql "SELECT id, title FROM note LIMIT 10"
+    ///   ugoite query /root/spaces/my-space --sql "SELECT _ugoite_id, field_100 FROM \"form_<FormId>\" LIMIT 10"
     ///
     ///   # Filter by form type
-    ///   ugoite query /root/spaces/my-space --sql "SELECT id, title FROM note WHERE title = 'Daily note'"
+    ///   ugoite query /root/spaces/my-space --sql "SELECT _ugoite_id FROM \"form_<FormId>\" WHERE field_100 = 'Daily note'"
     ///
     #[command(
-        long_about = "Query a Space with DataFusion SQL.\n\nEach Form is exposed as a lowercase relation with its Form fields plus id, title, created_at, and updated_at. Only authorized Form relations are resolvable.\n\nExamples:\n  # Core mode (full path)\n  ugoite query /root/spaces/my-space --sql \"SELECT id, title FROM note LIMIT 10\"\n\n  # Backend/API mode (space ID only)\n  ugoite query my-space --sql \"SELECT id, title FROM note WHERE title = 'Daily note'\""
+        long_about = "Query a Space with DataFusion SQL.\n\nThe backend returns a stable Form relation (form_<FormId>) and stable field columns (field_<FieldId>) alongside _ugoite_* metadata columns. Only authorized Form relations are resolvable.\n\nExamples:\n  # Core mode (full path)\n  ugoite query /root/spaces/my-space --sql \"SELECT _ugoite_id, field_100 FROM \\\"form_<FormId>\\\" LIMIT 10\"\n\n  # Backend/API mode (space ID only)\n  ugoite query my-space --sql \"SELECT _ugoite_id FROM \\\"form_<FormId>\\\" WHERE field_100 = 'Daily note'\""
     )]
     Query {
         #[arg(
@@ -85,7 +85,7 @@ enum Commands {
         space_path: String,
         #[arg(
             long,
-            help = "Read-only DataFusion SQL over authorized Iceberg Form relations. Relations are lowercase Form names and expose Form fields plus id, title, created_at, and updated_at.\n\nExample: \"SELECT id, title FROM note LIMIT 10\""
+            help = "Read-only DataFusion SQL over authorized Iceberg Form relations. Use the backend-provided form_<FormId> relation and field_<FieldId> columns, plus _ugoite_* metadata columns.\n\nExample: \"SELECT _ugoite_id, field_100 FROM \\\"form_<FormId>\\\" LIMIT 10\""
         )]
         sql: String,
     },

--- a/crates/ugoite-cli/tests/test_indexer.rs
+++ b/crates/ugoite-cli/tests/test_indexer.rs
@@ -13,7 +13,9 @@ fn ugoite_bin() -> String {
     path.to_string_lossy().to_string()
 }
 
-fn setup_space_with_entries(dir: &tempfile::TempDir) -> (String, String, std::path::PathBuf) {
+fn setup_space_with_entries(
+    dir: &tempfile::TempDir,
+) -> (String, String, std::path::PathBuf, String) {
     let root = dir.path().to_string_lossy().to_string();
     let config_path = dir.path().join("cli-config.json");
     let space_path = format!("{root}/spaces/idx-space");
@@ -27,7 +29,7 @@ fn setup_space_with_entries(dir: &tempfile::TempDir) -> (String, String, std::pa
     let form_file = dir.path().join("entry-form.json");
     std::fs::write(
         &form_file,
-        r#"{"name":"Entry","fields":{"Body":{"type":"markdown"}}}"#,
+        r#"{"id":"00000000-0000-0000-0000-000000000001","name":"Entry","fields":{"Body":{"id":100,"type":"markdown"}}}"#,
     )
     .unwrap();
 
@@ -36,6 +38,16 @@ fn setup_space_with_entries(dir: &tempfile::TempDir) -> (String, String, std::pa
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
         .expect("create form");
+    let form_output = Command::new(ugoite_bin())
+        .args(["form", "get", &space_path, "Entry"])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("get form");
+    let form_json: serde_json::Value = serde_json::from_slice(&form_output.stdout).unwrap();
+    let relation = form_json["sql_relation"]
+        .as_str()
+        .expect("backend SQL relation")
+        .to_string();
 
     let content1 = "---\nform: Entry\n---\n# Alpha Entry\n\n## Body\n\nsome words here";
     Command::new(ugoite_bin())
@@ -51,14 +63,14 @@ fn setup_space_with_entries(dir: &tempfile::TempDir) -> (String, String, std::pa
         .output()
         .expect("create entry 2");
 
-    (root, space_path, config_path)
+    (root, space_path, config_path, relation)
 }
 
 /// REQ-IDX-001: Indexer run does not report false success in this release.
 #[test]
 fn test_indexer_run_once() {
     let dir = tempfile::tempdir().unwrap();
-    let (_root, space_path, config_path) = setup_space_with_entries(&dir);
+    let (_root, space_path, config_path, _relation) = setup_space_with_entries(&dir);
 
     let output = Command::new(ugoite_bin())
         .args(["index", "run", &space_path])
@@ -78,7 +90,7 @@ fn test_indexer_run_once() {
 #[test]
 fn test_aggregate_stats() {
     let dir = tempfile::tempdir().unwrap();
-    let (_root, space_path, config_path) = setup_space_with_entries(&dir);
+    let (_root, space_path, config_path, _relation) = setup_space_with_entries(&dir);
 
     let output = Command::new(ugoite_bin())
         .args(["index", "stats", &space_path])
@@ -97,7 +109,7 @@ fn test_aggregate_stats() {
 #[test]
 fn test_aggregate_stats_includes_field_usage() {
     let dir = tempfile::tempdir().unwrap();
-    let (_root, space_path, config_path) = setup_space_with_entries(&dir);
+    let (_root, space_path, config_path, _relation) = setup_space_with_entries(&dir);
 
     let output = Command::new(ugoite_bin())
         .args(["index", "stats", &space_path])
@@ -218,14 +230,14 @@ fn test_extract_properties_precedence() {
 #[test]
 fn test_query_index() {
     let dir = tempfile::tempdir().unwrap();
-    let (_root, space_path, config_path) = setup_space_with_entries(&dir);
+    let (_root, space_path, config_path, relation) = setup_space_with_entries(&dir);
 
     let output = Command::new(ugoite_bin())
         .args([
             "query",
             &space_path,
             "--sql",
-            "SELECT * FROM entry LIMIT 10",
+            &format!("SELECT * FROM \"{relation}\" LIMIT 10"),
         ])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
@@ -242,14 +254,14 @@ fn test_query_index() {
 #[test]
 fn test_query_index_by_tag() {
     let dir = tempfile::tempdir().unwrap();
-    let (_root, space_path, config_path) = setup_space_with_entries(&dir);
+    let (_root, space_path, config_path, relation) = setup_space_with_entries(&dir);
 
     let output = Command::new(ugoite_bin())
         .args([
             "query",
             &space_path,
             "--sql",
-            "SELECT * FROM entry LIMIT 10",
+            &format!("SELECT * FROM \"{relation}\" LIMIT 10"),
         ])
         .env("UGOITE_CLI_CONFIG_PATH", &config_path)
         .output()
@@ -372,7 +384,7 @@ fn test_validate_properties_valid() {
 #[test]
 fn test_indexer_generates_inverted_index() {
     let dir = tempfile::tempdir().unwrap();
-    let (_root, space_path, config_path) = setup_space_with_entries(&dir);
+    let (_root, space_path, config_path, _relation) = setup_space_with_entries(&dir);
 
     let output = Command::new(ugoite_bin())
         .args(["index", "run", &space_path])
@@ -392,7 +404,7 @@ fn test_indexer_generates_inverted_index() {
 #[test]
 fn test_indexer_computes_word_count() {
     let dir = tempfile::tempdir().unwrap();
-    let (_root, space_path, config_path) = setup_space_with_entries(&dir);
+    let (_root, space_path, config_path, _relation) = setup_space_with_entries(&dir);
 
     let output = Command::new(ugoite_bin())
         .args(["index", "run", &space_path])

--- a/crates/ugoite-core/src/query.rs
+++ b/crates/ugoite-core/src/query.rs
@@ -25,7 +25,7 @@ pub struct AuthorizedQueryForm {
     /// Entry scope Core authorizes for this Form. The query adapter embeds this
     /// relation-specific boundary in the trusted view before SQL is planned.
     pub entry_scope: EntryScope,
-    /// User-defined Form columns which may be resolved or projected.
+    /// Backend-owned stable SQL columns which may be resolved or projected.
     pub columns: BTreeSet<String>,
     /// System columns which are intentionally part of this query contract.
     pub system_columns: BTreeSet<QuerySystemColumn>,

--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use uuid::Uuid;
 
-pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 2;
+pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 1;
 
 /// One immutable Iceberg table coordinate reachable from a Catalog Head.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -81,19 +81,6 @@ impl SpaceCheckpoint {
     pub fn validate_coordinate_checksum(&self) -> bool {
         self.format_version == SPACE_CHECKPOINT_FORMAT_VERSION
             && self.coordinate_checksum == self.computed_coordinate_checksum()
-    }
-
-    /// Decode only the current checkpoint representation. Older checkpoint
-    /// versions are deliberately rejected before deserializing their table
-    /// payload so a breaking format change remains explicit.
-    pub fn from_json_value(value: serde_json::Value) -> anyhow::Result<Self> {
-        let version = value.get("format_version").and_then(|value| value.as_u64());
-        anyhow::ensure!(
-            version == Some(u64::from(SPACE_CHECKPOINT_FORMAT_VERSION)),
-            "unsupported SpaceCheckpoint format version: {}",
-            version.map_or_else(|| "missing".to_string(), |version| version.to_string())
-        );
-        Ok(serde_json::from_value(value)?)
     }
 
     /// Reject ambiguous or malformed coordinates before any storage is read.
@@ -219,16 +206,5 @@ mod tests {
             second.computed_coordinate_checksum()
         );
         assert!(second.validate_coordinate_checksum());
-    }
-
-    #[test]
-    fn rejects_the_previous_checkpoint_format_before_payload_decode() {
-        let error = SpaceCheckpoint::from_json_value(serde_json::json!({
-            "format_version": 1,
-        }))
-        .expect_err("v1 checkpoints must be explicitly unsupported");
-        assert!(error
-            .to_string()
-            .contains("unsupported SpaceCheckpoint format version: 1"));
     }
 }

--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use uuid::Uuid;
 
-pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 1;
+pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 2;
 
 /// One immutable Iceberg table coordinate reachable from a Catalog Head.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -81,6 +81,19 @@ impl SpaceCheckpoint {
     pub fn validate_coordinate_checksum(&self) -> bool {
         self.format_version == SPACE_CHECKPOINT_FORMAT_VERSION
             && self.coordinate_checksum == self.computed_coordinate_checksum()
+    }
+
+    /// Decode only the current checkpoint representation. Older checkpoint
+    /// versions are deliberately rejected before deserializing their table
+    /// payload so a breaking format change remains explicit.
+    pub fn from_json_value(value: serde_json::Value) -> anyhow::Result<Self> {
+        let version = value.get("format_version").and_then(|value| value.as_u64());
+        anyhow::ensure!(
+            version == Some(u64::from(SPACE_CHECKPOINT_FORMAT_VERSION)),
+            "unsupported SpaceCheckpoint format version: {}",
+            version.map_or_else(|| "missing".to_string(), |version| version.to_string())
+        );
+        Ok(serde_json::from_value(value)?)
     }
 
     /// Reject ambiguous or malformed coordinates before any storage is read.
@@ -206,5 +219,16 @@ mod tests {
             second.computed_coordinate_checksum()
         );
         assert!(second.validate_coordinate_checksum());
+    }
+
+    #[test]
+    fn rejects_the_previous_checkpoint_format_before_payload_decode() {
+        let error = SpaceCheckpoint::from_json_value(serde_json::json!({
+            "format_version": 1,
+        }))
+        .expect_err("v1 checkpoints must be explicitly unsupported");
+        assert!(error
+            .to_string()
+            .contains("unsupported SpaceCheckpoint format version: 1"));
     }
 }

--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -3,6 +3,7 @@
 //! A checkpoint contains storage coordinates only.  It deliberately carries no
 //! authorization, SQL, or query-policy state.
 
+use crate::form::sql_relation_name;
 use crate::id::{FormId, SpaceId};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -15,10 +16,10 @@ pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 1;
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CheckpointTable {
     pub form_id: FormId,
-    /// The Form relation captured from immutable Iceberg metadata. It lets a
+    /// The stable SQL relation captured from immutable Iceberg metadata. It lets a
     /// query session resolve one requested Form without loading every Form
     /// definition from the checkpoint.
-    pub form_name: String,
+    pub form_relation: String,
     pub namespace: Vec<String>,
     pub table: String,
     pub table_uuid: String,
@@ -87,16 +88,19 @@ impl SpaceCheckpoint {
     /// their immutable publication and Catalog Head by the Iceberg adapter.
     pub fn validate_structure(&self) -> Result<(), &'static str> {
         let mut forms = BTreeSet::new();
-        let mut form_names = BTreeSet::new();
+        let mut form_relations = BTreeSet::new();
         let mut identifiers = BTreeSet::new();
         for table in &self.tables {
             if !forms.insert(table.form_id) {
                 return Err("checkpoint contains a duplicate Form ID");
             }
-            if table.form_name.trim().is_empty() {
+            if table.form_relation.trim().is_empty() {
                 return Err("checkpoint Form relation is empty");
             }
-            if !form_names.insert(table.form_name.to_ascii_lowercase()) {
+            if table.form_relation != sql_relation_name(table.form_id) {
+                return Err("checkpoint Form relation does not match immutable Form ID");
+            }
+            if !form_relations.insert(table.form_relation.clone()) {
                 return Err("checkpoint contains duplicate Form relations");
             }
             if table.namespace.is_empty() || table.namespace.iter().any(|part| part.is_empty()) {
@@ -165,6 +169,7 @@ struct CoordinateIdentity<'a> {
 #[cfg(test)]
 mod tests {
     use super::{CheckpointTable, SpaceCheckpoint};
+    use crate::form::sql_relation_name;
     use crate::id::{FormId, SpaceId};
     use uuid::Uuid;
 
@@ -178,7 +183,7 @@ mod tests {
             2,
             vec![CheckpointTable {
                 form_id: FormId::from(Uuid::from_u128(2)),
-                form_name: "form".into(),
+                form_relation: sql_relation_name(FormId::from(Uuid::from_u128(2))),
                 namespace: vec!["space_1".into()],
                 table: "form_2".into(),
                 table_uuid: "table".into(),

--- a/crates/ugoite-domain/src/checkpoint.rs
+++ b/crates/ugoite-domain/src/checkpoint.rs
@@ -3,7 +3,6 @@
 //! A checkpoint contains storage coordinates only.  It deliberately carries no
 //! authorization, SQL, or query-policy state.
 
-use crate::form::sql_relation_name;
 use crate::id::{FormId, SpaceId};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -16,10 +15,6 @@ pub const SPACE_CHECKPOINT_FORMAT_VERSION: u32 = 1;
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CheckpointTable {
     pub form_id: FormId,
-    /// The stable SQL relation captured from immutable Iceberg metadata. It lets a
-    /// query session resolve one requested Form without loading every Form
-    /// definition from the checkpoint.
-    pub form_relation: String,
     pub namespace: Vec<String>,
     pub table: String,
     pub table_uuid: String,
@@ -88,20 +83,10 @@ impl SpaceCheckpoint {
     /// their immutable publication and Catalog Head by the Iceberg adapter.
     pub fn validate_structure(&self) -> Result<(), &'static str> {
         let mut forms = BTreeSet::new();
-        let mut form_relations = BTreeSet::new();
         let mut identifiers = BTreeSet::new();
         for table in &self.tables {
             if !forms.insert(table.form_id) {
                 return Err("checkpoint contains a duplicate Form ID");
-            }
-            if table.form_relation.trim().is_empty() {
-                return Err("checkpoint Form relation is empty");
-            }
-            if table.form_relation != sql_relation_name(table.form_id) {
-                return Err("checkpoint Form relation does not match immutable Form ID");
-            }
-            if !form_relations.insert(table.form_relation.clone()) {
-                return Err("checkpoint contains duplicate Form relations");
             }
             if table.namespace.is_empty() || table.namespace.iter().any(|part| part.is_empty()) {
                 return Err("checkpoint table namespace is empty or invalid");
@@ -169,7 +154,6 @@ struct CoordinateIdentity<'a> {
 #[cfg(test)]
 mod tests {
     use super::{CheckpointTable, SpaceCheckpoint};
-    use crate::form::sql_relation_name;
     use crate::id::{FormId, SpaceId};
     use uuid::Uuid;
 
@@ -183,7 +167,6 @@ mod tests {
             2,
             vec![CheckpointTable {
                 form_id: FormId::from(Uuid::from_u128(2)),
-                form_relation: sql_relation_name(FormId::from(Uuid::from_u128(2))),
                 namespace: vec!["space_1".into()],
                 table: "form_2".into(),
                 table_uuid: "table".into(),
@@ -206,5 +189,11 @@ mod tests {
             second.computed_coordinate_checksum()
         );
         assert!(second.validate_coordinate_checksum());
+    }
+
+    #[test]
+    fn checkpoint_does_not_persist_derived_sql_relation() {
+        let value = serde_json::to_value(checkpoint()).expect("checkpoint serializes");
+        assert!(value["tables"][0].get("form_relation").is_none());
     }
 }

--- a/crates/ugoite-domain/src/form.rs
+++ b/crates/ugoite-domain/src/form.rs
@@ -96,34 +96,19 @@ pub struct FormDefinition {
 
 /// Returns the stable ASCII SQL relation exposed for a Form.
 ///
-/// Form names are portable storage identifiers and may contain `-`, while
-/// DataFusion relations are deliberately kept to unquoted ASCII identifiers.
-/// Keep ordinary names readable for SQL authors and encode characters that
-/// would otherwise collide with a different valid Form name.
-pub fn sql_relation_name(form_name: &str) -> String {
-    let mut relation = String::new();
-    for (index, character) in form_name.chars().enumerate() {
-        if character.is_ascii_alphanumeric() {
-            if index == 0 && character.is_ascii_digit() {
-                relation.push_str("_x");
-            }
-            relation.push(character.to_ascii_lowercase());
-        } else {
-            relation.push_str("_x");
-            let codepoint = if character == '_' {
-                b'_' as u32
-            } else {
-                character as u32
-            };
-            relation.push_str(&format!("{:x}", codepoint));
-            relation.push('_');
-        }
-    }
-    if relation.is_empty() {
-        "_x0_".to_string()
-    } else {
-        relation
-    }
+/// SQL identity follows the immutable Form identity rather than its editable
+/// display name. This keeps the relation unique for every valid Form set and
+/// preserves Saved SQL across Form renames.
+pub fn sql_relation_name(form_id: FormId) -> String {
+    format!("form_{}", form_id.as_uuid().simple())
+}
+
+/// Returns the stable ASCII SQL column exposed for a Form field.
+///
+/// Field names are editable labels. Field IDs are the immutable identity that
+/// Iceberg already uses for schema evolution, so SQL follows that identity.
+pub fn sql_column_name(field_id: FieldId) -> String {
+    format!("field_{}", field_id.get())
 }
 
 impl FormDefinition {
@@ -226,21 +211,18 @@ impl FormDefinition {
 
 #[cfg(test)]
 mod tests {
-    use super::sql_relation_name;
+    use super::{sql_column_name, sql_relation_name};
+    use crate::id::{FieldId, FormId};
+    use uuid::Uuid;
 
     #[test]
-    fn sql_relation_names_are_ascii_and_preserve_readable_names() {
-        assert_eq!(sql_relation_name("Meeting"), "meeting");
-        assert_eq!(sql_relation_name("daily-note"), "daily_x2d_note");
+    fn sql_names_follow_immutable_ids() {
+        let form_id = FormId::from(Uuid::from_u128(1));
         assert_eq!(
-            sql_relation_name("daily_x2d_note"),
-            "daily_x5f_x2d_x5f_note"
+            sql_relation_name(form_id),
+            "form_00000000000000000000000000000001"
         );
-        assert_ne!(
-            sql_relation_name("daily-note"),
-            sql_relation_name("daily_x2d_note")
-        );
-        assert_eq!(sql_relation_name("2fa"), "_x2fa");
+        assert_eq!(sql_column_name(FieldId::new(104).unwrap()), "field_104");
     }
 }
 

--- a/crates/ugoite-domain/src/form.rs
+++ b/crates/ugoite-domain/src/form.rs
@@ -94,6 +94,38 @@ pub struct FormDefinition {
     pub extension_metadata: BTreeMap<String, Value>,
 }
 
+/// Returns the stable ASCII SQL relation exposed for a Form.
+///
+/// Form names are portable storage identifiers and may contain `-`, while
+/// DataFusion relations are deliberately kept to unquoted ASCII identifiers.
+/// Keep ordinary names readable for SQL authors and encode characters that
+/// would otherwise collide with a different valid Form name.
+pub fn sql_relation_name(form_name: &str) -> String {
+    let mut relation = String::new();
+    for (index, character) in form_name.chars().enumerate() {
+        if character.is_ascii_alphanumeric() {
+            if index == 0 && character.is_ascii_digit() {
+                relation.push_str("_x");
+            }
+            relation.push(character.to_ascii_lowercase());
+        } else {
+            relation.push_str("_x");
+            let codepoint = if character == '_' {
+                b'_' as u32
+            } else {
+                character as u32
+            };
+            relation.push_str(&format!("{:x}", codepoint));
+            relation.push('_');
+        }
+    }
+    if relation.is_empty() {
+        "_x0_".to_string()
+    } else {
+        relation
+    }
+}
+
 impl FormDefinition {
     pub fn validate(&self) -> Result<(), DomainError> {
         if self.name.trim().is_empty() {
@@ -189,6 +221,26 @@ impl FormDefinition {
             .iter_mut()
             .find(|field| field.id == id)
             .ok_or(DomainError::UnknownField(id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sql_relation_name;
+
+    #[test]
+    fn sql_relation_names_are_ascii_and_preserve_readable_names() {
+        assert_eq!(sql_relation_name("Meeting"), "meeting");
+        assert_eq!(sql_relation_name("daily-note"), "daily_x2d_note");
+        assert_eq!(
+            sql_relation_name("daily_x2d_note"),
+            "daily_x5f_x2d_x5f_note"
+        );
+        assert_ne!(
+            sql_relation_name("daily-note"),
+            sql_relation_name("daily_x2d_note")
+        );
+        assert_eq!(sql_relation_name("2fa"), "_x2fa");
     }
 }
 

--- a/crates/ugoite-domain/src/search.rs
+++ b/crates/ugoite-domain/src/search.rs
@@ -1,22 +1,10 @@
-use crate::link::Link;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct SearchResult {
+pub struct KeywordSearchResult {
     pub id: String,
     pub title: String,
     pub form: String,
     pub created_at: f64,
     pub updated_at: f64,
-    #[serde(default)]
-    pub properties: Value,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    #[serde(default)]
-    pub links: Vec<Link>,
-    #[serde(default)]
-    pub assets: Vec<Value>,
-    #[serde(default)]
-    pub checksum: String,
 }

--- a/crates/ugoite-domain/src/search.rs
+++ b/crates/ugoite-domain/src/search.rs
@@ -1,6 +1,22 @@
+use crate::link::Link;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SearchResult {
     pub id: String,
+    pub title: String,
+    pub form: String,
+    pub created_at: f64,
+    pub updated_at: f64,
+    #[serde(default)]
+    pub properties: Value,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub links: Vec<Link>,
+    #[serde(default)]
+    pub assets: Vec<Value>,
+    #[serde(default)]
+    pub checksum: String,
 }

--- a/crates/ugoite-iceberg/src/form.rs
+++ b/crates/ugoite-iceberg/src/form.rs
@@ -7,7 +7,7 @@ use serde_json::{Map, Value};
 use std::collections::{BTreeMap, HashSet};
 use ugoite_core::error::AppError;
 use ugoite_core::metadata;
-use ugoite_domain::form::sql_relation_name;
+use ugoite_domain::form::{sql_column_name, sql_relation_name};
 use ugoite_domain::form::{
     FieldType, FormChange, FormChangeSet, FormDefinition, FormField, FormVersion,
 };
@@ -751,6 +751,12 @@ fn preserve_stable_identities(normalized: &mut Value, existing: &Value) -> Resul
 }
 
 fn enrich_form_definition(form_def: &Value) -> Result<Value> {
+    let form_id = FormId::from(Uuid::parse_str(
+        form_def
+            .get("id")
+            .and_then(Value::as_str)
+            .context("Form definition missing stable 'id' field")?,
+    )?);
     let name = form_def
         .get("name")
         .and_then(|v| v.as_str())
@@ -762,8 +768,29 @@ fn enrich_form_definition(form_def: &Value) -> Result<Value> {
         obj.insert("template".to_string(), Value::String(template));
         obj.insert(
             "sql_relation".to_string(),
-            Value::String(sql_relation_name(name)),
+            Value::String(sql_relation_name(form_id)),
         );
+        let fields = obj
+            .get_mut("fields")
+            .and_then(Value::as_object_mut)
+            .context("Form definition missing 'fields' object")?;
+        for field in fields.values_mut() {
+            let field_id = FieldId::new(
+                field
+                    .get("id")
+                    .and_then(Value::as_i64)
+                    .context("Form field definition missing stable 'id' field")?
+                    .try_into()
+                    .context("Form field id is outside the supported range")?,
+            )?;
+            field
+                .as_object_mut()
+                .context("Form field definition must be an object")?
+                .insert(
+                    "sql_column".to_string(),
+                    Value::String(sql_column_name(field_id)),
+                );
+        }
     }
     Ok(enriched)
 }

--- a/crates/ugoite-iceberg/src/form.rs
+++ b/crates/ugoite-iceberg/src/form.rs
@@ -7,6 +7,7 @@ use serde_json::{Map, Value};
 use std::collections::{BTreeMap, HashSet};
 use ugoite_core::error::AppError;
 use ugoite_core::metadata;
+use ugoite_domain::form::sql_relation_name;
 use ugoite_domain::form::{
     FieldType, FormChange, FormChangeSet, FormDefinition, FormField, FormVersion,
 };
@@ -759,6 +760,10 @@ fn enrich_form_definition(form_def: &Value) -> Result<Value> {
     let mut enriched = form_def.clone();
     if let Some(obj) = enriched.as_object_mut() {
         obj.insert("template".to_string(), Value::String(template));
+        obj.insert(
+            "sql_relation".to_string(),
+            Value::String(sql_relation_name(name)),
+        );
     }
     Ok(enriched)
 }

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -9,6 +9,7 @@ use serde_json::{Map, Value};
 use serde_yaml;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Duration;
+use ugoite_domain::form::sql_relation_name;
 use ugoite_domain::id::FormId;
 pub use ugoite_domain::text::compute_word_count;
 use uuid::Uuid;
@@ -194,6 +195,13 @@ pub fn datafusion_parameters(
                         .timestamp_micros();
                     datafusion::scalar::ScalarValue::TimestampMicrosecond(Some(value), None)
                 }
+                ("date", Value::String(value)) => {
+                    let value = NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                        .map_err(|_| anyhow!("SQL parameter {name} must be an ISO date"))?;
+                    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)
+                        .expect("the Unix epoch is a valid date");
+                    datafusion::scalar::ScalarValue::Date32(Some((value - epoch).num_days() as i32))
+                }
                 ("string", Value::Null) => datafusion::scalar::ScalarValue::Utf8(None),
                 ("boolean", Value::Null) => datafusion::scalar::ScalarValue::Boolean(None),
                 ("integer", Value::Null) => datafusion::scalar::ScalarValue::Int64(None),
@@ -201,7 +209,8 @@ pub fn datafusion_parameters(
                 ("timestamp", Value::Null) => {
                     datafusion::scalar::ScalarValue::TimestampMicrosecond(None, None)
                 }
-                ("string" | "boolean" | "integer" | "float" | "timestamp", _) => {
+                ("date", Value::Null) => datafusion::scalar::ScalarValue::Date32(None),
+                ("string" | "boolean" | "integer" | "float" | "timestamp" | "date", _) => {
                     return Err(anyhow!(
                         "SQL parameter {name} does not match declared type {kind}"
                     ))
@@ -675,7 +684,18 @@ pub fn sql_session_page_relation(sql: &str) -> Result<String> {
             "SQL session paging requires ORDER BY ending with _ugoite_id"
         ));
     }
-    Ok(name.to_string().to_ascii_lowercase())
+    let Some(identifier) = name.0.last() else {
+        return Err(anyhow!("SQL session paging requires a Form relation"));
+    };
+    if name.0.len() != 1 {
+        return Err(anyhow!(
+            "SQL session paging requires exactly one Form relation"
+        ));
+    }
+    let identifier = identifier
+        .as_ident()
+        .ok_or_else(|| anyhow!("SQL session paging requires a plain Form relation"))?;
+    Ok(identifier.value.to_ascii_lowercase())
 }
 
 pub async fn query_index_authorized(
@@ -729,7 +749,7 @@ pub async fn execute_sql_query_scoped(
 ) -> Result<Vec<Value>> {
     let readable_forms = readable_forms
         .iter()
-        .map(|form| form.to_ascii_lowercase())
+        .map(|form| sql_relation_name(form))
         .collect::<HashSet<_>>();
     execute_datafusion_sql(
         op,
@@ -753,7 +773,7 @@ pub async fn execute_sql_query_scoped_page(
 ) -> Result<(Vec<Value>, u64)> {
     let readable_forms = readable_forms
         .iter()
-        .map(|form| form.to_ascii_lowercase())
+        .map(|form| sql_relation_name(form))
         .collect::<HashSet<_>>();
     execute_datafusion_sql_page(
         op,
@@ -851,7 +871,7 @@ async fn datafusion_sql_context(
     let forms = workspace.list_forms().await?;
     let mut policy_forms = BTreeMap::new();
     for form in forms {
-        let relation = form.name.to_ascii_lowercase();
+        let relation = sql_relation_name(&form.name);
         let relation_entry_scope = match relation_scopes {
             Some(scopes) => match scopes.get(&relation) {
                 Some(scope) => scope.clone(),
@@ -1469,4 +1489,50 @@ async fn build_record(
     });
 
     Ok(Some(record))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{datafusion_parameters, sql_session_page_relation};
+    use chrono::DateTime;
+    use serde_json::{Map, Value};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn sql_session_relation_parser_uses_identifier_value_without_quotes() {
+        assert_eq!(
+            sql_session_page_relation(
+                r#"SELECT * FROM "meeting" ORDER BY _ugoite_updated_at DESC, _ugoite_id"#,
+            )
+            .expect("quoted relation is valid"),
+            "meeting"
+        );
+    }
+
+    #[test]
+    fn native_parameters_keep_date_and_microsecond_timestamp_types() {
+        let values = Map::from_iter([
+            (
+                "when".to_string(),
+                Value::String("2025-03-03T23:59:59.999999Z".to_string()),
+            ),
+            ("day".to_string(), Value::String("2025-03-03".to_string())),
+        ]);
+        let types = BTreeMap::from_iter([
+            ("when".to_string(), "timestamp".to_string()),
+            ("day".to_string(), "date".to_string()),
+        ]);
+        let parameters = datafusion_parameters(&values, &types).expect("typed parameters");
+        assert!(matches!(
+            parameters.get("when"),
+            Some(datafusion::scalar::ScalarValue::TimestampMicrosecond(Some(value), None))
+                if *value == DateTime::parse_from_rfc3339("2025-03-03T23:59:59.999999Z")
+                    .expect("timestamp")
+                    .timestamp_micros()
+        ));
+        assert!(matches!(
+            parameters.get("day"),
+            Some(datafusion::scalar::ScalarValue::Date32(Some(value))) if *value == 20150
+        ));
+    }
 }

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -9,7 +9,7 @@ use serde_json::{Map, Value};
 use serde_yaml;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::time::Duration;
-use ugoite_domain::form::sql_relation_name;
+use ugoite_domain::form::{sql_column_name, sql_relation_name};
 use ugoite_domain::id::FormId;
 pub use ugoite_domain::text::compute_word_count;
 use uuid::Uuid;
@@ -516,7 +516,11 @@ pub async fn sql_session_query_policy_at_checkpoint(
             form_id: form.id,
             relation,
             entry_scope,
-            columns: form.fields.into_iter().map(|field| field.name).collect(),
+            columns: form
+                .fields
+                .into_iter()
+                .map(|field| sql_column_name(field.id))
+                .collect(),
             system_columns: [
                 SqlSessionSystemColumn::ExternalId,
                 SqlSessionSystemColumn::Title,
@@ -749,7 +753,7 @@ pub async fn execute_sql_query_scoped(
 ) -> Result<Vec<Value>> {
     let readable_forms = readable_forms
         .iter()
-        .map(|form| sql_relation_name(form))
+        .map(|relation| relation.to_ascii_lowercase())
         .collect::<HashSet<_>>();
     execute_datafusion_sql(
         op,
@@ -773,7 +777,7 @@ pub async fn execute_sql_query_scoped_page(
 ) -> Result<(Vec<Value>, u64)> {
     let readable_forms = readable_forms
         .iter()
-        .map(|form| sql_relation_name(form))
+        .map(|relation| relation.to_ascii_lowercase())
         .collect::<HashSet<_>>();
     execute_datafusion_sql_page(
         op,
@@ -871,7 +875,7 @@ async fn datafusion_sql_context(
     let forms = workspace.list_forms().await?;
     let mut policy_forms = BTreeMap::new();
     for form in forms {
-        let relation = sql_relation_name(&form.name);
+        let relation = sql_relation_name(form.id);
         let relation_entry_scope = match relation_scopes {
             Some(scopes) => match scopes.get(&relation) {
                 Some(scope) => scope.clone(),
@@ -887,7 +891,11 @@ async fn datafusion_sql_context(
             AuthorizedQueryForm {
                 relation,
                 entry_scope: relation_entry_scope,
-                columns: form.fields.iter().map(|field| field.name.clone()).collect(),
+                columns: form
+                    .fields
+                    .iter()
+                    .map(|field| sql_column_name(field.id))
+                    .collect(),
                 system_columns: [
                     QuerySystemColumn::ExternalId,
                     QuerySystemColumn::Title,

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -1510,10 +1510,10 @@ mod tests {
     fn sql_session_relation_parser_uses_identifier_value_without_quotes() {
         assert_eq!(
             sql_session_page_relation(
-                r#"SELECT * FROM "meeting" ORDER BY _ugoite_updated_at DESC, _ugoite_id"#,
+                r#"SELECT * FROM "form_00000000000000000000000000000001" ORDER BY _ugoite_updated_at DESC, _ugoite_id"#,
             )
             .expect("quoted relation is valid"),
-            "meeting"
+            "form_00000000000000000000000000000001"
         );
     }
 

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -468,7 +468,7 @@ impl IcebergWorkspace {
         let mut matches = checkpoint
             .tables
             .iter()
-            .filter(|coordinate| sql_relation_name(&coordinate.form_name) == relation);
+            .filter(|coordinate| coordinate.form_relation == relation);
         let coordinate = matches
             .next()
             .ok_or_else(|| CheckpointUnavailable::new(format!("Form relation {relation}")))?;
@@ -485,7 +485,10 @@ impl IcebergWorkspace {
             .load_checkpoint_table(checkpoint, coordinate)
             .await?;
         let form = form_from_table(&table, coordinate.form_id)?;
-        if sql_relation_name(&form.name) != relation || coordinate.form_name != form.name {
+        if coordinate.form_relation != relation
+            || coordinate.form_relation != sql_relation_name(form.id)
+            || coordinate.form_id != form.id
+        {
             return Err(CheckpointIntegrityError::new(
                 "checkpoint Form relation does not match immutable Iceberg metadata",
             )
@@ -1238,7 +1241,7 @@ fn is_publication_conflict(error: &anyhow::Error) -> bool {
 }
 
 pub fn physical_form_name(form_id: FormId) -> String {
-    format!("form_{}", form_id.as_uuid().simple())
+    sql_relation_name(form_id)
 }
 
 pub fn namespace_for_space(space_id: SpaceId) -> NamespaceIdent {

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -495,7 +495,7 @@ impl IcebergWorkspace {
         let mut matches = checkpoint
             .tables
             .iter()
-            .filter(|coordinate| coordinate.form_relation == relation);
+            .filter(|coordinate| sql_relation_name(coordinate.form_id) == relation);
         let coordinate = matches
             .next()
             .ok_or_else(|| CheckpointUnavailable::new(format!("Form relation {relation}")))?;
@@ -512,12 +512,9 @@ impl IcebergWorkspace {
             .load_checkpoint_table(checkpoint, coordinate)
             .await?;
         let form = form_from_table(&table, coordinate.form_id)?;
-        if coordinate.form_relation != relation
-            || coordinate.form_relation != sql_relation_name(form.id)
-            || coordinate.form_id != form.id
-        {
+        if sql_relation_name(coordinate.form_id) != relation || coordinate.form_id != form.id {
             return Err(CheckpointIntegrityError::new(
-                "checkpoint Form relation does not match immutable Iceberg metadata",
+                "checkpoint Form ID does not match immutable Iceberg metadata",
             )
             .into());
         }

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -68,7 +68,9 @@ use tokio::sync::Semaphore;
 use ugoite_domain::entry::{
     EntryAsset, EntryIntegrity, EntryLink, EntryMetadata, EntryOperation, EntryRevision, FieldValue,
 };
-use ugoite_domain::form::{Compatibility, FieldType, FormChangeSet, FormDefinition, FormField};
+use ugoite_domain::form::{
+    sql_relation_name, Compatibility, FieldType, FormChangeSet, FormDefinition, FormField,
+};
 use ugoite_domain::id::{validate_checkpoint_name, FormId, RevisionId, SpaceId};
 use ugoite_storage::{operator_from_uri, SpaceCatalogStore};
 use uuid::Uuid;
@@ -466,7 +468,7 @@ impl IcebergWorkspace {
         let mut matches = checkpoint
             .tables
             .iter()
-            .filter(|coordinate| coordinate.form_name.eq_ignore_ascii_case(&relation));
+            .filter(|coordinate| sql_relation_name(&coordinate.form_name) == relation);
         let coordinate = matches
             .next()
             .ok_or_else(|| CheckpointUnavailable::new(format!("Form relation {relation}")))?;
@@ -483,7 +485,7 @@ impl IcebergWorkspace {
             .load_checkpoint_table(checkpoint, coordinate)
             .await?;
         let form = form_from_table(&table, coordinate.form_id)?;
-        if !form.name.eq_ignore_ascii_case(&relation) || coordinate.form_name != form.name {
+        if sql_relation_name(&form.name) != relation || coordinate.form_name != form.name {
             return Err(CheckpointIntegrityError::new(
                 "checkpoint Form relation does not match immutable Iceberg metadata",
             )

--- a/crates/ugoite-iceberg/src/query_context.rs
+++ b/crates/ugoite-iceberg/src/query_context.rs
@@ -20,6 +20,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use ugoite_core::query::{AuthorizedQueryPolicy, EntryScope, QuerySystemColumn};
+use ugoite_domain::form::sql_column_name;
 
 use crate::{form_from_table, IcebergWorkspace};
 
@@ -955,27 +956,21 @@ fn visible_columns(
     let form_columns = form
         .fields
         .iter()
-        .map(|field| field.name.as_str())
-        .collect::<BTreeSet<_>>();
-    if let Some(column) = policy
-        .columns
-        .iter()
-        .find(|column| !form_columns.contains(column.as_str()))
-    {
-        bail!("authorized query policy exposes unknown Form column {column}");
-    }
+        .map(|field| (sql_column_name(field.id), field.name.as_str()))
+        .collect::<HashMap<_, _>>();
     let mut visible = policy
         .columns
         .iter()
-        .map(|column| VisibleColumn {
-            // Form field names are immutable Iceberg column names.
-            source: column.clone(),
-            // Unquoted DataFusion identifiers are lowercase. Preserve the
-            // physical Iceberg name internally while exposing a stable,
-            // case-insensitive SQL surface.
-            name: column.to_ascii_lowercase(),
+        .map(|column| {
+            let source = form_columns.get(column).ok_or_else(|| {
+                anyhow!("authorized query policy exposes unknown Form column {column}")
+            })?;
+            Ok(VisibleColumn {
+                source: (*source).to_string(),
+                name: column.clone(),
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
     visible.extend(policy.system_columns.iter().map(system_column));
     let mut exposed = BTreeSet::new();
     if visible

--- a/crates/ugoite-iceberg/src/search.rs
+++ b/crates/ugoite-iceberg/src/search.rs
@@ -30,9 +30,8 @@ async fn search_entries_with_authorized_ids(
     readable_entry_ids: Option<&HashSet<String>>,
 ) -> Result<Vec<SearchResult>> {
     let query = query.to_lowercase();
-    let mut found_ids = HashSet::new();
-
     let rows = entry::list_entry_rows(op, ws_path).await?;
+    let mut results = Vec::new();
     for (_form_name, row) in rows {
         if row.deleted || readable_entry_ids.is_some_and(|allowed| !allowed.contains(&row.entry_id))
         {
@@ -40,13 +39,19 @@ async fn search_entries_with_authorized_ids(
         }
         let dump = serde_json::to_string(&row)?.to_lowercase();
         if dump.contains(&query) {
-            found_ids.insert(row.entry_id);
+            results.push(SearchResult {
+                id: row.entry_id,
+                title: row.title,
+                form: row.form,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+                properties: entry::merge_entry_fields(&row.fields, &row.extra_attributes),
+                tags: row.tags,
+                links: row.links,
+                assets: row.assets,
+                checksum: row.integrity.checksum,
+            });
         }
     }
-
-    let results = found_ids
-        .into_iter()
-        .map(|id| SearchResult { id })
-        .collect();
     Ok(results)
 }

--- a/crates/ugoite-iceberg/src/search.rs
+++ b/crates/ugoite-iceberg/src/search.rs
@@ -3,14 +3,14 @@ use opendal::Operator;
 use std::collections::HashSet;
 
 use crate::entry;
-pub use ugoite_domain::search::SearchResult;
+pub use ugoite_domain::search::KeywordSearchResult;
 
 /// Hybrid keyword search using index and content fallback.
 pub async fn search_entries(
     op: &Operator,
     ws_path: &str,
     query: &str,
-) -> Result<Vec<SearchResult>> {
+) -> Result<Vec<KeywordSearchResult>> {
     search_entries_with_authorized_ids(op, ws_path, query, None).await
 }
 
@@ -19,7 +19,7 @@ pub async fn search_entries_authorized(
     ws_path: &str,
     query: &str,
     readable_entry_ids: &HashSet<String>,
-) -> Result<Vec<SearchResult>> {
+) -> Result<Vec<KeywordSearchResult>> {
     search_entries_with_authorized_ids(op, ws_path, query, Some(readable_entry_ids)).await
 }
 
@@ -28,7 +28,7 @@ async fn search_entries_with_authorized_ids(
     ws_path: &str,
     query: &str,
     readable_entry_ids: Option<&HashSet<String>>,
-) -> Result<Vec<SearchResult>> {
+) -> Result<Vec<KeywordSearchResult>> {
     let query = query.to_lowercase();
     let rows = entry::list_entry_rows(op, ws_path).await?;
     let mut results = Vec::new();
@@ -39,17 +39,12 @@ async fn search_entries_with_authorized_ids(
         }
         let dump = serde_json::to_string(&row)?.to_lowercase();
         if dump.contains(&query) {
-            results.push(SearchResult {
+            results.push(KeywordSearchResult {
                 id: row.entry_id,
                 title: row.title,
                 form: row.form,
                 created_at: row.created_at,
                 updated_at: row.updated_at,
-                properties: entry::merge_entry_fields(&row.fields, &row.extra_attributes),
-                tags: row.tags,
-                links: row.links,
-                assets: row.assets,
-                checksum: row.integrity.checksum,
             });
         }
     }

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -15,7 +15,6 @@ use crate::{
     storage::operator_from_uri,
 };
 use ugoite_core::error::AppError;
-use ugoite_domain::form::sql_relation_name;
 use ugoite_domain::id::{
     validate_asset_id, validate_entry_id, validate_form_name, validate_revision_id,
     validate_space_id, validate_sql_id, validate_sql_session_id,
@@ -174,6 +173,24 @@ impl UgoiteService {
     pub async fn list_forms(&self, space_id: &str) -> Result<Vec<Value>> {
         validate_storage_id(validate_space_id(space_id))?;
         form::list_forms(&self.operator, &self.workspace_path(space_id)).await
+    }
+
+    async fn form_relations(&self, space_id: &str) -> Result<BTreeMap<String, String>> {
+        self.list_forms(space_id)
+            .await?
+            .into_iter()
+            .map(|form| {
+                let name = form
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Form is missing its name"))?;
+                let relation = form
+                    .get("sql_relation")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("Form is missing its SQL relation"))?;
+                Ok((name.to_string(), relation.to_string()))
+            })
+            .collect()
     }
 
     pub async fn get_form(&self, space_id: &str, form_name: &str) -> Result<Value> {
@@ -466,6 +483,7 @@ impl UgoiteService {
         principal_id: Uuid,
     ) -> Result<BTreeMap<String, HashSet<String>>> {
         let allowed = self.authorized_entry_ids(space_id, principal_id).await?;
+        let relations = self.form_relations(space_id).await?;
         let mut by_form = BTreeMap::<String, HashSet<String>>::new();
         for entry in self.list_entries(space_id).await? {
             let Some(entry_id) = entry.get("id").and_then(Value::as_str) else {
@@ -475,10 +493,12 @@ impl UgoiteService {
                 continue;
             };
             if allowed.contains(entry_id) {
-                by_form
-                    .entry(sql_relation_name(form))
-                    .or_default()
-                    .insert(entry_id.to_string());
+                if let Some(relation) = relations.get(form) {
+                    by_form
+                        .entry(relation.clone())
+                        .or_default()
+                        .insert(entry_id.to_string());
+                }
             }
         }
         Ok(by_form)
@@ -509,6 +529,7 @@ impl UgoiteService {
         let allowed = self
             .authorized_entry_ids_for_principals(space_id, principal_ids)
             .await?;
+        let relations = self.form_relations(space_id).await?;
         let mut by_form = BTreeMap::<String, HashSet<String>>::new();
         for entry in self.list_entries(space_id).await? {
             let (Some(entry_id), Some(form)) = (
@@ -518,10 +539,12 @@ impl UgoiteService {
                 continue;
             };
             if allowed.contains(entry_id) {
-                by_form
-                    .entry(sql_relation_name(form))
-                    .or_default()
-                    .insert(entry_id.to_string());
+                if let Some(relation) = relations.get(form) {
+                    by_form
+                        .entry(relation.clone())
+                        .or_default()
+                        .insert(entry_id.to_string());
+                }
             }
         }
         Ok(by_form)

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -15,6 +15,7 @@ use crate::{
     storage::operator_from_uri,
 };
 use ugoite_core::error::AppError;
+use ugoite_domain::form::sql_relation_name;
 use ugoite_domain::id::{
     validate_asset_id, validate_entry_id, validate_form_name, validate_revision_id,
     validate_space_id, validate_sql_id, validate_sql_session_id,
@@ -475,7 +476,7 @@ impl UgoiteService {
             };
             if allowed.contains(entry_id) {
                 by_form
-                    .entry(form.to_ascii_lowercase())
+                    .entry(sql_relation_name(form))
                     .or_default()
                     .insert(entry_id.to_string());
             }
@@ -518,7 +519,7 @@ impl UgoiteService {
             };
             if allowed.contains(entry_id) {
                 by_form
-                    .entry(form.to_ascii_lowercase())
+                    .entry(sql_relation_name(form))
                     .or_default()
                     .insert(entry_id.to_string());
             }

--- a/crates/ugoite-iceberg/src/service.rs
+++ b/crates/ugoite-iceberg/src/service.rs
@@ -398,7 +398,7 @@ impl UgoiteService {
         &self,
         space_id: &str,
         query: &str,
-    ) -> Result<Vec<search::SearchResult>> {
+    ) -> Result<Vec<search::KeywordSearchResult>> {
         validate_storage_id(validate_space_id(space_id))?;
         search::search_entries(&self.operator, &self.workspace_path(space_id), query).await
     }
@@ -664,7 +664,7 @@ impl UgoiteService {
         space_id: &str,
         principal_ids: &[Uuid],
         query: &str,
-    ) -> Result<Vec<search::SearchResult>> {
+    ) -> Result<Vec<search::KeywordSearchResult>> {
         let allowed = self
             .authorized_entry_ids_for_principals(space_id, principal_ids)
             .await?;
@@ -849,7 +849,7 @@ impl UgoiteService {
         space_id: &str,
         principal_id: Uuid,
         query: &str,
-    ) -> Result<Vec<search::SearchResult>> {
+    ) -> Result<Vec<search::KeywordSearchResult>> {
         let allowed = self.authorized_entry_ids(space_id, principal_id).await?;
         search::search_entries_authorized(
             &self.operator,

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -688,10 +688,7 @@ impl SpaceCatalog {
             }
             Err(_) => return checkpoint_issue(name, "checkpoint_unreadable", "checkpoint"),
         };
-        let checkpoint: SpaceCheckpoint = match serde_json::from_slice::<Value>(&bytes)
-            .map_err(|_| ())
-            .and_then(|value| SpaceCheckpoint::from_json_value(value).map_err(|_| ()))
-        {
+        let checkpoint: SpaceCheckpoint = match serde_json::from_slice(&bytes) {
             Ok(checkpoint) => checkpoint,
             Err(_) => return checkpoint_issue(name, "checkpoint_decode_failure", "checkpoint"),
         };
@@ -1000,9 +997,7 @@ impl SpaceCatalog {
             .read_checkpoint(name)
             .await
             .map_err(checkpoint_target_error)?;
-        let value: Value = serde_json::from_slice(&bytes)
-            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?;
-        SpaceCheckpoint::from_json_value(value)
+        serde_json::from_slice(&bytes)
             .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()).into())
     }
 

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -688,7 +688,10 @@ impl SpaceCatalog {
             }
             Err(_) => return checkpoint_issue(name, "checkpoint_unreadable", "checkpoint"),
         };
-        let checkpoint: SpaceCheckpoint = match serde_json::from_slice(&bytes) {
+        let checkpoint: SpaceCheckpoint = match serde_json::from_slice::<Value>(&bytes)
+            .map_err(|_| ())
+            .and_then(|value| SpaceCheckpoint::from_json_value(value).map_err(|_| ()))
+        {
             Ok(checkpoint) => checkpoint,
             Err(_) => return checkpoint_issue(name, "checkpoint_decode_failure", "checkpoint"),
         };
@@ -997,8 +1000,10 @@ impl SpaceCatalog {
             .read_checkpoint(name)
             .await
             .map_err(checkpoint_target_error)?;
-        Ok(serde_json::from_slice(&bytes)
-            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?)
+        let value: Value = serde_json::from_slice(&bytes)
+            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()))?;
+        SpaceCheckpoint::from_json_value(value)
+            .map_err(|error| crate::CheckpointIntegrityError::new(error.to_string()).into())
     }
 
     /// Re-establishes the immutable publication -> canonical Head chain that

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -882,7 +882,6 @@ impl SpaceCatalog {
         }
         Ok(CheckpointTable {
             form_id,
-            form_relation: crate::sql_relation_name(form_id),
             namespace: reference.identifier.namespace.clone(),
             table: reference.identifier.table.clone(),
             table_uuid: reference.table_uuid.clone(),

--- a/crates/ugoite-iceberg/src/space_catalog.rs
+++ b/crates/ugoite-iceberg/src/space_catalog.rs
@@ -882,15 +882,7 @@ impl SpaceCatalog {
         }
         Ok(CheckpointTable {
             form_id,
-            form_name: metadata
-                .properties()
-                .get(crate::FORM_NAME_PROPERTY)
-                .cloned()
-                .ok_or_else(|| {
-                    crate::CheckpointIntegrityError::new(
-                        "Iceberg table has no immutable Form relation name",
-                    )
-                })?,
+            form_relation: crate::sql_relation_name(form_id),
             namespace: reference.identifier.namespace.clone(),
             table: reference.identifier.table.clone(),
             table_uuid: reference.table_uuid.clone(),

--- a/crates/ugoite-iceberg/src/sql_session.rs
+++ b/crates/ugoite-iceberg/src/sql_session.rs
@@ -128,12 +128,11 @@ fn session_sql(meta: &Value) -> Result<&str> {
 }
 
 fn session_checkpoint(meta: &Value) -> Result<SpaceCheckpoint> {
-    serde_json::from_value(
+    SpaceCheckpoint::from_json_value(
         meta.get("checkpoint")
             .cloned()
             .ok_or_else(|| anyhow!("SQL session is missing its SpaceCheckpoint"))?,
     )
-    .map_err(Into::into)
 }
 
 fn session_parameters(meta: &Value) -> Result<HashMap<String, datafusion::scalar::ScalarValue>> {

--- a/crates/ugoite-iceberg/src/sql_session.rs
+++ b/crates/ugoite-iceberg/src/sql_session.rs
@@ -128,11 +128,12 @@ fn session_sql(meta: &Value) -> Result<&str> {
 }
 
 fn session_checkpoint(meta: &Value) -> Result<SpaceCheckpoint> {
-    SpaceCheckpoint::from_json_value(
+    serde_json::from_value(
         meta.get("checkpoint")
             .cloned()
             .ok_or_else(|| anyhow!("SQL session is missing its SpaceCheckpoint"))?,
     )
+    .map_err(Into::into)
 }
 
 fn session_parameters(meta: &Value) -> Result<HashMap<String, datafusion::scalar::ScalarValue>> {

--- a/crates/ugoite-iceberg/tests/authorized_query.rs
+++ b/crates/ugoite-iceberg/tests/authorized_query.rs
@@ -96,7 +96,7 @@ fn policy(form: &FormDefinition, readable: &[u128]) -> AuthorizedQueryPolicy {
                         .map(|id| EntryId::from(Uuid::from_u128(*id)))
                         .collect(),
                 ),
-                columns: ["title".into()].into_iter().collect(),
+                columns: ["field_100".into()].into_iter().collect(),
                 system_columns: BTreeSet::new(),
             },
         )]
@@ -133,7 +133,7 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
         .authorized_query_context(policy(&tasks, &[10]))
         .await?;
     let batches = context
-        .execute("SELECT * FROM tasks WHERE title IS NOT NULL")
+        .execute("SELECT * FROM tasks WHERE field_100 IS NOT NULL")
         .await?;
     assert_eq!(
         batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
@@ -149,7 +149,7 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
         "SELECT count(*) FROM tasks",
         "SELECT current_schema()",
         "SELECT current_catalog()",
-        "SELECT unregistered_udf(title) FROM tasks",
+        "SELECT unregistered_udf(field_100) FROM tasks",
         "SELECT UNNEST([1, 2])",
         "SELECT array_map([1, 2], x -> x + 1)",
         "SELECT * FROM generate_series(1, 2)",
@@ -160,9 +160,9 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
         );
     }
     for sql in [
-        "SELECT * FROM tasks t JOIN tasks other ON t.title = other.title",
+        "SELECT * FROM tasks t JOIN tasks other ON t.field_100 = other.field_100",
         "SELECT * FROM (SELECT * FROM tasks) nested",
-        "SELECT t.title FROM tasks AS t",
+        "SELECT t.field_100 FROM tasks AS t",
     ] {
         let batches = context.execute(sql).await?;
         assert_eq!(
@@ -172,7 +172,7 @@ async fn context_makes_unapproved_forms_entries_columns_and_system_objects_unres
     }
     assert_eq!(
         context
-            .execute("SELECT title AS entry_id FROM tasks")
+            .execute("SELECT field_100 AS entry_id FROM tasks")
             .await?
             .iter()
             .map(|batch| batch.num_rows())
@@ -204,7 +204,7 @@ async fn context_binds_native_datafusion_parameters_without_sql_substitution() -
 
     let rows = context
         .execute_with_parameters(
-            "SELECT title FROM tasks WHERE title = $title",
+            "SELECT field_100 FROM tasks WHERE field_100 = $title",
             HashMap::from([(
                 "title".to_string(),
                 datafusion::scalar::ScalarValue::Utf8(Some("allowed".into())),
@@ -215,7 +215,7 @@ async fn context_binds_native_datafusion_parameters_without_sql_substitution() -
 
     let injection = context
         .execute_with_parameters(
-            "SELECT title FROM tasks WHERE title = $title",
+            "SELECT field_100 FROM tasks WHERE field_100 = $title",
             HashMap::from([(
                 "title".to_string(),
                 datafusion::scalar::ScalarValue::Utf8(Some("allowed' OR 1=1 --".into())),
@@ -232,14 +232,14 @@ async fn context_binds_native_datafusion_parameters_without_sql_substitution() -
     );
     assert!(context
         .execute_with_parameters(
-            "SELECT title FROM tasks WHERE title = $title",
+            "SELECT field_100 FROM tasks WHERE field_100 = $title",
             HashMap::new()
         )
         .await
         .is_err());
     assert!(context
         .execute_with_parameters(
-            "SELECT title FROM tasks",
+            "SELECT field_100 FROM tasks",
             HashMap::from([(
                 "title".to_string(),
                 datafusion::scalar::ScalarValue::Utf8(Some("allowed".into())),
@@ -276,7 +276,7 @@ async fn duplicate_maximum_versions_fail_every_sql_shape() -> anyhow::Result<()>
     for sql in [
         "SELECT * FROM tasks",
         "SELECT count(*) FROM tasks",
-        "SELECT title FROM tasks LIMIT 1",
+        "SELECT field_100 FROM tasks LIMIT 1",
     ] {
         let error = context.execute(sql).await.expect_err(sql);
         assert!(matches!(
@@ -302,7 +302,9 @@ async fn physical_plan_keeps_iceberg_projection_filter_and_limit_pushdown() -> a
         .authorized_query_context(policy(&tasks, &[112]))
         .await?;
     let plan = context
-        .physical_plan_for_testing("SELECT title FROM tasks WHERE title = 'allowed' LIMIT 1")
+        .physical_plan_for_testing(
+            "SELECT field_100 FROM tasks WHERE field_100 = 'allowed' LIMIT 1",
+        )
         .await?;
     let normalized = plan.to_ascii_lowercase();
     assert!(normalized.contains("iceberg"), "{plan}");
@@ -461,7 +463,7 @@ async fn system_columns_are_queryable_only_when_explicitly_allowlisted() -> anyh
         .insert(QuerySystemColumn::EntryId);
     let context = workspace.authorized_query_context(wildcard).await?;
     let batches = context.execute("SELECT * FROM tasks").await?;
-    assert_eq!(batches[0].schema().field(0).name(), "title");
+    assert_eq!(batches[0].schema().field(0).name(), "field_100");
     assert_eq!(
         batches[0].schema().field(1).name(),
         QuerySystemColumn::EntryId.as_str()

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -155,10 +155,6 @@ async fn checkpoint_pins_one_head_and_uses_static_iceberg_coordinates() -> anyho
     );
     assert_eq!(checkpoint.tables.len(), 1);
     assert_eq!(checkpoint.tables[0].form_id, form.id);
-    assert_eq!(
-        checkpoint.tables[0].form_relation,
-        ugoite_domain::form::sql_relation_name(form.id)
-    );
     assert!(checkpoint.tables[0].snapshot_id.is_some());
     assert!(checkpoint.validate_coordinate_checksum());
     assert_eq!(

--- a/crates/ugoite-iceberg/tests/checkpoint.rs
+++ b/crates/ugoite-iceberg/tests/checkpoint.rs
@@ -1,7 +1,7 @@
 use iceberg::{NamespaceIdent, TableIdent};
 use std::collections::BTreeMap;
 use ugoite_domain::entry::{EntryMetadata, EntryOperation, EntryRevision, FieldValue};
-use ugoite_domain::form::{FieldType, FormDefinition, FormField, FormVersion};
+use ugoite_domain::form::{sql_relation_name, FieldType, FormDefinition, FormField, FormVersion};
 use ugoite_domain::id::{FieldId, FormId, SpaceId};
 use ugoite_iceberg::{
     publication_context, CheckpointIntegrityError, CheckpointUnavailable, IcebergWorkspace,
@@ -155,11 +155,17 @@ async fn checkpoint_pins_one_head_and_uses_static_iceberg_coordinates() -> anyho
     );
     assert_eq!(checkpoint.tables.len(), 1);
     assert_eq!(checkpoint.tables[0].form_id, form.id);
-    assert_eq!(checkpoint.tables[0].form_name, "Task");
+    assert_eq!(
+        checkpoint.tables[0].form_relation,
+        ugoite_domain::form::sql_relation_name(form.id)
+    );
     assert!(checkpoint.tables[0].snapshot_id.is_some());
     assert!(checkpoint.validate_coordinate_checksum());
     assert_eq!(
-        workspace.form_at_checkpoint(&checkpoint, "task").await?.id,
+        workspace
+            .form_at_checkpoint(&checkpoint, &sql_relation_name(form.id))
+            .await?
+            .id,
         form.id
     );
 

--- a/crates/ugoite-iceberg/tests/test_form.rs
+++ b/crates/ugoite-iceberg/tests/test_form.rs
@@ -23,10 +23,67 @@ async fn test_form_req_form_002_upsert_and_list_forms() -> anyhow::Result<()> {
     form::upsert_form(&op, ws_path, &form_value).await?;
 
     let forms = form::list_forms(&op, ws_path).await?;
-    assert!(forms
+    let meeting = forms
         .iter()
-        .any(|c| c.get("name").and_then(|v| v.as_str()) == Some("meeting")));
+        .find(|c| c.get("name").and_then(|v| v.as_str()) == Some("meeting"))
+        .expect("meeting Form");
+    assert!(meeting["sql_relation"].as_str().is_some());
+    assert_eq!(meeting["fields"]["date"]["sql_column"], "field_100");
+    assert_eq!(meeting["fields"]["summary"]["sql_column"], "field_101");
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_columns_follow_field_ids_across_case_collisions_and_renames() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "stable-sql-columns", "/tmp").await?;
+    let ws_path = "spaces/stable-sql-columns";
+
+    form::upsert_form(
+        &op,
+        ws_path,
+        &serde_json::json!({
+            "name": "CaseFields",
+            "fields": {
+                "Status": {"type": "string"},
+                "status": {"type": "string"}
+            }
+        }),
+    )
+    .await?;
+    let before = form::get_form(&op, ws_path, "CaseFields").await?;
+    let status_column = before["fields"]["Status"]["sql_column"]
+        .as_str()
+        .expect("Status SQL column")
+        .to_string();
+    let lowercase_status_column = before["fields"]["status"]["sql_column"]
+        .as_str()
+        .expect("status SQL column")
+        .to_string();
+    assert_ne!(status_column, lowercase_status_column);
+
+    form::upsert_form(
+        &op,
+        ws_path,
+        &serde_json::json!({
+            "name": "CaseFields",
+            "fields": {
+                "RenamedStatus": {"id": 100, "type": "string"},
+                "status": {"id": 101, "type": "string"}
+            }
+        }),
+    )
+    .await?;
+    let after = form::get_form(&op, ws_path, "CaseFields").await?;
+    assert_eq!(
+        after["fields"]["RenamedStatus"]["sql_column"],
+        status_column
+    );
+    assert_eq!(
+        after["fields"]["status"]["sql_column"],
+        lowercase_status_column
+    );
     Ok(())
 }
 

--- a/crates/ugoite-iceberg/tests/test_index.rs
+++ b/crates/ugoite-iceberg/tests/test_index.rs
@@ -115,6 +115,11 @@ async fn test_index_req_idx_008_query_sql() -> anyhow::Result<()> {
         }
     });
     form::upsert_form(&op, ws_path, &class_def).await?;
+    let meeting = form::get_form(&op, ws_path, "Meeting").await?;
+    let meeting_relation = meeting["sql_relation"].as_str().expect("SQL relation");
+    let date_column = meeting["fields"]["Date"]["sql_column"]
+        .as_str()
+        .expect("SQL column");
 
     let entry_one = "---\nform: Meeting\n---\n# Entry 1\n\n## Date\n2025-01-01\n\n## Topic\nalpha";
     entry::create_entry(&op, ws_path, "entry-1", entry_one, "author", &MockIntegrity).await?;
@@ -122,7 +127,9 @@ async fn test_index_req_idx_008_query_sql() -> anyhow::Result<()> {
     entry::create_entry(&op, ws_path, "entry-2", entry_two, "author", &MockIntegrity).await?;
 
     let payload = serde_json::json!({
-        "$sql": "SELECT * FROM Meeting WHERE Date >= '2025-02-01'"
+        "$sql": format!(
+            "SELECT * FROM \"{meeting_relation}\" WHERE \"{date_column}\" >= '2025-02-01'"
+        )
     })
     .to_string();
     let results = index::query_index(&op, ws_path, &payload).await?;
@@ -165,6 +172,8 @@ async fn test_index_req_idx_009_query_sql_joins() -> anyhow::Result<()> {
         }
     });
     form::upsert_form(&op, ws_path, &class_def).await?;
+    let entry_form = form::get_form(&op, ws_path, "Entry").await?;
+    let entry_relation = entry_form["sql_relation"].as_str().expect("SQL relation");
 
     let entry_one = "---\nform: Entry\n---\n# Entry 1\n\n## Body\nAlpha";
     let entry_two = "---\nform: Entry\n---\n# Entry 2\n\n## Body\nBeta";
@@ -182,7 +191,9 @@ async fn test_index_req_idx_009_query_sql_joins() -> anyhow::Result<()> {
     .await?;
 
     let payload = serde_json::json!({
-        "$sql": "SELECT e._ugoite_id AS left_id, f._ugoite_id AS right_id FROM entry e JOIN entry f ON e._ugoite_id = f._ugoite_id WHERE e._ugoite_id = 'entry-1'"
+        "$sql": format!(
+            "SELECT e._ugoite_id AS left_id, f._ugoite_id AS right_id FROM \"{entry_relation}\" e JOIN \"{entry_relation}\" f ON e._ugoite_id = f._ugoite_id WHERE e._ugoite_id = 'entry-1'"
+        )
     })
     .to_string();
     let results = index::query_index(&op, ws_path, &payload).await?;

--- a/crates/ugoite-iceberg/tests/test_saved_sql.rs
+++ b/crates/ugoite-iceberg/tests/test_saved_sql.rs
@@ -7,6 +7,8 @@ use ugoite_iceberg::saved_sql::{self, SqlPayload};
 use ugoite_iceberg::space;
 use ugoite_iceberg::sql_session;
 
+const FORM_RELATION: &str = "form_00000000000000000000000000000001";
+
 #[tokio::test]
 /// REQ-API-006
 async fn test_saved_sql_req_api_006_crud() -> anyhow::Result<()> {
@@ -17,7 +19,7 @@ async fn test_saved_sql_req_api_006_crud() -> anyhow::Result<()> {
 
     let payload = SqlPayload {
         name: "Recent Meetings".to_string(),
-        sql: "SELECT * FROM sql WHERE _ugoite_updated_at >= $since".to_string(),
+        sql: format!("SELECT * FROM \"{FORM_RELATION}\" WHERE _ugoite_updated_at >= $since"),
         variables: json!([
             {
                 "type": "date",
@@ -48,9 +50,9 @@ async fn test_saved_sql_req_api_006_crud() -> anyhow::Result<()> {
 
     let update_payload = SqlPayload {
         name: "Recent Meetings".to_string(),
-        sql:
-            "SELECT * FROM sql WHERE _ugoite_updated_at >= $since ORDER BY _ugoite_updated_at DESC"
-                .to_string(),
+        sql: format!(
+            "SELECT * FROM \"{FORM_RELATION}\" WHERE _ugoite_updated_at >= $since ORDER BY _ugoite_updated_at DESC, _ugoite_id"
+        ),
         variables: payload.variables.clone(),
     };
 
@@ -85,8 +87,9 @@ async fn advanced_search_sql_is_saved_and_materialized() -> anyhow::Result<()> {
     let integrity = FakeIntegrityProvider;
     let payload = SqlPayload {
         name: "Advanced search - form: Meeting - memo=s".to_string(),
-        sql: "SELECT _ugoite_id, _ugoite_title FROM sql ORDER BY _ugoite_updated_at DESC LIMIT 50"
-            .to_string(),
+        sql: format!(
+            "SELECT * FROM \"{FORM_RELATION}\" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50"
+        ),
         variables: json!([]),
     };
 
@@ -113,7 +116,7 @@ async fn test_saved_sql_req_api_007_validation_errors() -> anyhow::Result<()> {
 
     let missing_placeholder = SqlPayload {
         name: "Missing placeholder".to_string(),
-        sql: "SELECT * FROM sql".to_string(),
+        sql: format!("SELECT * FROM \"{FORM_RELATION}\""),
         variables: json!([
             {
                 "type": "date",
@@ -137,7 +140,7 @@ async fn test_saved_sql_req_api_007_validation_errors() -> anyhow::Result<()> {
 
     let undefined_placeholder = SqlPayload {
         name: "Undefined placeholder".to_string(),
-        sql: "SELECT * FROM sql WHERE _ugoite_updated_at >= $since".to_string(),
+        sql: format!("SELECT * FROM \"{FORM_RELATION}\" WHERE _ugoite_updated_at >= $since"),
         variables: json!([]),
     };
 

--- a/crates/ugoite-iceberg/tests/test_search.rs
+++ b/crates/ugoite-iceberg/tests/test_search.rs
@@ -33,13 +33,6 @@ async fn create_test_entry(
     Ok(())
 }
 
-#[derive(serde::Deserialize, Debug)]
-#[allow(dead_code)]
-struct SearchResultWrapper {
-    id: String,
-    // Add logic to extract matches if search struct exposes more
-}
-
 #[tokio::test]
 /// REQ-SRCH-001
 async fn test_search_req_srch_001_keyword_search() -> anyhow::Result<()> {
@@ -66,7 +59,6 @@ async fn test_search_req_srch_001_keyword_search() -> anyhow::Result<()> {
     let first = results.iter().find(|result| result.id == "entry1").unwrap();
     assert_eq!(first.title, "entry1");
     assert_eq!(first.form, "Entry");
-    assert!(first.properties.get("Body").is_some());
 
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/test_search.rs
+++ b/crates/ugoite-iceberg/tests/test_search.rs
@@ -59,10 +59,14 @@ async fn test_search_req_srch_001_keyword_search() -> anyhow::Result<()> {
     assert_eq!(results.len(), 2);
 
     // Check results contain expected entries
-    let found_ids: Vec<String> = results.into_iter().map(|s| s.id).collect();
+    let found_ids: Vec<String> = results.iter().map(|s| s.id.clone()).collect();
     assert!(found_ids.contains(&"entry1".to_string()));
     assert!(found_ids.contains(&"entry3".to_string()));
     assert!(!found_ids.contains(&"entry2".to_string()));
+    let first = results.iter().find(|result| result.id == "entry1").unwrap();
+    assert_eq!(first.title, "entry1");
+    assert_eq!(first.form, "Entry");
+    assert!(first.properties.get("Body").is_some());
 
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/test_sql_sessions.rs
+++ b/crates/ugoite-iceberg/tests/test_sql_sessions.rs
@@ -867,3 +867,73 @@ async fn sql_session_rejects_unsupported_sql_before_resolving_a_space_scope() ->
     assert!(error.to_string().contains("does not support joins"));
     Ok(())
 }
+
+#[tokio::test]
+async fn sql_session_uses_backend_relation_mapping_for_hyphenated_forms() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "test-sql-session-relation", "/tmp").await?;
+    let ws_path = "spaces/test-sql-session-relation";
+    let form_def = serde_json::json!({
+        "name": "Daily-Note",
+        "template": "# Daily-Note\n\n## Count\n",
+        "fields": {
+            "Count": {"type": "integer"},
+            "Enabled": {"type": "boolean"}
+        }
+    });
+    form::upsert_form(&op, ws_path, &form_def).await?;
+
+    let principal_ids = [Uuid::from_u128(92)];
+    let readable_entries_by_form = [("daily_x2d_note".to_string(), HashSet::new())]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let session = sql_session::create_sql_session_authorized_for_principals_by_form(
+        &op,
+        ws_path,
+        "SELECT * FROM \"daily_x2d_note\" ORDER BY _ugoite_id",
+        sql_session::SqlSessionCreateAuthorization {
+            authorization: sql_session::SqlSessionAuthorization {
+                principal_ids: &principal_ids,
+                policy_hash: AUTHORIZATION_POLICY_HASH,
+            },
+            readable_entries_by_form: &readable_entries_by_form,
+        },
+    )
+    .await?;
+    assert_eq!(session["status"], "ready");
+    assert_eq!(
+        session["query_policy"]["forms"][0]["relation"],
+        "daily_x2d_note"
+    );
+
+    let parameters = serde_json::Map::from_iter([
+        ("search_0".to_string(), serde_json::json!(10)),
+        (
+            "search_1".to_string(),
+            serde_json::json!("2025-03-04T00:00:00.000Z"),
+        ),
+        ("search_2".to_string(), serde_json::json!(true)),
+    ]);
+    let parameter_types = BTreeMap::from_iter([
+        ("search_0".to_string(), "integer".to_string()),
+        ("search_1".to_string(), "timestamp".to_string()),
+        ("search_2".to_string(), "boolean".to_string()),
+    ]);
+    let typed_session = sql_session::create_sql_session_authorized_for_principals_by_form_with_parameters(
+        &op,
+        ws_path,
+        "SELECT * FROM \"daily_x2d_note\" WHERE _ugoite_updated_at < $search_1 AND \"count\" = $search_0 AND \"enabled\" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id",
+        parameters,
+        parameter_types,
+        sql_session::SqlSessionCreateAuthorization {
+            authorization: sql_session::SqlSessionAuthorization {
+                principal_ids: &principal_ids,
+                policy_hash: AUTHORIZATION_POLICY_HASH,
+            },
+            readable_entries_by_form: &readable_entries_by_form,
+        },
+    )
+    .await?;
+    assert_eq!(typed_session["status"], "ready");
+    Ok(())
+}

--- a/crates/ugoite-iceberg/tests/test_sql_sessions.rs
+++ b/crates/ugoite-iceberg/tests/test_sql_sessions.rs
@@ -20,7 +20,7 @@ fn authorized_entries(form: &str, entry_ids: &[&str]) -> (Uuid, BTreeMap<String,
     (
         Uuid::from_u128(1),
         [(
-            form.to_ascii_lowercase(),
+            form.to_string(),
             entry_ids
                 .iter()
                 .map(|entry_id| (*entry_id).to_string())
@@ -64,6 +64,10 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
         "fields": {"Body": {"type": "markdown"}}
     });
     form::upsert_form(&op, ws_path, &form_def).await?;
+    let entry_relation = form::get_form(&op, ws_path, "Entry").await?["sql_relation"]
+        .as_str()
+        .expect("Form SQL relation")
+        .to_string();
 
     let entry_one = "---\nform: Entry\n---\n# Alpha\n\n## Body\nalpha";
     entry::create_entry(&op, ws_path, "entry-1", entry_one, "author", &MockIntegrity).await?;
@@ -72,7 +76,9 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
 
     let sql_payload = saved_sql::SqlPayload {
         name: "Alpha Query".to_string(),
-        sql: "SELECT * FROM entry WHERE _ugoite_title = $title ORDER BY _ugoite_id".to_string(),
+        sql: format!(
+            "SELECT * FROM \"{entry_relation}\" WHERE _ugoite_title = $title ORDER BY _ugoite_id"
+        ),
         variables: serde_json::json!([{
             "name": "title",
             "type": "string",
@@ -90,7 +96,7 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
     .await?;
 
     let (principal_id, readable_entries_by_form) =
-        authorized_entries("Entry", &["entry-1", "entry-2"]);
+        authorized_entries(&entry_relation, &["entry-1", "entry-2"]);
     let principal_ids = [principal_id];
     let authorization = sql_session::SqlSessionAuthorization {
         principal_ids: &principal_ids,
@@ -105,7 +111,7 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
     let error = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
-        "SELECT * FROM entry ORDER BY _ugoite_id",
+        &format!("SELECT * FROM \"{entry_relation}\" ORDER BY _ugoite_id"),
         sql_session::SqlSessionCreateAuthorization {
             authorization: sql_session::SqlSessionAuthorization {
                 principal_ids: &no_principals,
@@ -121,13 +127,13 @@ async fn test_sql_sessions_req_api_008_end_to_end() -> anyhow::Result<()> {
     let oversized_entries = (0..=ugoite_iceberg::index::SQL_SESSION_MAX_AUTHORIZATION_SCOPE_IDS)
         .map(|index| format!("entry-{index}"))
         .collect::<HashSet<_>>();
-    let oversized_scope = [("entry".to_string(), oversized_entries)]
+    let oversized_scope = [(entry_relation.clone(), oversized_entries)]
         .into_iter()
         .collect::<BTreeMap<_, _>>();
     let error = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
-        "SELECT * FROM entry ORDER BY _ugoite_id",
+        &format!("SELECT * FROM \"{entry_relation}\" ORDER BY _ugoite_id"),
         sql_session::SqlSessionCreateAuthorization {
             authorization,
             readable_entries_by_form: &oversized_scope,
@@ -232,6 +238,10 @@ async fn test_sql_sessions_req_api_008_scopes_rows_before_limit() -> anyhow::Res
         }),
     )
     .await?;
+    let public_task_relation = form::get_form(&op, ws_path, "PublicTask").await?["sql_relation"]
+        .as_str()
+        .expect("Form SQL relation")
+        .to_string();
     form::upsert_form(
         &op,
         ws_path,
@@ -272,7 +282,7 @@ async fn test_sql_sessions_req_api_008_scopes_rows_before_limit() -> anyhow::Res
     .await?;
 
     let (principal_id, readable_entries_by_form) =
-        authorized_entries("PublicTask", &["public-a", "public-b"]);
+        authorized_entries(&public_task_relation, &["public-a", "public-b"]);
     let principal_ids = [principal_id];
     let authorization = sql_session::SqlSessionAuthorization {
         principal_ids: &principal_ids,
@@ -285,7 +295,7 @@ async fn test_sql_sessions_req_api_008_scopes_rows_before_limit() -> anyhow::Res
     let session = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
-        "SELECT * FROM publictask ORDER BY _ugoite_id DESC LIMIT 2",
+        &format!("SELECT * FROM \"{public_task_relation}\" ORDER BY _ugoite_id DESC LIMIT 2"),
         create_authorization,
     )
     .await?;
@@ -350,6 +360,10 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         }),
     )
     .await?;
+    let task_relation = form::get_form(&op, ws_path, "Task").await?["sql_relation"]
+        .as_str()
+        .expect("Form SQL relation")
+        .to_string();
     entry::create_entry(
         &op,
         ws_path,
@@ -359,7 +373,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
         &MockIntegrity,
     )
     .await?;
-    let (principal_id, readable_entries_by_form) = authorized_entries("Task", &["task-1"]);
+    let (principal_id, readable_entries_by_form) = authorized_entries(&task_relation, &["task-1"]);
     let principal_ids = [principal_id];
     let authorization = sql_session::SqlSessionAuthorization {
         principal_ids: &principal_ids,
@@ -371,20 +385,20 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
     };
 
     for sql in [
-        "SELECT * FROM task",
-        "SELECT * FROM task ORDER BY _ugoite_updated_at",
-        "SELECT DISTINCT _ugoite_id FROM task ORDER BY _ugoite_id",
-        "SELECT _ugoite_title AS _ugoite_id FROM task ORDER BY _ugoite_id",
-        "SELECT * FROM task WHERE EXISTS (SELECT 1 FROM task t2 WHERE t2._ugoite_id = task._ugoite_id) ORDER BY _ugoite_id",
-        "SELECT (SELECT _ugoite_id FROM task LIMIT 1) FROM task ORDER BY _ugoite_id",
-        "SELECT * FROM task WHERE _ugoite_id IN (SELECT _ugoite_id FROM task) ORDER BY _ugoite_id",
-        "SELECT * FROM task ORDER BY _ugoite_id LIMIT 1 OFFSET 1000000",
+        format!("SELECT * FROM \"{task_relation}\""),
+        format!("SELECT * FROM \"{task_relation}\" ORDER BY _ugoite_updated_at"),
+        format!("SELECT DISTINCT _ugoite_id FROM \"{task_relation}\" ORDER BY _ugoite_id"),
+        format!("SELECT _ugoite_title AS _ugoite_id FROM \"{task_relation}\" ORDER BY _ugoite_id"),
+        format!("SELECT * FROM \"{task_relation}\" WHERE EXISTS (SELECT 1 FROM \"{task_relation}\" t2 WHERE t2._ugoite_id = \"{task_relation}\"._ugoite_id) ORDER BY _ugoite_id"),
+        format!("SELECT (SELECT _ugoite_id FROM \"{task_relation}\" LIMIT 1) FROM \"{task_relation}\" ORDER BY _ugoite_id"),
+        format!("SELECT * FROM \"{task_relation}\" WHERE _ugoite_id IN (SELECT _ugoite_id FROM \"{task_relation}\") ORDER BY _ugoite_id"),
+        format!("SELECT * FROM \"{task_relation}\" ORDER BY _ugoite_id LIMIT 1 OFFSET 1000000"),
     ] {
         assert!(
             sql_session::create_sql_session_authorized_for_principals_by_form(
                 &op,
                 ws_path,
-                sql,
+                &sql,
                 create_authorization,
             )
             .await
@@ -395,7 +409,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
     let session = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
-        "SELECT * FROM task ORDER BY _ugoite_id",
+        &format!("SELECT * FROM \"{task_relation}\" ORDER BY _ugoite_id"),
         create_authorization,
     )
     .await?;
@@ -445,7 +459,7 @@ async fn sql_sessions_reject_unsafe_pagination_and_authorization_changes() -> an
     let limit_zero = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
-        "SELECT * FROM task ORDER BY _ugoite_id LIMIT 0",
+        &format!("SELECT * FROM \"{task_relation}\" ORDER BY _ugoite_id LIMIT 0"),
         create_authorization,
     )
     .await?;
@@ -514,6 +528,10 @@ async fn sql_sessions_service_freezes_checkpoint_scope_and_policy() -> anyhow::R
             }),
         )
         .await?;
+    let task_relation = service.get_form(&space_id, "Task").await?["sql_relation"]
+        .as_str()
+        .expect("Form SQL relation")
+        .to_string();
     for (id, title) in [("task-1", "One"), ("task-2", "Two")] {
         service
             .create_entry(
@@ -548,7 +566,7 @@ async fn sql_sessions_service_freezes_checkpoint_scope_and_policy() -> anyhow::R
         .create_sql_session_authorized_for_principals(
             &space_id,
             &principals,
-            "SELECT * FROM task ORDER BY _ugoite_id",
+            &format!("SELECT * FROM \"{task_relation}\" ORDER BY _ugoite_id"),
         )
         .await?;
     let session_id = session["id"].as_str().expect("session ID");
@@ -565,7 +583,7 @@ async fn sql_sessions_service_freezes_checkpoint_scope_and_policy() -> anyhow::R
         .create_sql_session_authorized_for_principals(
             &space_id,
             &no_principals,
-            "SELECT * FROM task ORDER BY _ugoite_id",
+            &format!("SELECT * FROM \"{task_relation}\" ORDER BY _ugoite_id"),
         )
         .await
         .expect_err("session creation must reject an empty principal set");
@@ -690,6 +708,10 @@ async fn sql_sessions_apply_sparse_entry_denials_in_the_provider() -> anyhow::Re
             }),
         )
         .await?;
+    let task_relation = service.get_form(&space_id, "Task").await?["sql_relation"]
+        .as_str()
+        .expect("Form SQL relation")
+        .to_string();
     for (id, title) in [("task-public", "Public"), ("task-private", "Private")] {
         service
             .create_entry(
@@ -738,7 +760,7 @@ async fn sql_sessions_apply_sparse_entry_denials_in_the_provider() -> anyhow::Re
         .create_sql_session_authorized_for_principals(
             &space_id,
             &principals,
-            "SELECT * FROM task ORDER BY _ugoite_id",
+            &format!("SELECT * FROM \"{task_relation}\" ORDER BY _ugoite_id"),
         )
         .await?;
     assert_eq!(
@@ -882,15 +904,29 @@ async fn sql_session_uses_backend_relation_mapping_for_hyphenated_forms() -> any
         }
     });
     form::upsert_form(&op, ws_path, &form_def).await?;
+    let relation = form::get_form(&op, ws_path, "Daily-Note").await?["sql_relation"]
+        .as_str()
+        .expect("Form SQL relation")
+        .to_string();
+    let count_column = form::get_form(&op, ws_path, "Daily-Note").await?["fields"]["Count"]
+        ["sql_column"]
+        .as_str()
+        .expect("Form SQL column")
+        .to_string();
+    let enabled_column = form::get_form(&op, ws_path, "Daily-Note").await?["fields"]["Enabled"]
+        ["sql_column"]
+        .as_str()
+        .expect("Form SQL column")
+        .to_string();
 
     let principal_ids = [Uuid::from_u128(92)];
-    let readable_entries_by_form = [("daily_x2d_note".to_string(), HashSet::new())]
+    let readable_entries_by_form = [(relation.clone(), HashSet::new())]
         .into_iter()
         .collect::<BTreeMap<_, _>>();
     let session = sql_session::create_sql_session_authorized_for_principals_by_form(
         &op,
         ws_path,
-        "SELECT * FROM \"daily_x2d_note\" ORDER BY _ugoite_id",
+        &format!("SELECT * FROM \"{relation}\" ORDER BY _ugoite_id"),
         sql_session::SqlSessionCreateAuthorization {
             authorization: sql_session::SqlSessionAuthorization {
                 principal_ids: &principal_ids,
@@ -901,10 +937,7 @@ async fn sql_session_uses_backend_relation_mapping_for_hyphenated_forms() -> any
     )
     .await?;
     assert_eq!(session["status"], "ready");
-    assert_eq!(
-        session["query_policy"]["forms"][0]["relation"],
-        "daily_x2d_note"
-    );
+    assert_eq!(session["query_policy"]["forms"][0]["relation"], relation);
 
     let parameters = serde_json::Map::from_iter([
         ("search_0".to_string(), serde_json::json!(10)),
@@ -922,7 +955,7 @@ async fn sql_session_uses_backend_relation_mapping_for_hyphenated_forms() -> any
     let typed_session = sql_session::create_sql_session_authorized_for_principals_by_form_with_parameters(
         &op,
         ws_path,
-        "SELECT * FROM \"daily_x2d_note\" WHERE _ugoite_updated_at < $search_1 AND \"count\" = $search_0 AND \"enabled\" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id",
+        &format!("SELECT * FROM \"{relation}\" WHERE _ugoite_updated_at < $search_1 AND \"{count_column}\" = $search_0 AND \"{enabled_column}\" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id"),
         parameters,
         parameter_types,
         sql_session::SqlSessionCreateAuthorization {
@@ -935,5 +968,50 @@ async fn sql_session_uses_backend_relation_mapping_for_hyphenated_forms() -> any
     )
     .await?;
     assert_eq!(typed_session["status"], "ready");
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_relations_are_unique_for_case_distinct_forms() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "case-distinct-forms", "/tmp").await?;
+    let ws_path = "spaces/case-distinct-forms";
+    for name in ["Meeting", "meeting"] {
+        form::upsert_form(
+            &op,
+            ws_path,
+            &serde_json::json!({"name": name, "fields": {}}),
+        )
+        .await?;
+    }
+    let upper = form::get_form(&op, ws_path, "Meeting").await?;
+    let lower = form::get_form(&op, ws_path, "meeting").await?;
+    let upper_relation = upper["sql_relation"].as_str().expect("SQL relation");
+    let lower_relation = lower["sql_relation"].as_str().expect("SQL relation");
+    assert_ne!(upper_relation, lower_relation);
+
+    let principal_ids = [Uuid::from_u128(93)];
+    let readable_entries_by_form = [
+        (upper_relation.to_string(), HashSet::new()),
+        (lower_relation.to_string(), HashSet::new()),
+    ]
+    .into_iter()
+    .collect::<BTreeMap<_, _>>();
+    for relation in [upper_relation, lower_relation] {
+        let session = sql_session::create_sql_session_authorized_for_principals_by_form(
+            &op,
+            ws_path,
+            &format!("SELECT * FROM \"{relation}\" ORDER BY _ugoite_id"),
+            sql_session::SqlSessionCreateAuthorization {
+                authorization: sql_session::SqlSessionAuthorization {
+                    principal_ids: &principal_ids,
+                    policy_hash: AUTHORIZATION_POLICY_HASH,
+                },
+                readable_entries_by_form: &readable_entries_by_form,
+            },
+        )
+        .await?;
+        assert_eq!(session["status"], "ready");
+    }
     Ok(())
 }

--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -1,9 +1,14 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
+use ugoite_core::query::{
+    AuthorizedQueryForm, AuthorizedQueryPolicy, EntryScope, QueryLimits, QuerySystemColumn,
+};
 use ugoite_domain::entry::{
     EntryAsset, EntryIntegrity, EntryLink, EntryMetadata, EntryOperation, EntryRevision, FieldValue,
 };
 use ugoite_domain::form::{
-    FieldType, FormChange, FormChangeSet, FormDefinition, FormField, FormVersion,
+    sql_column_name, sql_relation_name, FieldType, FormChange, FormChangeSet, FormDefinition,
+    FormField, FormVersion,
 };
 use ugoite_domain::id::{FieldId, FormId, SpaceId};
 use ugoite_iceberg::{
@@ -283,6 +288,67 @@ async fn metadata_evolution_keeps_physical_identity() -> anyhow::Result<()> {
             .len(),
         1
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_relation_and_saved_query_survive_form_rename() -> anyhow::Result<()> {
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(305)),
+        "memory://iceberg-stable-sql-relation",
+    )
+    .await?;
+    let form = form();
+    create_form(&workspace, &form).await?;
+    let relation = sql_relation_name(form.id);
+    let saved_sql = format!("SELECT * FROM \"{relation}\" ORDER BY _ugoite_id");
+    let before = workspace.capture_checkpoint().await?;
+
+    evolve_form(
+        &workspace,
+        &FormChangeSet {
+            form_id: form.id,
+            expected_version: Some(form.version),
+            changes: vec![FormChange::RenameForm {
+                name: "Work item".into(),
+            }],
+        },
+    )
+    .await?;
+    let after = workspace.capture_checkpoint().await?;
+    assert_eq!(
+        workspace.form_at_checkpoint(&before, &relation).await?.name,
+        "Task"
+    );
+    assert_eq!(
+        workspace.form_at_checkpoint(&after, &relation).await?.name,
+        "Work item"
+    );
+
+    let context = workspace
+        .authorized_query_context(AuthorizedQueryPolicy {
+            forms: [(
+                form.id,
+                AuthorizedQueryForm {
+                    relation: relation.clone(),
+                    entry_scope: EntryScope::AllCurrent,
+                    columns: [sql_column_name(form.fields[0].id)].into_iter().collect(),
+                    system_columns: [QuerySystemColumn::ExternalId].into_iter().collect(),
+                },
+            )]
+            .into_iter()
+            .collect(),
+            checkpoint: Some(after),
+            limits: QueryLimits {
+                max_memory_bytes: 8 * 1024 * 1024,
+                max_rows: 10,
+                timeout: Duration::from_secs(5),
+                max_concurrency: 1,
+                allowed_functions: Default::default(),
+            },
+        })
+        .await?;
+    context.execute(&saved_sql).await?;
     Ok(())
 }
 

--- a/docs/spec/ui/pages/space-search.yaml
+++ b/docs/spec/ui/pages/space-search.yaml
@@ -1,5 +1,5 @@
 version: "0.1"
-updated: "2026-03-12"
+updated: "2026-07-31"
 page:
   id: space-search
   title: Entry Search
@@ -54,10 +54,12 @@ components:
       type: structured-search-form
       fields:
         - form
-        - tags
         - updated_from
         - updated_to
         - field_conditions[]
+      form_selection:
+        required: true
+        reason: SQL sessions are scoped to one Form and expose only Form fields plus reserved system columns.
       field_conditions:
         item_fields:
           - field

--- a/e2e/lib/client.ts
+++ b/e2e/lib/client.ts
@@ -82,6 +82,26 @@ export async function ensureDefaultForm(
 	}
 }
 
+export async function getDefaultFormRelation(
+	request: APIRequestContext,
+	spaceId?: string,
+): Promise<string> {
+	const resolvedSpaceId = spaceId ?? await getDefaultSpaceId(request);
+	const response = await request.get(
+		getBackendUrl(`/spaces/${resolvedSpaceId}/forms`),
+	);
+	if (!response.ok()) {
+		throw new Error(`Failed to list default Forms: ${response.status()}`);
+	}
+	const forms = await response.json() as Array<{
+		name?: string;
+		sql_relation?: string;
+	}>;
+	const relation = forms.find((form) => form.name === "Entry")?.sql_relation;
+	if (!relation) throw new Error("Default Entry Form has no SQL relation");
+	return relation;
+}
+
 export async function getDefaultSpaceId(
 	request: APIRequestContext,
 ): Promise<string> {

--- a/e2e/saved-sql-route.test.ts
+++ b/e2e/saved-sql-route.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { getBackendUrl, getFrontendUrl, waitForServers } from "./lib/client.ts";
+import {
+	ensureDefaultForm,
+	getBackendUrl,
+	getDefaultFormRelation,
+	getFrontendUrl,
+	waitForServers,
+} from "./lib/client.ts";
 
 const spaceId = "default";
 
@@ -36,10 +42,12 @@ test.describe("Saved SQL route", () => {
 		page,
 		request,
 	}) => {
+		await ensureDefaultForm(request);
+		const relation = await getDefaultFormRelation(request);
 		const sqlCreate = await request.post(getBackendUrl(`/spaces/${spaceId}/sql`), {
 			data: {
 				name: `Saved Detail Query ${Date.now()}`,
-				sql: "SELECT * FROM entries LIMIT 1",
+				sql: `SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
 				variables: [],
 			},
 		});
@@ -52,7 +60,9 @@ test.describe("Saved SQL route", () => {
 			});
 
 			await expect(page.getByRole("heading", { level: 1, name: /Saved Detail Query/ })).toBeVisible();
-			await expect(page.locator(".ui-sql-editor")).toContainText("SELECT * FROM entries LIMIT 1");
+			await expect(page.locator(".ui-sql-editor")).toContainText(
+				`SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
+			);
 			await page.getByRole("button", { name: "Run Query" }).click();
 			await expect(page).toHaveURL(new RegExp(`/spaces/${spaceId}/entries\\?session=`));
 		} finally {

--- a/e2e/search-ui.test.ts
+++ b/e2e/search-ui.test.ts
@@ -49,8 +49,8 @@ test.describe("Search UI", () => {
 		const entryTitle = `Search UI Advanced ${runId}`;
 		const historyPrefix = `Advanced search - form: ${formName}`;
 		const historyName =
-			`${historyPrefix} - tag: release - ` +
-			`updated-from: ${today} - updated-to: ${today} - Owner Name=alice`;
+			`${historyPrefix} - updated-from: ${today} - ` +
+			`updated-to: ${today} - Owner Name=alice`;
 		const entryContent = `---\nform: ${formName}\ntags:\n  - release\n  - search-ui\n---\n# ${entryTitle}\n\n## Owner Name\nalice\n\n## Body\nAdvanced search history should stay reusable.\n`;
 		let entryId: string | null = null;
 
@@ -66,7 +66,6 @@ test.describe("Search UI", () => {
 			});
 			await page.getByRole("button", { name: "Advanced search" }).click();
 			await page.getByLabel("Form").selectOption(formName);
-			await page.getByLabel("Tags (comma-separated)").fill("release");
 			await page.getByLabel("Updated from").fill(today);
 			await page.getByLabel("Updated to").fill(today);
 			await page.getByLabel("Field").selectOption("Owner Name");

--- a/e2e/ui-pages-screenshots.test.ts
+++ b/e2e/ui-pages-screenshots.test.ts
@@ -2,7 +2,8 @@ import { expect, test } from "@playwright/test";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import {
-  ensureDefaultForm,
+	ensureDefaultForm,
+	getDefaultFormRelation,
   getBackendUrl,
   waitForServers,
 } from "./lib/client.ts";
@@ -21,8 +22,9 @@ test.describe("UI page screenshot export @screenshot", () => {
     await ensureDefaultForm(request);
   });
 
-  test("REQ-E2E-004: export screenshots for all UI page specs", async ({ page, request }) => {
-    test.setTimeout(180_000);
+	test("REQ-E2E-004: export screenshots for all UI page specs", async ({ page, request }) => {
+		test.setTimeout(180_000);
+		const relation = await getDefaultFormRelation(request);
 
     const entryTitle = `E2E Screenshot Entry ${Date.now()}`;
     const entryRes = await request.post(
@@ -44,7 +46,7 @@ test.describe("UI page screenshot export @screenshot", () => {
         data: {
           id: sqlId,
           name: `E2E Screenshot Query ${Date.now()}`,
-          sql: "SELECT * FROM entries LIMIT 10",
+			sql: `SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 10`,
           variables: [],
         },
       },

--- a/e2e/ui-themes.test.ts
+++ b/e2e/ui-themes.test.ts
@@ -1,5 +1,10 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
-import { ensureDefaultForm, getBackendUrl, waitForServers } from "./lib/client.ts";
+import {
+	ensureDefaultForm,
+	getBackendUrl,
+	getDefaultFormRelation,
+	waitForServers,
+} from "./lib/client.ts";
 
 const spaceId = "default";
 const themes = ["materialize", "classic", "pop"] as const;
@@ -18,6 +23,7 @@ test.describe("UI theme flows", () => {
 	for (const theme of themes) {
 		test(themeTestTitles[theme], async ({ page, request }) => {
 			test.setTimeout(120_000);
+			const relation = await getDefaultFormRelation(request);
 			const runId = Date.now();
 			const entryTitle = `E2E Theme Entry ${theme} ${runId}`;
 			const variableQueryId = `e2e-theme-var-${theme}-${runId}`;
@@ -41,7 +47,7 @@ test.describe("UI theme flows", () => {
 					data: {
 						id: variableQueryId,
 						name: variableQueryName,
-						sql: "SELECT * FROM entries WHERE title = {{title}} LIMIT 10",
+						sql: `SELECT * FROM "${relation}" WHERE _ugoite_title = {{title}} ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 10`,
 						variables: [
 							{ type: "string", name: "title", description: "Title" },
 						],

--- a/frontend/src/components/SqlQueryEditor.test.tsx
+++ b/frontend/src/components/SqlQueryEditor.test.tsx
@@ -142,7 +142,7 @@ describe("REQ-FE-036: SQL Query Editor", () => {
     const onDiagnostics = vi.fn();
     const result = render(() => (
       <SqlQueryEditor
-        value="SELECT * FROM entries"
+        value='SELECT * FROM "form_00000000000000000000000000000001"'
         onChange={() => undefined}
         schema={buildSqlSchema([])}
         onDiagnostics={onDiagnostics}
@@ -153,7 +153,9 @@ describe("REQ-FE-036: SQL Query Editor", () => {
   });
 
   it("propagates editor updates through the change listener", async () => {
-    const [value, setValue] = createSignal("SELECT * FROM entries");
+    const [value, setValue] = createSignal(
+      'SELECT * FROM "form_00000000000000000000000000000001"',
+    );
     const onChange = vi.fn();
 
     const result = render(() => (
@@ -164,10 +166,14 @@ describe("REQ-FE-036: SQL Query Editor", () => {
       />
     ));
 
-    setValue("SELECT id FROM entries");
+    setValue(
+      'SELECT _ugoite_id FROM "form_00000000000000000000000000000001"',
+    );
 
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith("SELECT id FROM entries");
+      expect(onChange).toHaveBeenCalledWith(
+        'SELECT _ugoite_id FROM "form_00000000000000000000000000000001"',
+      );
     });
 
     result.unmount();

--- a/frontend/src/components/create-dialogs.tsx
+++ b/frontend/src/components/create-dialogs.tsx
@@ -465,7 +465,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
 
   const buildDefaultValue = (name: string, field: Form["fields"][string]) => {
     /* v8 ignore start */
-    if (name.toLowerCase() === "sql") return "SELECT * FROM entries LIMIT 50";
+    if (name.toLowerCase() === "sql") return "";
     switch (field.type) {
       case "integer":
       case "long":

--- a/frontend/src/lib/search-api.ts
+++ b/frontend/src/lib/search-api.ts
@@ -1,6 +1,5 @@
-import { normalizeTimestamp } from "./date-format";
-import type { EntryRecord, SearchResult } from "./types";
-import { normalizeEntryRecord } from "./date-format";
+import type { EntryRecord, KeywordSearchResult } from "./types";
+import { normalizeEntryRecord, normalizeTimestamp } from "./date-format";
 import { protocolFetch } from "./ugoite-client/protocol";
 
 export type EntrySummary = {
@@ -23,16 +22,20 @@ export const searchApi = {
     return entries.map(normalizeEntryRecord);
   },
 
-  async keyword(spaceId: string, query: string): Promise<SearchResult[]> {
-    const results = await protocolFetch<SearchResult[]>("search.keyword", {
-     space_id: spaceId,
-     q: query,
-   });
+  async keyword(
+    spaceId: string,
+    query: string,
+  ): Promise<KeywordSearchResult[]> {
+    const results = await protocolFetch<KeywordSearchResult[]>(
+      "search.keyword",
+      {
+        space_id: spaceId,
+        q: query,
+      },
+    );
     return results.map((result) => ({
       ...result,
-      created_at: result.created_at === undefined
-        ? undefined
-        : normalizeTimestamp(result.created_at),
+      created_at: normalizeTimestamp(result.created_at),
       updated_at: normalizeTimestamp(result.updated_at),
     }));
   },

--- a/frontend/src/lib/search-api.ts
+++ b/frontend/src/lib/search-api.ts
@@ -1,3 +1,4 @@
+import { normalizeTimestamp } from "./date-format";
 import type { EntryRecord, SearchResult } from "./types";
 import { protocolFetch } from "./ugoite-client/protocol";
 
@@ -21,10 +22,17 @@ export const searchApi = {
   },
 
   async keyword(spaceId: string, query: string): Promise<SearchResult[]> {
-    return await protocolFetch<SearchResult[]>("search.keyword", {
-      space_id: spaceId,
-      q: query,
-    });
+    const results = await protocolFetch<SearchResult[]>("search.keyword", {
+     space_id: spaceId,
+     q: query,
+   });
+    return results.map((result) => ({
+      ...result,
+      created_at: result.created_at === undefined
+        ? undefined
+        : normalizeTimestamp(result.created_at),
+      updated_at: normalizeTimestamp(result.updated_at),
+    }));
   },
 
   async rowReferenceOptions(

--- a/frontend/src/lib/search-store.ts
+++ b/frontend/src/lib/search-store.ts
@@ -1,14 +1,14 @@
 import { createSignal } from "solid-js";
-import type { EntryRecord, SearchResult } from "./types";
+import type { EntryRecord, KeywordSearchResult } from "./types";
 import { searchApi } from "./ugoite-client";
 
 export function createSearchStore(spaceId: () => string) {
-  const [results, setResults] = createSignal<SearchResult[]>([]);
+  const [results, setResults] = createSignal<KeywordSearchResult[]>([]);
   const [queryResults, setQueryResults] = createSignal<EntryRecord[]>([]);
   const [loading, setLoading] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
 
-  async function searchKeyword(query: string): Promise<SearchResult[]> {
+  async function searchKeyword(query: string): Promise<KeywordSearchResult[]> {
     setLoading(true);
     setError(null);
     try {

--- a/frontend/src/lib/sql-session-api.test.ts
+++ b/frontend/src/lib/sql-session-api.test.ts
@@ -1,7 +1,7 @@
 // REQ-FE-051: SQL session management
 import { beforeEach, describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
-import { sqlSessionApi } from "./ugoite-client";
+import { sqlSessionApi, sqlSessionRowToEntryRecord } from "./ugoite-client";
 import { resetMockData, seedSpace } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Space } from "./types";
@@ -54,13 +54,10 @@ describe("sqlSessionApi", () => {
           HttpResponse.json({
             rows: [
               {
-                id: "entry-1",
-                title: "Query Entry",
-                form: "Meeting",
-                updated_at: 1772960822.056,
-                properties: {},
-                tags: [],
-                links: [],
+                _ugoite_id: "entry-1",
+                _ugoite_title: "Query Entry",
+                _ugoite_updated_at: 1772960822.056,
+                field_100: "Active",
               },
             ],
             offset: 0,
@@ -71,9 +68,26 @@ describe("sqlSessionApi", () => {
     );
 
     const result = await sqlSessionApi.rows("sess-ws", "sess-1", 0, 25);
-    expect(result.rows[0].updated_at).toBe(
-      new Date(1772960822.056 * 1000).toISOString(),
-    );
+    expect(result.rows[0]._ugoite_id).toBe("entry-1");
+    expect(result.rows[0]._ugoite_updated_at).toBe(1772960822.056);
+  });
+
+  it("maps backend SQL system and field columns into an Entry card record", () => {
+    const record = sqlSessionRowToEntryRecord({
+      _ugoite_id: "entry-1",
+      _ugoite_title: "Query Entry",
+      _ugoite_created_at: "2026-03-01T00:00:00Z",
+      _ugoite_updated_at: 1772960822.056,
+      field_100: "Active",
+    });
+
+    expect(record).toMatchObject({
+      id: "entry-1",
+      title: "Query Entry",
+      created_at: "2026-03-01T00:00:00Z",
+      updated_at: new Date(1772960822.056 * 1000).toISOString(),
+      properties: { field_100: "Active" },
+    });
   });
 
   it("throws on create failure", async () => {

--- a/frontend/src/lib/sql-session-api.test.ts
+++ b/frontend/src/lib/sql-session-api.test.ts
@@ -90,6 +90,13 @@ describe("sqlSessionApi", () => {
     });
   });
 
+  it("rejects arbitrary SQL projections instead of creating an empty Entry card", () => {
+    expect(() => sqlSessionRowToEntryRecord({ field_100: "Active" }))
+      .toThrow(
+        "SQL session result is not an Entry projection",
+      );
+  });
+
   it("throws on create failure", async () => {
     server.use(
       http.post(

--- a/frontend/src/lib/sql-session-api.ts
+++ b/frontend/src/lib/sql-session-api.ts
@@ -10,15 +10,43 @@ import { protocolFetch } from "./ugoite-client/protocol";
 const isSqlSessionRow = (value: unknown): value is SqlSessionRow =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+export class SqlSessionEntryProjectionError extends Error {
+  constructor() {
+    super(
+      "SQL session result is not an Entry projection: expected _ugoite_id, _ugoite_title, and valid _ugoite_updated_at.",
+    );
+    this.name = "SqlSessionEntryProjectionError";
+  }
+}
+
 const timestampValue = (value: unknown): string | undefined => {
-  if (typeof value !== "string" && typeof value !== "number") return undefined;
-  return normalizeTimestamp(value);
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? normalizeTimestamp(value) : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const numeric = Number(trimmed);
+  if (!Number.isFinite(numeric) && Number.isNaN(Date.parse(trimmed))) {
+    return undefined;
+  }
+  return normalizeTimestamp(trimmed);
 };
 
 /** Convert the backend's Form SQL projection into the Entry card contract. */
 export const sqlSessionRowToEntryRecord = (
   row: SqlSessionRow,
 ): EntryRecord => {
+  if (
+    typeof row._ugoite_id !== "string" ||
+    !row._ugoite_id.trim() ||
+    typeof row._ugoite_title !== "string"
+  ) {
+    throw new SqlSessionEntryProjectionError();
+  }
+  const updatedAt = timestampValue(row._ugoite_updated_at);
+  if (!updatedAt) throw new SqlSessionEntryProjectionError();
+
   const properties = Object.fromEntries(
     Object.entries(row).filter(([key]) => key.startsWith("field_")),
   );
@@ -26,11 +54,11 @@ export const sqlSessionRowToEntryRecord = (
   const createdAt = timestampValue(row._ugoite_created_at);
 
   return {
-    id: String(row._ugoite_id ?? ""),
-    title: String(row._ugoite_title ?? ""),
+    id: row._ugoite_id,
+    title: row._ugoite_title,
     ...(form ? { form } : {}),
     ...(createdAt ? { created_at: createdAt } : {}),
-    updated_at: timestampValue(row._ugoite_updated_at) ?? "",
+    updated_at: updatedAt,
     properties,
     tags: [],
     links: [],

--- a/frontend/src/lib/sql-session-api.ts
+++ b/frontend/src/lib/sql-session-api.ts
@@ -1,6 +1,41 @@
 import { normalizeTimestamp } from "./date-format";
-import type { EntryRecord, SqlSession, SqlSessionRows } from "./types";
+import type {
+  EntryRecord,
+  SqlSession,
+  SqlSessionRow,
+  SqlSessionRows,
+} from "./types";
 import { protocolFetch } from "./ugoite-client/protocol";
+
+const isSqlSessionRow = (value: unknown): value is SqlSessionRow =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const timestampValue = (value: unknown): string | undefined => {
+  if (typeof value !== "string" && typeof value !== "number") return undefined;
+  return normalizeTimestamp(value);
+};
+
+/** Convert the backend's Form SQL projection into the Entry card contract. */
+export const sqlSessionRowToEntryRecord = (
+  row: SqlSessionRow,
+): EntryRecord => {
+  const properties = Object.fromEntries(
+    Object.entries(row).filter(([key]) => key.startsWith("field_")),
+  );
+  const form = typeof row.form === "string" ? row.form : undefined;
+  const createdAt = timestampValue(row._ugoite_created_at);
+
+  return {
+    id: String(row._ugoite_id ?? ""),
+    title: String(row._ugoite_title ?? ""),
+    ...(form ? { form } : {}),
+    ...(createdAt ? { created_at: createdAt } : {}),
+    updated_at: timestampValue(row._ugoite_updated_at) ?? "",
+    properties,
+    tags: [],
+    links: [],
+  };
+};
 
 export const sqlSessionApi = {
   async create(
@@ -52,10 +87,9 @@ export const sqlSessionApi = {
       undefined,
       { trackLoading: false },
     );
-    const rows = ((payload.rows ?? []) as EntryRecord[]).map((row) => ({
-      ...row,
-      updated_at: normalizeTimestamp(row.updated_at),
-    }));
+    const rows = Array.isArray(payload.rows)
+      ? payload.rows.filter(isSqlSessionRow)
+      : [];
     return {
       rows,
       offset: Number(payload.offset ?? 0),

--- a/frontend/src/lib/sql.test.ts
+++ b/frontend/src/lib/sql.test.ts
@@ -4,20 +4,24 @@ import type { Form } from "./types";
 
 describe("sql helpers", () => {
   it("should flag missing select clause", () => {
-    const diagnostics = sqlLintDiagnostics("FROM entries");
+    const diagnostics = sqlLintDiagnostics(
+      "FROM form_00000000000000000000000000000001",
+    );
     expect(diagnostics.some((diag) => diag.message.includes("SELECT"))).toBe(
       true,
     );
   });
 
   it("should accept valid select queries", () => {
-    const diagnostics = sqlLintDiagnostics("SELECT * FROM entries LIMIT 10");
+    const diagnostics = sqlLintDiagnostics(
+      'SELECT * FROM "form_00000000000000000000000000000001" LIMIT 10',
+    );
     expect(diagnostics).toHaveLength(0);
   });
 
-  it("should include entries table in schema", () => {
+  it("should expose no SQL schema without backend Form metadata", () => {
     const schema = buildSqlSchema([]);
-    expect(schema.tables?.entries).toContain("title");
+    expect(schema.tables).toEqual({});
   });
 
   it("should include form fields in schema", () => {
@@ -34,10 +38,18 @@ describe("sql helpers", () => {
       },
     ];
     const schema = buildSqlSchema(forms);
-    expect(schema.tables?.form_00000000000000000000000000000001).toContain(
+    const columns = schema.tables?.form_00000000000000000000000000000001;
+    expect(columns).toEqual([
+      "_ugoite_id",
+      "_ugoite_title",
+      "_ugoite_created_at",
+      "_ugoite_updated_at",
       "field_104",
-    );
-    expect(schema.tables?.entries).not.toContain("field_104");
+    ]);
+    expect(schema.tables).not.toHaveProperty("entries");
+    expect(columns).not.toContain("id");
+    expect(columns).not.toContain("title");
+    expect(columns).not.toContain("updated_at");
   });
 
   it("should flag empty query", () => {
@@ -52,14 +64,16 @@ describe("sql helpers", () => {
 
   it("should warn about multiple statements", () => {
     const diagnostics = sqlLintDiagnostics(
-      "SELECT * FROM entries; SELECT 1 FROM foo",
+      'SELECT * FROM "form_00000000000000000000000000000001"; SELECT 1 FROM foo',
     );
     expect(diagnostics.some((d) => d.message.includes("single statement")))
       .toBe(true);
   });
 
   it("should flag invalid LIMIT value", () => {
-    const diagnostics = sqlLintDiagnostics("SELECT * FROM entries LIMIT abc");
+    const diagnostics = sqlLintDiagnostics(
+      'SELECT * FROM "form_00000000000000000000000000000001" LIMIT abc',
+    );
     expect(diagnostics.some((d) => d.message.includes("LIMIT"))).toBe(true);
   });
 });

--- a/frontend/src/lib/sql.test.ts
+++ b/frontend/src/lib/sql.test.ts
@@ -23,15 +23,21 @@ describe("sql helpers", () => {
   it("should include form fields in schema", () => {
     const forms: Form[] = [
       {
+        id: "00000000-0000-0000-0000-000000000001",
         name: "Meeting",
+        sql_relation: "form_00000000000000000000000000000001",
         version: 1,
         template: "# Meeting\n\n## Date\n",
-        fields: { Date: { type: "date", required: false } },
+        fields: {
+          Date: { type: "date", required: false, sql_column: "field_104" },
+        },
       },
     ];
     const schema = buildSqlSchema(forms);
-    expect(schema.tables?.Meeting).toContain("Date");
-    expect(schema.tables?.entries).toContain("Date");
+    expect(schema.tables?.form_00000000000000000000000000000001).toContain(
+      "field_104",
+    );
+    expect(schema.tables?.entries).not.toContain("field_104");
   });
 
   it("should flag empty query", () => {

--- a/frontend/src/lib/sql.ts
+++ b/frontend/src/lib/sql.ts
@@ -5,17 +5,15 @@ import type { Form } from "./types";
 
 export type SqlSchema = NonNullable<SQLConfig["schema"]>;
 
-/* v8 ignore start */
-const BASE_COLUMNS = [...(sqlRules.base_columns ?? [])];
-const BASE_TABLES = [...(sqlRules.base_tables ?? ["entries"])];
-/* v8 ignore stop */
+const SQL_SYSTEM_COLUMNS = [
+  "_ugoite_id",
+  "_ugoite_title",
+  "_ugoite_created_at",
+  "_ugoite_updated_at",
+];
 
 export function buildSqlSchema(forms: Form[]): SqlSchema {
   const tables: Record<string, string[]> = {};
-  for (const table of BASE_TABLES) {
-    tables[table] = BASE_COLUMNS;
-  }
-
   for (const item of forms) {
     /* v8 ignore start */
     const relation = item.sql_relation?.trim();
@@ -23,7 +21,7 @@ export function buildSqlSchema(forms: Form[]): SqlSchema {
     const columns = Object.values(item.fields ?? {})
       .map((field) => field.sql_column?.trim())
       .filter((column): column is string => Boolean(column));
-    tables[relation] = [...BASE_COLUMNS, ...columns];
+    tables[relation] = [...SQL_SYSTEM_COLUMNS, ...columns];
     /* v8 ignore stop */
   }
 

--- a/frontend/src/lib/sql.ts
+++ b/frontend/src/lib/sql.ts
@@ -11,24 +11,19 @@ const BASE_TABLES = [...(sqlRules.base_tables ?? ["entries"])];
 /* v8 ignore stop */
 
 export function buildSqlSchema(forms: Form[]): SqlSchema {
-  const formFieldSet = new Set<string>();
-  for (const item of forms) {
-    /* v8 ignore start */
-    for (const field of Object.keys(item.fields ?? {})) {
-      /* v8 ignore stop */
-      formFieldSet.add(field);
-    }
-  }
-
-  const unionFields = [...BASE_COLUMNS, ...formFieldSet];
   const tables: Record<string, string[]> = {};
   for (const table of BASE_TABLES) {
-    tables[table] = unionFields;
+    tables[table] = BASE_COLUMNS;
   }
 
   for (const item of forms) {
     /* v8 ignore start */
-    tables[item.name] = [...BASE_COLUMNS, ...Object.keys(item.fields ?? {})];
+    const relation = item.sql_relation?.trim();
+    if (!relation) continue;
+    const columns = Object.values(item.fields ?? {})
+      .map((field) => field.sql_column?.trim())
+      .filter((column): column is string => Boolean(column));
+    tables[relation] = [...BASE_COLUMNS, ...columns];
     /* v8 ignore stop */
   }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -188,12 +188,16 @@ export interface EntryUpdatePayload {
 }
 
 export interface FormField {
+  id?: number;
   type: string;
   required: boolean;
   target_form?: string;
+  /** Backend-owned stable SQL column; never derive this from the field label. */
+  sql_column?: string;
 }
 
 export interface Form {
+  id?: string;
   name: string;
   /** Backend-owned DataFusion relation; never derive this from the Form name. */
   sql_relation?: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -195,6 +195,8 @@ export interface FormField {
 
 export interface Form {
   name: string;
+  /** Backend-owned DataFusion relation; never derive this from the Form name. */
+  sql_relation?: string;
   version: number;
   template: string;
   fields: Record<string, FormField>;
@@ -287,5 +289,16 @@ export interface ApiError {
   detail: string;
 }
 
-/** Search result entry */
-export type SearchResult = EntryRecord;
+/** Keyword-search result returned by the single backend Entry scan. */
+export interface SearchResult {
+  id: string;
+  title: string;
+  form: string;
+  created_at?: string | number;
+  updated_at: string | number;
+  properties: Record<string, unknown>;
+  tags: string[];
+  links: EntryLink[];
+  checksum?: string;
+  assets?: Asset[];
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -296,16 +296,11 @@ export interface ApiError {
   detail: string;
 }
 
-/** Keyword-search result returned by the single backend Entry scan. */
-export interface SearchResult {
+/** Minimal keyword-search result returned by the backend Entry scan. */
+export interface KeywordSearchResult {
   id: string;
   title: string;
   form: string;
-  created_at?: string | number;
+  created_at: string | number;
   updated_at: string | number;
-  properties: Record<string, unknown>;
-  tags: string[];
-  links: EntryLink[];
-  checksum?: string;
-  assets?: Asset[];
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -281,8 +281,11 @@ export interface SqlSession {
   };
 }
 
+/** A row from an arbitrary SQL session projection. */
+export type SqlSessionRow = Record<string, unknown>;
+
 export interface SqlSessionRows {
-  rows: EntryRecord[];
+  rows: SqlSessionRow[];
   offset: number;
   limit: number;
   totalCount: number;

--- a/frontend/src/lib/ugoite-client/index.ts
+++ b/frontend/src/lib/ugoite-client/index.ts
@@ -15,7 +15,11 @@ export { preferencesApi } from "../preferences-api";
 export { searchApi } from "../search-api";
 export { spaceApi } from "../space-api";
 export { sqlApi } from "../sql-api";
-export { sqlSessionApi, sqlSessionRowToEntryRecord } from "../sql-session-api";
+export {
+  sqlSessionApi,
+  SqlSessionEntryProjectionError,
+  sqlSessionRowToEntryRecord,
+} from "../sql-session-api";
 export { RevisionConflictError } from "../entry-api";
 export {
   getWasmSupportedOperations,

--- a/frontend/src/lib/ugoite-client/index.ts
+++ b/frontend/src/lib/ugoite-client/index.ts
@@ -15,15 +15,15 @@ export { preferencesApi } from "../preferences-api";
 export { searchApi } from "../search-api";
 export { spaceApi } from "../space-api";
 export { sqlApi } from "../sql-api";
-export { sqlSessionApi } from "../sql-session-api";
+export { sqlSessionApi, sqlSessionRowToEntryRecord } from "../sql-session-api";
 export { RevisionConflictError } from "../entry-api";
 export {
   getWasmSupportedOperations,
   prepareApiRequest,
   protocolFetch,
+  type ProtocolFetchOptions,
   UGOITE_API_OPERATIONS,
   UGOITE_WASM_PROTOCOL_VERSION,
   UgoiteApiError,
-  type ProtocolFetchOptions,
   type UgoiteApiOperation,
 } from "./protocol";

--- a/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
@@ -64,28 +64,28 @@ describe("/spaces/:space_id/entries", () => {
   it("REQ-FE-054: keeps the dedicated SQL session result route", async () => {
     searchParams.session = "session-1";
     server.use(
-      http.get(testApiUrl("/spaces/default/sql-sessions/session-1"), () =>
-        HttpResponse.json({
-          id: "session-1",
-          space_id: "default",
-          sql_id: "query-1",
-          sql: "SELECT 1",
-          status: "ready",
-          created_at: "2026-03-01T00:00:00Z",
-          expires_at: "2026-03-01T01:00:00Z",
-        })),
+      http.get(
+        testApiUrl("/spaces/default/sql-sessions/session-1"),
+        () =>
+          HttpResponse.json({
+            id: "session-1",
+            space_id: "default",
+            sql_id: "query-1",
+            sql: "SELECT 1",
+            status: "ready",
+            created_at: "2026-03-01T00:00:00Z",
+            expires_at: "2026-03-01T01:00:00Z",
+          }),
+      ),
       http.get(
         testApiUrl("/spaces/default/sql-sessions/session-1/rows"),
         () =>
           HttpResponse.json({
             rows: [{
-              id: "query-entry",
-              title: "Query Entry",
-              form: "Meeting",
-              updated_at: 1772960822.056,
-              properties: {},
-              tags: [],
-              links: [],
+              _ugoite_id: "query-entry",
+              _ugoite_title: "Query Entry",
+              _ugoite_updated_at: 1772960822.056,
+              field_100: "Active",
             }],
             offset: 0,
             limit: 24,
@@ -100,21 +100,29 @@ describe("/spaces/:space_id/entries", () => {
     expect(await screen.findByText("Query Entry")).toBeInTheDocument();
     expect(await screen.findByText(`Updated ${expectedDate}`))
       .toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Query Entry/ }));
+    expect(navigate).toHaveBeenCalledWith(
+      "/spaces/default/entries/query-entry",
+    );
   });
 
   it("returns to the Forms workspace when clearing SQL results", async () => {
     searchParams.session = "session-1";
     server.use(
-      http.get(testApiUrl("/spaces/default/sql-sessions/session-1"), () =>
-        HttpResponse.json({
-          id: "session-1",
-          space_id: "default",
-          sql_id: "query-1",
-          sql: "SELECT 1",
-          status: "ready",
-          created_at: "2026-03-01T00:00:00Z",
-          expires_at: "2026-03-01T01:00:00Z",
-        })),
+      http.get(
+        testApiUrl("/spaces/default/sql-sessions/session-1"),
+        () =>
+          HttpResponse.json({
+            id: "session-1",
+            space_id: "default",
+            sql_id: "query-1",
+            sql: "SELECT 1",
+            status: "ready",
+            created_at: "2026-03-01T00:00:00Z",
+            expires_at: "2026-03-01T01:00:00Z",
+          }),
+      ),
       http.get(
         testApiUrl("/spaces/default/sql-sessions/session-1/rows"),
         () =>

--- a/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.test.tsx
@@ -107,6 +107,39 @@ describe("/spaces/:space_id/entries", () => {
     );
   });
 
+  it("shows an explicit error for SQL rows that are not Entry projections", async () => {
+    searchParams.session = "session-1";
+    server.use(
+      http.get(
+        testApiUrl("/spaces/default/sql-sessions/session-1"),
+        () =>
+          HttpResponse.json({
+            id: "session-1",
+            status: "ready",
+          }),
+      ),
+      http.get(
+        testApiUrl("/spaces/default/sql-sessions/session-1/rows"),
+        () =>
+          HttpResponse.json({
+            rows: [{ field_100: "Active" }],
+            offset: 0,
+            limit: 24,
+            total_count: 1,
+          }),
+      ),
+    );
+
+    renderRoute();
+
+    expect(
+      await screen.findByText(/SQL session result is not an Entry projection/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Untitled/ }))
+      .not.toBeInTheDocument();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it("returns to the Forms workspace when clearing SQL results", async () => {
     searchParams.session = "session-1";
     server.use(

--- a/frontend/src/routes/spaces/[space_id]/entries/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.tsx
@@ -15,7 +15,7 @@ import { formApi } from "~/lib/ugoite-client";
 import { t } from "~/lib/i18n";
 import { createResource } from "~/lib/recoverable-resource";
 import { filterCreatableEntryForms } from "~/lib/metadata-forms";
-import { sqlSessionApi } from "~/lib/ugoite-client";
+import { sqlSessionApi, sqlSessionRowToEntryRecord } from "~/lib/ugoite-client";
 import type { EntryRecord, FormCreatePayload } from "~/lib/types";
 
 export default function SpaceEntriesIndexPane() {
@@ -78,7 +78,7 @@ export default function SpaceEntriesIndexPane() {
 
   const displayEntries = createMemo<EntryRecord[]>(() => {
     if (sessionId().trim()) {
-      return sessionRows()?.rows || [];
+      return sessionRows()?.rows.map(sqlSessionRowToEntryRecord) || [];
     }
     return ctx.entryStore.entries() || [];
   });

--- a/frontend/src/routes/spaces/[space_id]/entries/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.tsx
@@ -76,12 +76,26 @@ export default function SpaceEntriesIndexPane() {
     }
   });
 
-  const displayEntries = createMemo<EntryRecord[]>(() => {
-    if (sessionId().trim()) {
-      return sessionRows()?.rows.map(sqlSessionRowToEntryRecord) || [];
+  const displayEntryState = createMemo<{
+    entries: EntryRecord[];
+    error: Error | null;
+  }>(() => {
+    if (!sessionId().trim()) {
+      return { entries: ctx.entryStore.entries() || [], error: null };
     }
-    return ctx.entryStore.entries() || [];
+    const rows = sessionRows()?.rows;
+    if (!rows) return { entries: [], error: null };
+    try {
+      return { entries: rows.map(sqlSessionRowToEntryRecord), error: null };
+    } catch (error) {
+      return {
+        entries: [],
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
   });
+
+  const displayEntries = createMemo(() => displayEntryState().entries);
 
   const totalCount = createMemo(() =>
     sessionRows()?.totalCount ?? displayEntries().length
@@ -100,7 +114,7 @@ export default function SpaceEntriesIndexPane() {
 
   const error = createMemo(() => {
     if (sessionId().trim()) {
-      return session.error || sessionRows.error;
+      return session.error || sessionRows.error || displayEntryState().error;
     }
     return ctx.entryStore.error();
   });

--- a/frontend/src/routes/spaces/[space_id]/queries/new.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/new.tsx
@@ -1,6 +1,6 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import type { Diagnostic } from "@codemirror/lint";
-import { createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { SpaceShell } from "~/components/SpaceShell";
 import { SqlQueryEditor } from "~/components";
 import { formApi } from "~/lib/ugoite-client";
@@ -31,15 +31,24 @@ export default function SpaceQueryCreateRoute() {
   const navigate = useNavigate();
   const spaceId = () => params.space_id;
   const [queryName, setQueryName] = createSignal("");
-  const [sqlInput, setSqlInput] = createSignal(
-    "SELECT * FROM entries LIMIT 50",
-  );
+  const [sqlInput, setSqlInput] = createSignal("");
   const [diagnostics, setDiagnostics] = createSignal<Diagnostic[]>([]);
   const [error, setError] = createSignal<string | null>(null);
   const [isSaving, setIsSaving] = createSignal(false);
 
   const [forms] = createResource(async () => {
     return await formApi.list(spaceId());
+  });
+
+  const defaultSql = createMemo(() => {
+    const relation = forms()?.find((form) => form.sql_relation)?.sql_relation;
+    return relation
+      ? `SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50`
+      : "";
+  });
+
+  createEffect(() => {
+    if (!sqlInput().trim() && defaultSql()) setSqlInput(defaultSql());
   });
 
   const schema = () => buildSqlSchema((forms() || []) as Form[]);

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -85,10 +85,15 @@ describe("/spaces/:space_id/search", () => {
       links: [],
     };
     seedEntry("default", entry, record);
+    let entryListCalls = 0;
     server.use(
+      http.get(testApiUrl("/spaces/default/entries"), () => {
+        entryListCalls += 1;
+        return HttpResponse.json([]);
+      }),
       http.get(
         testApiUrl("/spaces/default/search"),
-        () => HttpResponse.json([{ id: entry.id }]),
+        () => HttpResponse.json([record]),
       ),
     );
 
@@ -102,11 +107,13 @@ describe("/spaces/:space_id/search", () => {
     expect(await screen.findByRole("button", { name: /Alpha Entry/ }))
       .toBeInTheDocument();
     expect(screen.getByText("1 result")).toBeInTheDocument();
+    expect(entryListCalls).toBe(0);
   });
 
   it("REQ-SRCH-005: advanced search compiles filters into saved SQL and runs a shared session", async () => {
     const meetingForm: Form = {
       name: "Meeting",
+      sql_relation: "meeting",
       version: 1,
       template: "# Meeting\n\n## Status\n",
       fields: {
@@ -116,10 +123,12 @@ describe("/spaces/:space_id/search", () => {
     seedForm("default", meetingForm);
 
     let savedSqlBody: { name?: string; sql?: string } | null = null;
-    let sessionSqlBody: { sql?: string } | null = null;
+    let sessionSqlBody: { sql?: string; parameters?: Record<string, unknown>; parameter_types?: Record<string, string> } | null = null;
+    const postOrder: string[] = [];
 
     server.use(
       http.post(testApiUrl("/spaces/default/sql"), async ({ request }) => {
+        postOrder.push("saved");
         savedSqlBody = (await request.json()) as {
           name?: string;
           sql?: string;
@@ -132,7 +141,8 @@ describe("/spaces/:space_id/search", () => {
       http.post(
         testApiUrl("/spaces/default/sql-sessions"),
         async ({ request }) => {
-          sessionSqlBody = (await request.json()) as { sql?: string };
+          postOrder.push("session");
+          sessionSqlBody = (await request.json()) as typeof sessionSqlBody;
           return HttpResponse.json(
             { id: "advanced-session", status: "ready", error: null },
             { status: 201 },
@@ -170,18 +180,142 @@ describe("/spaces/:space_id/search", () => {
         "Advanced search - form: Meeting - updated-from: 2025-03-01 - updated-to: 2025-03-03 - Status=Active",
       );
       expect(savedSqlBody?.sql).toBe(
-        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= TIMESTAMP '2025-03-01 00:00:00.000Z' AND _ugoite_updated_at <= TIMESTAMP '2025-03-03 23:59:59.999Z' AND \"status\" = 'Active' ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
+        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= TIMESTAMP '2025-03-01 00:00:00Z' AND _ugoite_updated_at < TIMESTAMP '2025-03-04 00:00:00Z' AND \"status\" = 'Active' ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
       );
-      expect(sessionSqlBody?.sql).toBe(savedSqlBody?.sql);
+      expect(sessionSqlBody?.sql).toBe(
+        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= $search_0 AND _ugoite_updated_at < $search_1 AND \"status\" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
+      );
+      expect(sessionSqlBody?.parameters).toEqual({
+        search_0: "2025-03-01T00:00:00.000Z",
+        search_1: "2025-03-04T00:00:00.000Z",
+        search_2: "Active",
+      });
+      expect(sessionSqlBody?.parameter_types).toEqual({
+        search_0: "timestamp",
+        search_1: "timestamp",
+        search_2: "string",
+      });
+      expect(postOrder).toEqual(["session", "saved"]);
       expect(navigateMock).toHaveBeenCalledWith(
         "/spaces/default/entries?session=advanced-session",
       );
     });
   });
 
+  it("uses native typed parameters for numeric and boolean fields", async () => {
+    seedForm("default", {
+      name: "Metrics",
+      sql_relation: "metrics",
+      version: 1,
+      template: "",
+      fields: {
+        Count: { type: "integer", required: false },
+        Enabled: { type: "boolean", required: false },
+      },
+    });
+    let sessionBody: { sql?: string; parameters?: Record<string, unknown>; parameter_types?: Record<string, string> } | null = null;
+    server.use(
+      http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
+        sessionBody = (await request.json()) as typeof sessionBody;
+        return HttpResponse.json({ id: "typed-session", status: "ready", error: null }, { status: 201 });
+      }),
+      http.post(testApiUrl("/spaces/default/sql"), () =>
+        HttpResponse.json({ id: "typed-saved", revision_id: "rev-typed" }, { status: 201 })
+      ),
+    );
+    render(() => <SpaceSearchRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
+    await screen.findByRole("option", { name: "Metrics" });
+    fireEvent.change(await screen.findByLabelText("Form"), { target: { value: "Metrics" } });
+    const fields = await screen.findAllByLabelText("Field");
+    fireEvent.change(fields[0], { target: { value: "Count" } });
+    fireEvent.input(screen.getAllByLabelText("Value")[0], { target: { value: "10" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add field condition" }));
+    const booleanFields = await screen.findAllByLabelText("Field");
+    fireEvent.change(booleanFields[1], { target: { value: "Enabled" } });
+    fireEvent.input(screen.getAllByLabelText("Value")[1], { target: { value: "true" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run advanced search" }));
+    await waitFor(() => {
+      expect(sessionBody?.parameters).toEqual({ search_0: 10, search_1: true });
+      expect(sessionBody?.parameter_types).toEqual({ search_0: "integer", search_1: "boolean" });
+      expect(sessionBody?.sql).toContain('"count" = $search_0');
+      expect(sessionBody?.sql).toContain('"enabled" = $search_1');
+    });
+  });
+
+  it("does not save invalid advanced SQL when session validation fails", async () => {
+    seedForm("default", {
+      name: "Daily-Note",
+      version: 1,
+      template: "",
+      fields: {},
+      sql_relation: "daily_x2d_note",
+    });
+    let savedCalls = 0;
+    let sessionSql = "";
+    server.use(
+      http.post(testApiUrl("/spaces/default/sql"), () => {
+        savedCalls += 1;
+        return HttpResponse.json({ id: "should-not-exist", revision_id: "rev-failed" }, { status: 201 });
+      }),
+      http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
+        sessionSql = ((await request.json()) as { sql: string }).sql;
+        return HttpResponse.json({ id: "failed-session", status: "failed", error: "planner rejected query" }, { status: 201 });
+      }),
+    );
+    render(() => <SpaceSearchRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
+    await screen.findByRole("option", { name: "Daily-Note" });
+    fireEvent.change(await screen.findByLabelText("Form"), { target: { value: "Daily-Note" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run advanced search" }));
+    await waitFor(() => {
+      expect(sessionSql).toContain('FROM "daily_x2d_note"');
+      expect(screen.getByText("planner rejected query")).toBeInTheDocument();
+      expect(savedCalls).toBe(0);
+    });
+  });
+
+  it("binds string contains values with literal LIKE wildcards", async () => {
+    seedForm("default", {
+      name: "Notes",
+      sql_relation: "notes",
+      version: 1,
+      template: "",
+      fields: { Memo: { type: "string", required: false } },
+    });
+    let sessionBody: {
+      sql?: string;
+      parameters?: Record<string, unknown>;
+    } | null = null;
+    server.use(
+      http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
+        sessionBody = (await request.json()) as typeof sessionBody;
+        return HttpResponse.json({ id: "contains-session", status: "ready", error: null }, { status: 201 });
+      }),
+      http.post(testApiUrl("/spaces/default/sql"), () =>
+        HttpResponse.json({ id: "contains-saved", revision_id: "rev-contains" }, { status: 201 })
+      ),
+    );
+    render(() => <SpaceSearchRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
+    await screen.findByRole("option", { name: "Notes" });
+    fireEvent.change(await screen.findByLabelText("Form"), { target: { value: "Notes" } });
+    await screen.findByRole("option", { name: "Memo" });
+    fireEvent.change(screen.getByLabelText("Field"), { target: { value: "Memo" } });
+    fireEvent.change(screen.getByLabelText("Match"), { target: { value: "contains" } });
+    fireEvent.input(screen.getByLabelText("Value"), { target: { value: "100%_match" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run advanced search" }));
+
+    await waitFor(() => {
+      expect(sessionBody?.parameters).toEqual({ search_0: "%100\\%\\_match%" });
+      expect(sessionBody?.sql).toContain('"memo" ILIKE $search_0 ESCAPE \'\\\'');
+    });
+  });
+
   it("keeps focus in a field-condition value while typing", async () => {
     seedForm("default", {
       name: "Meeting",
+      sql_relation: "meeting",
       version: 1,
       template: "",
       fields: { memo: { type: "string", required: false } },

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -412,6 +412,107 @@ describe("/spaces/:space_id/search", () => {
     });
   });
 
+  it("shows a ready session even when saving search history fails", async () => {
+    seedForm("default", {
+      name: "History failure",
+      sql_relation: entryRelation,
+      version: 1,
+      template: "",
+      fields: {},
+    });
+    let saveCalls = 0;
+    server.use(
+      http.post(testApiUrl("/spaces/default/sql"), () => {
+        saveCalls += 1;
+        return HttpResponse.json({ detail: "history storage unavailable" }, {
+          status: 500,
+        });
+      }),
+      http.post(
+        testApiUrl("/spaces/default/sql-sessions"),
+        () =>
+          HttpResponse.json({
+            id: "history-save-failed-session",
+            status: "ready",
+            error: null,
+          }, { status: 201 }),
+      ),
+    );
+
+    render(() => <SpaceSearchRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
+    await screen.findByRole("option", { name: "History failure" });
+    fireEvent.change(screen.getByLabelText("Form"), {
+      target: { value: "History failure" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run advanced search" }),
+    );
+
+    await waitFor(() => {
+      expect(saveCalls).toBe(1);
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/spaces/default/entries?session=history-save-failed-session",
+      );
+    });
+    expect(screen.queryByText("Failed to run advanced search.")).toBeNull();
+  });
+
+  it("shows a ready session when refreshing search history fails", async () => {
+    seedForm("default", {
+      name: "History refresh failure",
+      sql_relation: entryRelation,
+      version: 1,
+      template: "",
+      fields: {},
+    });
+    let listCalls = 0;
+    server.use(
+      http.get(testApiUrl("/spaces/default/sql"), () => {
+        listCalls += 1;
+        return listCalls === 1
+          ? HttpResponse.json([])
+          : HttpResponse.json({ detail: "history refresh unavailable" }, {
+            status: 500,
+          });
+      }),
+      http.post(
+        testApiUrl("/spaces/default/sql"),
+        () =>
+          HttpResponse.json({ id: "saved-history", revision_id: "rev-history" }, {
+            status: 201,
+          }),
+      ),
+      http.post(
+        testApiUrl("/spaces/default/sql-sessions"),
+        () =>
+          HttpResponse.json({
+            id: "history-refresh-failed-session",
+            status: "ready",
+            error: null,
+          }, { status: 201 }),
+      ),
+    );
+
+    render(() => <SpaceSearchRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
+    await screen.findByRole("option", { name: "History refresh failure" });
+    fireEvent.change(screen.getByLabelText("Form"), {
+      target: { value: "History refresh failure" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run advanced search" }),
+    );
+
+    await waitFor(() => {
+      expect(listCalls).toBeGreaterThanOrEqual(2);
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/spaces/default/entries?session=history-refresh-failed-session",
+      );
+    });
+    expect(screen.queryByText("Failed to run advanced search.")).toBeNull();
+  });
+
   it("binds string contains values with literal LIKE wildcards", async () => {
     seedForm("default", {
       name: "Notes",

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -86,6 +86,7 @@ describe("/spaces/:space_id/search", () => {
     };
     seedEntry("default", entry, record);
     let entryListCalls = 0;
+    let sqlSessionCalls = 0;
     server.use(
       http.get(testApiUrl("/spaces/default/entries"), () => {
         entryListCalls += 1;
@@ -95,6 +96,13 @@ describe("/spaces/:space_id/search", () => {
         testApiUrl("/spaces/default/search"),
         () => HttpResponse.json([record]),
       ),
+      http.post(testApiUrl("/spaces/default/sql-sessions"), () => {
+        sqlSessionCalls += 1;
+        return HttpResponse.json(
+          { detail: "Quick search must not create a SQL session" },
+          { status: 500 },
+        );
+      }),
     );
 
     render(() => <SpaceSearchRoute />);
@@ -108,6 +116,7 @@ describe("/spaces/:space_id/search", () => {
       .toBeInTheDocument();
     expect(screen.getByText("1 result")).toBeInTheDocument();
     expect(entryListCalls).toBe(0);
+    expect(sqlSessionCalls).toBe(0);
   });
 
   it("REQ-SRCH-005: advanced search compiles filters into saved SQL and runs a shared session", async () => {

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -5,16 +5,16 @@ import { http, HttpResponse } from "msw";
 import SpaceSearchRoute from "./search";
 import {
   resetMockData,
-  seedEntry,
   seedForm,
   seedSpace,
   seedSqlEntry,
 } from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
-import type { Entry, EntryRecord, Form, Space } from "~/lib/types";
+import type { Form, KeywordSearchResult, Space } from "~/lib/types";
 import { testApiUrl } from "~/test/http-origin";
 
 const navigateMock = vi.fn();
+const entryRelation = "form_00000000000000000000000000000001";
 
 vi.mock("@solidjs/router", () => ({
   A: (props: { href: string; class?: string; children: unknown }) => (
@@ -47,7 +47,8 @@ describe("/spaces/:space_id/search", () => {
     seedSqlEntry("default", {
       id: "query-1",
       name: "Recent Search",
-      sql: "SELECT * FROM entries LIMIT 10",
+      sql:
+        `SELECT * FROM "${entryRelation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 10`,
       variables: [],
       created_at: 1772960822.056,
       updated_at: 1772960822.056,
@@ -66,25 +67,13 @@ describe("/spaces/:space_id/search", () => {
   });
 
   it("REQ-SRCH-004: runs a direct keyword search and renders matching entries", async () => {
-    const entry: Entry = {
+    const record: KeywordSearchResult = {
       id: "entry-1",
       title: "Alpha Entry",
-      content:
-        "---\nform: Entry\n---\n# Alpha Entry\n\n## Body\nKeyword-first search is easier.",
-      revision_id: "rev-1",
+      form: "Entry",
       created_at: "2025-01-01T00:00:00Z",
       updated_at: "2025-01-02T00:00:00Z",
     };
-    const record: EntryRecord = {
-      id: entry.id,
-      title: entry.title ?? "Alpha Entry",
-      form: "Entry",
-      updated_at: entry.updated_at,
-      properties: { Body: "Keyword-first search is easier." },
-      tags: ["search"],
-      links: [],
-    };
-    seedEntry("default", entry, record);
     let entryListCalls = 0;
     let sqlSessionCalls = 0;
     server.use(
@@ -122,7 +111,7 @@ describe("/spaces/:space_id/search", () => {
   it("REQ-SRCH-005: advanced search compiles filters into saved SQL and runs a shared session", async () => {
     const meetingForm: Form = {
       name: "Meeting",
-      sql_relation: "meeting",
+      sql_relation: entryRelation,
       version: 1,
       template: "# Meeting\n\n## Status\n",
       fields: {
@@ -193,10 +182,10 @@ describe("/spaces/:space_id/search", () => {
         "Advanced search - form: Meeting - updated-from: 2025-03-01 - updated-to: 2025-03-03 - Status=Active",
       );
       expect(savedSqlBody?.sql).toBe(
-        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= TIMESTAMP '2025-03-01 00:00:00Z' AND _ugoite_updated_at < TIMESTAMP '2025-03-04 00:00:00Z' AND \"field_100\" = 'Active' ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
+        `SELECT * FROM "${entryRelation}" WHERE _ugoite_updated_at >= TIMESTAMP '2025-03-01 00:00:00Z' AND _ugoite_updated_at < TIMESTAMP '2025-03-04 00:00:00Z' AND "field_100" = 'Active' ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50`,
       );
       expect(sessionSqlBody?.sql).toBe(
-        'SELECT * FROM "meeting" WHERE _ugoite_updated_at >= $search_0 AND _ugoite_updated_at < $search_1 AND "field_100" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50',
+        `SELECT * FROM "${entryRelation}" WHERE _ugoite_updated_at >= $search_0 AND _ugoite_updated_at < $search_1 AND "field_100" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50`,
       );
       expect(sessionSqlBody?.parameters).toEqual({
         search_0: "2025-03-01T00:00:00.000Z",
@@ -519,7 +508,8 @@ describe("/spaces/:space_id/search", () => {
     seedSqlEntry("default", {
       id: "saved-ready",
       name: "Ready history",
-      sql: "SELECT * FROM entries WHERE title = 'Alpha'",
+      sql:
+        `SELECT * FROM "${entryRelation}" WHERE _ugoite_title = 'Alpha' ORDER BY _ugoite_updated_at DESC, _ugoite_id`,
       variables: [],
       created_at: "2025-01-01T00:00:00Z",
       updated_at: "2025-01-02T00:00:00Z",
@@ -528,11 +518,21 @@ describe("/spaces/:space_id/search", () => {
     seedSqlEntry("default", {
       id: "saved-vars",
       name: "Needs variables",
-      sql: "SELECT * FROM entries WHERE title = {{title}}",
+      sql:
+        `SELECT * FROM "${entryRelation}" WHERE _ugoite_title = {{title}} ORDER BY _ugoite_updated_at DESC, _ugoite_id`,
       variables: [{ type: "string", name: "title", description: "Title" }],
       created_at: "2025-01-01T00:00:00Z",
       updated_at: "2025-01-03T00:00:00Z",
       revision_id: "rev-2",
+    });
+    seedSqlEntry("default", {
+      id: "saved-legacy",
+      name: "Legacy SQL",
+      sql: "SELECT * FROM entries WHERE title = 'Alpha'",
+      variables: [],
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-04T00:00:00Z",
+      revision_id: "rev-3",
     });
 
     let sessionSqlBody: { sql?: string } | null = null;
@@ -540,7 +540,14 @@ describe("/spaces/:space_id/search", () => {
       http.post(
         testApiUrl("/spaces/default/sql-sessions"),
         async ({ request }) => {
-          sessionSqlBody = (await request.json()) as { sql?: string };
+          const body = (await request.json()) as { sql?: string };
+          if (body.sql && /\bentries\b/i.test(body.sql)) {
+            return HttpResponse.json(
+              { detail: "Legacy SQL relations are unsupported" },
+              { status: 422 },
+            );
+          }
+          sessionSqlBody = body;
           return HttpResponse.json(
             { id: "history-session", status: "ready", error: null },
             { status: 201 },
@@ -556,7 +563,7 @@ describe("/spaces/:space_id/search", () => {
     );
     await waitFor(() => {
       expect(sessionSqlBody?.sql).toBe(
-        "SELECT * FROM entries WHERE title = 'Alpha'",
+        `SELECT * FROM "${entryRelation}" WHERE _ugoite_title = 'Alpha' ORDER BY _ugoite_updated_at DESC, _ugoite_id`,
       );
       expect(navigateMock).toHaveBeenCalledWith(
         "/spaces/default/entries?session=history-session",
@@ -568,6 +575,12 @@ describe("/spaces/:space_id/search", () => {
     expect(navigateMock).toHaveBeenCalledWith(
       "/spaces/default/queries/saved-vars/variables",
     );
+
+    navigateMock.mockReset();
+    fireEvent.click(await screen.findByRole("button", { name: /Legacy SQL/ }));
+    expect(await screen.findByText(/Legacy SQL relations are unsupported/))
+      .toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("links the Assets facet to the Space asset workspace", () => {

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -117,13 +117,17 @@ describe("/spaces/:space_id/search", () => {
       version: 1,
       template: "# Meeting\n\n## Status\n",
       fields: {
-        Status: { type: "string", required: false },
+        Status: { type: "string", required: false, sql_column: "field_100" },
       },
     };
     seedForm("default", meetingForm);
 
     let savedSqlBody: { name?: string; sql?: string } | null = null;
-    let sessionSqlBody: { sql?: string; parameters?: Record<string, unknown>; parameter_types?: Record<string, string> } | null = null;
+    let sessionSqlBody: {
+      sql?: string;
+      parameters?: Record<string, unknown>;
+      parameter_types?: Record<string, string>;
+    } | null = null;
     const postOrder: string[] = [];
 
     server.use(
@@ -180,10 +184,10 @@ describe("/spaces/:space_id/search", () => {
         "Advanced search - form: Meeting - updated-from: 2025-03-01 - updated-to: 2025-03-03 - Status=Active",
       );
       expect(savedSqlBody?.sql).toBe(
-        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= TIMESTAMP '2025-03-01 00:00:00Z' AND _ugoite_updated_at < TIMESTAMP '2025-03-04 00:00:00Z' AND \"status\" = 'Active' ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
+        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= TIMESTAMP '2025-03-01 00:00:00Z' AND _ugoite_updated_at < TIMESTAMP '2025-03-04 00:00:00Z' AND \"field_100\" = 'Active' ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
       );
       expect(sessionSqlBody?.sql).toBe(
-        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= $search_0 AND _ugoite_updated_at < $search_1 AND \"status\" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
+        'SELECT * FROM "meeting" WHERE _ugoite_updated_at >= $search_0 AND _ugoite_updated_at < $search_1 AND "field_100" = $search_2 ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50',
       );
       expect(sessionSqlBody?.parameters).toEqual({
         search_0: "2025-03-01T00:00:00.000Z",
@@ -209,37 +213,158 @@ describe("/spaces/:space_id/search", () => {
       version: 1,
       template: "",
       fields: {
-        Count: { type: "integer", required: false },
-        Enabled: { type: "boolean", required: false },
+        Count: { type: "integer", required: false, sql_column: "field_100" },
+        Enabled: { type: "boolean", required: false, sql_column: "field_101" },
       },
     });
-    let sessionBody: { sql?: string; parameters?: Record<string, unknown>; parameter_types?: Record<string, string> } | null = null;
+    let sessionBody: {
+      sql?: string;
+      parameters?: Record<string, unknown>;
+      parameter_types?: Record<string, string>;
+    } | null = null;
     server.use(
-      http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
-        sessionBody = (await request.json()) as typeof sessionBody;
-        return HttpResponse.json({ id: "typed-session", status: "ready", error: null }, { status: 201 });
-      }),
-      http.post(testApiUrl("/spaces/default/sql"), () =>
-        HttpResponse.json({ id: "typed-saved", revision_id: "rev-typed" }, { status: 201 })
+      http.post(
+        testApiUrl("/spaces/default/sql-sessions"),
+        async ({ request }) => {
+          sessionBody = (await request.json()) as typeof sessionBody;
+          return HttpResponse.json({
+            id: "typed-session",
+            status: "ready",
+            error: null,
+          }, { status: 201 });
+        },
+      ),
+      http.post(
+        testApiUrl("/spaces/default/sql"),
+        () =>
+          HttpResponse.json({ id: "typed-saved", revision_id: "rev-typed" }, {
+            status: 201,
+          }),
       ),
     );
     render(() => <SpaceSearchRoute />);
     fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
     await screen.findByRole("option", { name: "Metrics" });
-    fireEvent.change(await screen.findByLabelText("Form"), { target: { value: "Metrics" } });
+    fireEvent.change(await screen.findByLabelText("Form"), {
+      target: { value: "Metrics" },
+    });
     const fields = await screen.findAllByLabelText("Field");
     fireEvent.change(fields[0], { target: { value: "Count" } });
-    fireEvent.input(screen.getAllByLabelText("Value")[0], { target: { value: "10" } });
-    fireEvent.click(screen.getByRole("button", { name: "Add field condition" }));
+    fireEvent.input(screen.getAllByLabelText("Value")[0], {
+      target: { value: "10" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add field condition" }),
+    );
     const booleanFields = await screen.findAllByLabelText("Field");
     fireEvent.change(booleanFields[1], { target: { value: "Enabled" } });
-    fireEvent.input(screen.getAllByLabelText("Value")[1], { target: { value: "true" } });
-    fireEvent.click(screen.getByRole("button", { name: "Run advanced search" }));
+    fireEvent.input(screen.getAllByLabelText("Value")[1], {
+      target: { value: "true" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run advanced search" }),
+    );
     await waitFor(() => {
       expect(sessionBody?.parameters).toEqual({ search_0: 10, search_1: true });
-      expect(sessionBody?.parameter_types).toEqual({ search_0: "integer", search_1: "boolean" });
-      expect(sessionBody?.sql).toContain('"count" = $search_0');
-      expect(sessionBody?.sql).toContain('"enabled" = $search_1');
+      expect(sessionBody?.parameter_types).toEqual({
+        search_0: "integer",
+        search_1: "boolean",
+      });
+      expect(sessionBody?.sql).toContain('"field_100" = $search_0');
+      expect(sessionBody?.sql).toContain('"field_101" = $search_1');
+    });
+  });
+
+  it("does not offer long or nanosecond fields as approximate Advanced search types", async () => {
+    seedForm("default", {
+      name: "Precise metrics",
+      sql_relation: "form_precise_metrics",
+      version: 1,
+      template: "",
+      fields: {
+        LargeCount: { type: "long", required: false, sql_column: "field_100" },
+        PreciseTime: {
+          type: "timestamp_ns",
+          required: false,
+          sql_column: "field_101",
+        },
+      },
+    });
+    render(() => <SpaceSearchRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
+    await screen.findByRole("option", { name: "Precise metrics" });
+    fireEvent.change(await screen.findByLabelText("Form"), {
+      target: { value: "Precise metrics" },
+    });
+
+    expect(
+      await screen.findByRole("option", { name: "LargeCount (unsupported)" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("option", { name: "PreciseTime (unsupported)" }),
+    ).toBeDisabled();
+  });
+
+  it("resets field conditions when the selected Form changes", async () => {
+    seedForm("default", {
+      name: "Form A",
+      sql_relation: "form_a",
+      version: 1,
+      template: "",
+      fields: {
+        Status: { type: "string", required: false, sql_column: "field_100" },
+      },
+    });
+    seedForm("default", {
+      name: "Form B",
+      sql_relation: "form_b",
+      version: 1,
+      template: "",
+      fields: {
+        Owner: { type: "string", required: false, sql_column: "field_101" },
+      },
+    });
+    let sessionSql = "";
+    server.use(
+      http.post(
+        testApiUrl("/spaces/default/sql-sessions"),
+        async ({ request }) => {
+          sessionSql = ((await request.json()) as { sql: string }).sql;
+          return HttpResponse.json({
+            id: "form-switch-session",
+            status: "ready",
+            error: null,
+          }, { status: 201 });
+        },
+      ),
+      http.post(
+        testApiUrl("/spaces/default/sql"),
+        () =>
+          HttpResponse.json({
+            id: "form-switch-saved",
+            revision_id: "rev-switch",
+          }, { status: 201 }),
+      ),
+    );
+    render(() => <SpaceSearchRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
+    const formSelect = await screen.findByLabelText("Form");
+    fireEvent.change(formSelect, { target: { value: "Form A" } });
+    fireEvent.change(await screen.findByLabelText("Field"), {
+      target: { value: "Status" },
+    });
+    fireEvent.input(screen.getByLabelText("Value"), {
+      target: { value: "open" },
+    });
+    fireEvent.change(formSelect, { target: { value: "Form B" } });
+
+    const resetField = await screen.findByLabelText("Field");
+    expect(resetField).toHaveValue("");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run advanced search" }),
+    );
+    await waitFor(() => {
+      expect(sessionSql).not.toContain('"field_100"');
     });
   });
 
@@ -256,18 +381,32 @@ describe("/spaces/:space_id/search", () => {
     server.use(
       http.post(testApiUrl("/spaces/default/sql"), () => {
         savedCalls += 1;
-        return HttpResponse.json({ id: "should-not-exist", revision_id: "rev-failed" }, { status: 201 });
+        return HttpResponse.json({
+          id: "should-not-exist",
+          revision_id: "rev-failed",
+        }, { status: 201 });
       }),
-      http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
-        sessionSql = ((await request.json()) as { sql: string }).sql;
-        return HttpResponse.json({ id: "failed-session", status: "failed", error: "planner rejected query" }, { status: 201 });
-      }),
+      http.post(
+        testApiUrl("/spaces/default/sql-sessions"),
+        async ({ request }) => {
+          sessionSql = ((await request.json()) as { sql: string }).sql;
+          return HttpResponse.json({
+            id: "failed-session",
+            status: "failed",
+            error: "planner rejected query",
+          }, { status: 201 });
+        },
+      ),
     );
     render(() => <SpaceSearchRoute />);
     fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
     await screen.findByRole("option", { name: "Daily-Note" });
-    fireEvent.change(await screen.findByLabelText("Form"), { target: { value: "Daily-Note" } });
-    fireEvent.click(screen.getByRole("button", { name: "Run advanced search" }));
+    fireEvent.change(await screen.findByLabelText("Form"), {
+      target: { value: "Daily-Note" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run advanced search" }),
+    );
     await waitFor(() => {
       expect(sessionSql).toContain('FROM "daily_x2d_note"');
       expect(screen.getByText("planner rejected query")).toBeInTheDocument();
@@ -281,34 +420,60 @@ describe("/spaces/:space_id/search", () => {
       sql_relation: "notes",
       version: 1,
       template: "",
-      fields: { Memo: { type: "string", required: false } },
+      fields: {
+        Memo: { type: "string", required: false, sql_column: "field_100" },
+      },
     });
     let sessionBody: {
       sql?: string;
       parameters?: Record<string, unknown>;
     } | null = null;
     server.use(
-      http.post(testApiUrl("/spaces/default/sql-sessions"), async ({ request }) => {
-        sessionBody = (await request.json()) as typeof sessionBody;
-        return HttpResponse.json({ id: "contains-session", status: "ready", error: null }, { status: 201 });
-      }),
-      http.post(testApiUrl("/spaces/default/sql"), () =>
-        HttpResponse.json({ id: "contains-saved", revision_id: "rev-contains" }, { status: 201 })
+      http.post(
+        testApiUrl("/spaces/default/sql-sessions"),
+        async ({ request }) => {
+          sessionBody = (await request.json()) as typeof sessionBody;
+          return HttpResponse.json({
+            id: "contains-session",
+            status: "ready",
+            error: null,
+          }, { status: 201 });
+        },
+      ),
+      http.post(
+        testApiUrl("/spaces/default/sql"),
+        () =>
+          HttpResponse.json({
+            id: "contains-saved",
+            revision_id: "rev-contains",
+          }, { status: 201 }),
       ),
     );
     render(() => <SpaceSearchRoute />);
     fireEvent.click(screen.getByRole("button", { name: "Advanced search" }));
     await screen.findByRole("option", { name: "Notes" });
-    fireEvent.change(await screen.findByLabelText("Form"), { target: { value: "Notes" } });
+    fireEvent.change(await screen.findByLabelText("Form"), {
+      target: { value: "Notes" },
+    });
     await screen.findByRole("option", { name: "Memo" });
-    fireEvent.change(screen.getByLabelText("Field"), { target: { value: "Memo" } });
-    fireEvent.change(screen.getByLabelText("Match"), { target: { value: "contains" } });
-    fireEvent.input(screen.getByLabelText("Value"), { target: { value: "100%_match" } });
-    fireEvent.click(screen.getByRole("button", { name: "Run advanced search" }));
+    fireEvent.change(screen.getByLabelText("Field"), {
+      target: { value: "Memo" },
+    });
+    fireEvent.change(screen.getByLabelText("Match"), {
+      target: { value: "contains" },
+    });
+    fireEvent.input(screen.getByLabelText("Value"), {
+      target: { value: "100%_match" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Run advanced search" }),
+    );
 
     await waitFor(() => {
       expect(sessionBody?.parameters).toEqual({ search_0: "%100\\%\\_match%" });
-      expect(sessionBody?.sql).toContain('"memo" ILIKE $search_0 ESCAPE \'\\\'');
+      expect(sessionBody?.sql).toContain(
+        "\"field_100\" ILIKE $search_0 ESCAPE '\\'",
+      );
     });
   });
 
@@ -318,7 +483,9 @@ describe("/spaces/:space_id/search", () => {
       sql_relation: "meeting",
       version: 1,
       template: "",
-      fields: { memo: { type: "string", required: false } },
+      fields: {
+        memo: { type: "string", required: false, sql_column: "field_100" },
+      },
     });
     render(() => <SpaceSearchRoute />);
 

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -85,42 +85,10 @@ describe("/spaces/:space_id/search", () => {
       links: [],
     };
     seedEntry("default", entry, record);
-    let metadataSql: string | null = null;
     server.use(
       http.get(
         testApiUrl("/spaces/default/search"),
         () => HttpResponse.json([{ id: entry.id }]),
-      ),
-      http.get(
-        testApiUrl("/spaces/default/entries"),
-        () =>
-          new HttpResponse(
-            "bulk entry list should not be used for keyword search",
-            {
-              status: 500,
-            },
-          ),
-      ),
-      http.post(
-        testApiUrl("/spaces/default/sql-sessions"),
-        async ({ request }) => {
-          const body = (await request.json()) as { sql?: string };
-          metadataSql = body.sql ?? null;
-          return HttpResponse.json(
-            { id: "keyword-session", status: "ready", error: null },
-            { status: 201 },
-          );
-        },
-      ),
-      http.get(
-        testApiUrl("/spaces/default/sql-sessions/keyword-session/rows"),
-        () =>
-          HttpResponse.json({
-            rows: [record],
-            offset: 0,
-            limit: 1,
-            total_count: 1,
-          }),
       ),
     );
 
@@ -134,9 +102,6 @@ describe("/spaces/:space_id/search", () => {
     expect(await screen.findByRole("button", { name: /Alpha Entry/ }))
       .toBeInTheDocument();
     expect(screen.getByText("1 result")).toBeInTheDocument();
-    expect(metadataSql).toBe(
-      "SELECT * FROM entries WHERE id IN ('entry-1') LIMIT 1",
-    );
   });
 
   it("REQ-SRCH-005: advanced search compiles filters into saved SQL and runs a shared session", async () => {
@@ -183,9 +148,6 @@ describe("/spaces/:space_id/search", () => {
     fireEvent.change(screen.getByLabelText("Form"), {
       target: { value: "Meeting" },
     });
-    fireEvent.input(screen.getByLabelText("Tags (comma-separated)"), {
-      target: { value: "project" },
-    });
     fireEvent.input(screen.getByLabelText("Updated from"), {
       target: { value: "2025-03-01" },
     });
@@ -205,10 +167,10 @@ describe("/spaces/:space_id/search", () => {
 
     await waitFor(() => {
       expect(savedSqlBody?.name).toBe(
-        "Advanced search - form: Meeting - tag: project - updated-from: 2025-03-01 - updated-to: 2025-03-03 - Status=Active",
+        "Advanced search - form: Meeting - updated-from: 2025-03-01 - updated-to: 2025-03-03 - Status=Active",
       );
       expect(savedSqlBody?.sql).toBe(
-        "SELECT * FROM entries WHERE form = 'Meeting' AND tags = 'project' AND updated_at >= 1740787200 AND updated_at <= 1741046399 AND properties.\"Status\" = 'Active' ORDER BY updated_at DESC LIMIT 50",
+        "SELECT * FROM \"meeting\" WHERE _ugoite_updated_at >= TIMESTAMP '2025-03-01 00:00:00.000Z' AND _ugoite_updated_at <= TIMESTAMP '2025-03-03 23:59:59.999Z' AND \"status\" = 'Active' ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50",
       );
       expect(sessionSqlBody?.sql).toBe(savedSqlBody?.sql);
       expect(navigateMock).toHaveBeenCalledWith(

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -3,16 +3,15 @@ import { createMemo, createSignal, For, Index, Show } from "solid-js";
 import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { formatDateLabel } from "~/lib/date-format";
-import { entryApi } from "~/lib/ugoite-client";
 import { formApi } from "~/lib/ugoite-client";
 import { searchApi } from "~/lib/ugoite-client";
 import { sqlSessionApi } from "~/lib/ugoite-client";
 import { sqlApi } from "~/lib/ugoite-client";
-import type { EntryRecord, SearchResult, SqlEntry } from "~/lib/types";
+import type { SearchResult, SqlEntry } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
 
 type SearchMode = "keyword" | "advanced";
-type FieldMatchOperator = "equals" | "contains";
+type FieldMatchOperator = "equals" | "contains" | "lt" | "lte" | "gt" | "gte";
 
 type FieldCondition = {
   id: string;
@@ -23,13 +22,33 @@ type FieldCondition = {
 
 type AdvancedSearchCriteria = {
   formName: string;
+  sqlRelation: string;
   updatedFrom: string;
   updatedTo: string;
   fieldConditions: Array<{
     field: string;
+    type: SearchFieldType;
     operator: FieldMatchOperator;
     value: string;
   }>;
+};
+
+type SearchFieldType = "string" | "boolean" | "integer" | "float" |
+  "date" | "timestamp" | "unsupported";
+
+type SearchParameterValue = string | number | boolean | null;
+
+type AdvancedSearchQuery = {
+  sql: string;
+  historySql: string;
+  parameters: Record<string, SearchParameterValue>;
+  parameterTypes: Record<string, string>;
+};
+
+type AvailableField = {
+  name: string;
+  type: SearchFieldType;
+  supported: boolean;
 };
 
 const ADVANCED_SEARCH_LIMIT = 50;
@@ -49,105 +68,217 @@ function parseTimestamp(value: string | number | null | undefined): number {
   return Number.isNaN(timestamp) ? 0 : timestamp;
 }
 
-function coerceSearchResult(
-  result: Partial<SearchResult> & { id: string },
-  fallback?: EntryRecord,
-): SearchResult {
-  return {
-    id: result.id,
-    title: result.title || fallback?.title || "Untitled",
-    form: result.form ?? fallback?.form,
-    updated_at: result.updated_at || fallback?.updated_at || "",
-    properties: result.properties ?? fallback?.properties ?? {},
-    tags: result.tags ?? fallback?.tags ?? [],
-    links: result.links ?? fallback?.links ?? [],
-    canvas_position: result.canvas_position ?? fallback?.canvas_position,
-    checksum: result.checksum ?? fallback?.checksum,
-    assets: result.assets ?? fallback?.assets,
-  };
+function normalizeFieldType(type: string): SearchFieldType {
+  switch (type) {
+    case "string":
+    case "markdown":
+      return "string";
+    case "boolean":
+      return "boolean";
+    case "integer":
+    case "long":
+      return "integer";
+    case "number":
+    case "float":
+    case "double":
+      return "float";
+    case "date":
+      return "date";
+    case "timestamp":
+    case "timestamp_tz":
+    case "timestamp_ns":
+    case "timestamp_tz_ns":
+      return "timestamp";
+    default:
+      return "unsupported";
+  }
 }
 
-function dateInputToSqlTimestamp(
+function operatorsForFieldType(type: SearchFieldType): FieldMatchOperator[] {
+  if (type === "string") return ["equals", "contains"];
+  if (type === "boolean") return ["equals"];
+  if (type === "integer" || type === "float" || type === "date" ||
+    type === "timestamp") {
+    return ["equals", "lt", "lte", "gt", "gte"];
+  }
+  return [];
+}
+
+function operatorLabel(operator: FieldMatchOperator): string {
+  return {
+    equals: "equals",
+    contains: "contains",
+    lt: "less than",
+    lte: "less than or equal",
+    gt: "greater than",
+    gte: "greater than or equal",
+  }[operator];
+}
+
+function fieldInputType(type: SearchFieldType): "text" | "number" | "date" | "datetime-local" {
+  if (type === "integer" || type === "float") return "number";
+  if (type === "date") return "date";
+  if (type === "timestamp") return "datetime-local";
+  return "text";
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll(
+    "_",
+    "\\_",
+  );
+}
+
+function dateInput(
   value: string,
   boundary: "start" | "end",
-): string | null {
-  if (!value) return null;
+): { parameter: string; literal: string } | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
   const [yearText, monthText, dayText] = value.split("-");
   const year = Number(yearText);
   const month = Number(monthText);
   const day = Number(dayText);
-  if (![year, month, day].every(Number.isInteger)) {
-    return null;
-  }
-  const startOfDay = new Date(Date.UTC(year, month - 1, day));
+  const date = new Date(Date.UTC(year, month - 1, day));
   if (
-    startOfDay.getUTCFullYear() !== year ||
-    startOfDay.getUTCMonth() !== month - 1 ||
-    startOfDay.getUTCDate() !== day
-  ) {
-    return null;
-  }
-  const time = boundary === "start" ? "00:00:00.000" : "23:59:59.999";
-  return `TIMESTAMP '${yearText}-${monthText}-${dayText} ${time}Z'`;
+    ![year, month, day].every(Number.isInteger) ||
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) return null;
+  if (boundary === "end") date.setUTCDate(date.getUTCDate() + 1);
+  const dateText = date.toISOString().slice(0, 10);
+  return {
+    parameter: `${dateText}T00:00:00.000Z`,
+    literal: `TIMESTAMP '${dateText} 00:00:00Z'`,
+  };
 }
 
-async function enrichKeywordResults(
-  spaceId: string,
-  results: SearchResult[],
-): Promise<SearchResult[]> {
-  const idsNeedingEnrichment = [
-    ...new Set(
-      results.filter((result) => !result.title || !result.updated_at).map((
-        result,
-      ) => result.id),
-    ),
-  ];
-  if (idsNeedingEnrichment.length === 0) {
-    return results;
+function sqlLiteral(value: SearchParameterValue, type: string): string {
+  if (value === null) return "NULL";
+  if (type === "string") return escapeSqlLiteral(String(value));
+  if (type === "boolean") return value ? "TRUE" : "FALSE";
+  if (type === "integer" || type === "float") return String(value);
+  if (type === "date") return `DATE '${String(value)}'`;
+  if (type === "timestamp") {
+    return `TIMESTAMP '${String(value).replace("T", " ")}'`;
   }
-
-  // Keyword search returns stable Entry IDs. Resolve display metadata through
-  // the Entry index rather than manufacturing a cross-Form SQL session: SQL
-  // sessions intentionally expose one Form and require a total order.
-  const entries = await entryApi.list(spaceId);
-  const metadataById = new Map(entries.map((entry) => [entry.id, entry] as const));
-  return results.map((result) =>
-    coerceSearchResult(result, metadataById.get(result.id))
-  );
+  return escapeSqlLiteral(String(value));
 }
 
-function buildAdvancedSearchSql(criteria: AdvancedSearchCriteria): string {
-  if (!criteria.formName) {
-    return "";
-  }
+function buildAdvancedSearchQuery(
+  criteria: AdvancedSearchCriteria,
+): AdvancedSearchQuery | null {
+  if (!criteria.formName || !criteria.sqlRelation) return null;
 
-  const conditions: string[] = [];
+  const sessionConditions: string[] = [];
+  const historyConditions: string[] = [];
+  const parameters: Record<string, SearchParameterValue> = {};
+  const parameterTypes: Record<string, string> = {};
+  let parameterIndex = 0;
+  const bind = (
+    value: SearchParameterValue,
+    type: string,
+    literal: string,
+  ) => {
+    const name = `search_${parameterIndex++}`;
+    parameters[name] = value;
+    parameterTypes[name] = type;
+    return { parameter: `$${name}`, literal };
+  };
 
-  const updatedFrom = dateInputToSqlTimestamp(criteria.updatedFrom, "start");
-  if (updatedFrom) {
-    conditions.push(`_ugoite_updated_at >= ${updatedFrom}`);
-  }
+  const addDateCondition = (value: string, operator: ">=" | "<") => {
+    const converted = dateInput(value, operator === ">=" ? "start" : "end");
+    if (!converted) throw new Error(`Invalid date: ${value}`);
+    const bound = bind(converted.parameter, "timestamp", converted.literal);
+    sessionConditions.push(`_ugoite_updated_at ${operator} ${bound.parameter}`);
+    historyConditions.push(`_ugoite_updated_at ${operator} ${bound.literal}`);
+  };
 
-  const updatedTo = dateInputToSqlTimestamp(criteria.updatedTo, "end");
-  if (updatedTo) {
-    conditions.push(`_ugoite_updated_at <= ${updatedTo}`);
-  }
+  if (criteria.updatedFrom) addDateCondition(criteria.updatedFrom, ">=");
+  if (criteria.updatedTo) addDateCondition(criteria.updatedTo, "<");
 
   for (const condition of criteria.fieldConditions) {
     const fieldPath = quoteSqlIdentifier(condition.field.toLowerCase());
-    if (condition.operator === "contains") {
-      conditions.push(
-        `${fieldPath} ILIKE ${escapeSqlLiteral(`%${condition.value}%`)}`,
-      );
+    const operator = condition.operator === "equals"
+      ? "="
+      : condition.operator === "contains"
+      ? "ILIKE"
+      : condition.operator === "lt"
+      ? "<"
+      : condition.operator === "lte"
+      ? "<="
+      : condition.operator === "gt"
+      ? ">"
+      : ">=";
+    let value: SearchParameterValue;
+    let type: string;
+    let literalValue: string;
+    if (condition.type === "string") {
+      type = "string";
+      value = condition.operator === "contains"
+        ? `%${escapeLikePattern(condition.value)}%`
+        : condition.value;
+      literalValue = escapeSqlLiteral(String(value));
+    } else if (condition.type === "boolean") {
+      if (condition.value !== "true" && condition.value !== "false") {
+        throw new Error(`${condition.field} requires true or false.`);
+      }
+      type = "boolean";
+      value = condition.value === "true";
+      literalValue = value ? "TRUE" : "FALSE";
+    } else if (condition.type === "integer") {
+      if (!/^-?\d+$/.test(condition.value) ||
+        !Number.isSafeInteger(Number(condition.value))) {
+        throw new Error(`${condition.field} requires an integer.`);
+      }
+      type = "integer";
+      value = Number(condition.value);
+      literalValue = String(value);
+    } else if (condition.type === "float") {
+      const number = Number(condition.value);
+      if (!Number.isFinite(number)) {
+        throw new Error(`${condition.field} requires a number.`);
+      }
+      type = "float";
+      value = number;
+      literalValue = String(number);
+    } else if (condition.type === "date") {
+      const converted = dateInput(condition.value, "start");
+      if (!converted) throw new Error(`${condition.field} requires YYYY-MM-DD.`);
+      type = "date";
+      value = converted.parameter.slice(0, 10);
+      literalValue = sqlLiteral(value, type);
+    } else if (condition.type === "timestamp") {
+      const timestamp = new Date(condition.value);
+      if (Number.isNaN(timestamp.getTime())) {
+        throw new Error(`${condition.field} requires an RFC3339 timestamp.`);
+      }
+      type = "timestamp";
+      value = timestamp.toISOString();
+      literalValue = sqlLiteral(value, type);
+    } else {
       continue;
     }
-    conditions.push(`${fieldPath} = ${escapeSqlLiteral(condition.value)}`);
+    const bound = bind(value, type, literalValue);
+    const escape = condition.operator === "contains" ? " ESCAPE '\\'" : "";
+    sessionConditions.push(`${fieldPath} ${operator} ${bound.parameter}${escape}`);
+    historyConditions.push(`${fieldPath} ${operator} ${bound.literal}${escape}`);
   }
 
-  const where = conditions.length > 0
-    ? ` WHERE ${conditions.join(" AND ")}`
+  const sessionWhere = sessionConditions.length > 0
+    ? ` WHERE ${sessionConditions.join(" AND ")}`
     : "";
-  return `SELECT * FROM ${quoteSqlIdentifier(criteria.formName.toLowerCase())}${where} ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT ${ADVANCED_SEARCH_LIMIT}`;
+  const historyWhere = historyConditions.length > 0
+    ? ` WHERE ${historyConditions.join(" AND ")}`
+    : "";
+  const render = (where: string) =>
+    `SELECT * FROM ${quoteSqlIdentifier(criteria.sqlRelation)}${where} ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT ${ADVANCED_SEARCH_LIMIT}`;
+  return {
+    sql: render(sessionWhere),
+    historySql: render(historyWhere),
+    parameters,
+    parameterTypes,
+  };
 }
 
 function buildSearchHistoryName(criteria: AdvancedSearchCriteria): string {
@@ -166,7 +297,7 @@ function buildSearchHistoryName(criteria: AdvancedSearchCriteria): string {
   }
 
   for (const condition of criteria.fieldConditions.slice(0, 2)) {
-    const symbol = condition.operator === "contains" ? "~" : "=";
+    const symbol = { equals: "=", contains: "~", lt: "<", lte: "<=", gt: ">", gte: ">=" }[condition.operator];
     parts.push(`${condition.field}${symbol}${condition.value}`);
   }
 
@@ -229,16 +360,22 @@ export default function SpaceSearchRoute() {
     )
   );
 
+  const selectedForm = createMemo(() => availableForms().find((entryForm) =>
+    entryForm.name === advancedFormName().trim()
+  ));
+
   const availableFields = createMemo(() => {
-    const formName = advancedFormName().trim();
-    if (!formName) return [] as string[];
-    const selectedForm = availableForms().find((entryForm) =>
-      entryForm.name === formName
-    );
-    if (!selectedForm?.fields) return [] as string[];
-    return Object.keys(selectedForm.fields).sort((left, right) =>
-      left.localeCompare(right)
-    );
+    if (!selectedForm()?.fields) return [] as AvailableField[];
+    return Object.entries(selectedForm()?.fields ?? {})
+      .map(([name, field]) => {
+        const type = normalizeFieldType(field.type);
+        return {
+          name,
+          type,
+          supported: operatorsForFieldType(type).length > 0,
+        };
+      })
+      .sort((left, right) => left.name.localeCompare(right.name));
   });
 
   const searchHistory = createMemo(() =>
@@ -250,15 +387,26 @@ export default function SpaceSearchRoute() {
 
   const advancedCriteria = createMemo<AdvancedSearchCriteria>(() => ({
     formName: advancedFormName().trim(),
+    sqlRelation: selectedForm()?.sql_relation ?? "",
     updatedFrom: advancedUpdatedFrom().trim(),
     updatedTo: advancedUpdatedTo().trim(),
     fieldConditions: fieldConditions()
-      .map((condition) => ({
-        field: condition.field.trim(),
-        operator: condition.operator,
-        value: condition.value.trim(),
-      }))
-      .filter((condition) => condition.field && condition.value),
+      .map((condition) => {
+        const field = availableFields().find((item) =>
+          item.name === condition.field.trim()
+        );
+        return {
+          field: condition.field.trim(),
+          type: field?.type ?? "unsupported",
+          operator: condition.operator,
+          value: condition.value.trim(),
+          supported: field?.supported ?? false,
+        };
+      })
+      .filter((condition) =>
+        condition.field && condition.value && condition.supported
+      )
+      .map(({ supported: _supported, ...condition }) => condition),
   }));
 
   const keywordResultCountLabel = createMemo(() => {
@@ -274,10 +422,15 @@ export default function SpaceSearchRoute() {
     setFieldConditions((current) =>
       current.map((condition) =>
         condition.id === id
-          ? {
-            ...condition,
-            [key]: value,
-          }
+          ? (() => {
+            const next = { ...condition, [key]: value };
+            if (key === "field") {
+              const field = availableFields().find((item) => item.name === value);
+              const operators = operatorsForFieldType(field?.type ?? "unsupported");
+              if (!operators.includes(next.operator)) next.operator = "equals";
+            }
+            return next;
+          })()
           : condition
       )
     );
@@ -298,7 +451,7 @@ export default function SpaceSearchRoute() {
     setKeywordLoading(true);
     try {
       const results = await searchApi.keyword(spaceId(), query);
-      setKeywordResults(await enrichKeywordResults(spaceId(), results));
+      setKeywordResults(results);
     } catch (err) {
       setKeywordResults([]);
       setActionError(
@@ -343,10 +496,16 @@ export default function SpaceSearchRoute() {
 
   const handleAdvancedSearch = async () => {
     const criteria = advancedCriteria();
-    const sql = buildAdvancedSearchSql(criteria);
-    if (!sql) {
+    let query: AdvancedSearchQuery | null;
+    try {
+      query = buildAdvancedSearchQuery(criteria);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Invalid search condition.");
+      return;
+    }
+    if (!query) {
       setActionError(
-        "Choose a Form before running an advanced search.",
+        "Choose a Form with a backend SQL relation before running an advanced search.",
       );
       return;
     }
@@ -357,22 +516,26 @@ export default function SpaceSearchRoute() {
     try {
       const existing = searchHistory().find(
         (entry) =>
-          entry.sql.trim() === sql.trim() &&
+          entry.sql.trim() === query.historySql.trim() &&
           (!entry.variables || entry.variables.length === 0),
       );
-      if (!existing) {
-        await sqlApi.create(spaceId(), {
-          name: buildSearchHistoryName(criteria),
-          sql,
-          variables: [],
-        });
-        await refetchSavedSearches();
-      }
-
-      const session = await sqlSessionApi.create(spaceId(), sql);
+      const session = await sqlSessionApi.create(
+        spaceId(),
+        query.sql,
+        query.parameters,
+        query.parameterTypes,
+      );
       if (session.status === "failed") {
         setActionError(session.error || "Advanced search failed.");
         return;
+      }
+      if (!existing) {
+        await sqlApi.create(spaceId(), {
+          name: buildSearchHistoryName(criteria),
+          sql: query.historySql,
+          variables: [],
+        });
+        await refetchSavedSearches();
       }
       navigate(
         `/spaces/${spaceId()}/entries?session=${
@@ -575,8 +738,10 @@ export default function SpaceSearchRoute() {
                           >
                             <option value="">Choose a field</option>
                             <For each={availableFields()}>
-                              {(fieldName) => (
-                                <option value={fieldName}>{fieldName}</option>
+                              {(field) => (
+                                <option value={field.name} disabled={!field.supported}>
+                                  {field.name}{field.supported ? "" : " (unsupported)"}
+                                </option>
                               )}
                             </For>
                           </select>
@@ -600,8 +765,11 @@ export default function SpaceSearchRoute() {
                               event.currentTarget.value,
                             )}
                         >
-                          <option value="equals">equals</option>
-                          <option value="contains">contains</option>
+                          <For each={operatorsForFieldType(availableFields().find((field) => field.name === condition().field)?.type ?? "unsupported")}>
+                            {(operator) => (
+                              <option value={operator}>{operatorLabel(operator)}</option>
+                            )}
+                          </For>
                         </select>
                       </div>
                       <div>
@@ -610,9 +778,9 @@ export default function SpaceSearchRoute() {
                         </label>
                         <input
                           id={`value-${condition().id}`}
-                          type="text"
+                          type={fieldInputType(availableFields().find((field) => field.name === condition().field)?.type ?? "string")}
                           class="ui-input mt-2 w-full"
-                          placeholder="alice"
+                          placeholder={availableFields().find((field) => field.name === condition().field)?.type === "boolean" ? "true or false" : "alice"}
                           value={condition().value}
                           onInput={(event) =>
                             updateFieldCondition(

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -580,12 +580,17 @@ export default function SpaceSearchRoute() {
         return;
       }
       if (!existing) {
-        await sqlApi.create(spaceId(), {
-          name: buildSearchHistoryName(criteria),
-          sql: query.historySql,
-          variables: [],
-        });
-        await refetchSavedSearches();
+        try {
+          await sqlApi.create(spaceId(), {
+            name: buildSearchHistoryName(criteria),
+            sql: query.historySql,
+            variables: [],
+          });
+          await refetchSavedSearches();
+        } catch {
+          // Search history is a best-effort convenience. A ready session must
+          // remain usable even when persistence or its refresh is unavailable.
+        }
       }
       navigate(
         `/spaces/${spaceId()}/entries?session=${

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -27,14 +27,22 @@ type AdvancedSearchCriteria = {
   updatedTo: string;
   fieldConditions: Array<{
     field: string;
+    sqlColumn: string;
     type: SearchFieldType;
     operator: FieldMatchOperator;
     value: string;
+    supported: boolean;
   }>;
 };
 
-type SearchFieldType = "string" | "boolean" | "integer" | "float" |
-  "date" | "timestamp" | "unsupported";
+type SearchFieldType =
+  | "string"
+  | "boolean"
+  | "integer"
+  | "float"
+  | "date"
+  | "timestamp"
+  | "unsupported";
 
 type SearchParameterValue = string | number | boolean | null;
 
@@ -47,6 +55,7 @@ type AdvancedSearchQuery = {
 
 type AvailableField = {
   name: string;
+  sqlColumn: string;
   type: SearchFieldType;
   supported: boolean;
 };
@@ -76,7 +85,6 @@ function normalizeFieldType(type: string): SearchFieldType {
     case "boolean":
       return "boolean";
     case "integer":
-    case "long":
       return "integer";
     case "number":
     case "float":
@@ -85,9 +93,6 @@ function normalizeFieldType(type: string): SearchFieldType {
     case "date":
       return "date";
     case "timestamp":
-    case "timestamp_tz":
-    case "timestamp_ns":
-    case "timestamp_tz_ns":
       return "timestamp";
     default:
       return "unsupported";
@@ -97,8 +102,10 @@ function normalizeFieldType(type: string): SearchFieldType {
 function operatorsForFieldType(type: SearchFieldType): FieldMatchOperator[] {
   if (type === "string") return ["equals", "contains"];
   if (type === "boolean") return ["equals"];
-  if (type === "integer" || type === "float" || type === "date" ||
-    type === "timestamp") {
+  if (
+    type === "integer" || type === "float" || type === "date" ||
+    type === "timestamp"
+  ) {
     return ["equals", "lt", "lte", "gt", "gte"];
   }
   return [];
@@ -115,7 +122,9 @@ function operatorLabel(operator: FieldMatchOperator): string {
   }[operator];
 }
 
-function fieldInputType(type: SearchFieldType): "text" | "number" | "date" | "datetime-local" {
+function fieldInputType(
+  type: SearchFieldType,
+): "text" | "number" | "date" | "datetime-local" {
   if (type === "integer" || type === "float") return "number";
   if (type === "date") return "date";
   if (type === "timestamp") return "datetime-local";
@@ -198,7 +207,15 @@ function buildAdvancedSearchQuery(
   if (criteria.updatedTo) addDateCondition(criteria.updatedTo, "<");
 
   for (const condition of criteria.fieldConditions) {
-    const fieldPath = quoteSqlIdentifier(condition.field.toLowerCase());
+    if (!condition.field || !condition.value) {
+      throw new Error("Choose a field and enter a value for every condition.");
+    }
+    if (!condition.supported || !condition.sqlColumn) {
+      throw new Error(
+        `${condition.field} is not supported by Advanced search.`,
+      );
+    }
+    const fieldPath = quoteSqlIdentifier(condition.sqlColumn);
     const operator = condition.operator === "equals"
       ? "="
       : condition.operator === "contains"
@@ -227,8 +244,10 @@ function buildAdvancedSearchQuery(
       value = condition.value === "true";
       literalValue = value ? "TRUE" : "FALSE";
     } else if (condition.type === "integer") {
-      if (!/^-?\d+$/.test(condition.value) ||
-        !Number.isSafeInteger(Number(condition.value))) {
+      if (
+        !/^-?\d+$/.test(condition.value) ||
+        !Number.isSafeInteger(Number(condition.value))
+      ) {
         throw new Error(`${condition.field} requires an integer.`);
       }
       type = "integer";
@@ -244,7 +263,9 @@ function buildAdvancedSearchQuery(
       literalValue = String(number);
     } else if (condition.type === "date") {
       const converted = dateInput(condition.value, "start");
-      if (!converted) throw new Error(`${condition.field} requires YYYY-MM-DD.`);
+      if (!converted) {
+        throw new Error(`${condition.field} requires YYYY-MM-DD.`);
+      }
       type = "date";
       value = converted.parameter.slice(0, 10);
       literalValue = sqlLiteral(value, type);
@@ -261,8 +282,12 @@ function buildAdvancedSearchQuery(
     }
     const bound = bind(value, type, literalValue);
     const escape = condition.operator === "contains" ? " ESCAPE '\\'" : "";
-    sessionConditions.push(`${fieldPath} ${operator} ${bound.parameter}${escape}`);
-    historyConditions.push(`${fieldPath} ${operator} ${bound.literal}${escape}`);
+    sessionConditions.push(
+      `${fieldPath} ${operator} ${bound.parameter}${escape}`,
+    );
+    historyConditions.push(
+      `${fieldPath} ${operator} ${bound.literal}${escape}`,
+    );
   }
 
   const sessionWhere = sessionConditions.length > 0
@@ -272,7 +297,9 @@ function buildAdvancedSearchQuery(
     ? ` WHERE ${historyConditions.join(" AND ")}`
     : "";
   const render = (where: string) =>
-    `SELECT * FROM ${quoteSqlIdentifier(criteria.sqlRelation)}${where} ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT ${ADVANCED_SEARCH_LIMIT}`;
+    `SELECT * FROM ${
+      quoteSqlIdentifier(criteria.sqlRelation)
+    }${where} ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT ${ADVANCED_SEARCH_LIMIT}`;
   return {
     sql: render(sessionWhere),
     historySql: render(historyWhere),
@@ -297,7 +324,14 @@ function buildSearchHistoryName(criteria: AdvancedSearchCriteria): string {
   }
 
   for (const condition of criteria.fieldConditions.slice(0, 2)) {
-    const symbol = { equals: "=", contains: "~", lt: "<", lte: "<=", gt: ">", gte: ">=" }[condition.operator];
+    const symbol = {
+      equals: "=",
+      contains: "~",
+      lt: "<",
+      lte: "<=",
+      gt: ">",
+      gte: ">=",
+    }[condition.operator];
     parts.push(`${condition.field}${symbol}${condition.value}`);
   }
 
@@ -360,9 +394,11 @@ export default function SpaceSearchRoute() {
     )
   );
 
-  const selectedForm = createMemo(() => availableForms().find((entryForm) =>
-    entryForm.name === advancedFormName().trim()
-  ));
+  const selectedForm = createMemo(() =>
+    availableForms().find((entryForm) =>
+      entryForm.name === advancedFormName().trim()
+    )
+  );
 
   const availableFields = createMemo(() => {
     if (!selectedForm()?.fields) return [] as AvailableField[];
@@ -371,8 +407,10 @@ export default function SpaceSearchRoute() {
         const type = normalizeFieldType(field.type);
         return {
           name,
+          sqlColumn: field.sql_column?.trim() ?? "",
           type,
-          supported: operatorsForFieldType(type).length > 0,
+          supported: Boolean(field.sql_column?.trim()) &&
+            operatorsForFieldType(type).length > 0,
         };
       })
       .sort((left, right) => left.name.localeCompare(right.name));
@@ -397,16 +435,15 @@ export default function SpaceSearchRoute() {
         );
         return {
           field: condition.field.trim(),
+          sqlColumn: field?.sqlColumn ?? "",
           type: field?.type ?? "unsupported",
           operator: condition.operator,
           value: condition.value.trim(),
           supported: field?.supported ?? false,
         };
       })
-      .filter((condition) =>
-        condition.field && condition.value && condition.supported
-      )
-      .map(({ supported: _supported, ...condition }) => condition),
+      .filter((condition) => condition.field || condition.value)
+      .map((condition) => condition),
   }));
 
   const keywordResultCountLabel = createMemo(() => {
@@ -425,8 +462,12 @@ export default function SpaceSearchRoute() {
           ? (() => {
             const next = { ...condition, [key]: value };
             if (key === "field") {
-              const field = availableFields().find((item) => item.name === value);
-              const operators = operatorsForFieldType(field?.type ?? "unsupported");
+              const field = availableFields().find((item) =>
+                item.name === value
+              );
+              const operators = operatorsForFieldType(
+                field?.type ?? "unsupported",
+              );
               if (!operators.includes(next.operator)) next.operator = "equals";
             }
             return next;
@@ -434,6 +475,11 @@ export default function SpaceSearchRoute() {
           : condition
       )
     );
+  };
+
+  const handleAdvancedFormChange = (value: string) => {
+    setAdvancedFormName(value);
+    setFieldConditions([createFieldCondition()]);
   };
 
   const handleKeywordSearch = async () => {
@@ -500,7 +546,9 @@ export default function SpaceSearchRoute() {
     try {
       query = buildAdvancedSearchQuery(criteria);
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : "Invalid search condition.");
+      setActionError(
+        err instanceof Error ? err.message : "Invalid search condition.",
+      );
       return;
     }
     if (!query) {
@@ -569,402 +617,450 @@ export default function SpaceSearchRoute() {
 
         <div class="searchPage">
           <aside class="facet surface">
-            <button type="button" classList={{ active: mode() === "keyword" }} onClick={() => setMode("keyword")}><UiIcon name="entry" /> Entries</button>
-            <button type="button" onClick={() => setMode("advanced")} classList={{ active: mode() === "advanced" }}><UiIcon name="forms" /> Forms</button>
+            <button
+              type="button"
+              classList={{ active: mode() === "keyword" }}
+              onClick={() =>
+                setMode("keyword")}
+            >
+              <UiIcon name="entry" /> Entries
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setMode("advanced")}
+              classList={{ active: mode() === "advanced" }}
+            >
+              <UiIcon name="forms" /> Forms
+            </button>
             <A href={`/spaces/${spaceId()}/assets`}>
               <UiIcon name="asset" /> Assets
             </A>
-            <A href={`/spaces/${spaceId()}/sql`}><UiIcon name="sql" /> Saved SQL</A>
+            <A href={`/spaces/${spaceId()}/sql`}>
+              <UiIcon name="sql" /> Saved SQL
+            </A>
           </aside>
           <main>
-        <div class="ui-card p-5">
-          <div class="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              class={mode() === "keyword"
-                ? "ui-button ui-button-primary text-sm"
-                : "ui-button ui-button-secondary text-sm"}
-              onClick={() => setMode("keyword")}
-            >
-              Quick search
-            </button>
-            <button
-              type="button"
-              class={mode() === "advanced"
-                ? "ui-button ui-button-primary text-sm"
-                : "ui-button ui-button-secondary text-sm"}
-              onClick={() => setMode("advanced")}
-            >
-              Advanced search
-            </button>
-          </div>
-
-          <Show when={mode() === "keyword"}>
-            <form
-              class="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void handleKeywordSearch();
-              }}
-            >
-              <div class="flex-1">
-                <label class="ui-label" for="search-keywords">
-                  Search keywords
-                </label>
-                <div class="searchBox">
-                  <UiIcon name="search" />
-                <input
-                  id="search-keywords"
-                  type="text"
-                  class=""
-                  placeholder="Search entries by title, fields, tags, or content"
-                  value={keywordQuery()}
-                  onInput={(event) =>
-                    setKeywordQuery(event.currentTarget.value)}
-                /></div>
-              </div>
-              <div class="sm:self-end">
+            <div class="ui-card p-5">
+              <div class="flex flex-wrap items-center gap-2">
                 <button
-                  type="submit"
-                  class="ui-button ui-button-primary text-sm"
-                  disabled={keywordLoading()}
+                  type="button"
+                  class={mode() === "keyword"
+                    ? "ui-button ui-button-primary text-sm"
+                    : "ui-button ui-button-secondary text-sm"}
+                  onClick={() =>
+                    setMode("keyword")}
                 >
-                  {keywordLoading() ? "Searching..." : "Search entries"}
+                  Quick search
+                </button>
+                <button
+                  type="button"
+                  class={mode() === "advanced"
+                    ? "ui-button ui-button-primary text-sm"
+                    : "ui-button ui-button-secondary text-sm"}
+                  onClick={() => setMode("advanced")}
+                >
+                  Advanced search
                 </button>
               </div>
-            </form>
-          </Show>
 
-          <Show when={mode() === "advanced"}>
-            <div class="mt-5 ui-stack-sm">
-              <div class="grid gap-4 md:grid-cols-2">
-                <div>
-                  <label class="ui-label" for="advanced-form">
-                    Form
-                  </label>
-                  <select
-                    id="advanced-form"
-                    class="ui-input mt-2 w-full"
-                    value={advancedFormName()}
-                    onChange={(event) =>
-                      setAdvancedFormName(event.currentTarget.value)}
-                  >
-                    <option value="">Choose a Form</option>
-                    <For each={availableForms()}>
-                      {(entryForm) => (
-                        <option value={entryForm.name}>{entryForm.name}</option>
-                      )}
-                    </For>
-                  </select>
-                </div>
-                <div>
-                  <label class="ui-label" for="advanced-updated-from">
-                    Updated from
-                  </label>
-                  <input
-                    id="advanced-updated-from"
-                    type="date"
-                    class="ui-input mt-2 w-full"
-                    value={advancedUpdatedFrom()}
-                    onInput={(event) =>
-                      setAdvancedUpdatedFrom(event.currentTarget.value)}
-                  />
-                </div>
-                <div>
-                  <label class="ui-label" for="advanced-updated-to">
-                    Updated to
-                  </label>
-                  <input
-                    id="advanced-updated-to"
-                    type="date"
-                    class="ui-input mt-2 w-full"
-                    value={advancedUpdatedTo()}
-                    onInput={(event) =>
-                      setAdvancedUpdatedTo(event.currentTarget.value)}
-                  />
-                </div>
-              </div>
+              <Show when={mode() === "keyword"}>
+                <form
+                  class="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleKeywordSearch();
+                  }}
+                >
+                  <div class="flex-1">
+                    <label class="ui-label" for="search-keywords">
+                      Search keywords
+                    </label>
+                    <div class="searchBox">
+                      <UiIcon name="search" />
+                      <input
+                        id="search-keywords"
+                        type="text"
+                        class=""
+                        placeholder="Search entries by title, fields, tags, or content"
+                        value={keywordQuery()}
+                        onInput={(event) =>
+                          setKeywordQuery(event.currentTarget.value)}
+                      />
+                    </div>
+                  </div>
+                  <div class="sm:self-end">
+                    <button
+                      type="submit"
+                      class="ui-button ui-button-primary text-sm"
+                      disabled={keywordLoading()}
+                    >
+                      {keywordLoading() ? "Searching..." : "Search entries"}
+                    </button>
+                  </div>
+                </form>
+              </Show>
 
-              <div class="mt-4 ui-stack-sm">
-                <div class="flex items-center justify-between gap-2">
-                  <h2 class="text-base font-semibold">Field conditions</h2>
-                  <button
-                    type="button"
-                    class="ui-button ui-button-secondary text-sm"
-                    onClick={() =>
-                      setFieldConditions((
-                        current,
-                      ) => [...current, createFieldCondition()])}
-                  >
-                    Add field condition
-                  </button>
-                </div>
+              <Show when={mode() === "advanced"}>
+                <div class="mt-5 ui-stack-sm">
+                  <div class="grid gap-4 md:grid-cols-2">
+                    <div>
+                      <label class="ui-label" for="advanced-form">
+                        Form
+                      </label>
+                      <select
+                        id="advanced-form"
+                        class="ui-input mt-2 w-full"
+                        value={advancedFormName()}
+                        onChange={(event) =>
+                          handleAdvancedFormChange(event.currentTarget.value)}
+                      >
+                        <option value="">Choose a Form</option>
+                        <For each={availableForms()}>
+                          {(entryForm) => (
+                            <option value={entryForm.name}>
+                              {entryForm.name}
+                            </option>
+                          )}
+                        </For>
+                      </select>
+                    </div>
+                    <div>
+                      <label class="ui-label" for="advanced-updated-from">
+                        Updated from
+                      </label>
+                      <input
+                        id="advanced-updated-from"
+                        type="date"
+                        class="ui-input mt-2 w-full"
+                        value={advancedUpdatedFrom()}
+                        onInput={(event) =>
+                          setAdvancedUpdatedFrom(event.currentTarget.value)}
+                      />
+                    </div>
+                    <div>
+                      <label class="ui-label" for="advanced-updated-to">
+                        Updated to
+                      </label>
+                      <input
+                        id="advanced-updated-to"
+                        type="date"
+                        class="ui-input mt-2 w-full"
+                        value={advancedUpdatedTo()}
+                        onInput={(event) =>
+                          setAdvancedUpdatedTo(event.currentTarget.value)}
+                      />
+                    </div>
+                  </div>
 
-                <Index each={fieldConditions()}>
-                  {(condition) => (
-                    <div class="ui-card grid gap-3 p-3 md:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1.6fr)_auto]">
-                      <div>
-                        <label class="ui-label" for={`field-${condition().id}`}>
-                          Field
-                        </label>
-                        <Show
-                          when={availableFields().length > 0}
-                          fallback={
-                            <input
-                              id={`field-${condition().id}`}
-                              type="text"
+                  <div class="mt-4 ui-stack-sm">
+                    <div class="flex items-center justify-between gap-2">
+                      <h2 class="text-base font-semibold">Field conditions</h2>
+                      <button
+                        type="button"
+                        class="ui-button ui-button-secondary text-sm"
+                        onClick={() =>
+                          setFieldConditions((
+                            current,
+                          ) => [...current, createFieldCondition()])}
+                      >
+                        Add field condition
+                      </button>
+                    </div>
+
+                    <Index each={fieldConditions()}>
+                      {(condition) => (
+                        <div class="ui-card grid gap-3 p-3 md:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1.6fr)_auto]">
+                          <div>
+                            <label
+                              class="ui-label"
+                              for={`field-${condition().id}`}
+                            >
+                              Field
+                            </label>
+                            <Show
+                              when={availableFields().length > 0}
+                              fallback={
+                                <input
+                                  id={`field-${condition().id}`}
+                                  type="text"
+                                  class="ui-input mt-2 w-full"
+                                  placeholder="Owner"
+                                  value={condition().field}
+                                  onInput={(event) =>
+                                    updateFieldCondition(
+                                      condition().id,
+                                      "field",
+                                      event.currentTarget.value,
+                                    )}
+                                />
+                              }
+                            >
+                              <select
+                                id={`field-${condition().id}`}
+                                class="ui-input mt-2 w-full"
+                                value={condition().field}
+                                onChange={(event) =>
+                                  updateFieldCondition(
+                                    condition().id,
+                                    "field",
+                                    event.currentTarget.value,
+                                  )}
+                              >
+                                <option value="">Choose a field</option>
+                                <For each={availableFields()}>
+                                  {(field) => (
+                                    <option
+                                      value={field.name}
+                                      disabled={!field.supported}
+                                    >
+                                      {field.name}
+                                      {field.supported ? "" : " (unsupported)"}
+                                    </option>
+                                  )}
+                                </For>
+                              </select>
+                            </Show>
+                          </div>
+                          <div>
+                            <label
+                              class="ui-label"
+                              for={`operator-${condition().id}`}
+                            >
+                              Match
+                            </label>
+                            <select
+                              id={`operator-${condition().id}`}
                               class="ui-input mt-2 w-full"
-                              placeholder="Owner"
-                              value={condition().field}
+                              value={condition().operator}
+                              onChange={(event) =>
+                                updateFieldCondition(
+                                  condition().id,
+                                  "operator",
+                                  event.currentTarget.value,
+                                )}
+                            >
+                              <For
+                                each={operatorsForFieldType(
+                                  availableFields().find((field) =>
+                                    field.name === condition().field
+                                  )?.type ?? "unsupported",
+                                )}
+                              >
+                                {(operator) => (
+                                  <option value={operator}>
+                                    {operatorLabel(operator)}
+                                  </option>
+                                )}
+                              </For>
+                            </select>
+                          </div>
+                          <div>
+                            <label
+                              class="ui-label"
+                              for={`value-${condition().id}`}
+                            >
+                              Value
+                            </label>
+                            <input
+                              id={`value-${condition().id}`}
+                              type={fieldInputType(
+                                availableFields().find((field) =>
+                                  field.name === condition().field
+                                )?.type ?? "string",
+                              )}
+                              class="ui-input mt-2 w-full"
+                              placeholder={availableFields().find((field) =>
+                                  field.name === condition().field
+                                )?.type === "boolean"
+                                ? "true or false"
+                                : "alice"}
+                              value={condition().value}
                               onInput={(event) =>
                                 updateFieldCondition(
                                   condition().id,
-                                  "field",
+                                  "value",
                                   event.currentTarget.value,
                                 )}
                             />
-                          }
-                        >
-                          <select
-                            id={`field-${condition().id}`}
-                            class="ui-input mt-2 w-full"
-                            value={condition().field}
-                            onChange={(event) =>
-                              updateFieldCondition(
-                                condition().id,
-                                "field",
-                                event.currentTarget.value,
-                              )}
-                          >
-                            <option value="">Choose a field</option>
-                            <For each={availableFields()}>
-                              {(field) => (
-                                <option value={field.name} disabled={!field.supported}>
-                                  {field.name}{field.supported ? "" : " (unsupported)"}
-                                </option>
-                              )}
-                            </For>
-                          </select>
-                        </Show>
-                      </div>
-                      <div>
-                        <label
-                          class="ui-label"
-                          for={`operator-${condition().id}`}
-                        >
-                          Match
-                        </label>
-                        <select
-                          id={`operator-${condition().id}`}
-                          class="ui-input mt-2 w-full"
-                          value={condition().operator}
-                          onChange={(event) =>
-                            updateFieldCondition(
-                              condition().id,
-                              "operator",
-                              event.currentTarget.value,
-                            )}
-                        >
-                          <For each={operatorsForFieldType(availableFields().find((field) => field.name === condition().field)?.type ?? "unsupported")}>
-                            {(operator) => (
-                              <option value={operator}>{operatorLabel(operator)}</option>
-                            )}
-                          </For>
-                        </select>
-                      </div>
-                      <div>
-                        <label class="ui-label" for={`value-${condition().id}`}>
-                          Value
-                        </label>
-                        <input
-                          id={`value-${condition().id}`}
-                          type={fieldInputType(availableFields().find((field) => field.name === condition().field)?.type ?? "string")}
-                          class="ui-input mt-2 w-full"
-                          placeholder={availableFields().find((field) => field.name === condition().field)?.type === "boolean" ? "true or false" : "alice"}
-                          value={condition().value}
-                          onInput={(event) =>
-                            updateFieldCondition(
-                              condition().id,
-                              "value",
-                              event.currentTarget.value,
-                            )}
-                        />
-                      </div>
-                      <div class="md:self-end">
-                        <button
-                          type="button"
-                          class="ui-button ui-button-secondary text-sm"
-                          onClick={() =>
-                            setFieldConditions((current) => {
-                              if (current.length === 1) {
-                                return [createFieldCondition()];
-                              }
-                              return current.filter((item) =>
-                                item.id !== condition().id
-                              );
-                            })}
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </Index>
-              </div>
+                          </div>
+                          <div class="md:self-end">
+                            <button
+                              type="button"
+                              class="ui-button ui-button-secondary text-sm"
+                              onClick={() =>
+                                setFieldConditions((current) => {
+                                  if (current.length === 1) {
+                                    return [createFieldCondition()];
+                                  }
+                                  return current.filter((item) =>
+                                    item.id !== condition().id
+                                  );
+                                })}
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </Index>
+                  </div>
 
-              <div class="mt-6 flex flex-wrap items-center justify-between gap-3">
-                <p class="text-sm ui-muted">
-                  Advanced searches compile to reusable SQL-backed history and
-                  open the shared query results view.
-                </p>
-                <button
-                  type="button"
-                  class="ui-button ui-button-primary text-sm"
-                  disabled={runningSearchId() === "advanced-search"}
-                  onClick={() => void handleAdvancedSearch()}
-                >
-                  {runningSearchId() === "advanced-search"
-                    ? "Running..."
-                    : "Run advanced search"}
-                </button>
-              </div>
-            </div>
-          </Show>
-        </div>
-
-        <div class="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
-          <section class="ui-card p-5">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h2 class="text-lg font-semibold">Keyword results</h2>
-                <Show when={keywordSearchPerformed() && !keywordLoading()}>
-                  <p class="mt-1 text-sm ui-muted">
-                    {keywordResultCountLabel()}
-                  </p>
-                </Show>
-              </div>
-            </div>
-
-            <div class="mt-4 ui-stack-sm">
-              <Show when={actionError()}>
-                <p class="text-sm ui-text-danger">{actionError()}</p>
-              </Show>
-              <Show when={keywordLoading()}>
-                <p class="text-sm ui-muted">Searching entries...</p>
-              </Show>
-              <Show
-                when={!keywordLoading() &&
-                  keywordSearchPerformed() &&
-                  keywordResults().length === 0 &&
-                  !actionError()}
-              >
-                <p class="text-sm ui-muted">No matching entries found.</p>
-              </Show>
-              <Show
-                when={!keywordSearchPerformed() && !keywordLoading() &&
-                  !actionError()}
-              >
-                <p class="text-sm ui-muted">
-                  Search results stay here so you can refine your query without
-                  leaving the page.
-                </p>
-              </Show>
-              <div class="grid gap-4 sm:grid-cols-2">
-                <For each={keywordResults()}>
-                  {(entry) => (
+                  <div class="mt-6 flex flex-wrap items-center justify-between gap-3">
+                    <p class="text-sm ui-muted">
+                      Advanced searches compile to reusable SQL-backed history
+                      and open the shared query results view.
+                    </p>
                     <button
                       type="button"
-                      class="ui-card ui-card-interactive text-left"
-                      onClick={() =>
-                        navigate(
-                          `/spaces/${spaceId()}/entries/${
-                            encodeURIComponent(entry.id)
-                          }`,
-                        )}
+                      class="ui-button ui-button-primary text-sm"
+                      disabled={runningSearchId() === "advanced-search"}
+                      onClick={() => void handleAdvancedSearch()}
                     >
-                      <div class="flex items-start justify-between gap-2">
-                        <h3 class="text-base font-semibold">
-                          {entry.title || "Untitled"}
-                        </h3>
-                        <Show when={entry.form}>
-                          <span class="ui-pill">{entry.form}</span>
-                        </Show>
-                      </div>
-                      <p class="mt-2 text-xs ui-muted">
-                        Updated {formatDateLabel(entry.updated_at)}
-                      </p>
+                      {runningSearchId() === "advanced-search"
+                        ? "Running..."
+                        : "Run advanced search"}
                     </button>
-                  )}
-                </For>
-              </div>
-            </div>
-          </section>
-
-          <aside class="ui-card p-5">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h2 class="text-lg font-semibold">Search history</h2>
-                <p class="mt-1 text-sm ui-muted">
-                  Saved searches and power-user SQL queries stay reusable here.
-                </p>
-              </div>
-              <button
-                type="button"
-                class="ui-button ui-button-secondary text-sm"
-                onClick={() => void refetchSavedSearches()}
-              >
-                Refresh history
-              </button>
+                  </div>
+                </div>
+              </Show>
             </div>
 
-            <div class="mt-4 ui-stack-sm">
-              <Show when={savedSearches.loading}>
-                <p class="text-sm ui-muted">Loading search history...</p>
-              </Show>
-              <Show when={savedSearches.error}>
-                <p class="text-sm ui-text-danger">
-                  Failed to load search history.
-                </p>
-              </Show>
-              <Show when={forms.loading}>
-                <p class="text-sm ui-muted">Loading form filters...</p>
-              </Show>
-              <Show when={forms.error}>
-                <p class="text-sm ui-text-danger">
-                  Failed to load forms for advanced search.
-                </p>
-              </Show>
-              <Show
-                when={!savedSearches.loading && searchHistory().length === 0}
-              >
-                <p class="text-sm ui-muted">No search history yet.</p>
-              </Show>
-              <For each={searchHistory()}>
-                {(entry) => (
+            <div class="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(18rem,1fr)]">
+              <section class="ui-card p-5">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h2 class="text-lg font-semibold">Keyword results</h2>
+                    <Show when={keywordSearchPerformed() && !keywordLoading()}>
+                      <p class="mt-1 text-sm ui-muted">
+                        {keywordResultCountLabel()}
+                      </p>
+                    </Show>
+                  </div>
+                </div>
+
+                <div class="mt-4 ui-stack-sm">
+                  <Show when={actionError()}>
+                    <p class="text-sm ui-text-danger">{actionError()}</p>
+                  </Show>
+                  <Show when={keywordLoading()}>
+                    <p class="text-sm ui-muted">Searching entries...</p>
+                  </Show>
+                  <Show
+                    when={!keywordLoading() &&
+                      keywordSearchPerformed() &&
+                      keywordResults().length === 0 &&
+                      !actionError()}
+                  >
+                    <p class="text-sm ui-muted">No matching entries found.</p>
+                  </Show>
+                  <Show
+                    when={!keywordSearchPerformed() && !keywordLoading() &&
+                      !actionError()}
+                  >
+                    <p class="text-sm ui-muted">
+                      Search results stay here so you can refine your query
+                      without leaving the page.
+                    </p>
+                  </Show>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <For each={keywordResults()}>
+                      {(entry) => (
+                        <button
+                          type="button"
+                          class="ui-card ui-card-interactive text-left"
+                          onClick={() =>
+                            navigate(
+                              `/spaces/${spaceId()}/entries/${
+                                encodeURIComponent(entry.id)
+                              }`,
+                            )}
+                        >
+                          <div class="flex items-start justify-between gap-2">
+                            <h3 class="text-base font-semibold">
+                              {entry.title || "Untitled"}
+                            </h3>
+                            <Show when={entry.form}>
+                              <span class="ui-pill">{entry.form}</span>
+                            </Show>
+                          </div>
+                          <p class="mt-2 text-xs ui-muted">
+                            Updated {formatDateLabel(entry.updated_at)}
+                          </p>
+                        </button>
+                      )}
+                    </For>
+                  </div>
+                </div>
+              </section>
+
+              <aside class="ui-card p-5">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h2 class="text-lg font-semibold">Search history</h2>
+                    <p class="mt-1 text-sm ui-muted">
+                      Saved searches and power-user SQL queries stay reusable
+                      here.
+                    </p>
+                  </div>
                   <button
                     type="button"
-                    class="ui-card ui-card-interactive w-full text-left"
-                    onClick={() => void runSavedSearch(entry)}
+                    class="ui-button ui-button-secondary text-sm"
+                    onClick={() => void refetchSavedSearches()}
                   >
-                    <div class="flex items-center justify-between gap-2">
-                      <h3 class="text-sm font-semibold">{entry.name}</h3>
-                      <span class="text-xs ui-muted">
-                        {runningSearchId() === entry.id
-                          ? "Running"
-                          : entry.variables?.length
-                          ? "Variables"
-                          : "Run again"}
-                      </span>
-                    </div>
-                    <p class="mt-2 text-xs ui-muted">
-                      Updated {formatDateLabel(entry.updated_at)}
-                    </p>
+                    Refresh history
                   </button>
-                )}
-              </For>
+                </div>
+
+                <div class="mt-4 ui-stack-sm">
+                  <Show when={savedSearches.loading}>
+                    <p class="text-sm ui-muted">Loading search history...</p>
+                  </Show>
+                  <Show when={savedSearches.error}>
+                    <p class="text-sm ui-text-danger">
+                      Failed to load search history.
+                    </p>
+                  </Show>
+                  <Show when={forms.loading}>
+                    <p class="text-sm ui-muted">Loading form filters...</p>
+                  </Show>
+                  <Show when={forms.error}>
+                    <p class="text-sm ui-text-danger">
+                      Failed to load forms for advanced search.
+                    </p>
+                  </Show>
+                  <Show
+                    when={!savedSearches.loading &&
+                      searchHistory().length === 0}
+                  >
+                    <p class="text-sm ui-muted">No search history yet.</p>
+                  </Show>
+                  <For each={searchHistory()}>
+                    {(entry) => (
+                      <button
+                        type="button"
+                        class="ui-card ui-card-interactive w-full text-left"
+                        onClick={() => void runSavedSearch(entry)}
+                      >
+                        <div class="flex items-center justify-between gap-2">
+                          <h3 class="text-sm font-semibold">{entry.name}</h3>
+                          <span class="text-xs ui-muted">
+                            {runningSearchId() === entry.id
+                              ? "Running"
+                              : entry.variables?.length
+                              ? "Variables"
+                              : "Run again"}
+                          </span>
+                        </div>
+                        <p class="mt-2 text-xs ui-muted">
+                          Updated {formatDateLabel(entry.updated_at)}
+                        </p>
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </aside>
             </div>
-          </aside>
-        </div>
           </main>
         </div>
       </div>

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -3,6 +3,7 @@ import { createMemo, createSignal, For, Index, Show } from "solid-js";
 import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { formatDateLabel } from "~/lib/date-format";
+import { entryApi } from "~/lib/ugoite-client";
 import { formApi } from "~/lib/ugoite-client";
 import { searchApi } from "~/lib/ugoite-client";
 import { sqlSessionApi } from "~/lib/ugoite-client";
@@ -22,7 +23,6 @@ type FieldCondition = {
 
 type AdvancedSearchCriteria = {
   formName: string;
-  tags: string[];
   updatedFrom: string;
   updatedTo: string;
   fieldConditions: Array<{
@@ -67,15 +67,10 @@ function coerceSearchResult(
   };
 }
 
-function buildKeywordMetadataSql(entryIds: string[]): string {
-  const ids = entryIds.map(escapeSqlLiteral).join(", ");
-  return `SELECT * FROM entries WHERE id IN (${ids}) LIMIT ${entryIds.length}`;
-}
-
-function dateInputToUnixSeconds(
+function dateInputToSqlTimestamp(
   value: string,
   boundary: "start" | "end",
-): number | null {
+): string | null {
   if (!value) return null;
   const [yearText, monthText, dayText] = value.split("-");
   const year = Number(yearText);
@@ -92,10 +87,8 @@ function dateInputToUnixSeconds(
   ) {
     return null;
   }
-  const millis = boundary === "start"
-    ? startOfDay.getTime()
-    : startOfDay.getTime() + 86_400_000 - 1;
-  return Math.floor(millis / 1000);
+  const time = boundary === "start" ? "00:00:00.000" : "23:59:59.999";
+  return `TIMESTAMP '${yearText}-${monthText}-${dayText} ${time}Z'`;
 }
 
 async function enrichKeywordResults(
@@ -113,52 +106,35 @@ async function enrichKeywordResults(
     return results;
   }
 
-  const session = await sqlSessionApi.create(
-    spaceId,
-    buildKeywordMetadataSql(idsNeedingEnrichment),
-  );
-  if (session.status === "failed") {
-    throw new Error(
-      session.error || "Failed to enrich keyword search results.",
-    );
-  }
-  const metadata = await sqlSessionApi.rows(
-    spaceId,
-    session.id,
-    0,
-    idsNeedingEnrichment.length,
-  );
-  const metadataById = new Map(
-    metadata.rows.map((entry) => [entry.id, entry] as const),
-  );
+  // Keyword search returns stable Entry IDs. Resolve display metadata through
+  // the Entry index rather than manufacturing a cross-Form SQL session: SQL
+  // sessions intentionally expose one Form and require a total order.
+  const entries = await entryApi.list(spaceId);
+  const metadataById = new Map(entries.map((entry) => [entry.id, entry] as const));
   return results.map((result) =>
     coerceSearchResult(result, metadataById.get(result.id))
   );
 }
 
 function buildAdvancedSearchSql(criteria: AdvancedSearchCriteria): string {
+  if (!criteria.formName) {
+    return "";
+  }
+
   const conditions: string[] = [];
 
-  if (criteria.formName) {
-    conditions.push(`form = ${escapeSqlLiteral(criteria.formName)}`);
+  const updatedFrom = dateInputToSqlTimestamp(criteria.updatedFrom, "start");
+  if (updatedFrom) {
+    conditions.push(`_ugoite_updated_at >= ${updatedFrom}`);
   }
 
-  for (const tag of criteria.tags) {
-    conditions.push(`tags = ${escapeSqlLiteral(tag)}`);
-  }
-
-  const updatedFrom = dateInputToUnixSeconds(criteria.updatedFrom, "start");
-  if (updatedFrom !== null) {
-    conditions.push(`updated_at >= ${updatedFrom}`);
-  }
-
-  const updatedTo = dateInputToUnixSeconds(criteria.updatedTo, "end");
-  if (updatedTo !== null) {
-    conditions.push(`updated_at <= ${updatedTo}`);
+  const updatedTo = dateInputToSqlTimestamp(criteria.updatedTo, "end");
+  if (updatedTo) {
+    conditions.push(`_ugoite_updated_at <= ${updatedTo}`);
   }
 
   for (const condition of criteria.fieldConditions) {
-    const fieldPath = `properties.${quoteSqlIdentifier(condition.field)}`;
+    const fieldPath = quoteSqlIdentifier(condition.field.toLowerCase());
     if (condition.operator === "contains") {
       conditions.push(
         `${fieldPath} ILIKE ${escapeSqlLiteral(`%${condition.value}%`)}`,
@@ -168,13 +144,10 @@ function buildAdvancedSearchSql(criteria: AdvancedSearchCriteria): string {
     conditions.push(`${fieldPath} = ${escapeSqlLiteral(condition.value)}`);
   }
 
-  if (conditions.length === 0) {
-    return "";
-  }
-
-  return `SELECT * FROM entries WHERE ${
-    conditions.join(" AND ")
-  } ORDER BY updated_at DESC LIMIT ${ADVANCED_SEARCH_LIMIT}`;
+  const where = conditions.length > 0
+    ? ` WHERE ${conditions.join(" AND ")}`
+    : "";
+  return `SELECT * FROM ${quoteSqlIdentifier(criteria.formName.toLowerCase())}${where} ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT ${ADVANCED_SEARCH_LIMIT}`;
 }
 
 function buildSearchHistoryName(criteria: AdvancedSearchCriteria): string {
@@ -182,10 +155,6 @@ function buildSearchHistoryName(criteria: AdvancedSearchCriteria): string {
 
   if (criteria.formName) {
     parts.push(`form: ${criteria.formName}`);
-  }
-
-  for (const tag of criteria.tags) {
-    parts.push(`tag: ${tag}`);
   }
 
   if (criteria.updatedFrom) {
@@ -239,7 +208,6 @@ export default function SpaceSearchRoute() {
     null,
   );
   const [advancedFormName, setAdvancedFormName] = createSignal("");
-  const [advancedTagsInput, setAdvancedTagsInput] = createSignal("");
   const [advancedUpdatedFrom, setAdvancedUpdatedFrom] = createSignal("");
   const [advancedUpdatedTo, setAdvancedUpdatedTo] = createSignal("");
   const [fieldConditions, setFieldConditions] = createSignal<FieldCondition[]>([
@@ -282,10 +250,6 @@ export default function SpaceSearchRoute() {
 
   const advancedCriteria = createMemo<AdvancedSearchCriteria>(() => ({
     formName: advancedFormName().trim(),
-    tags: advancedTagsInput()
-      .split(",")
-      .map((part) => part.trim())
-      .filter(Boolean),
     updatedFrom: advancedUpdatedFrom().trim(),
     updatedTo: advancedUpdatedTo().trim(),
     fieldConditions: fieldConditions()
@@ -382,7 +346,7 @@ export default function SpaceSearchRoute() {
     const sql = buildAdvancedSearchSql(criteria);
     if (!sql) {
       setActionError(
-        "Add at least one structured filter before running an advanced search.",
+        "Choose a Form before running an advanced search.",
       );
       return;
     }
@@ -522,27 +486,13 @@ export default function SpaceSearchRoute() {
                     onChange={(event) =>
                       setAdvancedFormName(event.currentTarget.value)}
                   >
-                    <option value="">Any form</option>
+                    <option value="">Choose a Form</option>
                     <For each={availableForms()}>
                       {(entryForm) => (
                         <option value={entryForm.name}>{entryForm.name}</option>
                       )}
                     </For>
                   </select>
-                </div>
-                <div>
-                  <label class="ui-label" for="advanced-tags">
-                    Tags (comma-separated)
-                  </label>
-                  <input
-                    id="advanced-tags"
-                    type="text"
-                    class="ui-input mt-2 w-full"
-                    placeholder="project, weekly-review"
-                    value={advancedTagsInput()}
-                    onInput={(event) =>
-                      setAdvancedTagsInput(event.currentTarget.value)}
-                  />
                 </div>
                 <div>
                   <label class="ui-label" for="advanced-updated-from">

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -7,7 +7,7 @@ import { formApi } from "~/lib/ugoite-client";
 import { searchApi } from "~/lib/ugoite-client";
 import { sqlSessionApi } from "~/lib/ugoite-client";
 import { sqlApi } from "~/lib/ugoite-client";
-import type { SearchResult, SqlEntry } from "~/lib/types";
+import type { KeywordSearchResult, SqlEntry } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
 
 type SearchMode = "keyword" | "advanced";
@@ -363,7 +363,9 @@ export default function SpaceSearchRoute() {
 
   const [mode, setMode] = createSignal<SearchMode>("keyword");
   const [keywordQuery, setKeywordQuery] = createSignal("");
-  const [keywordResults, setKeywordResults] = createSignal<SearchResult[]>([]);
+  const [keywordResults, setKeywordResults] = createSignal<
+    KeywordSearchResult[]
+  >([]);
   const [keywordSearchPerformed, setKeywordSearchPerformed] = createSignal(
     false,
   );

--- a/frontend/src/routes/spaces/[space_id]/sql/[sql_id].test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/[sql_id].test.tsx
@@ -9,6 +9,7 @@ import type { Space } from "~/lib/types";
 import { testApiUrl } from "~/test/http-origin";
 
 const navigateMock = vi.fn();
+const entryRelation = "form_00000000000000000000000000000001";
 
 vi.mock("@solidjs/router", () => ({
   A: (props: { href: string; class?: string; children: unknown }) => (
@@ -61,7 +62,8 @@ describe("/spaces/:space_id/sql/:sql_id", () => {
     seedSqlEntry("default", {
       id: "saved-query",
       name: "Recent Search",
-      sql: "SELECT * FROM entries LIMIT 10",
+      sql:
+        `SELECT * FROM "${entryRelation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 10`,
       variables: [{
         name: "owner",
         type: "string",
@@ -81,7 +83,9 @@ describe("/spaces/:space_id/sql/:sql_id", () => {
       "data-disabled",
       "true",
     );
-    expect(screen.getByText("SELECT * FROM entries LIMIT 10"))
+    expect(screen.getByText(
+      `SELECT * FROM "${entryRelation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 10`,
+    ))
       .toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open Variables" }))
       .toHaveAttribute(
@@ -111,7 +115,8 @@ describe("/spaces/:space_id/sql/:sql_id", () => {
     seedSqlEntry("default", {
       id: "saved-query",
       name: "Runnable Query",
-      sql: "SELECT * FROM entries LIMIT 1",
+      sql:
+        `SELECT * FROM "${entryRelation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
       variables: [],
       created_at: "2025-03-01T00:00:00Z",
       updated_at: "2025-03-02T00:00:00Z",
@@ -122,7 +127,9 @@ describe("/spaces/:space_id/sql/:sql_id", () => {
         testApiUrl("/spaces/default/sql-sessions"),
         async ({ request }) => {
           const body = (await request.json()) as { sql?: string };
-          expect(body.sql).toBe("SELECT * FROM entries LIMIT 1");
+          expect(body.sql).toBe(
+            `SELECT * FROM "${entryRelation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
+          );
           return HttpResponse.json(
             { id: "session-1", status: "ready", error: null },
             { status: 201 },

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -123,6 +123,9 @@ export const seedEntry = (
 };
 
 export const seedForm = (spaceId: string, entryForm: Form) => {
+  if (!entryForm.sql_relation) {
+    throw new Error(`seedForm requires backend sql_relation for ${entryForm.name}`);
+  }
   mockForms.get(spaceId)?.set(entryForm.name, entryForm);
 };
 

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -124,7 +124,9 @@ export const seedEntry = (
 
 export const seedForm = (spaceId: string, entryForm: Form) => {
   if (!entryForm.sql_relation) {
-    throw new Error(`seedForm requires backend sql_relation for ${entryForm.name}`);
+    throw new Error(
+      `seedForm requires backend sql_relation for ${entryForm.name}`,
+    );
   }
   mockForms.get(spaceId)?.set(entryForm.name, entryForm);
 };
@@ -682,6 +684,12 @@ export const handlers = [
     async ({ params, request }) => {
       const spaceId = params.spaceId as string;
       const body = (await request.json()) as { sql: string };
+      if (typeof body.sql === "string" && /\bentries\b/i.test(body.sql)) {
+        return HttpResponse.json(
+          { detail: "Legacy SQL relations are unsupported" },
+          { status: 422 },
+        );
+      }
       const id = crypto.randomUUID();
       const session = {
         id,

--- a/shared/sql/ugoite-sql-rules.json
+++ b/shared/sql/ugoite-sql-rules.json
@@ -21,32 +21,6 @@
     "OR",
     "NOT"
   ],
-  "base_tables": ["entries", "links", "assets"],
-  "base_columns": [
-    "id",
-    "title",
-    "form",
-    "updated_at",
-    "space_id",
-    "word_count",
-    "tags"
-  ],
-  "table_columns": {
-    "entries": [
-      "id",
-      "title",
-      "form",
-      "updated_at",
-      "space_id",
-      "word_count",
-      "tags",
-      "properties",
-      "links",
-      "assets"
-    ],
-    "links": ["id", "source", "target", "kind"],
-    "assets": ["id", "entry_id", "name", "path"]
-  },
   "lint": {
     "require_select": true,
     "require_from": true,


### PR DESCRIPTION
## Summary

- Fix frontend search SQL sessions to use backend-owned, stable FormId and FieldId SQL identities.
- Keep SQL session rows generic at the client boundary and explicitly map `_ugoite_*` and `field_*` columns for Entry cards.
- Reject arbitrary SQL projections that are not valid Entry projections instead of rendering empty cards.
- Keep Quick Search as a minimal, dedicated DTO with one backend scan and no SQL-session or Entry-list enrichment.
- Remove legacy `entries`/`links`/`assets` SQL schema suggestions and update successful Saved SQL fixtures to the Form relation contract.
- Preserve the internal Space checkpoint format version at 1 per #1830 while applying the breaking `form_relation` structure change without migration or compatibility readers.

## Related Issue (required)

closes #1854

## Testing

- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
- [x] `mise run test`
- [x] `cargo test -p ugoite-iceberg --test checkpoint --test test_sql_sessions`
- [x] Frontend SQL/session/search regression tests
- [x] Legacy SQL session rejection and non-Entry SQL projection error tests
- [ ] `mise run e2e:smoke` (not run locally; requires the E2E container image)
