### PR TITLE
fix(frontend): keep form field values writable

### DIFF
--- a/docs/spec/ui/pages/space-entry-detail.yaml
+++ b/docs/spec/ui/pages/space-entry-detail.yaml
@@ -51,11 +51,11 @@ components:
             - title
             - typed-form-fields
           field_controls:
-            boolean: select
+            boolean: free-form-text-input
             list: multiline-input
             markdown: multiline-input
             row_reference: searchable-entry-picker
-            scalar: typed-input
+            scalar: free-form-text-input
           validation: inline
         - id: entry-preview
           type: markdown-preview

--- a/frontend/src/components/EntryDetailPane.test.tsx
+++ b/frontend/src/components/EntryDetailPane.test.tsx
@@ -205,7 +205,7 @@ describe("EntryDetailPane", () => {
       title: "Timestamp Entry",
       form: "Event",
       content:
-        "---\nform: Event\n---\n\n# Timestamp Entry\n\n## Started\n2026-07-18T12:34:56Z\n\n## Observed\n2026-07-18T21:34:56+09:00\n\n## Precise\n2026-07-18T12:34:56.123456789Z",
+        "---\nform: Event\n---\n\n# Timestamp Entry\n\n## Amount\n12.5\n\n## Started\n2026-07-18T12:34:56Z\n\n## Observed\n2026-07-18T21:34:56+09:00\n\n## Precise\n2026-07-18T12:34:56.123456789Z\n\n## Date\n2026-07-\n\n## Time\n12:",
       revision_id: "rev-1",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
@@ -221,9 +221,12 @@ describe("EntryDetailPane", () => {
             version: 1,
             template: "# Event\n",
             fields: {
+              Amount: { type: "double", required: false },
               Started: { type: "timestamp", required: false },
               Observed: { type: "timestamp_tz", required: false },
               Precise: { type: "timestamp_ns", required: false },
+              Date: { type: "date", required: false },
+              Time: { type: "time", required: false },
             },
           },
         ]}
@@ -232,9 +235,15 @@ describe("EntryDetailPane", () => {
     ));
 
     const started = await screen.findByLabelText("Started");
-    expect(started).toHaveAttribute("type", "datetime-local");
-    expect(started).toHaveValue("2026-07-18T12:34:56.000");
-    expect(started).toHaveAttribute("step", "any");
+    expect(started).toHaveAttribute("type", "text");
+    expect(started).toHaveValue("2026-07-18T12:34:56Z");
+    expect(started).not.toHaveAttribute("step");
+
+    const amount = screen.getByLabelText("Amount");
+    expect(amount).toHaveAttribute("type", "text");
+    expect(amount).toHaveAttribute("inputmode", "decimal");
+    fireEvent.input(amount, { target: { value: "12." } });
+    expect(amount).toHaveValue("12.");
 
     const observed = screen.getByLabelText("Observed");
     expect(observed).toHaveAttribute("type", "text");
@@ -243,6 +252,14 @@ describe("EntryDetailPane", () => {
     const precise = screen.getByLabelText("Precise");
     expect(precise).toHaveAttribute("type", "text");
     expect(precise).toHaveValue("2026-07-18T12:34:56.123456789Z");
+
+    const date = screen.getByLabelText("Date");
+    expect(date).toHaveAttribute("type", "text");
+    expect(date).toHaveValue("2026-07-");
+
+    const time = screen.getByLabelText("Time");
+    expect(time).toHaveAttribute("type", "text");
+    expect(time).toHaveValue("12:");
   });
 
   it("REQ-FE-052: explains forms that have no structured fields", async () => {
@@ -342,6 +359,7 @@ describe("EntryDetailPane", () => {
     ));
 
     expect(await screen.findByLabelText("Summary")).toHaveValue("hello");
+    expect(screen.getByLabelText("Done")).toHaveAttribute("type", "text");
     expect(screen.getByLabelText("Done")).toHaveValue("maybe");
     expect(
       screen.getByText(

--- a/frontend/src/components/EntryDetailPane.tsx
+++ b/frontend/src/components/EntryDetailPane.tsx
@@ -186,20 +186,8 @@ function buildEditorGuidance(form: Form | null, markdown: string) {
   return { missingRequired, unknownSections, typeIssues };
 }
 
-function resolveInputType(field: FormField) {
-  if (NUMERIC_FIELD_TYPES.has(field.type)) return "number";
-  if (field.type === "date") return "date";
-  if (field.type === "time") return "time";
-  if (field.type === "timestamp") return "datetime-local";
-  return "text";
-}
-
-function resolveInputValue(field: FormField, value: string) {
-  if (field.type !== "timestamp") return value;
-  const match =
-    /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)(?:Z|[+-]\d{2}:\d{2})$/
-      .exec(value);
-  return match?.[1] ?? value;
+function resolveInputMode(field: FormField): "decimal" | undefined {
+  return NUMERIC_FIELD_TYPES.has(field.type) ? "decimal" : undefined;
 }
 
 function createFieldInputId(fieldName: string, index: number) {
@@ -740,28 +728,6 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
   ) => {
     const value = () => fieldValue(fieldName);
 
-    if (fieldDef.type === "boolean") {
-      const currentValue = () => value().trim();
-      const isCanonical = () =>
-        !currentValue() || ["true", "false"].includes(currentValue());
-      return (
-        <select
-          id={fieldId}
-          class="ui-input"
-          value={currentValue()}
-          onChange={(event) =>
-            handleFieldChange(fieldName, event.currentTarget.value)}
-        >
-          <Show when={!isCanonical()}>
-            <option value={currentValue()}>{currentValue()}</option>
-          </Show>
-          <option value="">{t("entryDetail.boolean.unset")}</option>
-          <option value="true">{t("entryDetail.boolean.true")}</option>
-          <option value="false">{t("entryDetail.boolean.false")}</option>
-        </select>
-      );
-    }
-
     if (fieldDef.type === "row_reference" && fieldDef.target_form?.trim()) {
       return (
         <EntryRowReferenceField
@@ -797,9 +763,9 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
       <input
         id={fieldId}
         class="ui-input"
-        type={resolveInputType(fieldDef)}
-        value={resolveInputValue(fieldDef, value())}
-        step={fieldDef.type === "timestamp" ? "any" : undefined}
+        type="text"
+        inputmode={resolveInputMode(fieldDef)}
+        value={value()}
         placeholder={t("entryDetail.fieldPlaceholder")}
         onInput={(event) =>
           handleFieldChange(fieldName, event.currentTarget.value)}

--- a/frontend/src/components/create-dialogs.test.tsx
+++ b/frontend/src/components/create-dialogs.test.tsx
@@ -563,6 +563,61 @@ describe("CreateEntryDialog", () => {
     expect((countInput as HTMLInputElement).value).toBe("0");
   });
 
+  it("REQ-FE-037: keeps numeric and temporal fields writable while editing", async () => {
+    const onSubmit = vi.fn();
+    const forms = [
+      {
+        name: "Event",
+        version: 1,
+        fields: {
+          Amount: { type: "double", required: false },
+          StartedAt: { type: "timestamp_tz", required: false },
+        },
+        template: "",
+      },
+    ];
+
+    render(() => (
+      <CreateEntryDialog
+        open={true}
+        forms={forms}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("Enter entry title..."), {
+      target: { value: "Writable Event" },
+    });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "Event" },
+    });
+
+    const amount = screen.getByLabelText(/Amount/);
+    expect(amount).toHaveAttribute("type", "text");
+    expect(amount).toHaveAttribute("inputmode", "decimal");
+    fireEvent.input(amount, { target: { value: "12." } });
+    expect(amount).toHaveValue("12.");
+
+    const startedAt = screen.getByLabelText(/StartedAt/);
+    expect(startedAt).toHaveAttribute("type", "text");
+    fireEvent.input(startedAt, {
+      target: { value: "2026-07-18T12:34:56.123456789+09:00" },
+    });
+    expect(startedAt).toHaveValue("2026-07-18T12:34:56.123456789+09:00");
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(onSubmit).toHaveBeenCalledWith(
+      "Writable Event",
+      "Event",
+      {
+        Amount: "12.",
+        StartedAt: "2026-07-18T12:34:56.123456789+09:00",
+      },
+      "webform",
+    );
+  });
+
   it("REQ-FE-037: renders optional fields in webform mode", async () => {
     const onSubmit = vi.fn();
     const onClose = vi.fn();

--- a/frontend/src/components/create-dialogs.tsx
+++ b/frontend/src/components/create-dialogs.tsx
@@ -81,14 +81,6 @@ const isLongTextField = (name: string, def: Form["fields"][string]) =>
 const isTextareaField = (name: string, def: Form["fields"][string]) =>
   isLongTextField(name, def) || def.type === "object_list";
 
-const resolveInputType = (def: Form["fields"][string]) => {
-  if (numericFieldTypes.has(def.type)) return "number";
-  if (def.type === "date") return "date";
-  if (def.type === "time") return "time";
-  if (def.type.startsWith("timestamp")) return "datetime-local";
-  return "text";
-};
-
 const createFieldInputId = (prefix: string, name: string, index: number) => {
   const normalized = name
     .trim()
@@ -714,7 +706,6 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
     }
 
     const useTextarea = isTextareaField(name, def);
-    const inputType = resolveInputType(def);
     const value = fieldValues()[name] ?? "";
 
     if (useTextarea) {
@@ -732,7 +723,8 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
     return (
       <input
         id={fieldId}
-        type={inputType}
+        type="text"
+        inputmode={numericFieldTypes.has(def.type) ? "decimal" : undefined}
         class="ui-input"
         value={value}
         onInput={(event) => setFieldValue(name, event.currentTarget.value)}


### PR DESCRIPTION
## Summary

- Keep structured form field values as raw editable strings in entry editing and entry creation.
- Use `inputmode="decimal"` only as a numeric keyboard hint; remove native input normalization and rejection for numeric, date, time, timestamp, and boolean fields.
- Preserve the existing save-time type guidance and document the free-form field controls.

## Related Issue (required)

closes #1871

## Testing

- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `cargo check --workspace --all-targets --all-features --locked`
- [x] `deno task check`
- [x] `cargo run -p xtask -- openapi-check`
- [x] `cargo run -p xtask -- architecture-check`
- [x] `cargo run -p xtask -- docs-current-stack-check`
- [x] `cargo run -p xtask -- legacy-auth-check`
- [x] `mise run test:frontend` (70 files, 505 tests)
- [ ] `deno task --cwd frontend coverage` (all tests pass, but the existing repository-wide 100% coverage threshold is not met)
