### PR TITLE
fix: make Space invitation acceptance idempotent

### DIFF
--- a/crates/ugoite-identity/src/node_identity.rs
+++ b/crates/ugoite-identity/src/node_identity.rs
@@ -164,7 +164,17 @@ pub struct AccountInvitation {
     pub accepted_account_id: Option<Uuid>,
     #[serde(default)]
     pub accepted_principal_id: Option<Uuid>,
+    #[serde(default)]
+    pub acceptance_kind: Option<InvitationAcceptanceKind>,
     pub created_by: Uuid,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvitationAcceptanceKind {
+    ExistingAccount,
+    PasskeyRegistration,
+    Oidc,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -395,6 +405,16 @@ pub struct InvitationRegistrationFinish {
     pub account: HumanAccount,
     pub session_id: String,
     pub invitation: AccountInvitation,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum InvitationRegistrationStart {
+    Register {
+        challenge_id: Uuid,
+        public_key: Box<CreationChallengeResponse>,
+    },
+    Resume,
 }
 
 #[derive(Debug)]
@@ -780,7 +800,7 @@ impl NodeIdentityService {
     pub async fn start_invitation_registration(
         &self,
         invitation_token: &str,
-    ) -> Result<RegistrationStart> {
+    ) -> Result<InvitationRegistrationStart> {
         let _guard = self.state_lock.lock().await;
         let mut state = self.read_state().await?;
         let invitation = state
@@ -789,10 +809,22 @@ impl NodeIdentityService {
             .find(|invitation| invitation.token_hash == token_hash(invitation_token))
             .cloned()
             .ok_or_else(|| anyhow!("invitation is invalid"))?;
-        validate_expiry(&invitation.expires_at, "invitation")?;
         if invitation.used_at.is_some() {
+            if matches!(
+                invitation.acceptance_kind,
+                Some(InvitationAcceptanceKind::PasskeyRegistration)
+            ) && invitation.accepted_account_id.is_some()
+                && invitation.accepted_principal_id.is_some()
+                && invitation
+                    .accepted_account_id
+                    .and_then(|account_id| state.accounts.get(&account_id))
+                    .is_some_and(|account| matches!(account.status, AccountStatus::Active))
+            {
+                return Ok(InvitationRegistrationStart::Resume);
+            }
             bail!("invitation was already used");
         }
+        validate_expiry(&invitation.expires_at, "invitation")?;
         let account_id = Uuid::now_v7();
         let (mut public_key, registration) = self
             .webauthn
@@ -821,9 +853,9 @@ impl NodeIdentityService {
             },
         );
         self.write_state(&state).await?;
-        Ok(RegistrationStart {
+        Ok(InvitationRegistrationStart::Register {
             challenge_id,
-            public_key,
+            public_key: Box::new(public_key),
         })
     }
 
@@ -837,7 +869,8 @@ impl NodeIdentityService {
         let mut state = self.read_state().await?;
         let challenge = state
             .registration_challenges
-            .remove(&challenge_id)
+            .get(&challenge_id)
+            .cloned()
             .ok_or_else(|| anyhow!("unknown or consumed registration challenge"))?;
         validate_expiry(&challenge.expires_at, "registration challenge")?;
         let RegistrationPurpose::Invitation { invitation_id } = challenge.purpose else {
@@ -900,7 +933,9 @@ impl NodeIdentityService {
         invitation.used_at = Some(timestamp(Utc::now()));
         invitation.accepted_account_id = Some(account.account_id);
         invitation.accepted_principal_id = Some(Uuid::now_v7());
+        invitation.acceptance_kind = Some(InvitationAcceptanceKind::PasskeyRegistration);
         let invitation = invitation.clone();
+        state.registration_challenges.remove(&challenge_id);
         let session_id = self
             .create_session(
                 &state,
@@ -910,6 +945,61 @@ impl NodeIdentityService {
             )
             .await?;
         self.write_state(&state).await?;
+        Ok(InvitationRegistrationFinish {
+            account,
+            session_id,
+            invitation,
+        })
+    }
+
+    pub async fn resume_invitation_registration(
+        &self,
+        invitation_token: &str,
+    ) -> Result<InvitationRegistrationFinish> {
+        let _guard = self.state_lock.lock().await;
+        let state = self.read_state().await?;
+        let invitation = state
+            .invitations
+            .values()
+            .find(|invitation| invitation.token_hash == token_hash(invitation_token))
+            .cloned()
+            .ok_or_else(|| anyhow!("invitation is invalid"))?;
+        if !matches!(
+            invitation.acceptance_kind,
+            Some(InvitationAcceptanceKind::PasskeyRegistration)
+        ) || invitation.used_at.is_none()
+        {
+            bail!("invitation registration cannot be resumed");
+        }
+        let account_id = invitation
+            .accepted_account_id
+            .ok_or_else(|| anyhow!("invitation registration claim is incomplete"))?;
+        let account = state
+            .accounts
+            .get(&account_id)
+            .filter(|account| matches!(account.status, AccountStatus::Active))
+            .cloned()
+            .ok_or_else(|| anyhow!("invitation registration claim is incomplete"))?;
+        let method_id = state
+            .authentication_methods
+            .values()
+            .find(|method| {
+                method.account_id == account_id
+                    && matches!(method.kind, AuthenticationMethodKind::Passkey)
+                    && state.passkeys.values().any(|passkey| {
+                        passkey.account_id == account_id && passkey.method_id == method.method_id
+                    })
+            })
+            .map(|method| method.method_id)
+            .ok_or_else(|| anyhow!("invitation registration claim is incomplete"))?;
+        let session_id = self
+            .create_session(
+                &state,
+                account_id,
+                method_id,
+                AssuranceLevel::PhishingResistant,
+            )
+            .await?;
         Ok(InvitationRegistrationFinish {
             account,
             session_id,
@@ -1593,6 +1683,7 @@ impl NodeIdentityService {
             used_at: None,
             accepted_account_id: None,
             accepted_principal_id: None,
+            acceptance_kind: None,
             created_by: actor,
         };
         state.invitations.insert(invitation_id, invitation.clone());
@@ -1633,26 +1724,21 @@ impl NodeIdentityService {
                 .invitations
                 .get_mut(&invitation_id)
                 .ok_or_else(|| anyhow!("invitation is invalid"))?;
-            validate_expiry(&invitation.expires_at, "invitation")?;
             if invitation.used_at.is_some() {
                 if invitation.accepted_account_id == Some(account_id)
                     && invitation.accepted_principal_id.is_some()
                 {
-                    if let Some(existing_principal_id) = existing_principal_id {
-                        if invitation.accepted_principal_id != Some(existing_principal_id) {
-                            invitation.accepted_principal_id = Some(existing_principal_id);
-                            write_state = true;
-                        }
-                    }
                     invitation.clone()
                 } else {
                     bail!("invitation is invalid");
                 }
             } else {
+                validate_expiry(&invitation.expires_at, "invitation")?;
                 invitation.used_at = Some(timestamp(Utc::now()));
                 invitation.accepted_account_id = Some(account_id);
                 invitation.accepted_principal_id =
                     Some(existing_principal_id.unwrap_or_else(Uuid::now_v7));
+                invitation.acceptance_kind = Some(InvitationAcceptanceKind::ExistingAccount);
                 write_state = true;
                 invitation.clone()
             }
@@ -2431,19 +2517,22 @@ impl NodeIdentityService {
                     .values_mut()
                     .find(|invitation| invitation.token_hash == invitation_hash)
                     .ok_or_else(|| anyhow!("invitation is invalid"))?;
-                validate_expiry(&invitation.expires_at, "invitation")?;
-                if invitation.used_at.is_some()
-                    && invitation.accepted_account_id != Some(account_id)
-                {
-                    bail!("invitation is invalid");
-                }
-                if invitation.used_at.is_none() {
+                if invitation.used_at.is_some() {
+                    if invitation.accepted_account_id != Some(account_id)
+                        || !matches!(
+                            invitation.acceptance_kind,
+                            Some(InvitationAcceptanceKind::Oidc)
+                        )
+                    {
+                        bail!("invitation is invalid");
+                    }
+                } else {
+                    validate_expiry(&invitation.expires_at, "invitation")?;
                     invitation.used_at = Some(timestamp(Utc::now()));
                     invitation.accepted_account_id = Some(account_id);
                     invitation.accepted_principal_id =
                         Some(existing_principal_id.unwrap_or_else(Uuid::now_v7));
-                } else if let Some(existing_principal_id) = existing_principal_id {
-                    invitation.accepted_principal_id = Some(existing_principal_id);
+                    invitation.acceptance_kind = Some(InvitationAcceptanceKind::Oidc);
                 }
                 Some(invitation.clone())
             } else {
@@ -2476,6 +2565,7 @@ impl NodeIdentityService {
             invitation.used_at = Some(timestamp(Utc::now()));
             invitation.accepted_account_id = Some(account.account_id);
             invitation.accepted_principal_id = Some(Uuid::now_v7());
+            invitation.acceptance_kind = Some(InvitationAcceptanceKind::Oidc);
             let invitation_copy = invitation.clone();
             state.accounts.insert(account.account_id, account.clone());
             (account, Some(invitation_copy))
@@ -3183,6 +3273,77 @@ mod tests {
                 .count(),
             1
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn claimed_invitation_principal_is_immutable_and_retry_ignores_expiry() -> Result<()> {
+        let service = NodeIdentityService::new_for_tests("localhost", "http://localhost:8000")?;
+        service.bootstrap_if_needed().await?;
+        let account_id = Uuid::now_v7();
+        let other_account_id = Uuid::now_v7();
+        let space_uid = Uuid::now_v7();
+        let principal_id = Uuid::now_v7();
+        let mut state = service.read_state().await?;
+        state.accounts.insert(
+            account_id,
+            HumanAccount {
+                account_id,
+                display_name: "Existing owner".to_string(),
+                status: AccountStatus::Active,
+                created_at: timestamp(Utc::now()),
+                node_roles: BTreeSet::new(),
+            },
+        );
+        state.accounts.insert(
+            other_account_id,
+            HumanAccount {
+                account_id: other_account_id,
+                display_name: "Other account".to_string(),
+                status: AccountStatus::Active,
+                created_at: timestamp(Utc::now()),
+                node_roles: BTreeSet::new(),
+            },
+        );
+        state.bindings.push(PrincipalBinding {
+            space_uid,
+            principal_id,
+            node_account_id: account_id,
+            binding_method: BindingMethod::Setup,
+        });
+        service.write_state(&state).await?;
+        let (_, token) = service
+            .issue_invitation(
+                account_id,
+                "Invited owner",
+                Some(space_uid),
+                Some("viewer".to_string()),
+            )
+            .await?;
+
+        let (_, first) = service
+            .accept_invitation_for_account(&token, account_id)
+            .await?;
+        let claimed_principal = first.accepted_principal_id;
+        assert!(service
+            .accept_invitation_for_account(&token, other_account_id)
+            .await
+            .is_err());
+        let replacement_principal = Uuid::now_v7();
+        let mut state = service.read_state().await?;
+        let invitation = state
+            .invitations
+            .get_mut(&first.invitation_id)
+            .expect("issued invitation");
+        invitation.expires_at = "2000-01-01T00:00:00.000Z".to_string();
+        invitation.accepted_principal_id = Some(replacement_principal);
+        service.write_state(&state).await?;
+
+        let (_, retry) = service
+            .accept_invitation_for_account(&token, account_id)
+            .await?;
+        assert_eq!(retry.accepted_principal_id, Some(replacement_principal));
+        assert_ne!(retry.accepted_principal_id, claimed_principal);
         Ok(())
     }
 

--- a/crates/ugoite-identity/src/node_identity.rs
+++ b/crates/ugoite-identity/src/node_identity.rs
@@ -351,6 +351,19 @@ pub struct NodeState {
     pub oidc_attempts: BTreeMap<String, OidcLoginAttempt>,
 }
 
+fn bound_principal_for_account(
+    state: &NodeState,
+    space_uid: Option<Uuid>,
+    account_id: Uuid,
+) -> Option<Uuid> {
+    let space_uid = space_uid?;
+    state
+        .bindings
+        .iter()
+        .find(|binding| binding.space_uid == space_uid && binding.node_account_id == account_id)
+        .map(|binding| binding.principal_id)
+}
+
 #[derive(Debug, Serialize)]
 pub struct BootstrapResult {
     pub setup_secret: String,
@@ -1606,24 +1619,47 @@ impl NodeIdentityService {
             .find(|invitation| invitation.token_hash == token_hash(invitation_token))
             .map(|invitation| invitation.invitation_id)
             .ok_or_else(|| anyhow!("invitation is invalid"))?;
-        let invitation = state
-            .invitations
-            .get_mut(&invitation_id)
-            .ok_or_else(|| anyhow!("invitation is invalid"))?;
-        validate_expiry(&invitation.expires_at, "invitation")?;
-        if invitation.used_at.is_some() {
-            if invitation.accepted_account_id == Some(account_id)
-                && invitation.accepted_principal_id.is_some()
-            {
-                return Ok((account, invitation.clone()));
+        let existing_principal_id = bound_principal_for_account(
+            &state,
+            state
+                .invitations
+                .get(&invitation_id)
+                .and_then(|invitation| invitation.space_uid),
+            account_id,
+        );
+        let mut write_state = false;
+        let invitation = {
+            let invitation = state
+                .invitations
+                .get_mut(&invitation_id)
+                .ok_or_else(|| anyhow!("invitation is invalid"))?;
+            validate_expiry(&invitation.expires_at, "invitation")?;
+            if invitation.used_at.is_some() {
+                if invitation.accepted_account_id == Some(account_id)
+                    && invitation.accepted_principal_id.is_some()
+                {
+                    if let Some(existing_principal_id) = existing_principal_id {
+                        if invitation.accepted_principal_id != Some(existing_principal_id) {
+                            invitation.accepted_principal_id = Some(existing_principal_id);
+                            write_state = true;
+                        }
+                    }
+                    invitation.clone()
+                } else {
+                    bail!("invitation is invalid");
+                }
+            } else {
+                invitation.used_at = Some(timestamp(Utc::now()));
+                invitation.accepted_account_id = Some(account_id);
+                invitation.accepted_principal_id =
+                    Some(existing_principal_id.unwrap_or_else(Uuid::now_v7));
+                write_state = true;
+                invitation.clone()
             }
-            bail!("invitation is invalid");
+        };
+        if write_state {
+            self.write_state(&state).await?;
         }
-        invitation.used_at = Some(timestamp(Utc::now()));
-        invitation.accepted_account_id = Some(account_id);
-        invitation.accepted_principal_id = Some(Uuid::now_v7());
-        let invitation = invitation.clone();
-        self.write_state(&state).await?;
         Ok((account, invitation))
     }
 
@@ -1644,13 +1680,22 @@ impl NodeIdentityService {
         self.write_state(&state).await
     }
 
-    pub async fn principal_for_account(&self, space_uid: Uuid, account_id: Uuid) -> Result<Uuid> {
+    pub async fn binding_for_account(
+        &self,
+        space_uid: Uuid,
+        account_id: Uuid,
+    ) -> Result<Option<Uuid>> {
         let state = self.read_state().await?;
-        state
-            .bindings
-            .iter()
-            .find(|binding| binding.space_uid == space_uid && binding.node_account_id == account_id)
-            .map(|binding| binding.principal_id)
+        Ok(bound_principal_for_account(
+            &state,
+            Some(space_uid),
+            account_id,
+        ))
+    }
+
+    pub async fn principal_for_account(&self, space_uid: Uuid, account_id: Uuid) -> Result<Uuid> {
+        self.binding_for_account(space_uid, account_id)
+            .await?
             .ok_or_else(|| anyhow!("account is not bound to a principal in this space"))
     }
 
@@ -2374,6 +2419,13 @@ impl NodeIdentityService {
                 .cloned()
                 .ok_or_else(|| anyhow!("OIDC account is not active"))?;
             let invitation = if let Some(invitation_hash) = invitation_hash {
+                let invitation_space_uid = state
+                    .invitations
+                    .values()
+                    .find(|invitation| invitation.token_hash == invitation_hash)
+                    .and_then(|invitation| invitation.space_uid);
+                let existing_principal_id =
+                    bound_principal_for_account(&state, invitation_space_uid, account_id);
                 let invitation = state
                     .invitations
                     .values_mut()
@@ -2388,7 +2440,10 @@ impl NodeIdentityService {
                 if invitation.used_at.is_none() {
                     invitation.used_at = Some(timestamp(Utc::now()));
                     invitation.accepted_account_id = Some(account_id);
-                    invitation.accepted_principal_id = Some(Uuid::now_v7());
+                    invitation.accepted_principal_id =
+                        Some(existing_principal_id.unwrap_or_else(Uuid::now_v7));
+                } else if let Some(existing_principal_id) = existing_principal_id {
+                    invitation.accepted_principal_id = Some(existing_principal_id);
                 }
                 Some(invitation.clone())
             } else {
@@ -3070,6 +3125,64 @@ mod tests {
             .await?;
         assert_eq!(first.accepted_principal_id, retry.accepted_principal_id);
         assert!(first.used_at.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn existing_space_binding_accepts_invitation_without_creating_a_second_principal(
+    ) -> Result<()> {
+        let service = NodeIdentityService::new_for_tests("localhost", "http://localhost:8000")?;
+        service.bootstrap_if_needed().await?;
+        let account_id = Uuid::now_v7();
+        let space_uid = Uuid::now_v7();
+        let principal_id = Uuid::now_v7();
+        let mut state = service.read_state().await?;
+        state.accounts.insert(
+            account_id,
+            HumanAccount {
+                account_id,
+                display_name: "Existing owner".to_string(),
+                status: AccountStatus::Active,
+                created_at: timestamp(Utc::now()),
+                node_roles: BTreeSet::new(),
+            },
+        );
+        state.bindings.push(PrincipalBinding {
+            space_uid,
+            principal_id,
+            node_account_id: account_id,
+            binding_method: BindingMethod::Setup,
+        });
+        service.write_state(&state).await?;
+        let (_, token) = service
+            .issue_invitation(
+                account_id,
+                "Invited owner",
+                Some(space_uid),
+                Some("viewer".to_string()),
+            )
+            .await?;
+
+        let (_, invitation) = service
+            .accept_invitation_for_account(&token, account_id)
+            .await?;
+        assert_eq!(invitation.accepted_account_id, Some(account_id));
+        assert_eq!(invitation.accepted_principal_id, Some(principal_id));
+
+        let (_, retry) = service
+            .accept_invitation_for_account(&token, account_id)
+            .await?;
+        assert_eq!(retry.accepted_principal_id, Some(principal_id));
+        assert_eq!(
+            service
+                .read_state()
+                .await?
+                .bindings
+                .iter()
+                .filter(|binding| binding.space_uid == space_uid)
+                .count(),
+            1
+        );
         Ok(())
     }
 

--- a/crates/ugoite-identity/src/node_identity.rs
+++ b/crates/ugoite-identity/src/node_identity.rs
@@ -151,7 +151,8 @@ pub struct NodeAuditInput<'a> {
     pub safe_metadata: serde_json::Value,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AccountInvitation {
     pub invitation_id: Uuid,
     pub token_hash: String,
@@ -159,73 +160,8 @@ pub struct AccountInvitation {
     pub space_uid: Option<Uuid>,
     pub role: Option<String>,
     pub expires_at: String,
-    #[serde(default)]
     pub acceptance: Option<InvitationAcceptance>,
     pub created_by: Uuid,
-}
-
-impl<'de> Deserialize<'de> for AccountInvitation {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct AccountInvitationData {
-            invitation_id: Uuid,
-            token_hash: String,
-            display_name: String,
-            space_uid: Option<Uuid>,
-            role: Option<String>,
-            expires_at: String,
-            #[serde(default)]
-            acceptance: Option<InvitationAcceptance>,
-            #[serde(default)]
-            used_at: Option<String>,
-            #[serde(default)]
-            accepted_account_id: Option<Uuid>,
-            #[serde(default)]
-            accepted_principal_id: Option<Uuid>,
-            #[serde(default)]
-            acceptance_kind: Option<InvitationAcceptanceKind>,
-            created_by: Uuid,
-        }
-
-        let data = AccountInvitationData::deserialize(deserializer)?;
-        let acceptance = match data.acceptance {
-            Some(acceptance) => Some(acceptance),
-            None => match (
-                data.used_at,
-                data.accepted_account_id,
-                data.accepted_principal_id,
-                data.acceptance_kind,
-            ) {
-                (Some(claimed_at), Some(account_id), Some(principal_id), Some(kind)) => {
-                    Some(InvitationAcceptance::Pending {
-                        account_id,
-                        principal_id,
-                        kind,
-                        claimed_at,
-                    })
-                }
-                (None, None, None, None) => None,
-                _ => {
-                    return Err(serde::de::Error::custom(
-                        "invitation has an incomplete legacy acceptance claim",
-                    ));
-                }
-            },
-        };
-        Ok(Self {
-            invitation_id: data.invitation_id,
-            token_hash: data.token_hash,
-            display_name: data.display_name,
-            space_uid: data.space_uid,
-            role: data.role,
-            expires_at: data.expires_at,
-            acceptance,
-            created_by: data.created_by,
-        })
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -3052,6 +2988,93 @@ fn random_user_code() -> Result<String> {
 mod tests {
     use super::*;
     use ugoite_storage::operator_from_uri;
+
+    fn main_invitation_json(used: bool) -> serde_json::Value {
+        let account_id = Uuid::now_v7();
+        let principal_id = Uuid::now_v7();
+        let mut invitation = serde_json::json!({
+            "invitation_id": Uuid::now_v7(),
+            "token_hash": "token-hash",
+            "display_name": "Invited user",
+            "space_uid": Uuid::now_v7(),
+            "role": "viewer",
+            "expires_at": "2099-01-01T00:00:00.000Z",
+            "used_at": null,
+            "accepted_account_id": null,
+            "accepted_principal_id": null,
+            "created_by": Uuid::now_v7(),
+        });
+        if used {
+            invitation["used_at"] = serde_json::json!("2026-07-31T00:00:00.000Z");
+            invitation["accepted_account_id"] = serde_json::json!(account_id);
+            invitation["accepted_principal_id"] = serde_json::json!(principal_id);
+        }
+        invitation
+    }
+
+    #[test]
+    fn invitation_acceptance_states_round_trip() -> Result<()> {
+        let account_id = Uuid::now_v7();
+        let principal_id = Uuid::now_v7();
+        let states = vec![
+            None,
+            Some(InvitationAcceptance::Pending {
+                account_id,
+                principal_id,
+                kind: InvitationAcceptanceKind::ExistingAccount,
+                claimed_at: "2026-07-31T00:00:00.000Z".to_string(),
+            }),
+            Some(InvitationAcceptance::Completed {
+                account_id,
+                principal_id,
+                kind: InvitationAcceptanceKind::PasskeyRegistration,
+                claimed_at: "2026-07-31T00:00:00.000Z".to_string(),
+                completed_at: "2026-07-31T00:01:00.000Z".to_string(),
+            }),
+        ];
+
+        for acceptance in states {
+            let invitation = AccountInvitation {
+                invitation_id: Uuid::now_v7(),
+                token_hash: "token-hash".to_string(),
+                display_name: "Invited user".to_string(),
+                space_uid: Some(Uuid::now_v7()),
+                role: Some("viewer".to_string()),
+                expires_at: "2099-01-01T00:00:00.000Z".to_string(),
+                acceptance,
+                created_by: Uuid::now_v7(),
+            };
+            let encoded = serde_json::to_value(&invitation)?;
+            let decoded: AccountInvitation = serde_json::from_value(encoded.clone())?;
+            assert_eq!(serde_json::to_value(decoded)?, encoded);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn main_invitation_formats_are_rejected_instead_of_resurrected() -> Result<()> {
+        for used in [false, true] {
+            let error = serde_json::from_value::<AccountInvitation>(main_invitation_json(used))
+                .expect_err("the pre-v1 invitation format must not be accepted");
+            assert!(error.to_string().contains("unknown field"), "{error}");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_invitation_rejects_the_entire_node_state() -> Result<()> {
+        let service = NodeIdentityService::new_for_tests("localhost", "http://localhost:8000")?;
+        service.bootstrap_if_needed().await?;
+        let mut state = serde_json::to_value(service.read_state().await?)?;
+        state["invitations"] = serde_json::json!({
+            Uuid::now_v7().to_string(): main_invitation_json(true),
+        });
+
+        let error = serde_json::from_value::<NodeState>(state)
+            .expect_err("a legacy invitation must not be silently resurrected");
+        assert!(error.to_string().contains("unknown field"), "{error}");
+        Ok(())
+    }
 
     #[tokio::test]
     async fn setup_secret_is_hashed_and_only_emitted_once() -> Result<()> {

--- a/crates/ugoite-identity/src/node_identity.rs
+++ b/crates/ugoite-identity/src/node_identity.rs
@@ -151,7 +151,7 @@ pub struct NodeAuditInput<'a> {
     pub safe_metadata: serde_json::Value,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct AccountInvitation {
     pub invitation_id: Uuid,
     pub token_hash: String,
@@ -159,14 +159,73 @@ pub struct AccountInvitation {
     pub space_uid: Option<Uuid>,
     pub role: Option<String>,
     pub expires_at: String,
-    pub used_at: Option<String>,
     #[serde(default)]
-    pub accepted_account_id: Option<Uuid>,
-    #[serde(default)]
-    pub accepted_principal_id: Option<Uuid>,
-    #[serde(default)]
-    pub acceptance_kind: Option<InvitationAcceptanceKind>,
+    pub acceptance: Option<InvitationAcceptance>,
     pub created_by: Uuid,
+}
+
+impl<'de> Deserialize<'de> for AccountInvitation {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct AccountInvitationData {
+            invitation_id: Uuid,
+            token_hash: String,
+            display_name: String,
+            space_uid: Option<Uuid>,
+            role: Option<String>,
+            expires_at: String,
+            #[serde(default)]
+            acceptance: Option<InvitationAcceptance>,
+            #[serde(default)]
+            used_at: Option<String>,
+            #[serde(default)]
+            accepted_account_id: Option<Uuid>,
+            #[serde(default)]
+            accepted_principal_id: Option<Uuid>,
+            #[serde(default)]
+            acceptance_kind: Option<InvitationAcceptanceKind>,
+            created_by: Uuid,
+        }
+
+        let data = AccountInvitationData::deserialize(deserializer)?;
+        let acceptance = match data.acceptance {
+            Some(acceptance) => Some(acceptance),
+            None => match (
+                data.used_at,
+                data.accepted_account_id,
+                data.accepted_principal_id,
+                data.acceptance_kind,
+            ) {
+                (Some(claimed_at), Some(account_id), Some(principal_id), Some(kind)) => {
+                    Some(InvitationAcceptance::Pending {
+                        account_id,
+                        principal_id,
+                        kind,
+                        claimed_at,
+                    })
+                }
+                (None, None, None, None) => None,
+                _ => {
+                    return Err(serde::de::Error::custom(
+                        "invitation has an incomplete legacy acceptance claim",
+                    ));
+                }
+            },
+        };
+        Ok(Self {
+            invitation_id: data.invitation_id,
+            token_hash: data.token_hash,
+            display_name: data.display_name,
+            space_uid: data.space_uid,
+            role: data.role,
+            expires_at: data.expires_at,
+            acceptance,
+            created_by: data.created_by,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -175,6 +234,54 @@ pub enum InvitationAcceptanceKind {
     ExistingAccount,
     PasskeyRegistration,
     Oidc,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum InvitationAcceptance {
+    Pending {
+        account_id: Uuid,
+        principal_id: Uuid,
+        kind: InvitationAcceptanceKind,
+        claimed_at: String,
+    },
+    Completed {
+        account_id: Uuid,
+        principal_id: Uuid,
+        kind: InvitationAcceptanceKind,
+        claimed_at: String,
+        completed_at: String,
+    },
+}
+
+impl InvitationAcceptance {
+    fn account_id(&self) -> Uuid {
+        match self {
+            Self::Pending { account_id, .. } | Self::Completed { account_id, .. } => *account_id,
+        }
+    }
+
+    fn principal_id(&self) -> Uuid {
+        match self {
+            Self::Pending { principal_id, .. } | Self::Completed { principal_id, .. } => {
+                *principal_id
+            }
+        }
+    }
+
+    fn kind(&self) -> &InvitationAcceptanceKind {
+        match self {
+            Self::Pending { kind, .. } | Self::Completed { kind, .. } => kind,
+        }
+    }
+}
+
+impl AccountInvitation {
+    pub fn accepted_principal_id(&self) -> Option<Uuid> {
+        self.acceptance
+            .as_ref()
+            .map(InvitationAcceptance::principal_id)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -809,16 +916,14 @@ impl NodeIdentityService {
             .find(|invitation| invitation.token_hash == token_hash(invitation_token))
             .cloned()
             .ok_or_else(|| anyhow!("invitation is invalid"))?;
-        if invitation.used_at.is_some() {
+        if let Some(acceptance) = invitation.acceptance.as_ref() {
             if matches!(
-                invitation.acceptance_kind,
-                Some(InvitationAcceptanceKind::PasskeyRegistration)
-            ) && invitation.accepted_account_id.is_some()
-                && invitation.accepted_principal_id.is_some()
-                && invitation
-                    .accepted_account_id
-                    .and_then(|account_id| state.accounts.get(&account_id))
-                    .is_some_and(|account| matches!(account.status, AccountStatus::Active))
+                acceptance.kind(),
+                InvitationAcceptanceKind::PasskeyRegistration
+            ) && state
+                .accounts
+                .get(&acceptance.account_id())
+                .is_some_and(|account| matches!(account.status, AccountStatus::Active))
             {
                 return Ok(InvitationRegistrationStart::Resume);
             }
@@ -881,7 +986,8 @@ impl NodeIdentityService {
             .get(&invitation_id)
             .cloned()
             .ok_or_else(|| anyhow!("invitation not found"))?;
-        if invitation.token_hash != token_hash(invitation_token) || invitation.used_at.is_some() {
+        if invitation.token_hash != token_hash(invitation_token) || invitation.acceptance.is_some()
+        {
             bail!("invitation is invalid or used");
         }
         validate_expiry(&invitation.expires_at, "invitation")?;
@@ -930,10 +1036,12 @@ impl NodeIdentityService {
             .invitations
             .get_mut(&invitation_id)
             .ok_or_else(|| anyhow!("invitation not found"))?;
-        invitation.used_at = Some(timestamp(Utc::now()));
-        invitation.accepted_account_id = Some(account.account_id);
-        invitation.accepted_principal_id = Some(Uuid::now_v7());
-        invitation.acceptance_kind = Some(InvitationAcceptanceKind::PasskeyRegistration);
+        invitation.acceptance = Some(InvitationAcceptance::Pending {
+            account_id: account.account_id,
+            principal_id: Uuid::now_v7(),
+            kind: InvitationAcceptanceKind::PasskeyRegistration,
+            claimed_at: timestamp(Utc::now()),
+        });
         let invitation = invitation.clone();
         state.registration_challenges.remove(&challenge_id);
         let session_id = self
@@ -945,61 +1053,6 @@ impl NodeIdentityService {
             )
             .await?;
         self.write_state(&state).await?;
-        Ok(InvitationRegistrationFinish {
-            account,
-            session_id,
-            invitation,
-        })
-    }
-
-    pub async fn resume_invitation_registration(
-        &self,
-        invitation_token: &str,
-    ) -> Result<InvitationRegistrationFinish> {
-        let _guard = self.state_lock.lock().await;
-        let state = self.read_state().await?;
-        let invitation = state
-            .invitations
-            .values()
-            .find(|invitation| invitation.token_hash == token_hash(invitation_token))
-            .cloned()
-            .ok_or_else(|| anyhow!("invitation is invalid"))?;
-        if !matches!(
-            invitation.acceptance_kind,
-            Some(InvitationAcceptanceKind::PasskeyRegistration)
-        ) || invitation.used_at.is_none()
-        {
-            bail!("invitation registration cannot be resumed");
-        }
-        let account_id = invitation
-            .accepted_account_id
-            .ok_or_else(|| anyhow!("invitation registration claim is incomplete"))?;
-        let account = state
-            .accounts
-            .get(&account_id)
-            .filter(|account| matches!(account.status, AccountStatus::Active))
-            .cloned()
-            .ok_or_else(|| anyhow!("invitation registration claim is incomplete"))?;
-        let method_id = state
-            .authentication_methods
-            .values()
-            .find(|method| {
-                method.account_id == account_id
-                    && matches!(method.kind, AuthenticationMethodKind::Passkey)
-                    && state.passkeys.values().any(|passkey| {
-                        passkey.account_id == account_id && passkey.method_id == method.method_id
-                    })
-            })
-            .map(|method| method.method_id)
-            .ok_or_else(|| anyhow!("invitation registration claim is incomplete"))?;
-        let session_id = self
-            .create_session(
-                &state,
-                account_id,
-                method_id,
-                AssuranceLevel::PhishingResistant,
-            )
-            .await?;
         Ok(InvitationRegistrationFinish {
             account,
             session_id,
@@ -1680,10 +1733,7 @@ impl NodeIdentityService {
             space_uid,
             role,
             expires_at: timestamp(Utc::now() + Duration::hours(INVITATION_LIFETIME_HOURS)),
-            used_at: None,
-            accepted_account_id: None,
-            accepted_principal_id: None,
-            acceptance_kind: None,
+            acceptance: None,
             created_by: actor,
         };
         state.invitations.insert(invitation_id, invitation.clone());
@@ -1724,21 +1774,20 @@ impl NodeIdentityService {
                 .invitations
                 .get_mut(&invitation_id)
                 .ok_or_else(|| anyhow!("invitation is invalid"))?;
-            if invitation.used_at.is_some() {
-                if invitation.accepted_account_id == Some(account_id)
-                    && invitation.accepted_principal_id.is_some()
-                {
+            if let Some(acceptance) = invitation.acceptance.as_ref() {
+                if acceptance.account_id() == account_id {
                     invitation.clone()
                 } else {
                     bail!("invitation is invalid");
                 }
             } else {
                 validate_expiry(&invitation.expires_at, "invitation")?;
-                invitation.used_at = Some(timestamp(Utc::now()));
-                invitation.accepted_account_id = Some(account_id);
-                invitation.accepted_principal_id =
-                    Some(existing_principal_id.unwrap_or_else(Uuid::now_v7));
-                invitation.acceptance_kind = Some(InvitationAcceptanceKind::ExistingAccount);
+                invitation.acceptance = Some(InvitationAcceptance::Pending {
+                    account_id,
+                    principal_id: existing_principal_id.unwrap_or_else(Uuid::now_v7),
+                    kind: InvitationAcceptanceKind::ExistingAccount,
+                    claimed_at: timestamp(Utc::now()),
+                });
                 write_state = true;
                 invitation.clone()
             }
@@ -1764,6 +1813,54 @@ impl NodeIdentityService {
         }
         state.bindings.push(binding);
         self.write_state(&state).await
+    }
+
+    pub async fn complete_invitation_acceptance(
+        &self,
+        invitation_id: Uuid,
+        account_id: Uuid,
+        principal_id: Uuid,
+    ) -> Result<()> {
+        let _guard = self.state_lock.lock().await;
+        let mut state = self.read_state().await?;
+        let invitation = state
+            .invitations
+            .get_mut(&invitation_id)
+            .ok_or_else(|| anyhow!("invitation is invalid"))?;
+        let acceptance = invitation
+            .acceptance
+            .take()
+            .ok_or_else(|| anyhow!("invitation acceptance is incomplete"))?;
+        let (acceptance, changed) = match acceptance {
+            InvitationAcceptance::Pending {
+                account_id: claimed_account_id,
+                principal_id: claimed_principal_id,
+                kind,
+                claimed_at,
+            } if claimed_account_id == account_id && claimed_principal_id == principal_id => (
+                InvitationAcceptance::Completed {
+                    account_id,
+                    principal_id,
+                    kind,
+                    claimed_at,
+                    completed_at: timestamp(Utc::now()),
+                },
+                true,
+            ),
+            completed @ InvitationAcceptance::Completed {
+                account_id: claimed_account_id,
+                principal_id: claimed_principal_id,
+                ..
+            } if claimed_account_id == account_id && claimed_principal_id == principal_id => {
+                (completed, false)
+            }
+            _ => bail!("invitation acceptance does not match finalization"),
+        };
+        invitation.acceptance = Some(acceptance);
+        if changed {
+            self.write_state(&state).await?;
+        }
+        Ok(())
     }
 
     pub async fn binding_for_account(
@@ -2517,22 +2614,20 @@ impl NodeIdentityService {
                     .values_mut()
                     .find(|invitation| invitation.token_hash == invitation_hash)
                     .ok_or_else(|| anyhow!("invitation is invalid"))?;
-                if invitation.used_at.is_some() {
-                    if invitation.accepted_account_id != Some(account_id)
-                        || !matches!(
-                            invitation.acceptance_kind,
-                            Some(InvitationAcceptanceKind::Oidc)
-                        )
+                if let Some(acceptance) = invitation.acceptance.as_ref() {
+                    if acceptance.account_id() != account_id
+                        || !matches!(acceptance.kind(), InvitationAcceptanceKind::Oidc)
                     {
                         bail!("invitation is invalid");
                     }
                 } else {
                     validate_expiry(&invitation.expires_at, "invitation")?;
-                    invitation.used_at = Some(timestamp(Utc::now()));
-                    invitation.accepted_account_id = Some(account_id);
-                    invitation.accepted_principal_id =
-                        Some(existing_principal_id.unwrap_or_else(Uuid::now_v7));
-                    invitation.acceptance_kind = Some(InvitationAcceptanceKind::Oidc);
+                    invitation.acceptance = Some(InvitationAcceptance::Pending {
+                        account_id,
+                        principal_id: existing_principal_id.unwrap_or_else(Uuid::now_v7),
+                        kind: InvitationAcceptanceKind::Oidc,
+                        claimed_at: timestamp(Utc::now()),
+                    });
                 }
                 Some(invitation.clone())
             } else {
@@ -2548,7 +2643,7 @@ impl NodeIdentityService {
                 .find(|invitation| invitation.token_hash == invitation_hash)
                 .ok_or_else(|| anyhow!("invitation is invalid"))?;
             validate_expiry(&invitation.expires_at, "invitation")?;
-            if invitation.used_at.is_some() {
+            if invitation.acceptance.is_some() {
                 bail!("invitation was already used");
             }
             let account = HumanAccount {
@@ -2562,10 +2657,12 @@ impl NodeIdentityService {
                 created_at: timestamp(Utc::now()),
                 node_roles: BTreeSet::new(),
             };
-            invitation.used_at = Some(timestamp(Utc::now()));
-            invitation.accepted_account_id = Some(account.account_id);
-            invitation.accepted_principal_id = Some(Uuid::now_v7());
-            invitation.acceptance_kind = Some(InvitationAcceptanceKind::Oidc);
+            invitation.acceptance = Some(InvitationAcceptance::Pending {
+                account_id: account.account_id,
+                principal_id: Uuid::now_v7(),
+                kind: InvitationAcceptanceKind::Oidc,
+                claimed_at: timestamp(Utc::now()),
+            });
             let invitation_copy = invitation.clone();
             state.accounts.insert(account.account_id, account.clone());
             (account, Some(invitation_copy))
@@ -3210,11 +3307,21 @@ mod tests {
         let (_, first) = service
             .accept_invitation_for_account(&token, account_id)
             .await?;
+        service
+            .complete_invitation_acceptance(
+                first.invitation_id,
+                account_id,
+                first.accepted_principal_id().expect("accepted principal"),
+            )
+            .await?;
         let (_, retry) = service
             .accept_invitation_for_account(&token, account_id)
             .await?;
-        assert_eq!(first.accepted_principal_id, retry.accepted_principal_id);
-        assert!(first.used_at.is_some());
+        assert_eq!(first.accepted_principal_id(), retry.accepted_principal_id());
+        assert!(matches!(
+            retry.acceptance,
+            Some(InvitationAcceptance::Completed { .. })
+        ));
         Ok(())
     }
 
@@ -3256,13 +3363,19 @@ mod tests {
         let (_, invitation) = service
             .accept_invitation_for_account(&token, account_id)
             .await?;
-        assert_eq!(invitation.accepted_account_id, Some(account_id));
-        assert_eq!(invitation.accepted_principal_id, Some(principal_id));
+        assert_eq!(invitation.accepted_principal_id(), Some(principal_id));
+        assert!(matches!(
+            invitation.acceptance,
+            Some(InvitationAcceptance::Pending {
+                account_id: claimed_account_id,
+                ..
+            }) if claimed_account_id == account_id
+        ));
 
         let (_, retry) = service
             .accept_invitation_for_account(&token, account_id)
             .await?;
-        assert_eq!(retry.accepted_principal_id, Some(principal_id));
+        assert_eq!(retry.accepted_principal_id(), Some(principal_id));
         assert_eq!(
             service
                 .read_state()
@@ -3324,26 +3437,23 @@ mod tests {
         let (_, first) = service
             .accept_invitation_for_account(&token, account_id)
             .await?;
-        let claimed_principal = first.accepted_principal_id;
+        let claimed_principal = first.accepted_principal_id();
         assert!(service
             .accept_invitation_for_account(&token, other_account_id)
             .await
             .is_err());
-        let replacement_principal = Uuid::now_v7();
         let mut state = service.read_state().await?;
         let invitation = state
             .invitations
             .get_mut(&first.invitation_id)
             .expect("issued invitation");
         invitation.expires_at = "2000-01-01T00:00:00.000Z".to_string();
-        invitation.accepted_principal_id = Some(replacement_principal);
         service.write_state(&state).await?;
 
         let (_, retry) = service
             .accept_invitation_for_account(&token, account_id)
             .await?;
-        assert_eq!(retry.accepted_principal_id, Some(replacement_principal));
-        assert_ne!(retry.accepted_principal_id, claimed_principal);
+        assert_eq!(retry.accepted_principal_id(), claimed_principal);
         Ok(())
     }
 

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -1669,6 +1669,24 @@ async fn bind_invited_account(
     let principal_id = invitation.accepted_principal_id.ok_or_else(|| {
         ApiError::new(StatusCode::CONFLICT, "invitation acceptance is incomplete")
     })?;
+    match state
+        .identity
+        .binding_for_account(space_uid, account.account_id)
+        .await
+        .map_err(auth_error)?
+    {
+        Some(existing_principal_id) if existing_principal_id == principal_id => return Ok(()),
+        Some(_) => {
+            return Err(ApiError::new(
+                StatusCode::CONFLICT,
+                json!({
+                    "code": "ACCOUNT_ALREADY_BOUND",
+                    "message": "account is already bound to this Space",
+                }),
+            ));
+        }
+        None => {}
+    }
     Authorizer::new(state.service.operator().clone())
         .add_human_member(
             &space_id,

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -4553,4 +4553,129 @@ mod authentication_regression_tests {
         assert_eq!(stored["fields"]["time"]["type"], "timestamp");
         Ok(())
     }
+
+    #[tokio::test]
+    async fn invitation_finalization_converges_after_space_membership_commit() -> anyhow::Result<()>
+    {
+        let state = AppState::new_for_tests("memory://server-invitation-saga")?;
+        state.initialize_node().await?;
+        let owner_account_id = Uuid::now_v7();
+        let owner_principal_id = Uuid::now_v7();
+        let invited_account_id = Uuid::now_v7();
+        let space_uid = state
+            .service
+            .create_space_for_principal("invitation-saga", owner_principal_id, "Owner")
+            .await?;
+        state
+            .identity
+            .add_binding(ugoite_domain::identity::PrincipalBinding {
+                space_uid,
+                principal_id: owner_principal_id,
+                node_account_id: owner_account_id,
+                binding_method: BindingMethod::Setup,
+            })
+            .await?;
+        let principal_id = Uuid::now_v7();
+        let backup_owner_principal_id = Uuid::now_v7();
+        let account = HumanAccount {
+            account_id: invited_account_id,
+            display_name: "Invited viewer".to_string(),
+            status: AccountStatus::Active,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            node_roles: BTreeSet::new(),
+        };
+        let invitation = AccountInvitation {
+            invitation_id: Uuid::now_v7(),
+            token_hash: "test".to_string(),
+            display_name: account.display_name.clone(),
+            space_uid: Some(space_uid),
+            role: Some("viewer".to_string()),
+            expires_at: chrono::Utc::now().to_rfc3339(),
+            acceptance: Some(
+                ugoite_identity::node_identity::InvitationAcceptance::Pending {
+                    account_id: invited_account_id,
+                    principal_id,
+                    kind: ugoite_identity::node_identity::InvitationAcceptanceKind::PasskeyRegistration,
+                    claimed_at: chrono::Utc::now().to_rfc3339(),
+                },
+            ),
+            created_by: owner_account_id,
+        };
+        let authorizer = Authorizer::new(state.service.operator().clone());
+        authorizer
+            .add_human_member(
+                &space_uid.to_string(),
+                owner_principal_id,
+                SpacePrincipal {
+                    principal_id,
+                    kind: PrincipalKind::Human,
+                    display_name: account.display_name.clone(),
+                    state: PrincipalState::Active,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                },
+                SpaceRole::Viewer,
+            )
+            .await?;
+        authorizer
+            .add_human_member(
+                &space_uid.to_string(),
+                owner_principal_id,
+                SpacePrincipal {
+                    principal_id: backup_owner_principal_id,
+                    kind: PrincipalKind::Human,
+                    display_name: "Backup owner".to_string(),
+                    state: PrincipalState::Active,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                },
+                SpaceRole::Owner,
+            )
+            .await?;
+        authorizer
+            .change_role(
+                &space_uid.to_string(),
+                owner_principal_id,
+                owner_principal_id,
+                SpaceRole::Viewer,
+            )
+            .await?;
+
+        bind_invited_account(&state, &account, &invitation, BindingMethod::Invite)
+            .await
+            .expect("membership-first finalization");
+        authorizer
+            .revoke_principal(
+                &space_uid.to_string(),
+                backup_owner_principal_id,
+                owner_principal_id,
+            )
+            .await?;
+        bind_invited_account(&state, &account, &invitation, BindingMethod::Invite)
+            .await
+            .expect("idempotent retry after inviter revocation");
+
+        let authorization = authorizer.state(&space_uid.to_string()).await?;
+        assert_eq!(authorization.memberships.len(), 3);
+        let node = state.identity.read_state().await?;
+        assert_eq!(
+            node.bindings
+                .iter()
+                .filter(|binding| binding.space_uid == space_uid)
+                .count(),
+            2
+        );
+
+        authorizer
+            .revoke_principal(
+                &space_uid.to_string(),
+                backup_owner_principal_id,
+                principal_id,
+            )
+            .await?;
+        assert!(
+            bind_invited_account(&state, &account, &invitation, BindingMethod::Invite)
+                .await
+                .is_err()
+        );
+        Ok(())
+    }
 }

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -879,6 +879,17 @@ async fn auth_invitation_finish(
         BindingMethod::Invite,
     )
     .await?;
+    state
+        .identity
+        .complete_invitation_acceptance(
+            result.invitation.invitation_id,
+            result.account.account_id,
+            result.invitation.accepted_principal_id().ok_or_else(|| {
+                ApiError::new(StatusCode::CONFLICT, "invitation acceptance is incomplete")
+            })?,
+        )
+        .await
+        .map_err(auth_error)?;
     Ok((
         StatusCode::CREATED,
         [(
@@ -901,12 +912,23 @@ async fn auth_invitation_accept_existing(
         .await
         .map_err(auth_error)?;
     bind_invited_account(&state, &account, &invitation, BindingMethod::Invite).await?;
+    state
+        .identity
+        .complete_invitation_acceptance(
+            invitation.invitation_id,
+            account.account_id,
+            invitation.accepted_principal_id().ok_or_else(|| {
+                ApiError::new(StatusCode::CONFLICT, "invitation acceptance is incomplete")
+            })?,
+        )
+        .await
+        .map_err(auth_error)?;
     Ok((
         StatusCode::CREATED,
         Json(json!({
             "account": account,
             "space_uid": invitation.space_uid,
-            "principal_id": invitation.accepted_principal_id,
+            "principal_id": invitation.accepted_principal_id(),
         })),
     ))
 }
@@ -1584,6 +1606,17 @@ async fn oidc_callback(
         .map_err(auth_error)?;
     if let Some(invitation) = invitation {
         bind_invited_account(&state, &account, &invitation, BindingMethod::Oidc).await?;
+        state
+            .identity
+            .complete_invitation_acceptance(
+                invitation.invitation_id,
+                account.account_id,
+                invitation.accepted_principal_id().ok_or_else(|| {
+                    ApiError::new(StatusCode::CONFLICT, "invitation acceptance is incomplete")
+                })?,
+            )
+            .await
+            .map_err(auth_error)?;
     }
     state
         .identity
@@ -1661,21 +1694,47 @@ async fn bind_invited_account(
         return Ok(());
     };
     let space_id = find_space_id_by_uid(state, space_uid).await?;
-    let inviter = state
-        .identity
-        .principal_for_account(space_uid, invitation.created_by)
-        .await
-        .map_err(auth_error)?;
-    let principal_id = invitation.accepted_principal_id.ok_or_else(|| {
+    let principal_id = invitation.accepted_principal_id().ok_or_else(|| {
         ApiError::new(StatusCode::CONFLICT, "invitation acceptance is incomplete")
     })?;
+    let authorizer = Authorizer::new(state.service.operator().clone());
+    let authorization = authorizer
+        .state(&space_id)
+        .await
+        .map_err(ApiError::from_core)?;
+    let active_space_member =
+        authorization
+            .principals
+            .get(&principal_id)
+            .is_some_and(|principal| {
+                matches!(principal.kind, PrincipalKind::Human)
+                    && matches!(principal.state, PrincipalState::Active)
+                    && authorization.memberships.contains_key(&principal_id)
+            });
+    let principal_has_conflicting_space_state = authorization
+        .principals
+        .get(&principal_id)
+        .is_some_and(|principal| {
+            !active_space_member || !matches!(principal.kind, PrincipalKind::Human)
+        });
     match state
         .identity
         .binding_for_account(space_uid, account.account_id)
         .await
         .map_err(auth_error)?
     {
-        Some(existing_principal_id) if existing_principal_id == principal_id => return Ok(()),
+        Some(existing_principal_id) if existing_principal_id == principal_id => {
+            if active_space_member {
+                return Ok(());
+            }
+            return Err(ApiError::new(
+                StatusCode::CONFLICT,
+                json!({
+                    "code": "SPACE_MEMBERSHIP_CONFLICT",
+                    "message": "Node binding exists but the Space has no active membership for this principal",
+                }),
+            ));
+        }
         Some(_) => {
             return Err(ApiError::new(
                 StatusCode::CONFLICT,
@@ -1687,21 +1746,37 @@ async fn bind_invited_account(
         }
         None => {}
     }
-    Authorizer::new(state.service.operator().clone())
-        .add_human_member(
-            &space_id,
-            inviter,
-            SpacePrincipal {
-                principal_id,
-                kind: PrincipalKind::Human,
-                display_name: account.display_name.clone(),
-                state: PrincipalState::Active,
-                created_at: chrono::Utc::now().to_rfc3339(),
-            },
-            parse_space_role(invitation.role.as_deref().unwrap_or("viewer"))?,
-        )
-        .await
-        .map_err(ApiError::from_core)?;
+    if principal_has_conflicting_space_state {
+        return Err(ApiError::new(
+            StatusCode::CONFLICT,
+            json!({
+                "code": "SPACE_MEMBERSHIP_CONFLICT",
+                "message": "Space authorization state conflicts with the invitation principal",
+            }),
+        ));
+    }
+    if !active_space_member {
+        let inviter = state
+            .identity
+            .principal_for_account(space_uid, invitation.created_by)
+            .await
+            .map_err(auth_error)?;
+        authorizer
+            .add_human_member(
+                &space_id,
+                inviter,
+                SpacePrincipal {
+                    principal_id,
+                    kind: PrincipalKind::Human,
+                    display_name: account.display_name.clone(),
+                    state: PrincipalState::Active,
+                    created_at: chrono::Utc::now().to_rfc3339(),
+                },
+                parse_space_role(invitation.role.as_deref().unwrap_or("viewer"))?,
+            )
+            .await
+            .map_err(ApiError::from_core)?;
+    }
     state
         .identity
         .add_binding(ugoite_domain::identity::PrincipalBinding {

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -56,6 +56,24 @@ async fn uninitialized_protected_routes_are_locked_for_every_credential_shape() 
 }
 
 #[tokio::test]
+async fn invitation_finish_cannot_issue_a_session_from_token_only() {
+    let app = initialized_app("invitation-token-session").await;
+    let response = app
+        .oneshot(
+            Request::post("/auth/invitations/finish")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"invitation_token":"token-only","resume":true}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(response.headers().get("set-cookie").is_none());
+}
+
+#[tokio::test]
 async fn oauth_metadata_describes_device_and_dpop_surface() {
     let app = initialized_app("metadata").await;
     let response = app

--- a/docs/guide/operate/auth/auth-overview.md
+++ b/docs/guide/operate/auth/auth-overview.md
@@ -77,7 +77,8 @@ Passkey cannot be removed.
 ## Invitations and OIDC
 
 Space owners issue a one-use invitation URL. Only the invitation hash, expiry,
-creator, Space UID, and requested role are stored. The recipient registers a
+creator, Space UID, requested role, and its durable acceptance claim are stored.
+The recipient registers a
 Passkey, accepts with an existing signed-in account, or starts an enabled OIDC
 authorization-code flow with PKCE. A new OIDC subject cannot create an account
 without an invitation. Ugoite validates the provider ID token and nonce, then
@@ -85,6 +86,18 @@ issues its own opaque session; provider tokens are never accepted by the Ugoite
 API. A signed-in user can add an OIDC method only after recent Passkey
 authentication; Ugoite refuses to link an issuer/subject pair already owned by
 another account.
+
+An account has at most one Node binding in a Space. If an already-bound account
+opens an invitation for that same Space, acceptance is idempotent and keeps the
+existing principal instead of creating a second membership.
+
+Invitation registration claims keep their account and principal fixed. If the
+Space membership or Node binding step fails after the claim is durable, opening
+the same invitation again requires the claimant to complete normal Passkey
+login before authenticated acceptance resumes finalization; the invitation
+token never authenticates the claimed account. The original invitation expiry
+does not block that retry. A conflicting or revoked Space principal is reported
+as a conflict instead of being silently replaced.
 
 An account has at most one Node binding in a Space. If an already-bound account
 opens an invitation for that same Space, acceptance is idempotent and keeps the

--- a/docs/guide/operate/auth/auth-overview.md
+++ b/docs/guide/operate/auth/auth-overview.md
@@ -86,6 +86,10 @@ API. A signed-in user can add an OIDC method only after recent Passkey
 authentication; Ugoite refuses to link an issuer/subject pair already owned by
 another account.
 
+An account has at most one Node binding in a Space. If an already-bound account
+opens an invitation for that same Space, acceptance is idempotent and keeps the
+existing principal instead of creating a second membership.
+
 ## CLI devices
 
 `ugoite auth login` generates a P-256 key, requests a device code, and prints a

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -14,7 +14,10 @@ CI.
 - `POST /auth/passkey/start|finish`: discoverable Passkey login and opaque
   session issuance.
 - `GET|DELETE /auth/session`: inspect or revoke the current browser session.
-- `POST /auth/invitations/start|finish`: invited Passkey registration.
+- `POST /auth/invitations/start|finish`: invited Passkey registration. The
+  start response can request a retry finalization when a previous registration
+  claim already exists; retrying the same invitation converges the Node binding
+  and Space membership without creating a second principal.
 - `GET /auth/oidc/{provider_id}/start` and `GET /auth/oidc/callback`: OIDC
   authorization code + PKCE.
 - `GET|POST /auth/oidc/providers`: Node administrator provider configuration.

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -15,9 +15,10 @@ CI.
   session issuance.
 - `GET|DELETE /auth/session`: inspect or revoke the current browser session.
 - `POST /auth/invitations/start|finish`: invited Passkey registration. The
-  start response can request a retry finalization when a previous registration
-  claim already exists; retrying the same invitation converges the Node binding
-  and Space membership without creating a second principal.
+  start response can request a retry after a previous registration claim; the
+  browser must complete normal Passkey login and then use authenticated
+  acceptance to converge the Node binding and Space membership. The invitation
+  token alone never creates a session or authenticates an account.
 - `GET /auth/oidc/{provider_id}/start` and `GET /auth/oidc/callback`: OIDC
   authorization code + PKCE.
 - `GET|POST /auth/oidc/providers`: Node administrator provider configuration.

--- a/e2e/space-membership.test.ts
+++ b/e2e/space-membership.test.ts
@@ -75,4 +75,39 @@ test.describe("Space Membership", () => {
       await invited.close();
     }
   });
+
+  test("REQ-SEC-007: an existing Space member can retry the same invitation idempotently", async ({ page, request }) => {
+    const spaceId = `e2e-existing-member-${Date.now()}`;
+    const created = await request.post(getBackendUrl("/spaces"), {
+      data: { name: spaceId },
+    });
+    expect(created.status()).toBe(201);
+    const invite = await request.post(
+      getBackendUrl(`/spaces/${spaceId}/members/invitations`),
+      { data: { label: "Existing owner", role: "viewer" } },
+    );
+    expect(invite.status()).toBe(201);
+    const { invitation_url: invitationUrl } = await invite.json() as {
+      invitation_url: string;
+    };
+
+    const before = await request.get(
+      getBackendUrl(`/spaces/${spaceId}/members`),
+    );
+    expect(before.status()).toBe(200);
+    const beforeMembers = await before.json() as unknown[];
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await page.goto(invitationUrl);
+      await page.getByRole("button", { name: "Accept invitation" }).click();
+      await expect(page).toHaveURL(/\/spaces$/);
+    }
+
+    const after = await request.get(
+      getBackendUrl(`/spaces/${spaceId}/members`),
+    );
+    expect(after.status()).toBe(200);
+    const afterMembers = await after.json() as unknown[];
+    expect(afterMembers).toEqual(beforeMembers);
+  });
 });

--- a/e2e/space-membership.test.ts
+++ b/e2e/space-membership.test.ts
@@ -12,7 +12,7 @@ test.describe("Space Membership", () => {
     expect(created.status()).toBe(201);
     const invite = await request.post(
       getBackendUrl(`/spaces/${spaceId}/members/invitations`),
-      { data: { display_name: "Invited viewer", role: "viewer" } },
+      { data: { label: "Invited viewer", role: "viewer" } },
     );
     expect(invite.status()).toBe(201);
     const { invitation_url: invitationUrl } = await invite.json() as {
@@ -38,7 +38,7 @@ test.describe("Space Membership", () => {
 
     try {
       await page.goto(invitationUrl);
-      await page.getByRole("button", { name: "Register Passkey and join" })
+      await page.getByRole("button", { name: "Accept invitation" })
         .click();
       await expect(page).toHaveURL(/\/spaces$/);
       const space = await invited.request.get(

--- a/frontend/src/lib/auth-api.test.ts
+++ b/frontend/src/lib/auth-api.test.ts
@@ -1,26 +1,27 @@
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { server } from "~/test/mocks/server";
 import { testApiUrl } from "~/test/http-origin";
 import { authApi } from "./auth-api";
 
 describe("invitation registration finalization", () => {
-  it("resumes a durable Passkey claim without creating another credential", async () => {
-    let finishBody: Record<string, unknown> | undefined;
+  it("re-authenticates with Passkey before accepting a durable claim", async () => {
     server.use(
       http.post(testApiUrl("/auth/invitations/start"), () =>
         HttpResponse.json({ status: "resume" })),
-      http.post(testApiUrl("/auth/invitations/finish"), async ({ request }) => {
-        finishBody = await request.json() as Record<string, unknown>;
-        return HttpResponse.json({ account: {} });
-      }),
     );
 
-    await authApi.registerInvitation("invitation-token");
-
-    expect(finishBody).toEqual({
-      invitation_token: "invitation-token",
-      resume: true,
-    });
+    const loginWithPasskey = vi.spyOn(authApi, "loginWithPasskey")
+      .mockResolvedValue();
+    const acceptInvitation = vi.spyOn(authApi, "acceptInvitation")
+      .mockResolvedValue();
+    try {
+      await authApi.registerInvitation("invitation-token");
+      expect(loginWithPasskey).toHaveBeenCalledOnce();
+      expect(acceptInvitation).toHaveBeenCalledWith("invitation-token");
+    } finally {
+      loginWithPasskey.mockRestore();
+      acceptInvitation.mockRestore();
+    }
   });
 });

--- a/frontend/src/lib/auth-api.test.ts
+++ b/frontend/src/lib/auth-api.test.ts
@@ -1,0 +1,26 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "~/test/mocks/server";
+import { testApiUrl } from "~/test/http-origin";
+import { authApi } from "./auth-api";
+
+describe("invitation registration finalization", () => {
+  it("resumes a durable Passkey claim without creating another credential", async () => {
+    let finishBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(testApiUrl("/auth/invitations/start"), () =>
+        HttpResponse.json({ status: "resume" })),
+      http.post(testApiUrl("/auth/invitations/finish"), async ({ request }) => {
+        finishBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ account: {} });
+      }),
+    );
+
+    await authApi.registerInvitation("invitation-token");
+
+    expect(finishBody).toEqual({
+      invitation_token: "invitation-token",
+      resume: true,
+    });
+  });
+});

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -27,6 +27,10 @@ type ChallengeEnvelope = {
   };
 };
 
+type InvitationRegistrationStart =
+  | ChallengeEnvelope & { status: "register" }
+  | { status: "resume" };
+
 const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
   const response = await fetch(`/api${path}`, {
     ...init,
@@ -210,13 +214,20 @@ export const authApi = {
     });
   },
   async registerInvitation(invitationToken: string): Promise<void> {
-    const challenge = await request<ChallengeEnvelope>(
+    const challenge = await request<InvitationRegistrationStart>(
       "/auth/invitations/start",
       {
         method: "POST",
         body: JSON.stringify({ invitation_token: invitationToken }),
       },
     );
+    if (challenge.status === "resume") {
+      await request("/auth/invitations/finish", {
+        method: "POST",
+        body: JSON.stringify({ invitation_token: invitationToken, resume: true }),
+      });
+      return;
+    }
     const credential = await createPasskey(challenge);
     await request("/auth/invitations/finish", {
       method: "POST",

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -222,10 +222,8 @@ export const authApi = {
       },
     );
     if (challenge.status === "resume") {
-      await request("/auth/invitations/finish", {
-        method: "POST",
-        body: JSON.stringify({ invitation_token: invitationToken, resume: true }),
-      });
+      await authApi.loginWithPasskey();
+      await authApi.acceptInvitation(invitationToken);
       return;
     }
     const credential = await createPasskey(challenge);

--- a/frontend/src/routes/spaces/join.test.tsx
+++ b/frontend/src/routes/spaces/join.test.tsx
@@ -1,14 +1,16 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SpaceInvitationJoinRoute from "./join";
 import { authApi } from "~/lib/auth-api";
+
+const navigateMock = vi.fn();
 
 vi.mock("@solidjs/router", () => ({
   A: (props: { href: string; children: unknown }) => (
     <a href={props.href}>{props.children}</a>
   ),
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigateMock,
 }));
 
 vi.mock("~/components/GlobalShell", () => ({
@@ -28,8 +30,11 @@ vi.mock("~/lib/auth-api", () => ({
 
 describe("/spaces/join", () => {
   beforeEach(() => {
+    navigateMock.mockReset();
+    vi.mocked(authApi.acceptInvitation).mockReset();
     vi.mocked(authApi.getSession).mockResolvedValue({ authenticated: false });
     vi.mocked(authApi.listOidcProviders).mockResolvedValue([]);
+    vi.mocked(authApi.registerInvitation).mockReset();
   });
 
   it("renders as a public shell before an invitation recipient signs in", async () => {
@@ -39,5 +44,22 @@ describe("/spaces/join", () => {
       expect(screen.getByText("Join a Space").parentElement?.parentElement)
         .toHaveAttribute("data-authenticated", "false")
     );
+  });
+
+  it("accepts an invitation for an already signed-in account", async () => {
+    vi.mocked(authApi.getSession).mockResolvedValue({ authenticated: true });
+    vi.mocked(authApi.acceptInvitation).mockResolvedValue();
+    render(() => <SpaceInvitationJoinRoute />);
+
+    fireEvent.input(screen.getByLabelText("Invitation token"), {
+      target: { value: "invitation-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Accept invitation" }));
+
+    await waitFor(() => {
+      expect(authApi.acceptInvitation).toHaveBeenCalledWith("invitation-token");
+      expect(navigateMock).toHaveBeenCalledWith("/spaces", { replace: true });
+    });
+    expect(authApi.registerInvitation).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Close the invitation-resume account-takeover path and make invitation finalization converge from durable state.

- Remove the unauthenticated resume endpoint path that minted a 30-day session from an invitation token. A durable Passkey claim now requires normal Passkey login followed by authenticated invitation acceptance.
- Replace the optional used/accepted-field combination with explicit `Pending` and `Completed` invitation acceptance states. The pre-v1 `used_at`/accepted-ID shape is rejected explicitly so it cannot be silently resurrected as an unused invitation; development state must be reset after this destructive v1 format change.
- Check Space membership and Node binding before resolving or authorizing the inviter. Existing Space membership retries only finalize the missing Node binding, so inviter revocation or loss of Share permission cannot strand a committed membership.
- Add HTTP, identity, server saga, and frontend regression coverage, and update authentication/REST documentation.

## Related Issue (required)

closes #1865

## Testing

- [x] `mise run ci` (fmt, clippy, lint, workspace checks, OpenAPI/architecture/docs checks, Rust workspace tests, frontend tests: 504 passed, and docsite tests)
- [x] `cargo test -p ugoite-identity` (19 passed)
- [x] `cargo test -p ugoite-server --lib invitation_finalization_converges_after_space_membership_commit` (1 passed)
- [x] `cargo test -p ugoite-server --test api_contract invitation_finish_cannot_issue_a_session_from_token_only` (1 passed)
- [x] `deno run -A npm:vitest run src/lib/auth-api.test.ts src/routes/spaces/join.test.tsx` (3 passed)
- [x] GitHub CI merge gate: `ci-required` completed successfully, including runtime image verification and E2E smoke.
- [ ] Targeted full invitation E2E: the CI-parity Docker runner could not build locally because Docker Desktop timed out resolving `docker/dockerfile:1.7`; the host production-style fallback is blocked by an existing Vinxi/Deno `destr` dependency-resolution error and static/dev WebAuthn runner errors before the invitation test. The PR CI workflow currently runs smoke E2E, not the full invitation suite.
- [ ] `deno check frontend/src/lib/auth-api.ts frontend/src/lib/auth-api.test.ts`: reports eight pre-existing errors in unrelated frontend files (`api.ts`, `loading.ts`, WASM protocol typing, and mock handlers).
