### PR TITLE
fix(entries): make form creation one revision and preserve timestamp semantics

### DIFF
--- a/crates/ugoite-iceberg/src/asset.rs
+++ b/crates/ugoite-iceberg/src/asset.rs
@@ -33,7 +33,7 @@ fn asset_form_definition() -> serde_json::Value {
         "fields": {
             "name": {"type": "string", "required": true},
             "link": {"type": "string", "required": true},
-            "uploaded_at": {"type": "timestamp", "required": true}
+            "uploaded_at": {"type": "timestamp_tz", "required": true}
         },
         "allow_extra_attributes": "deny"
     })

--- a/crates/ugoite-iceberg/src/entry.rs
+++ b/crates/ugoite-iceberg/src/entry.rs
@@ -41,6 +41,10 @@ fn revision_not_found(entry_id: &str, revision_id: &str) -> AppError {
     )
 }
 
+fn invalid_entry_input(message: impl Into<String>) -> anyhow::Error {
+    AppError::invalid_input(ErrorCode::InvalidInput, message).into()
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct IntegrityPayload {
     #[serde(default)]
@@ -1028,8 +1032,8 @@ async fn prepare_entry<I: IntegrityProvider>(
 ) -> Result<(EntryMeta, String, Value, RevisionRow)> {
     let normalized_content = normalize_ugoite_links(content);
     let (frontmatter, sections) = parse_markdown(&normalized_content);
-    let form_name =
-        extract_form(&frontmatter).ok_or_else(|| anyhow!("Form is required for entry creation"))?;
+    let form_name = extract_form(&frontmatter)
+        .ok_or_else(|| invalid_entry_input("Form is required for entry creation"))?;
     let form_def = form::read_form_definition(op, ws_path, &form_name).await?;
 
     let form_fields = form_field_names(&form_def);
@@ -1037,16 +1041,20 @@ async fn prepare_entry<I: IntegrityProvider>(
     let policy = extra_attributes_policy(&form_def);
     let (extras, extra_attributes) = collect_extra_attributes(&sections, &form_set);
     if !extras.is_empty() && policy == ExtraAttributesPolicy::Deny {
-        return Err(anyhow!("Unknown form fields: {}", extras.join(", ")));
+        return Err(invalid_entry_input(format!(
+            "Unknown form fields: {}",
+            extras.join(", ")
+        )));
     }
 
     let properties = index::extract_properties(&normalized_content);
     let (casted, warnings) = index::validate_properties(&properties, &form_def)?;
     if !warnings.is_empty() {
-        return Err(anyhow!(
+        let message = format!(
             "Form validation failed: {}",
             serde_json::to_string(&warnings)?
-        ));
+        );
+        return Err(invalid_entry_input(message));
     }
 
     let mut fields = Map::new();
@@ -1370,10 +1378,10 @@ pub async fn update_entry<I: IntegrityProvider>(
 
     let normalized_content = normalize_ugoite_links(content);
     let (frontmatter, sections) = parse_markdown(&normalized_content);
-    let updated_form =
-        extract_form(&frontmatter).ok_or_else(|| anyhow!("Form is required for entry update"))?;
+    let updated_form = extract_form(&frontmatter)
+        .ok_or_else(|| invalid_entry_input("Form is required for entry update"))?;
     if updated_form != form_name {
-        return Err(anyhow!("Form change is not supported"));
+        return Err(invalid_entry_input("Form change is not supported"));
     }
 
     let form_def = form::read_form_definition(op, ws_path, &form_name).await?;
@@ -1382,16 +1390,20 @@ pub async fn update_entry<I: IntegrityProvider>(
     let policy = extra_attributes_policy(&form_def);
     let (extras, extra_attributes) = collect_extra_attributes(&sections, &form_set);
     if !extras.is_empty() && policy == ExtraAttributesPolicy::Deny {
-        return Err(anyhow!("Unknown form fields: {}", extras.join(", ")));
+        return Err(invalid_entry_input(format!(
+            "Unknown form fields: {}",
+            extras.join(", ")
+        )));
     }
 
     let properties = index::extract_properties(&normalized_content);
     let (casted, warnings) = index::validate_properties(&properties, &form_def)?;
     if !warnings.is_empty() {
-        return Err(anyhow!(
+        let message = format!(
             "Form validation failed: {}",
             serde_json::to_string(&warnings)?
-        ));
+        );
+        return Err(invalid_entry_input(message));
     }
 
     let mut fields = Map::new();

--- a/crates/ugoite-iceberg/src/iceberg_store.rs
+++ b/crates/ugoite-iceberg/src/iceberg_store.rs
@@ -1,7 +1,8 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Error, Result};
 use opendal::Operator;
 use serde_json::Value;
 use std::collections::HashSet;
+use ugoite_core::error::{AppError, ErrorCode};
 use ugoite_domain::entry::EntryRevision;
 use ugoite_domain::form::FormDefinition;
 use ugoite_domain::id::SpaceId;
@@ -68,7 +69,10 @@ async fn domain_form_by_name(
         .into_iter()
         .find(|form| form.name == form_name)
         .ok_or_else(|| {
-            anyhow!("Form is not registered in the authoritative SpaceCatalog: {form_name}")
+            Error::from(AppError::not_found(
+                ErrorCode::FormNotFound,
+                format!("Form not found: {form_name}"),
+            ))
         })?;
     Ok((workspace, form))
 }

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use arrow_json::writer::ArrayWriter;
 use base64::Engine as _;
-use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, SecondsFormat, Timelike, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use opendal::Operator;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -1086,31 +1086,44 @@ fn parse_boolean(value: &str) -> Option<bool> {
     }
 }
 
-fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
-    if let Ok(timestamp) = DateTime::parse_from_rfc3339(value) {
-        return Some(timestamp.with_timezone(&Utc));
+fn parse_wall_timestamp(value: &str) -> Option<NaiveDateTime> {
+    ["%Y-%m-%dT%H:%M:%S%.f", "%Y-%m-%dT%H:%M"]
+        .into_iter()
+        .find_map(|format| NaiveDateTime::parse_from_str(value, format).ok())
+}
+
+fn parse_zoned_timestamp(value: &str) -> Option<DateTime<chrono::FixedOffset>> {
+    DateTime::parse_from_rfc3339(value).ok()
+}
+
+fn format_wall_timestamp(timestamp: NaiveDateTime, nanosecond_precision: bool) -> String {
+    let base = timestamp.format("%Y-%m-%dT%H:%M:%S").to_string();
+    let nanos = if nanosecond_precision {
+        timestamp.nanosecond()
+    } else {
+        (timestamp.nanosecond() / 1_000) * 1_000
+    };
+    if nanos == 0 {
+        return base;
     }
+    let fraction = format!("{nanos:09}").trim_end_matches('0').to_string();
+    format!("{base}.{fraction}")
+}
 
-    [
-        "%Y-%m-%dT%H:%M:%S%.f",
-        "%Y-%m-%d %H:%M:%S%.f",
-        "%Y-%m-%dT%H:%M",
-        "%Y-%m-%d %H:%M",
-    ]
-    .into_iter()
-    .find_map(|format| {
-        NaiveDateTime::parse_from_str(value, format)
-            .ok()
-            .map(|timestamp| timestamp.and_utc())
+fn normalize_wall_timestamp(value: &str, nanosecond_precision: bool) -> Option<String> {
+    parse_wall_timestamp(value)
+        .map(|timestamp| format_wall_timestamp(timestamp, nanosecond_precision))
+}
+
+fn normalize_zoned_timestamp(value: &str, nanosecond_precision: bool) -> Option<String> {
+    parse_zoned_timestamp(value).map(|timestamp| {
+        let timestamp = timestamp.with_timezone(&chrono::Utc);
+        if nanosecond_precision {
+            timestamp.to_rfc3339_opts(chrono::SecondsFormat::Nanos, false)
+        } else {
+            timestamp.to_rfc3339()
+        }
     })
-}
-
-fn normalize_timestamp(value: &str) -> Option<String> {
-    parse_timestamp(value).map(|timestamp| timestamp.to_rfc3339())
-}
-
-fn normalize_timestamp_ns(value: &str) -> Option<String> {
-    parse_timestamp(value).map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Nanos, false))
 }
 
 fn normalize_time(value: &str) -> Option<String> {
@@ -1292,19 +1305,19 @@ pub fn validate_properties(properties: &Value, entry_form: &Value) -> Result<(Va
                 _ => None,
             },
             "timestamp" => match raw_value {
-                Value::String(ref s) => normalize_timestamp(s).map(Value::String),
+                Value::String(ref s) => normalize_wall_timestamp(s, false).map(Value::String),
                 _ => None,
             },
             "timestamp_tz" => match raw_value {
-                Value::String(ref s) => normalize_timestamp(s).map(Value::String),
+                Value::String(ref s) => normalize_zoned_timestamp(s, false).map(Value::String),
                 _ => None,
             },
             "timestamp_ns" => match raw_value {
-                Value::String(ref s) => normalize_timestamp_ns(s).map(Value::String),
+                Value::String(ref s) => normalize_wall_timestamp(s, true).map(Value::String),
                 _ => None,
             },
             "timestamp_tz_ns" => match raw_value {
-                Value::String(ref s) => normalize_timestamp_ns(s).map(Value::String),
+                Value::String(ref s) => normalize_zoned_timestamp(s, true).map(Value::String),
                 _ => None,
             },
             "uuid" => match raw_value {

--- a/crates/ugoite-iceberg/src/index.rs
+++ b/crates/ugoite-iceberg/src/index.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use arrow_json::writer::ArrayWriter;
 use base64::Engine as _;
-use chrono::{DateTime, NaiveDate, NaiveTime, SecondsFormat, Timelike, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, SecondsFormat, Timelike, Utc};
 use opendal::Operator;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -1086,17 +1086,31 @@ fn parse_boolean(value: &str) -> Option<bool> {
     }
 }
 
+fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(value) {
+        return Some(timestamp.with_timezone(&Utc));
+    }
+
+    [
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M",
+        "%Y-%m-%d %H:%M",
+    ]
+    .into_iter()
+    .find_map(|format| {
+        NaiveDateTime::parse_from_str(value, format)
+            .ok()
+            .map(|timestamp| timestamp.and_utc())
+    })
+}
+
 fn normalize_timestamp(value: &str) -> Option<String> {
-    DateTime::parse_from_rfc3339(value)
-        .ok()
-        .map(|dt| dt.with_timezone(&Utc).to_rfc3339())
+    parse_timestamp(value).map(|timestamp| timestamp.to_rfc3339())
 }
 
 fn normalize_timestamp_ns(value: &str) -> Option<String> {
-    DateTime::parse_from_rfc3339(value).ok().map(|dt| {
-        dt.with_timezone(&Utc)
-            .to_rfc3339_opts(SecondsFormat::Nanos, false)
-    })
+    parse_timestamp(value).map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Nanos, false))
 }
 
 fn normalize_time(value: &str) -> Option<String> {

--- a/crates/ugoite-iceberg/src/lib.rs
+++ b/crates/ugoite-iceberg/src/lib.rs
@@ -1926,12 +1926,30 @@ fn field_array(
                 })
                 .collect::<Result<Vec<_>>>()?,
         ))),
