### PR TITLE
fix(frontend): unify account settings navigation

### DIFF
--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -15,7 +15,7 @@ const labels = {
   },
 } as const;
 
-export function AccountMenu() {
+export function AccountMenu(props: { settingsHref?: string } = {}) {
   const [open, setOpen] = createSignal(false);
   const copy = () => labels[locale() === "ja" ? "ja" : "en"];
 
@@ -40,7 +40,7 @@ export function AccountMenu() {
         <div class="accountMenuPanel" role="menu">
           <div class="accountMenuTitle">{copy().account}</div>
           <a
-            href="/settings/security"
+            href={props.settingsHref ?? "/settings/security"}
             role="menuitem"
             onClick={() => setOpen(false)}
           >

--- a/frontend/src/components/SpaceShell.test.tsx
+++ b/frontend/src/components/SpaceShell.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setLocale } from "~/lib/i18n";
@@ -52,6 +52,21 @@ describe("v5 SpaceShell", () => {
     for (const link of screen.getAllByRole("link", { name: "Forms" })) {
       expect(link).toHaveClass("active");
     }
+  });
+  it("opens account settings inside the current Space settings navigation", () => {
+    render(() => (
+      <SpaceShell spaceId="my-space" activeNavigation="home">
+        <p>Content</p>
+      </SpaceShell>
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Account" }));
+
+    expect(screen.getByRole("menuitem", { name: "Account settings" }))
+      .toHaveAttribute(
+        "href",
+        "/spaces/my-space/settings?section=credentials",
+      );
   });
   it("offers the other available spaces in the workspace selector", () => {
     render(() => (

--- a/frontend/src/components/SpaceShell.tsx
+++ b/frontend/src/components/SpaceShell.tsx
@@ -137,7 +137,9 @@ export function SpaceShell(props: SpaceShellProps) {
             <UiIcon name="menu" />
           </button>
           <div class="crumbTop">{crumb()}</div>
-          <AccountMenu />
+          <AccountMenu
+            settingsHref={`/spaces/${props.spaceId}/settings?section=credentials`}
+          />
         </header>
         <div class="content">{props.children}</div>
       </section>


### PR DESCRIPTION
## Summary

- Route account-menu settings from every Space view through the canonical Space settings page with Credentials selected.
- Keep the existing settings sidebar visible so General, Members, Agents, Credentials, and Storage remain available from the same destination.
- Add a frontend regression test for the account-settings destination.

## Related Issue (required)

closes #1860

## Testing

- [x] `deno task --cwd frontend test src/components/SpaceShell.test.tsx`
- [x] `deno task frontend:test`
- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
