### PR TITLE
fix: explain unsupported Form field type changes

### DIFF
--- a/crates/ugoite-api-client/src/lib.rs
+++ b/crates/ugoite-api-client/src/lib.rs
@@ -1401,6 +1401,37 @@ mod tests {
     }
 
     #[test]
+    fn test_api_req_api_001_preserves_unsupported_form_type_change_details() {
+        let error = decode_response(
+            "form.upsert",
+            ApiResponse {
+                status: 422,
+                status_text: "Unprocessable Entity".into(),
+                headers: vec![],
+                body: json!({
+                    "code": "FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED",
+                    "message": "Changing the type of existing Form field 'time' from 'timestamp' to 'date' is not supported; create a new field instead"
+                })
+                .to_string(),
+            },
+        )
+        .expect_err("unsupported Form type changes must fail");
+
+        assert_eq!(
+            error.message,
+            "Failed to create form: Changing the type of existing Form field 'time' from 'timestamp' to 'date' is not supported; create a new field instead"
+        );
+        assert_eq!(
+            error
+                .payload
+                .as_deref()
+                .and_then(|payload| payload.get("code"))
+                .and_then(Value::as_str),
+            Some("FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED")
+        );
+    }
+
+    #[test]
     fn test_api_req_api_001_uses_status_text_for_non_message_detail_values() {
         let error = decode_response(
             "auth.get_config",

--- a/crates/ugoite-core/src/error.rs
+++ b/crates/ugoite-core/src/error.rs
@@ -33,6 +33,7 @@ pub enum ErrorCode {
     SqlSessionExpired,
     ReindexNotImplemented,
     StorageConnectionFailed,
+    FormFieldTypeChangeNotSupported,
     InvalidInput,
 }
 
@@ -58,6 +59,7 @@ impl ErrorCode {
             Self::SqlSessionExpired => "SQL_SESSION_EXPIRED",
             Self::ReindexNotImplemented => "REINDEX_NOT_IMPLEMENTED",
             Self::StorageConnectionFailed => "STORAGE_CONNECTION_FAILED",
+            Self::FormFieldTypeChangeNotSupported => "FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED",
             Self::InvalidInput => "INVALID_INPUT",
         }
     }
@@ -90,6 +92,22 @@ impl AppError {
 
     pub fn invalid_input(code: ErrorCode, message: impl Into<String>) -> Self {
         Self::new(ErrorKind::InvalidInput, code, message)
+    }
+
+    pub fn form_field_type_change_not_supported(
+        field_name: impl Into<String>,
+        source_type: impl Into<String>,
+        target_type: impl Into<String>,
+    ) -> Self {
+        let field_name = field_name.into();
+        let source_type = source_type.into();
+        let target_type = target_type.into();
+        Self::invalid_input(
+            ErrorCode::FormFieldTypeChangeNotSupported,
+            format!(
+                "Changing the type of existing Form field '{field_name}' from '{source_type}' to '{target_type}' is not supported; create a new field instead"
+            ),
+        )
     }
 
     pub fn forbidden(message: impl Into<String>) -> Self {

--- a/crates/ugoite-domain/src/form.rs
+++ b/crates/ugoite-domain/src/form.rs
@@ -71,15 +71,6 @@ impl FieldType {
             Self::RowReference => "row_reference",
         }
     }
-
-    pub fn can_widen_to(&self, target: &Self) -> bool {
-        self == target
-            || matches!(
-                (self, target),
-                (Self::Integer, Self::Long)
-                    | (Self::Integer | Self::Long | Self::Float, Self::Double)
-            )
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -242,18 +233,14 @@ impl FormChangeSet {
                 FormChange::ChangeRequired { .. } => Compatibility::Compatible,
                 FormChange::ChangeFieldType {
                     field_id,
-                    field_type,
+                    ..
                 } => {
-                    let source = current
+                    current
                         .fields
                         .iter()
                         .find(|field| field.id == *field_id)
                         .ok_or(DomainError::UnknownField(*field_id))?;
-                    if source.field_type.can_widen_to(field_type) {
-                        Compatibility::Compatible
-                    } else {
-                        Compatibility::Breaking
-                    }
+                    Compatibility::Breaking
                 }
             };
             result = result.max(compatibility);

--- a/crates/ugoite-domain/src/form.rs
+++ b/crates/ugoite-domain/src/form.rs
@@ -231,10 +231,7 @@ impl FormChangeSet {
                 | FormChange::DeprecateField { .. }
                 | FormChange::RestoreField { .. } => Compatibility::Compatible,
                 FormChange::ChangeRequired { .. } => Compatibility::Compatible,
-                FormChange::ChangeFieldType {
-                    field_id,
-                    ..
-                } => {
+                FormChange::ChangeFieldType { field_id, .. } => {
                     current
                         .fields
                         .iter()

--- a/crates/ugoite-domain/src/form.rs
+++ b/crates/ugoite-domain/src/form.rs
@@ -48,6 +48,30 @@ pub enum FieldType {
 }
 
 impl FieldType {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Markdown => "markdown",
+            Self::Sql => "sql",
+            Self::Boolean => "boolean",
+            Self::Integer => "integer",
+            Self::Long => "long",
+            Self::Float => "float",
+            Self::Double => "double",
+            Self::Date => "date",
+            Self::Time => "time",
+            Self::Timestamp => "timestamp",
+            Self::TimestampTz => "timestamp_tz",
+            Self::TimestampNs => "timestamp_ns",
+            Self::TimestampTzNs => "timestamp_tz_ns",
+            Self::Uuid => "uuid",
+            Self::Binary => "binary",
+            Self::List => "list",
+            Self::ObjectList => "object_list",
+            Self::RowReference => "row_reference",
+        }
+    }
+
     pub fn can_widen_to(&self, target: &Self) -> bool {
         self == target
             || matches!(

--- a/crates/ugoite-domain/tests/test_iceberg_native_domain.rs
+++ b/crates/ugoite-domain/tests/test_iceberg_native_domain.rs
@@ -96,6 +96,31 @@ fn required_addition_is_forward_compatible_and_narrowing_is_breaking() {
 }
 
 #[test]
+fn every_existing_form_field_type_change_is_breaking_before_v1() {
+    for (source, target) in [
+        (FieldType::Integer, FieldType::Long),
+        (FieldType::Integer, FieldType::Double),
+        (FieldType::Long, FieldType::Double),
+        (FieldType::Float, FieldType::Double),
+    ] {
+        let mut original = form();
+        original.fields[0].field_type = source;
+        let changes = FormChangeSet {
+            form_id: original.id,
+            expected_version: Some(original.version),
+            changes: vec![FormChange::ChangeFieldType {
+                field_id: field_id(100),
+                field_type: target,
+            }],
+        };
+        assert_eq!(
+            changes.compatibility(&original).unwrap(),
+            Compatibility::Breaking
+        );
+    }
+}
+
+#[test]
 fn revision_validation_enforces_versions_parent_and_tombstones() {
     let form = form();
     let first = EntryRevision {

--- a/crates/ugoite-iceberg/src/form.rs
+++ b/crates/ugoite-iceberg/src/form.rs
@@ -516,27 +516,7 @@ pub(crate) fn from_domain_form(form: &FormDefinition) -> Value {
 }
 
 fn domain_field_type_name(field_type: &FieldType) -> &'static str {
-    match field_type {
-        FieldType::String => "string",
-        FieldType::Markdown => "markdown",
-        FieldType::Sql => "sql",
-        FieldType::Boolean => "boolean",
-        FieldType::Integer => "integer",
-        FieldType::Long => "long",
-        FieldType::Float => "float",
-        FieldType::Double => "double",
-        FieldType::Date => "date",
-        FieldType::Time => "time",
-        FieldType::Timestamp => "timestamp",
-        FieldType::TimestampTz => "timestamp_tz",
-        FieldType::TimestampNs => "timestamp_ns",
-        FieldType::TimestampTzNs => "timestamp_tz_ns",
-        FieldType::Uuid => "uuid",
-        FieldType::Binary => "binary",
-        FieldType::List => "list",
-        FieldType::ObjectList => "object_list",
-        FieldType::RowReference => "row_reference",
-    }
+    field_type.as_str()
 }
 
 fn normalize_form_definition_with_options(

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -65,7 +65,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, LazyLock, Mutex};
 use tokio::sync::Semaphore;
-use ugoite_core::error::{AppError, ErrorCode};
+use ugoite_core::error::AppError;
 use ugoite_domain::entry::{
     EntryAsset, EntryIntegrity, EntryLink, EntryMetadata, EntryOperation, EntryRevision, FieldValue,
 };
@@ -87,7 +87,7 @@ const NESTED_FIELD_ID_BASE: i32 = 1_000_000;
 fn unsupported_form_field_type_change(
     current: &FormDefinition,
     changes: &FormChangeSet,
-) -> AppError {
+) -> Result<AppError> {
     changes
         .changes
         .iter()
@@ -106,12 +106,7 @@ fn unsupported_form_field_type_change(
                 field_type.as_str(),
             ))
         })
-        .unwrap_or_else(|| {
-            AppError::invalid_input(
-                ErrorCode::FormFieldTypeChangeNotSupported,
-                "Changing the type of an existing Form field is not supported; create a new field instead",
-            )
-        })
+        .context("breaking Form compatibility did not contain a field type change")
 }
 
 /// A durable checkpoint or one of its immutable targets cannot be resolved.
@@ -599,7 +594,7 @@ impl IcebergWorkspace {
         }
         match changes.compatibility(&current)? {
             Compatibility::Breaking => {
-                return Err(unsupported_form_field_type_change(&current, changes).into())
+                return Err(unsupported_form_field_type_change(&current, changes)?.into())
             }
             Compatibility::MigrationRequired => {
                 return Err(anyhow!("Form change requires a populated migration plan"))
@@ -629,7 +624,9 @@ impl IcebergWorkspace {
             if physical.field_type.as_ref()
                 != &iceberg_type(&evolved_field.field_type, field.id.get())
             {
-                return Err(unsupported_form_field_type_change(&current, changes).into());
+                return Err(anyhow!(
+                    "Iceberg schema is inconsistent with the existing Form definition"
+                ));
             }
         }
         if let Some(space_catalog) = &self.space_catalog {

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -65,10 +65,13 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, LazyLock, Mutex};
 use tokio::sync::Semaphore;
+use ugoite_core::error::{AppError, ErrorCode};
 use ugoite_domain::entry::{
     EntryAsset, EntryIntegrity, EntryLink, EntryMetadata, EntryOperation, EntryRevision, FieldValue,
 };
-use ugoite_domain::form::{Compatibility, FieldType, FormChangeSet, FormDefinition, FormField};
+use ugoite_domain::form::{
+    Compatibility, FieldType, FormChange, FormChangeSet, FormDefinition, FormField,
+};
 use ugoite_domain::id::{validate_checkpoint_name, FormId, RevisionId, SpaceId};
 use ugoite_storage::{operator_from_uri, SpaceCatalogStore};
 use uuid::Uuid;
@@ -80,6 +83,36 @@ const FORM_VERSION_PROPERTY: &str = "ugoite.form.version";
 const TARGET_FILE_SIZE_PROPERTY: &str = "write.target-file-size-bytes";
 const FIRST_FORM_FIELD_ID: i32 = 100;
 const NESTED_FIELD_ID_BASE: i32 = 1_000_000;
+
+fn unsupported_form_field_type_change(
+    current: &FormDefinition,
+    changes: &FormChangeSet,
+) -> AppError {
+    changes
+        .changes
+        .iter()
+        .find_map(|change| {
+            let FormChange::ChangeFieldType {
+                field_id,
+                field_type,
+            } = change
+            else {
+                return None;
+            };
+            let source = current.fields.iter().find(|field| field.id == *field_id)?;
+            Some(AppError::form_field_type_change_not_supported(
+                &source.name,
+                source.field_type.as_str(),
+                field_type.as_str(),
+            ))
+        })
+        .unwrap_or_else(|| {
+            AppError::invalid_input(
+                ErrorCode::FormFieldTypeChangeNotSupported,
+                "Changing the type of an existing Form field is not supported; create a new field instead",
+            )
+        })
+}
 
 /// A durable checkpoint or one of its immutable targets cannot be resolved.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -566,9 +599,7 @@ impl IcebergWorkspace {
         }
         match changes.compatibility(&current)? {
             Compatibility::Breaking => {
-                return Err(anyhow!(
-                    "breaking Form change requires an explicit major migration"
-                ))
+                return Err(unsupported_form_field_type_change(&current, changes).into())
             }
             Compatibility::MigrationRequired => {
                 return Err(anyhow!("Form change requires a populated migration plan"))
@@ -598,9 +629,7 @@ impl IcebergWorkspace {
             if physical.field_type.as_ref()
                 != &iceberg_type(&evolved_field.field_type, field.id.get())
             {
-                return Err(anyhow!(
-                    "Iceberg field type changes require an explicit migration"
-                ));
+                return Err(unsupported_form_field_type_change(&current, changes).into());
             }
         }
         if let Some(space_catalog) = &self.space_catalog {

--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -352,31 +352,56 @@ async fn existing_form_field_type_changes_are_typed_and_leave_form_unchanged() -
     .await?;
     let mut form = form();
     form.fields[0].field_type = FieldType::Timestamp;
+    form.fields.push(FormField {
+        id: FieldId::new(101).unwrap(),
+        name: "count".into(),
+        field_type: FieldType::Integer,
+        required: false,
+        label: None,
+        description: None,
+        semantic_role: None,
+        reference_form: None,
+        validation: None,
+        enum_values: Vec::new(),
+        deprecated: false,
+    });
     create_form(&workspace, &form).await?;
+    let checkpoint_before = workspace.capture_checkpoint().await?;
 
-    let error = evolve_form(
-        &workspace,
-        &FormChangeSet {
-            form_id: form.id,
-            expected_version: Some(form.version),
-            changes: vec![FormChange::ChangeFieldType {
-                field_id: FieldId::new(100).unwrap(),
-                field_type: FieldType::Date,
-            }],
-        },
-    )
-    .await
-    .expect_err("existing Form field type changes must be rejected");
-    let app_error = error
-        .downcast_ref::<AppError>()
-        .expect("type-change rejection must remain a typed application error");
-    assert_eq!(app_error.kind(), ErrorKind::InvalidInput);
-    assert_eq!(app_error.code(), ErrorCode::FormFieldTypeChangeNotSupported);
-    assert_eq!(
-        app_error.message(),
-        "Changing the type of existing Form field 'title' from 'timestamp' to 'date' is not supported; create a new field instead"
-    );
-    assert_eq!(workspace.load_form(form.id).await?, form);
+    for (field_id, target_type, expected_message) in [
+        (
+            FieldId::new(100).unwrap(),
+            FieldType::Date,
+            "Changing the type of existing Form field 'title' from 'timestamp' to 'date' is not supported; create a new field instead",
+        ),
+        (
+            FieldId::new(101).unwrap(),
+            FieldType::Long,
+            "Changing the type of existing Form field 'count' from 'integer' to 'long' is not supported; create a new field instead",
+        ),
+    ] {
+        let error = evolve_form(
+            &workspace,
+            &FormChangeSet {
+                form_id: form.id,
+                expected_version: Some(form.version),
+                changes: vec![FormChange::ChangeFieldType {
+                    field_id,
+                    field_type: target_type,
+                }],
+            },
+        )
+        .await
+        .expect_err("existing Form field type changes must be rejected");
+        let app_error = error
+            .downcast_ref::<AppError>()
+            .expect("type-change rejection must remain a typed application error");
+        assert_eq!(app_error.kind(), ErrorKind::InvalidInput);
+        assert_eq!(app_error.code(), ErrorCode::FormFieldTypeChangeNotSupported);
+        assert_eq!(app_error.message(), expected_message);
+        assert_eq!(workspace.load_form(form.id).await?, form);
+        assert_eq!(workspace.capture_checkpoint().await?, checkpoint_before);
+    }
     Ok(())
 }
 

--- a/crates/ugoite-iceberg/tests/workspace.rs
+++ b/crates/ugoite-iceberg/tests/workspace.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use ugoite_core::error::{AppError, ErrorCode, ErrorKind};
 use ugoite_domain::entry::{
     EntryAsset, EntryIntegrity, EntryLink, EntryMetadata, EntryOperation, EntryRevision, FieldValue,
 };
@@ -338,6 +339,44 @@ async fn local_catalog_evolves_schema_bearing_changes() -> anyhow::Result<()> {
             .as_ref(),
         &iceberg::spec::Type::Primitive(iceberg::spec::PrimitiveType::Date),
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn existing_form_field_type_changes_are_typed_and_leave_form_unchanged() -> anyhow::Result<()>
+{
+    let workspace = IcebergWorkspace::memory_for_tests(
+        SpaceId::from(Uuid::from_u128(5)),
+        "memory://iceberg-unsupported-form-type-change",
+    )
+    .await?;
+    let mut form = form();
+    form.fields[0].field_type = FieldType::Timestamp;
+    create_form(&workspace, &form).await?;
+
+    let error = evolve_form(
+        &workspace,
+        &FormChangeSet {
+            form_id: form.id,
+            expected_version: Some(form.version),
+            changes: vec![FormChange::ChangeFieldType {
+                field_id: FieldId::new(100).unwrap(),
+                field_type: FieldType::Date,
+            }],
+        },
+    )
+    .await
+    .expect_err("existing Form field type changes must be rejected");
+    let app_error = error
+        .downcast_ref::<AppError>()
+        .expect("type-change rejection must remain a typed application error");
+    assert_eq!(app_error.kind(), ErrorKind::InvalidInput);
+    assert_eq!(app_error.code(), ErrorCode::FormFieldTypeChangeNotSupported);
+    assert_eq!(
+        app_error.message(),
+        "Changing the type of existing Form field 'title' from 'timestamp' to 'date' is not supported; create a new field instead"
+    );
+    assert_eq!(workspace.load_form(form.id).await?, form);
     Ok(())
 }
 

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -4431,4 +4431,20 @@ mod authentication_regression_tests {
         )
         .is_err());
     }
+
+    #[test]
+    fn unsupported_form_field_type_changes_are_client_errors_with_actionable_details() {
+        let error = ApiError::from_core(
+            AppError::form_field_type_change_not_supported("time", "timestamp", "date").into(),
+        );
+
+        assert_eq!(error.status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(
+            error.detail,
+            json!({
+                "code": "FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED",
+                "message": "Changing the type of existing Form field 'time' from 'timestamp' to 'date' is not supported; create a new field instead"
+            })
+        );
+    }
 }

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -4365,6 +4365,8 @@ pub fn openapi_snapshot() -> Value {
 #[cfg(test)]
 mod authentication_regression_tests {
     use super::*;
+    use axum::{body::Body, http::Request, routing::post};
+    use tower::ServiceExt;
 
     fn token_claims(sub: Uuid, actor_principal_id: Option<Uuid>) -> AccessTokenClaims {
         AccessTokenClaims {
@@ -4446,5 +4448,89 @@ mod authentication_regression_tests {
                 "message": "Changing the type of existing Form field 'time' from 'timestamp' to 'date' is not supported; create a new field instead"
             })
         );
+    }
+
+    #[tokio::test]
+    async fn form_type_change_route_returns_422_with_the_workspace_error() -> anyhow::Result<()> {
+        let state = AppState::new_for_tests("memory://server-form-type-change-route")?;
+        let principal_id = Uuid::from_u128(1859);
+        let space_id = state
+            .service
+            .create_space_for_principal("form-type-change", principal_id, "Route test")
+            .await?
+            .to_string();
+        let form_id = Uuid::from_u128(1862);
+        let original = json!({
+            "id": form_id,
+            "name": "Meeting",
+            "version": 1,
+            "fields": {
+                "time": {"id": 100, "type": "timestamp", "required": false}
+            },
+            "allow_extra_attributes": "deny"
+        });
+        state.service.upsert_form(&space_id, &original).await?;
+
+        let desired = json!({
+            "id": form_id,
+            "name": "Meeting",
+            "version": 1,
+            "fields": {
+                "time": {"id": 100, "type": "date", "required": false}
+            },
+            "allow_extra_attributes": "deny"
+        });
+        let space_uid = state.service.space_uid(&space_id).await?;
+        let identity = RequestIdentityContext {
+            request_identity: RequestIdentity {
+                subject: AuthenticatedSubject::HumanAccount {
+                    account_id: principal_id,
+                },
+                actor: Actor::Human {
+                    account_id: principal_id,
+                },
+                credential_id: Uuid::from_u128(1863),
+                authentication_method: RequestAuthenticationMethod::Passkey,
+                assurance: AssuranceLevel::PhishingResistant,
+                constraints: CredentialConstraints::default(),
+                session_id: None,
+            },
+            account_id: principal_id,
+            display_name: "Route test".into(),
+            node_admin: false,
+            token_principal_id: Some(principal_id),
+            token_actor_principal_id: None,
+            token_space_uid: Some(space_uid),
+            token_actions: Some(
+                ["read", "create", "update"]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+            ),
+            recent_passkey: true,
+        };
+        let route = Router::new()
+            .route("/spaces/{space_id}/forms", post(upsert_form))
+            .layer(Extension(identity))
+            .with_state(state.clone());
+        let response = route
+            .oneshot(
+                Request::post(format!("/spaces/{space_id}/forms"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(desired.to_string()))?,
+            )
+            .await
+            .expect("Form route response");
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+        let body: Value = serde_json::from_slice(&body)?;
+        assert_eq!(body["code"], "FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED");
+        assert_eq!(
+            body["message"],
+            "Changing the type of existing Form field 'time' from 'timestamp' to 'date' is not supported; create a new field instead"
+        );
+        let stored = state.service.get_form(&space_id, "Meeting").await?;
+        assert_eq!(stored["fields"]["time"]["type"], "timestamp");
+        Ok(())
     }
 }

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -50,3 +50,8 @@ response.
 Errors are structured JSON. Authentication failures use 401; valid identities
 lacking Space/token/resource permission use 403; stale/used one-time credentials
 fail without revealing stored secret material.
+
+Form evolution that changes the type of an existing field is intentionally
+unsupported before v1. The server returns HTTP 422 with code
+`FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED` and a message naming the field and
+recommending a new field; it does not return this expected rejection as a 500.

--- a/docs/spec/data-model/overview.md
+++ b/docs/spec/data-model/overview.md
@@ -50,8 +50,9 @@ Form-level ACL fields are not persisted or enforced in this release. Field names
 
 Each Form has an immutable UUID and one physical `form_<uuid>` Iceberg table.
 The display name is mutable metadata. Field IDs are stable Iceberg field IDs;
-rename keeps the ID, optional additions do not rewrite data, and destructive
-changes require an explicit migration.
+rename keeps the ID, optional additions do not rewrite data, and changing the
+type of an existing field is rejected. Before v1, create a new field when a
+different type is needed; no migration compatibility path is exposed.
 
 The table is an append-only revision log. Common columns include `entry_id`,
 `revision_id`, `parent_revision_id`, `entry_version`, `operation`,

--- a/frontend/src/components/create-dialogs.test.tsx
+++ b/frontend/src/components/create-dialogs.test.tsx
@@ -2369,6 +2369,40 @@ describe("EditFormDialog", () => {
     );
   });
 
+  it("REQ-FE-043: displays the shared unsupported field type error", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(
+      new Error(
+        "Failed to create form: Changing the type of existing Form field 'time' from 'timestamp' to 'date' is not supported; create a new field instead",
+      ),
+    );
+    const timestampForm: Form = {
+      ...mockForm,
+      fields: {
+        time: { type: "timestamp", required: false },
+      },
+    };
+
+    render(() => (
+      <EditFormDialog
+        open={true}
+        entryForm={timestampForm}
+        columnTypes={["timestamp", "date"]}
+        formNames={["ExistingForm"]}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    ));
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "date" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Changing the type of existing Form field 'time' from 'timestamp' to 'date' is not supported; create a new field instead",
+    );
+  });
+
   it("REQ-FE-032: removes a column from the edit dialog", async () => {
     const onSubmit = vi.fn();
     const onClose = vi.fn();


### PR DESCRIPTION
## Summary

- Return `FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED` as a typed HTTP 422 invalid-input error when an existing Form field type changes.
- Enforce the pre-v1 no-type-evolution policy in the domain compatibility decision; leave Iceberg schema mismatches as internal consistency failures.
- Surface the field name, source and target types, and create-new-field guidance through the backend, shared API client, frontend, and CLI paths.
- Prove that rejected changes do not publish a new Catalog Head or mutate append-only checkpoint coordinates.

## Related Issue (required)

closes #1859

## Testing

- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run check`
- [x] `mise run test:rust`
- [x] `deno task test src/components/create-dialogs.test.tsx`
- [x] `mise run test:docsite`
- [x] Domain coverage for all former widening paths and server route coverage for HTTP 422