-        FieldType::Timestamp | FieldType::TimestampTz => {
+        FieldType::Timestamp => {
             let values = values
                 .iter()
                 .map(|value| match value {
                     Some(FieldValue::String(value)) => {
-                        parse_timestamp_micros(value).map_err(|error| {
+                        parse_wall_timestamp_micros(value).map_err(|error| {
+                            anyhow!(
+                                "invalid timestamp value for field '{}': {error}",
+                                field.name
+                            )
+                        })
+                    }
+                    Some(FieldValue::Null) | None => Ok(None),
+                    _ => Err(anyhow!("timestamp field '{}' must be a string", field.name)),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Arc::new(TimestampMicrosecondArray::from(values)))
+        }
+        FieldType::TimestampTz => {
+            let values = values
+                .iter()
+                .map(|value| match value {
+                    Some(FieldValue::String(value)) => {
+                        parse_zoned_timestamp_micros(value).map_err(|error| {
                             anyhow!(
                                 "invalid timestamp value for field '{}': {error}",
                                 field.name
@@ -1943,18 +1961,14 @@ fn field_array(
                 })
                 .collect::<Result<Vec<_>>>()?;
             let array = TimestampMicrosecondArray::from(values);
-            if matches!(field.field_type, FieldType::TimestampTz) {
-                Ok(Arc::new(array.with_timezone("+00:00")))
-            } else {
-                Ok(Arc::new(array))
-            }
+            Ok(Arc::new(array.with_timezone("+00:00")))
         }
-        FieldType::TimestampNs | FieldType::TimestampTzNs => {
+        FieldType::TimestampNs => {
             let values = values
                 .iter()
                 .map(|value| match value {
                     Some(FieldValue::String(value)) => {
-                        parse_timestamp_nanos(value).map_err(|error| {
+                        parse_wall_timestamp_nanos(value).map_err(|error| {
                             anyhow!(
                                 "invalid nanosecond timestamp for field '{}': {error}",
                                 field.name
@@ -1965,12 +1979,27 @@ fn field_array(
                     _ => Err(anyhow!("timestamp field '{}' must be a string", field.name)),
                 })
                 .collect::<Result<Vec<_>>>()?;
-            let array = TimestampNanosecondArray::from(values);
-            if matches!(field.field_type, FieldType::TimestampTzNs) {
-                Ok(Arc::new(array.with_timezone("+00:00")))
-            } else {
-                Ok(Arc::new(array))
-            }
+            Ok(Arc::new(TimestampNanosecondArray::from(values)))
+        }
+        FieldType::TimestampTzNs => {
+            let values = values
+                .iter()
+                .map(|value| match value {
+                    Some(FieldValue::String(value)) => {
+                        parse_zoned_timestamp_nanos(value).map_err(|error| {
+                            anyhow!(
+                                "invalid nanosecond timestamp for field '{}': {error}",
+                                field.name
+                            )
+                        })
+                    }
+                    Some(FieldValue::Null) | None => Ok(None),
+                    _ => Err(anyhow!("timestamp field '{}' must be a string", field.name)),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Arc::new(
+                TimestampNanosecondArray::from(values).with_timezone("+00:00"),
+            ))
         }
         FieldType::Uuid => {
             let mut builder = FixedSizeBinaryBuilder::with_capacity(values.len(), 16);
@@ -2027,26 +2056,54 @@ fn parse_time_micros(value: &str) -> Result<Option<i64>> {
     ))
 }
 
-fn parse_timestamp_micros(value: &str) -> Result<Option<i64>> {
-    if let Ok(timestamp) = DateTime::parse_from_rfc3339(value) {
-        return Ok(Some(timestamp.timestamp_micros()));
-    }
+fn parse_wall_timestamp_micros(value: &str) -> Result<Option<i64>> {
     let timestamp = NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f")
-        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f"))?;
-    Ok(Some(timestamp.and_utc().timestamp_micros()))
+        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M"))?;
+    Ok(Some(wall_timestamp_micros(timestamp)?))
 }
 
-fn parse_timestamp_nanos(value: &str) -> Result<Option<i64>> {
-    if let Ok(timestamp) = DateTime::parse_from_rfc3339(value) {
-        return Ok(Some(timestamp.timestamp_nanos_opt().context(
-            "timestamp is outside the representable nanosecond range",
-        )?));
-    }
+fn parse_zoned_timestamp_micros(value: &str) -> Result<Option<i64>> {
+    Ok(Some(
+        DateTime::parse_from_rfc3339(value)?.timestamp_micros(),
+    ))
+}
+
+fn parse_wall_timestamp_nanos(value: &str) -> Result<Option<i64>> {
     let timestamp = NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f")
-        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S%.f"))?;
-    Ok(Some(timestamp.and_utc().timestamp_nanos_opt().context(
-        "timestamp is outside the representable nanosecond range",
-    )?))
+        .or_else(|_| NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M"))?;
+    Ok(Some(wall_timestamp_nanos(timestamp)?))
+}
+
+/// Encode a timezone-less Iceberg timestamp as its wall-clock coordinate.
+/// This is numeric encoding only; it does not infer or apply a timezone.
+fn wall_timestamp_micros(timestamp: NaiveDateTime) -> Result<i64> {
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .expect("valid Unix epoch");
+    timestamp
+        .signed_duration_since(epoch)
+        .num_microseconds()
+        .context("timestamp is outside the representable microsecond range")
+}
+
+/// Encode a timezone-less Iceberg timestamp as its wall-clock coordinate.
+/// This is numeric encoding only; it does not infer or apply a timezone.
+fn wall_timestamp_nanos(timestamp: NaiveDateTime) -> Result<i64> {
+    let epoch = NaiveDate::from_ymd_opt(1970, 1, 1)
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .expect("valid Unix epoch");
+    timestamp
+        .signed_duration_since(epoch)
+        .num_nanoseconds()
+        .context("timestamp is outside the representable nanosecond range")
+}
+
+fn parse_zoned_timestamp_nanos(value: &str) -> Result<Option<i64>> {
+    Ok(Some(
+        DateTime::parse_from_rfc3339(value)?
+            .timestamp_nanos_opt()
+            .context("timestamp is outside the representable nanosecond range")?,
+    ))
 }
 
 fn uuid_value_at(array: &dyn Array, row: usize) -> Result<Uuid> {
@@ -2359,22 +2416,34 @@ fn field_value_at(column: &dyn Array, row: usize, kind: &FieldType) -> Result<Op
                 .ok_or_else(invalid)?
                 .value(row),
         )?),
-        FieldType::Timestamp | FieldType::TimestampTz => FieldValue::String(timestamp_from_micros(
+        FieldType::Timestamp => FieldValue::String(wall_timestamp_from_micros(
             column
                 .as_any()
                 .downcast_ref::<TimestampMicrosecondArray>()
                 .ok_or_else(invalid)?
                 .value(row),
         )?),
-        FieldType::TimestampNs | FieldType::TimestampTzNs => {
-            FieldValue::String(timestamp_from_nanos(
-                column
-                    .as_any()
-                    .downcast_ref::<TimestampNanosecondArray>()
-                    .ok_or_else(invalid)?
-                    .value(row),
-            )?)
-        }
+        FieldType::TimestampTz => FieldValue::String(timestamp_from_micros(
+            column
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .ok_or_else(invalid)?
+                .value(row),
+        )?),
+        FieldType::TimestampNs => FieldValue::String(wall_timestamp_from_nanos(
+            column
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .ok_or_else(invalid)?
+                .value(row),
+        )?),
+        FieldType::TimestampTzNs => FieldValue::String(timestamp_from_nanos(
+            column
+                .as_any()
+                .downcast_ref::<TimestampNanosecondArray>()
+                .ok_or_else(invalid)?
+                .value(row),
+        )?),
         FieldType::Uuid => FieldValue::String(
             Uuid::from_slice(
                 column
@@ -2482,6 +2551,23 @@ fn timestamp_from_micros(micros: i64) -> Result<String> {
         .map(|timestamp: DateTime<chrono::Utc>| timestamp.to_rfc3339())
 }
 
+fn wall_timestamp_from_micros(micros: i64) -> Result<String> {
+    DateTime::from_timestamp_micros(micros)
+        .context("timestamp is outside the supported range")
+        .map(|timestamp: DateTime<chrono::Utc>| {
+            let naive = timestamp.naive_utc();
+            let base = naive.format("%Y-%m-%dT%H:%M:%S").to_string();
+            let fraction = format!("{:06}", naive.and_utc().timestamp_subsec_micros())
+                .trim_end_matches('0')
+                .to_string();
+            if fraction.is_empty() {
+                base
+            } else {
+                format!("{base}.{fraction}")
+            }
+        })
+}
+
 fn timestamp_from_nanos(nanos: i64) -> Result<String> {
     let seconds = nanos.div_euclid(1_000_000_000);
     let nanos = u32::try_from(nanos.rem_euclid(1_000_000_000))?;
@@ -2489,6 +2575,25 @@ fn timestamp_from_nanos(nanos: i64) -> Result<String> {
         .context("timestamp is outside the supported range")
         .map(|timestamp: DateTime<chrono::Utc>| {
             timestamp.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true)
+        })
+}
+
+fn wall_timestamp_from_nanos(nanos: i64) -> Result<String> {
+    let seconds = nanos.div_euclid(1_000_000_000);
+    let nanos = u32::try_from(nanos.rem_euclid(1_000_000_000))?;
+    DateTime::from_timestamp(seconds, nanos)
+        .context("timestamp is outside the supported range")
+        .map(|timestamp: DateTime<chrono::Utc>| {
+            let naive = timestamp.naive_utc();
+            let base = naive.format("%Y-%m-%dT%H:%M:%S").to_string();
+            let fraction = format!("{:09}", naive.nanosecond())
+                .trim_end_matches('0')
+                .to_string();
+            if fraction.is_empty() {
+                base
+            } else {
+                format!("{base}.{fraction}")
+            }
         })
 }
 

--- a/crates/ugoite-iceberg/tests/test_entry.rs
+++ b/crates/ugoite-iceberg/tests/test_entry.rs
@@ -43,6 +43,62 @@ async fn test_entry_req_entry_001_create_entry_basic() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn entry_create_with_numeric_and_all_timestamp_fields_publishes_one_revision(
+) -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "entry-create-fields", "/tmp").await?;
+    let ws_path = "spaces/entry-create-fields";
+    form::upsert_form(
+        &op,
+        ws_path,
+        &serde_json::json!({
+            "name": "Entry",
+            "fields": {
+                "Body": {"type": "markdown"},
+                "test number": {"type": "double"},
+                "ts": {"type": "timestamp"},
+                "ts tz": {"type": "timestamp_tz"},
+                "ts ns": {"type": "timestamp_ns"},
+                "ts tz ns": {"type": "timestamp_tz_ns"},
+            },
+            "allow_extra_attributes": "allow_columns",
+        }),
+    )
+    .await?;
+    let integrity = FakeIntegrityProvider;
+    let content = "---\nform: Entry\n---\n# Entry\n\n## Body\nmemememo\n\n## test number\n0\n\n## ts\n2026-08-21T10:48\n\n## ts tz\n2026-08-21T10:48:00+09:00\n\n## ts ns\n2026-08-21T10:48:00.123456789\n\n## ts tz ns\n2026-08-21T10:48:00.123456789+09:00";
+
+    let created = entry::create_entry(
+        &op,
+        ws_path,
+        "entry-create-fields-1",
+        content,
+        "author",
+        &integrity,
+    )
+    .await?;
+    let current = entry::get_entry_content(&op, ws_path, "entry-create-fields-1").await?;
+    let history = entry::get_entry_history(&op, ws_path, "entry-create-fields-1").await?;
+    let revisions = history["revisions"].as_array().expect("revision array");
+
+    assert_eq!(created.id, "entry-create-fields-1");
+    assert_eq!(revisions.len(), 1);
+    assert_eq!(revisions[0]["revision_id"], current.revision_id);
+    assert!(current.markdown.contains("## ts\n2026-08-21T10:48:00"));
+    assert!(current
+        .markdown
+        .contains("## ts tz\n2026-08-21T01:48:00+00:00"));
+    assert!(current
+        .markdown
+        .contains("## ts ns\n2026-08-21T10:48:00.123456789"));
+    assert!(current
+        .markdown
+        .contains("## ts tz ns\n2026-08-21T01:48:00.123456789Z"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn entry_update_after_create_with_numeric_and_timestamp_fields() -> anyhow::Result<()> {
     let op = setup_operator()?;
     space::create_space(&op, "entry-form-fields", "/tmp").await?;
@@ -92,13 +148,11 @@ async fn entry_update_after_create_with_numeric_and_timestamp_fields() -> anyhow
     .await?;
 
     let updated = entry::get_entry_content(&op, ws_path, "entry-form-fields-1").await?;
-    assert!(updated
-        .markdown
-        .contains("## ts\n2026-08-21T10:48:00+00:00"));
+    assert!(updated.markdown.contains("## ts\n2026-08-21T10:48:00"));
 
     let invalid_content = updated
         .markdown
-        .replace("2026-08-21T10:48:00+00:00", "not-a-timestamp");
+        .replace("2026-08-21T10:48:00", "not-a-timestamp");
     let error = entry::update_entry(
         &op,
         ws_path,

--- a/crates/ugoite-iceberg/tests/test_entry.rs
+++ b/crates/ugoite-iceberg/tests/test_entry.rs
@@ -43,6 +43,86 @@ async fn test_entry_req_entry_001_create_entry_basic() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn entry_update_after_create_with_numeric_and_timestamp_fields() -> anyhow::Result<()> {
+    let op = setup_operator()?;
+    space::create_space(&op, "entry-form-fields", "/tmp").await?;
+    let ws_path = "spaces/entry-form-fields";
+    form::upsert_form(
+        &op,
+        ws_path,
+        &serde_json::json!({
+            "name": "Entry",
+            "fields": {
+                "Body": {"type": "markdown"},
+                "test number": {"type": "double"},
+                "ts": {"type": "timestamp"},
+            },
+            "allow_extra_attributes": "allow_columns",
+        }),
+    )
+    .await?;
+    let integrity = FakeIntegrityProvider;
+    let content = "---\nform: Entry\n---\n# Entry\n\n## Body\nmemememo";
+
+    entry::create_entry(
+        &op,
+        ws_path,
+        "entry-form-fields-1",
+        content,
+        "author",
+        &integrity,
+    )
+    .await?;
+    let current = entry::get_entry_content(&op, ws_path, "entry-form-fields-1").await?;
+
+    let updated_content = format!(
+        "{}\n\n## test number\n0\n\n## ts\n2026-08-21T10:48",
+        current.markdown.replace("memememo", "memememo updated")
+    );
+    entry::update_entry(
+        &op,
+        ws_path,
+        "entry-form-fields-1",
+        &updated_content,
+        Some(&current.revision_id),
+        "author",
+        None,
+        &integrity,
+    )
+    .await?;
+
+    let updated = entry::get_entry_content(&op, ws_path, "entry-form-fields-1").await?;
+    assert!(updated
+        .markdown
+        .contains("## ts\n2026-08-21T10:48:00+00:00"));
+
+    let invalid_content = updated
+        .markdown
+        .replace("2026-08-21T10:48:00+00:00", "not-a-timestamp");
+    let error = entry::update_entry(
+        &op,
+        ws_path,
+        "entry-form-fields-1",
+        &invalid_content,
+        Some(&updated.revision_id),
+        "author",
+        None,
+        &integrity,
+    )
+    .await
+    .expect_err("invalid timestamp input must be rejected");
+    let app_error = error
+        .downcast_ref::<ugoite_core::error::AppError>()
+        .expect("entry validation failures must remain typed application errors");
+    assert_eq!(
+        app_error.code(),
+        ugoite_core::error::ErrorCode::InvalidInput
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn explicit_entry_batch_creates_all_entries() -> anyhow::Result<()> {
     let op = setup_operator()?;
     space::create_space(&op, "batched-entry-space", "/tmp").await?;

--- a/crates/ugoite-iceberg/tests/test_index.rs
+++ b/crates/ugoite-iceberg/tests/test_index.rs
@@ -213,7 +213,7 @@ fn test_index_req_idx_010_rich_content_parsing() -> anyhow::Result<()> {
         }
     });
 
-    let markdown = "---\nclass: Meeting\n---\n# Title\n\n## Done\ntrue\n\n## Count\n42\n\n## Rate\n3.14\n\n## Event\n2025-01-02T03:04:05Z\n\n## EventTz\n2025-01-02T12:04:05+09:00\n\n## EventNs\n2025-01-02T03:04:05.123456789Z\n\n## EventTzNs\n2025-01-02T12:04:05.123456789+09:00\n\n## Time\n13:45:30.123456\n\n## Uid\nA7F9F5D2-8B7E-4DB1-9B0A-0E9A2B3F4C5D\n\n## Blob\nhex:64617461\n\n## Items\n- Alpha\n- Beta\n";
+    let markdown = "---\nclass: Meeting\n---\n# Title\n\n## Done\ntrue\n\n## Count\n42\n\n## Rate\n3.14\n\n## Event\n2025-01-02T03:04:05\n\n## EventTz\n2025-01-02T12:04:05+09:00\n\n## EventNs\n2025-01-02T03:04:05.123456789\n\n## EventTzNs\n2025-01-02T12:04:05.123456789+09:00\n\n## Time\n13:45:30.123456\n\n## Uid\nA7F9F5D2-8B7E-4DB1-9B0A-0E9A2B3F4C5D\n\n## Blob\nhex:64617461\n\n## Items\n- Alpha\n- Beta\n";
     let props = index::extract_properties(markdown);
     let (casted, warnings) = index::validate_properties(&props, &class_def)?;
     assert!(warnings.is_empty());
@@ -225,7 +225,7 @@ fn test_index_req_idx_010_rich_content_parsing() -> anyhow::Result<()> {
     assert!((rate - (314.0 / 100.0)).abs() < 0.0001);
     assert_eq!(
         casted_obj.get("Event").and_then(|v| v.as_str()),
-        Some("2025-01-02T03:04:05+00:00")
+        Some("2025-01-02T03:04:05")
     );
     assert_eq!(
         casted_obj.get("EventTz").and_then(|v| v.as_str()),
@@ -233,7 +233,7 @@ fn test_index_req_idx_010_rich_content_parsing() -> anyhow::Result<()> {
     );
     assert_eq!(
         casted_obj.get("EventNs").and_then(|v| v.as_str()),
-        Some("2025-01-02T03:04:05.123456789+00:00")
+        Some("2025-01-02T03:04:05.123456789")
     );
     assert_eq!(
         casted_obj.get("EventTzNs").and_then(|v| v.as_str()),
@@ -254,6 +254,45 @@ fn test_index_req_idx_010_rich_content_parsing() -> anyhow::Result<()> {
     assert_eq!(items[0].as_str(), Some("Alpha"));
     assert_eq!(items[1].as_str(), Some("Beta"));
 
+    Ok(())
+}
+
+#[test]
+fn timestamp_types_reject_values_with_the_wrong_timezone_contract() -> anyhow::Result<()> {
+    let form_def = serde_json::json!({
+        "name": "Event",
+        "fields": {
+            "Wall": {"type": "timestamp"},
+            "Instant": {"type": "timestamp_tz"},
+            "WallNs": {"type": "timestamp_ns"},
+            "InstantNs": {"type": "timestamp_tz_ns"},
+        }
+    });
+
+    let wall_with_offset = serde_json::json!({
+        "Wall": "2025-01-02T03:04:05+09:00",
+        "Instant": "2025-01-02T03:04:05+09:00",
+        "WallNs": "2025-01-02T03:04:05.123456789+09:00",
+        "InstantNs": "2025-01-02T03:04:05.123456789+09:00",
+    });
+    let (_, warnings) = index::validate_properties(&wall_with_offset, &form_def)?;
+    assert_eq!(warnings.len(), 2);
+    assert!(warnings.iter().all(|warning| {
+        warning["code"] == "invalid_type"
+            && ["Wall", "WallNs"].contains(&warning["field"].as_str().unwrap_or_default())
+    }));
+
+    let naive_timezone_values = serde_json::json!({
+        "Wall": "2025-01-02T03:04:05",
+        "Instant": "2025-01-02T03:04:05",
+        "WallNs": "2025-01-02T03:04:05.123456789",
+        "InstantNs": "2025-01-02T03:04:05.123456789",
+    });
+    let (_, warnings) = index::validate_properties(&naive_timezone_values, &form_def)?;
+    assert_eq!(warnings.len(), 2);
+    assert!(warnings.iter().all(|warning| {
+        ["Instant", "InstantNs"].contains(&warning["field"].as_str().unwrap_or_default())
+    }));
     Ok(())
 }
 

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -4460,7 +4460,11 @@ pub fn openapi_snapshot() -> Value {
 #[cfg(test)]
 mod authentication_regression_tests {
     use super::*;
-    use axum::{body::Body, http::Request, routing::post};
+    use axum::{
+        body::Body,
+        http::Request,
+        routing::{get, post, put},
+    };
     use tower::ServiceExt;
 
     fn token_claims(sub: Uuid, actor_principal_id: Option<Uuid>) -> AccessTokenClaims {
@@ -4485,6 +4489,37 @@ mod authentication_regression_tests {
             cnf: Confirmation {
                 jkt: "thumbprint".to_string(),
             },
+        }
+    }
+
+    fn content_identity(principal_id: Uuid, space_uid: Uuid) -> RequestIdentityContext {
+        RequestIdentityContext {
+            request_identity: RequestIdentity {
+                subject: AuthenticatedSubject::HumanAccount {
+                    account_id: principal_id,
+                },
+                actor: Actor::Human {
+                    account_id: principal_id,
+                },
+                credential_id: Uuid::now_v7(),
+                authentication_method: RequestAuthenticationMethod::Passkey,
+                assurance: AssuranceLevel::PhishingResistant,
+                constraints: CredentialConstraints::default(),
+                session_id: None,
+            },
+            account_id: principal_id,
+            display_name: "Route test".into(),
+            node_admin: false,
+            token_principal_id: Some(principal_id),
+            token_actor_principal_id: None,
+            token_space_uid: Some(space_uid),
+            token_actions: Some(
+                ["read", "create", "update"]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+            ),
+            recent_passkey: true,
         }
     }
 
@@ -4576,34 +4611,7 @@ mod authentication_regression_tests {
             "allow_extra_attributes": "deny"
         });
         let space_uid = state.service.space_uid(&space_id).await?;
-        let identity = RequestIdentityContext {
-            request_identity: RequestIdentity {
-                subject: AuthenticatedSubject::HumanAccount {
-                    account_id: principal_id,
-                },
-                actor: Actor::Human {
-                    account_id: principal_id,
-                },
-                credential_id: Uuid::from_u128(1863),
-                authentication_method: RequestAuthenticationMethod::Passkey,
-                assurance: AssuranceLevel::PhishingResistant,
-                constraints: CredentialConstraints::default(),
-                session_id: None,
-            },
-            account_id: principal_id,
-            display_name: "Route test".into(),
-            node_admin: false,
-            token_principal_id: Some(principal_id),
-            token_actor_principal_id: None,
-            token_space_uid: Some(space_uid),
-            token_actions: Some(
-                ["read", "create", "update"]
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect(),
-            ),
-            recent_passkey: true,
-        };
+        let identity = content_identity(principal_id, space_uid);
         let route = Router::new()
             .route("/spaces/{space_id}/forms", post(upsert_form))
             .layer(Extension(identity))
@@ -4626,6 +4634,151 @@ mod authentication_regression_tests {
         );
         let stored = state.service.get_form(&space_id, "Meeting").await?;
         assert_eq!(stored["fields"]["time"]["type"], "timestamp");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn entry_routes_keep_input_errors_typed_and_create_atomic() -> anyhow::Result<()> {
+        let state = AppState::new_for_tests("memory://server-entry-create-contract")?;
+        let principal_id = Uuid::from_u128(1872);
+        let space_id = state
+            .service
+            .create_space_for_principal("entry-create-contract", principal_id, "Route test")
+            .await?
+            .to_string();
+        state
+            .service
+            .upsert_form(
+                &space_id,
+                &json!({
+                    "name": "Entry",
+                    "fields": {
+                        "Body": {"type": "markdown"},
+                        "test number": {"type": "double"},
+                        "ts": {"type": "timestamp"}
+                    },
+                    "allow_extra_attributes": "allow_columns"
+                }),
+            )
+            .await?;
+        let space_uid = state.service.space_uid(&space_id).await?;
+        let route = Router::new()
+            .route("/spaces/{space_id}/entries", post(create_entry))
+            .route("/spaces/{space_id}/entries/{entry_id}", put(update_entry))
+            .route(
+                "/spaces/{space_id}/entries/{entry_id}/history",
+                get(entry_history),
+            )
+            .layer(Extension(content_identity(principal_id, space_uid)))
+            .with_state(state.clone());
+
+        let invalid_response = route
+            .clone()
+            .oneshot(
+                Request::post(format!("/spaces/{space_id}/entries"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "id": "invalid-entry",
+                            "markdown": "---\nform: Entry\n---\n# Invalid\n\n## Body\nBody\n\n## test number\n0\n\n## ts\nnot-a-timestamp"
+                        })
+                        .to_string(),
+                    ))?,
+            )
+            .await
+            .expect("invalid entry response");
+        assert_eq!(invalid_response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let invalid_body = axum::body::to_bytes(invalid_response.into_body(), usize::MAX).await?;
+        let invalid_body: Value = serde_json::from_slice(&invalid_body)?;
+        assert_eq!(invalid_body["code"], "INVALID_INPUT");
+        assert!(state.service.list_entries(&space_id).await?.is_empty());
+
+        let missing_form_response = route
+            .clone()
+            .oneshot(
+                Request::post(format!("/spaces/{space_id}/entries"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "id": "missing-form-entry",
+                            "markdown": "---\nform: Missing\n---\n# Missing form"
+                        })
+                        .to_string(),
+                    ))?,
+            )
+            .await
+            .expect("missing form response");
+        assert_eq!(missing_form_response.status(), StatusCode::NOT_FOUND);
+        let missing_form_body =
+            axum::body::to_bytes(missing_form_response.into_body(), usize::MAX).await?;
+        let missing_form_body: Value = serde_json::from_slice(&missing_form_body)?;
+        assert_eq!(missing_form_body["code"], "FORM_NOT_FOUND");
+        assert!(state.service.list_entries(&space_id).await?.is_empty());
+
+        let success_response = route
+            .clone()
+            .oneshot(
+                Request::post(format!("/spaces/{space_id}/entries"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "id": "created-entry",
+                            "markdown": "---\nform: Entry\n---\n# Created\n\n## Body\nBody\n\n## test number\n0\n\n## ts\n2026-08-21T10:48"
+                        })
+                        .to_string(),
+                    ))?,
+            )
+            .await
+            .expect("successful entry response");
+        assert_eq!(success_response.status(), StatusCode::CREATED);
+        let success_body = axum::body::to_bytes(success_response.into_body(), usize::MAX).await?;
+        let success_body: Value = serde_json::from_slice(&success_body)?;
+        assert_eq!(success_body["id"], "created-entry");
+        let created_revision_id = success_body["revision_id"]
+            .as_str()
+            .expect("create response revision id");
+
+        let invalid_update_response = route
+            .clone()
+            .oneshot(
+                Request::put(format!(
+                    "/spaces/{space_id}/entries/created-entry"
+                ))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "markdown": "---\nform: Entry\n---\n# Created\n\n## Body\nBody\n\n## test number\n0\n\n## ts\nnot-a-timestamp",
+                        "parent_revision_id": created_revision_id
+                    })
+                    .to_string(),
+                ))?,
+            )
+            .await
+            .expect("invalid entry update response");
+        assert_eq!(
+            invalid_update_response.status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        let invalid_update_body =
+            axum::body::to_bytes(invalid_update_response.into_body(), usize::MAX).await?;
+        let invalid_update_body: Value = serde_json::from_slice(&invalid_update_body)?;
+        assert_eq!(invalid_update_body["code"], "INVALID_INPUT");
+
+        let history_response = route
+            .oneshot(
+                Request::get(format!("/spaces/{space_id}/entries/created-entry/history"))
+                    .body(Body::empty())?,
+            )
+            .await
+            .expect("entry history response");
+        assert_eq!(history_response.status(), StatusCode::OK);
+        let history_body = axum::body::to_bytes(history_response.into_body(), usize::MAX).await?;
+        let history_body: Value = serde_json::from_slice(&history_body)?;
+        let revisions = history_body["revisions"]
+            .as_array()
+            .expect("revision array");
+        assert_eq!(revisions.len(), 1);
+        assert_eq!(revisions[0]["revision_id"], created_revision_id);
         Ok(())
     }
 

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -63,6 +63,14 @@ recommending a new field; it does not return this expected rejection as a 500.
 Entry create and update validate Markdown sections against the selected Form.
 Invalid field values, missing required fields, missing Form metadata, and
 unknown fields return HTTP 422 with code `INVALID_INPUT`; they are not internal
-server failures. Timestamp fields accept RFC3339 values and browser
-`datetime-local` values with minute precision, which are normalized to UTC
-before the append-only revision is published.
+server failures. A referenced Form that does not exist returns HTTP 404 with
+code `FORM_NOT_FOUND`; storage failures remain internal/dependency failures.
+
+Timestamp field formats follow the Iceberg logical type. `timestamp` and
+`timestamp_ns` are timezone-less wall-clock values in the form
+`YYYY-MM-DDTHH:MM[:SS[.fraction]]`; offsets and RFC3339 timezone markers are
+rejected. `timestamp_tz` and `timestamp_tz_ns` require an offset-bearing
+RFC3339 value and normalize it to UTC before the append-only revision is
+published. Browser `datetime-local` values are used directly for timezone-less
+fields; the frontend adds the browser offset when it submits a timezone-aware
+field.

--- a/docs/spec/api/rest.md
+++ b/docs/spec/api/rest.md
@@ -59,3 +59,10 @@ Form evolution that changes the type of an existing field is intentionally
 unsupported before v1. The server returns HTTP 422 with code
 `FORM_FIELD_TYPE_CHANGE_NOT_SUPPORTED` and a message naming the field and
 recommending a new field; it does not return this expected rejection as a 500.
+
+Entry create and update validate Markdown sections against the selected Form.
+Invalid field values, missing required fields, missing Form metadata, and
+unknown fields return HTTP 422 with code `INVALID_INPUT`; they are not internal
+server failures. Timestamp fields accept RFC3339 values and browser
+`datetime-local` values with minute precision, which are normalized to UTC
+before the append-only revision is published.

--- a/docs/spec/data-model/overview.md
+++ b/docs/spec/data-model/overview.md
@@ -67,6 +67,13 @@ Iceberg primitive types. Markdown, SQL, row references, and ordinary strings
 remain Iceberg strings; binary entry values are base64 text at the domain
 boundary and binary data in the table.
 
+The timestamp types retain their distinct logical meanings. `timestamp` and
+`timestamp_ns` are timezone-less wall-clock values and preserve the entered
+local date-time. `timestamp_tz` and `timestamp_tz_ns` represent an instant,
+require an offset-bearing RFC3339 value at the domain boundary, and are stored
+normalized to UTC. The server never infers a timezone for a timezone-less
+value.
+
 ## Markdown mapping
 
 The global template is:

--- a/e2e/entries.test.ts
+++ b/e2e/entries.test.ts
@@ -207,6 +207,110 @@ test.describe("Entries CRUD", () => {
 		await expect(page.locator("#entry-form")).toHaveValue("Entry");
 	});
 
+	test("REQ-ENTRY-1872: form entry creation is one POST and one clean revision", async ({
+		page,
+		request,
+	}) => {
+		const timestamp = Date.now();
+		const formName = `EntryCreateFields-${timestamp}`;
+		const title = `Entry create boundary ${timestamp}`;
+		const formResponse = await request.post(
+			getBackendUrl("/spaces/default/forms"),
+			{
+				data: {
+					name: formName,
+					version: 1,
+					template: `# ${formName}\n\n## Body\n\n## test number\n\n## ts\n`,
+					fields: {
+						Body: { type: "markdown", required: false },
+						"test number": { type: "double", required: false },
+						ts: { type: "timestamp", required: false },
+					},
+				},
+			},
+		);
+		expect(formResponse.status()).toBe(201);
+
+		let entryPostCount = 0;
+		let entryPutCount = 0;
+		page.on("request", (requestEvent) => {
+			const url = new URL(requestEvent.url());
+			if (
+				requestEvent.method() === "POST" &&
+				url.pathname === "/api/spaces/default/entries"
+			) entryPostCount += 1;
+			if (
+				requestEvent.method() === "PUT" &&
+				/^\/api\/spaces\/default\/entries\/[^/]+$/.test(url.pathname)
+			) entryPutCount += 1;
+		});
+
+		await page.goto(
+			getFrontendUrl(
+				`/spaces/default/entries/new?form=${encodeURIComponent(formName)}`,
+			),
+			{ waitUntil: "domcontentloaded" },
+		);
+		await settleUiLoading(page);
+		await expect(page.getByLabel("Title")).toHaveValue(formName);
+		await page.getByLabel("Title").fill(title);
+		await page.getByLabel("test number").fill("0");
+		await page.getByLabel("ts").fill("2026-08-21T10:48");
+
+		const createResponsePromise = page.waitForResponse((response) => {
+			const url = new URL(response.url());
+			return response.request().method() === "POST" &&
+				url.pathname === "/api/spaces/default/entries";
+		});
+		const detailResponsePromise = page.waitForResponse((response) => {
+			const url = new URL(response.url());
+			return response.request().method() === "GET" &&
+				/^\/api\/spaces\/default\/entries\/[^/]+$/.test(url.pathname);
+		});
+		await page.getByRole("button", { name: "Save" }).click();
+		const createResponse = await createResponsePromise;
+		expect(createResponse.status()).toBe(201);
+		const created = (await createResponse.json()) as {
+			id: string;
+			revision_id: string;
+		};
+		const detailResponse = await detailResponsePromise;
+		expect(detailResponse.status()).toBe(200);
+		const detail = (await detailResponse.json()) as { revision_id: string };
+
+		await expect(page).toHaveURL(
+			new RegExp(`/spaces/default/entries/${created.id}$`),
+		);
+		await expect(page.getByText("All changes saved")).toBeVisible();
+		await expect(page.getByText("Unsaved changes")).toHaveCount(0);
+		await expect(page.locator(".ui-alert-error")).toHaveCount(0);
+		expect(entryPostCount).toBe(1);
+		expect(entryPutCount).toBe(0);
+		expect(detail.revision_id).toBe(created.revision_id);
+
+		const historyResponse = await request.get(
+			getBackendUrl(`/spaces/default/entries/${created.id}/history`),
+		);
+		expect(historyResponse.ok()).toBeTruthy();
+		const history = (await historyResponse.json()) as {
+			revisions: Array<{ revision_id: string }>;
+		};
+		expect(history.revisions).toHaveLength(1);
+		expect(history.revisions[0]?.revision_id).toBe(created.revision_id);
+
+		const entryResponse = await request.get(
+			getBackendUrl(`/spaces/default/entries/${created.id}`),
+		);
+		expect(entryResponse.ok()).toBeTruthy();
+		const entry = (await entryResponse.json()) as { content: string };
+		expect(entry.content).toContain("## test number\n0");
+		expect(entry.content).toContain("## ts\n2026-08-21T10:48:00");
+
+		await request.delete(
+			getBackendUrl(`/spaces/default/entries/${created.id}`),
+		);
+	});
+
 	test("REQ-FE-065: create-entry uses a searchable row_reference picker and stores the selected entry_id", async ({
 		page,
 		request,

--- a/frontend/src/components/EntryDetailPane.test.tsx
+++ b/frontend/src/components/EntryDetailPane.test.tsx
@@ -147,7 +147,66 @@ describe("EntryDetailPane", () => {
       markdown:
         "---\nform: Meeting\n---\n\n# Planning \n\n## Summary\nProject \n\n## Notes\nDetails \n\n\n## Items\none\ntwo\n\n",
     });
-    expect(onCreated).toHaveBeenCalledWith("created-entry");
+    expect(onCreated).toHaveBeenCalledWith({
+      id: "created-entry",
+      revision_id: "created-revision",
+    });
+  });
+
+  it("REQ-ENTRY-1872: creates numeric and timestamp fields in one clean revision", async () => {
+    const onCreated = vi.fn();
+    const createMock = entryApi.create as ReturnType<typeof vi.fn>;
+    createMock.mockResolvedValue({
+      id: "created-entry",
+      revision_id: "created-revision",
+    });
+    const form: Form = {
+      name: "Entry",
+      version: 1,
+      template: "# Entry\n\n## Body\n\n## test number\n\n## ts\n",
+      fields: {
+        Body: { type: "markdown", required: false },
+        "test number": { type: "double", required: false },
+        ts: { type: "timestamp", required: false },
+      },
+    };
+
+    render(() => (
+      <EntryDetailPane
+        spaceId={() => "default"}
+        forms={() => [form]}
+        createForm={() => form}
+        onCreated={onCreated}
+        onDeleted={vi.fn()}
+      />
+    ));
+
+    fireEvent.input(await screen.findByLabelText("test number"), {
+      target: { value: "0" },
+    });
+    fireEvent.input(screen.getByLabelText("ts"), {
+      target: { value: "2026-08-21T10:48" },
+    });
+
+    const save = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(save);
+    fireEvent.click(save);
+
+    await waitFor(() => expect(entryApi.create).toHaveBeenCalledTimes(1));
+    expect(entryApi.update).not.toHaveBeenCalled();
+    expect(entryApi.create).toHaveBeenCalledWith("default", {
+      markdown: expect.stringContaining("## test number\n0"),
+    });
+    expect(createMock.mock.calls[0][1].markdown).toContain(
+      "## ts\n2026-08-21T10:48",
+    );
+    expect(onCreated).toHaveBeenCalledWith({
+      id: "created-entry",
+      revision_id: "created-revision",
+    });
+    expect(screen.getByText("All changes saved")).toBeInTheDocument();
+    expect(save).toBeDisabled();
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
   });
 
   it("keeps nested Markdown headings out of form field values", async () => {

--- a/frontend/src/components/EntryDetailPane.tsx
+++ b/frontend/src/components/EntryDetailPane.tsx
@@ -38,7 +38,7 @@ export interface EntryDetailPaneProps {
   onCreateFormChange?: (formName: string) => void;
   onDeleted: () => void;
   onCancel?: () => void;
-  onCreated?: (entryId: string) => void;
+  onCreated?: (result: { id: string; revision_id: string }) => void;
   onAfterSave?: () => void;
 }
 
@@ -646,6 +646,7 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
   };
 
   const handleSave = async () => {
+    if (isSaving()) return;
     const context = resolveSaveContext();
     /* v8 ignore start */
     if (!context.ok) {
@@ -669,7 +670,7 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
       setLastSavedContent(contentToSave);
       setIsDirty(editorContent() !== contentToSave);
       props.onAfterSave?.();
-      if (context.create) props.onCreated?.(result.id);
+      if (context.create) props.onCreated?.(result);
     } catch (error) {
       handleSaveError(error);
     } finally {

--- a/frontend/src/lib/entry-input.test.ts
+++ b/frontend/src/lib/entry-input.test.ts
@@ -4,6 +4,49 @@ import { buildEntryMarkdownByMode } from "~/lib/entry-input";
 import type { Form } from "~/lib/types";
 
 describe("buildEntryMarkdownByMode", () => {
+  it("REQ-ENTRY-1872: adds the browser offset only for timezone-aware fields", () => {
+    const formDef: Form = {
+      name: "Event",
+      version: 1,
+      template: "# Event\n",
+      fields: {
+        Local: { type: "timestamp", required: false },
+        Instant: { type: "timestamp_tz", required: false },
+      },
+    };
+    const result = buildEntryMarkdownByMode(
+      formDef,
+      "Event",
+      {
+        Local: "2026-08-21T10:48",
+        Instant: "2026-08-21T10:48",
+      },
+      "webform",
+    );
+
+    expect(result).toContain("## Local\n2026-08-21T10:48");
+    expect(result).toMatch(
+      /## Instant\n2026-08-21T10:48:00[+-]\d{2}:\d{2}/,
+    );
+  });
+
+  it("REQ-ENTRY-1872: preserves an explicit timezone value", () => {
+    const formDef: Form = {
+      name: "Event",
+      version: 1,
+      template: "# Event\n",
+      fields: { Instant: { type: "timestamp_tz", required: false } },
+    };
+    const result = buildEntryMarkdownByMode(
+      formDef,
+      "Event",
+      { Instant: "2026-08-21T10:48:00+09:00" },
+      "webform",
+    );
+
+    expect(result).toContain("## Instant\n2026-08-21T10:48:00+09:00");
+  });
+
   it("REQ-FE-037: preserves user markdown whitespace in markdown mode", () => {
     const formDef: Form = {
       name: "Meeting",

--- a/frontend/src/lib/entry-input.ts
+++ b/frontend/src/lib/entry-input.ts
@@ -5,6 +5,38 @@ import {
 } from "~/lib/markdown";
 import type { Form } from "~/lib/types";
 
+const ZONED_TIMESTAMP_TYPES = new Set(["timestamp_tz", "timestamp_tz_ns"]);
+const LOCAL_DATETIME_PATTERN =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2})(?::(\d{2})(\.\d+)?)?$/;
+
+const pad = (value: number) => String(value).padStart(2, "0");
+
+const addBrowserTimezoneOffset = (value: string): string => {
+  const match = LOCAL_DATETIME_PATTERN.exec(value);
+  if (!match) return value;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteOffset = Math.abs(offsetMinutes);
+  const offset = `${sign}${pad(Math.floor(absoluteOffset / 60))}:${pad(
+    absoluteOffset % 60,
+  )}`;
+  const seconds = match[2] ?? "00";
+  const fraction = match[3] ?? "";
+  return `${match[1]}:${seconds}${fraction}${offset}`;
+};
+
+export const normalizeEntryFieldValue = (
+  field: Form["fields"][string],
+  value: string,
+): string => {
+  if (!ZONED_TIMESTAMP_TYPES.has(field.type)) return value;
+  return addBrowserTimezoneOffset(value);
+};
+
 export type EntryInputMode = "markdown" | "webform" | "chat";
 
 export const buildEntryMarkdownFromFields = (
@@ -18,7 +50,11 @@ export const buildEntryMarkdownFromFields = (
   );
   for (const [name, value] of Object.entries(fieldValues)) {
     if (name.startsWith("__") || !value.trim()) continue;
-    content = updateH2Section(content, name, value.trim());
+    const field = formDef.fields?.[name];
+    const normalizedValue = field
+      ? normalizeEntryFieldValue(field, value.trim())
+      : value.trim();
+    content = updateH2Section(content, name, normalizedValue);
   }
   return content;
 };

--- a/frontend/src/routes/spaces/[space_id]/entries/new.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/new.test.tsx
@@ -20,7 +20,7 @@ vi.mock("~/components/EntryDetailPane", () => ({
   EntryDetailPane: (props: {
     createForm?: () => Form | undefined;
     onCreateFormChange?: (name: string) => void;
-    onCreated?: (id: string) => void;
+    onCreated?: (result: { id: string; revision_id: string }) => void;
     onDeleted: () => void;
   }) => (
     <div>
@@ -31,7 +31,11 @@ vi.mock("~/components/EntryDetailPane", () => ({
       >
         Select Meeting
       </button>
-      <button type="button" onClick={() => props.onCreated?.("entry-1")}>
+      <button
+        type="button"
+        onClick={() =>
+          props.onCreated?.({ id: "entry-1", revision_id: "revision-1" })}
+      >
         Save entry
       </button>
       <button type="button" onClick={props.onDeleted}>Cancel</button>

--- a/frontend/src/routes/spaces/[space_id]/entries/new.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/new.tsx
@@ -105,7 +105,7 @@ export default function NewEntryRoute() {
                 onCreateFormChange={setSelectedFormName}
                 onDeleted={() =>
                   navigate(`/spaces/${spaceId()}/forms`)}
-                onCreated={(entryId) =>
+                onCreated={({ id: entryId }) =>
                   navigate(
                     `/spaces/${spaceId()}/entries/${
                       encodeURIComponent(entryId)


### PR DESCRIPTION
## Summary

- Make frontend Form entry creation a single `POST /entries`: consume the create response `{id, revision_id}` as the authoritative state, guard duplicate saves, and navigate only after the clean revision is reflected.
- Preserve Iceberg timestamp semantics: `timestamp`/`timestamp_ns` remain timezone-less wall-clock values, while `timestamp_tz`/`timestamp_tz_ns` require RFC3339 offsets and normalize to UTC. Remove the undocumented space-separated format.
- Keep missing Forms typed as `FORM_NOT_FOUND`, preserve storage failures as internal errors, and verify HTTP 422/`INVALID_INPUT` plus no partial persistence at the REST boundary.

## Related Issue (required)

closes #1872

## Testing

- [x] `mise run check`
- [x] `mise run fmt:check`
- [x] `mise run lint`
- [x] `mise run test:docsite`
- [x] `mise run test:frontend` (70 files, 507 tests)
- [x] Rust workspace portion of `mise run test` (all Rust tests passed; the aggregate command had one existing Vitest worker-start timeout in `src/lib/date-format.test.ts`)
- [x] `cargo test -p ugoite-iceberg --test test_index -- --nocapture`
- [x] `cargo test -p ugoite-iceberg --test test_entry -- --nocapture`
- [x] `cargo test -p ugoite-server --lib entry_routes_keep_input_errors_typed_and_create_atomic -- --nocapture`
- [x] Frontend unit tests for one-create/zero-update, response revision propagation, and browser offset handling
- [x] Added Playwright E2E coverage for one POST, zero PUT, clean UI state, response revision, and one-revision history
- [ ] Playwright E2E execution in this environment: Docker BuildKit failed with a filesystem I/O error; direct runners also hit existing setup/Vinxi/API environment failures before the new scenario could execute
