### PR TITLE
fix(frontend): preserve the Space shell during navigation

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -21,6 +21,7 @@
     "npm:@playwright/test@^1.60.0": "1.60.0",
     "npm:@solidjs/router@~0.16.1": "0.16.1_solid-js@1.9.13",
     "npm:@solidjs/start@^1.3.2": "1.3.2_vinxi@0.5.11__@types+node@25.9.1__yaml@2.9.0_vite@8.1.0__esbuild@0.28.1__yaml@2.9.0_yaml@2.9.0",
+    "npm:@solidjs/testing-library@0.8.10": "0.8.10_@solidjs+router@0.16.1__solid-js@1.9.13_solid-js@1.9.13",
     "npm:@solidjs/testing-library@~0.8.10": "0.8.10_@solidjs+router@0.16.1__solid-js@1.9.13_solid-js@1.9.13",
     "npm:@tailwindcss/node@4.3.0": "4.3.0",
     "npm:@tailwindcss/oxide@4.3.0": "4.3.0",

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,4 +1,5 @@
-import { createSignal, type JSX, Show } from "solid-js";
+import { A, useNavigate, useParams } from "@solidjs/router";
+import { createSignal, Show } from "solid-js";
 import { authApi } from "~/lib/ugoite-client";
 import { locale } from "~/lib/i18n";
 
@@ -15,30 +16,19 @@ const labels = {
   },
 } as const;
 
-type AccountMenuLinkProps = {
-  href: string;
-  role: "menuitem";
-  onClick: () => void;
-  children: JSX.Element;
-};
-
-type AccountMenuProps = {
-  settingsHref?: string;
-  settingsLink?: (props: AccountMenuLinkProps) => JSX.Element;
-  onSignOut?: () => void | Promise<void>;
-};
-
-export function AccountMenu(props: AccountMenuProps = {}) {
+export function AccountMenu() {
+  const navigate = useNavigate();
+  const params = useParams<{ space_id?: string }>();
   const [open, setOpen] = createSignal(false);
   const copy = () => labels[locale() === "ja" ? "ja" : "en"];
+  const settingsHref = () =>
+    params.space_id
+      ? `/spaces/${params.space_id}/settings?section=credentials`
+      : "/settings/security";
 
   const signOut = async () => {
     await authApi.clearSession();
-    if (props.onSignOut) {
-      await props.onSignOut();
-      return;
-    }
-    if (typeof window !== "undefined") window.location.assign("/login");
+    navigate("/login", { replace: true });
   };
 
   return (
@@ -56,22 +46,13 @@ export function AccountMenu(props: AccountMenuProps = {}) {
       <Show when={open()}>
         <div class="accountMenuPanel" role="menu">
           <div class="accountMenuTitle">{copy().account}</div>
-          {props.settingsLink
-            ? props.settingsLink({
-              href: props.settingsHref ?? "/settings/security",
-              role: "menuitem",
-              onClick: () => setOpen(false),
-              children: copy().settings,
-            })
-            : (
-              <a
-                href={props.settingsHref ?? "/settings/security"}
-                role="menuitem"
-                onClick={() => setOpen(false)}
-              >
-                {copy().settings}
-              </a>
-            )}
+          <A
+            href={settingsHref()}
+            role="menuitem"
+            onClick={() => setOpen(false)}
+          >
+            {copy().settings}
+          </A>
           <button
             type="button"
             role="menuitem"

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show } from "solid-js";
+import { createSignal, type JSX, Show } from "solid-js";
 import { authApi } from "~/lib/ugoite-client";
 import { locale } from "~/lib/i18n";
 
@@ -15,12 +15,29 @@ const labels = {
   },
 } as const;
 
-export function AccountMenu(props: { settingsHref?: string } = {}) {
+type AccountMenuLinkProps = {
+  href: string;
+  role: "menuitem";
+  onClick: () => void;
+  children: JSX.Element;
+};
+
+type AccountMenuProps = {
+  settingsHref?: string;
+  settingsLink?: (props: AccountMenuLinkProps) => JSX.Element;
+  onSignOut?: () => void | Promise<void>;
+};
+
+export function AccountMenu(props: AccountMenuProps = {}) {
   const [open, setOpen] = createSignal(false);
   const copy = () => labels[locale() === "ja" ? "ja" : "en"];
 
   const signOut = async () => {
     await authApi.clearSession();
+    if (props.onSignOut) {
+      await props.onSignOut();
+      return;
+    }
     if (typeof window !== "undefined") window.location.assign("/login");
   };
 
@@ -39,13 +56,22 @@ export function AccountMenu(props: { settingsHref?: string } = {}) {
       <Show when={open()}>
         <div class="accountMenuPanel" role="menu">
           <div class="accountMenuTitle">{copy().account}</div>
-          <a
-            href={props.settingsHref ?? "/settings/security"}
-            role="menuitem"
-            onClick={() => setOpen(false)}
-          >
-            {copy().settings}
-          </a>
+          {props.settingsLink
+            ? props.settingsLink({
+              href: props.settingsHref ?? "/settings/security",
+              role: "menuitem",
+              onClick: () => setOpen(false),
+              children: copy().settings,
+            })
+            : (
+              <a
+                href={props.settingsHref ?? "/settings/security"}
+                role="menuitem"
+                onClick={() => setOpen(false)}
+              >
+                {copy().settings}
+              </a>
+            )}
           <button
             type="button"
             role="menuitem"

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,4 +1,4 @@
-import { A, useNavigate, useParams } from "@solidjs/router";
+import { useNavigate, useParams } from "@solidjs/router";
 import { createSignal, Show } from "solid-js";
 import { authApi } from "~/lib/ugoite-client";
 import { locale } from "~/lib/i18n";
@@ -46,13 +46,13 @@ export function AccountMenu() {
       <Show when={open()}>
         <div class="accountMenuPanel" role="menu">
           <div class="accountMenuTitle">{copy().account}</div>
-          <A
+          <a
             href={settingsHref()}
             role="menuitem"
             onClick={() => setOpen(false)}
           >
             {copy().settings}
-          </A>
+          </a>
           <button
             type="button"
             role="menuitem"

--- a/frontend/src/components/GlobalShell.navigation.test.tsx
+++ b/frontend/src/components/GlobalShell.navigation.test.tsx
@@ -1,0 +1,31 @@
+import "@testing-library/jest-dom/vitest";
+import { createMemoryHistory, MemoryRouter, Route } from "@solidjs/router";
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+import { GlobalShell } from "./GlobalShell";
+
+describe("GlobalShell router navigation", () => {
+  it("does not mark duplicate global links as current", () => {
+    const history = createMemoryHistory();
+    history.set({ value: "/spaces", replace: true, scroll: false });
+
+    render(() => (
+      <MemoryRouter history={history}>
+        <Route
+          path="/spaces"
+          component={() => (
+            <GlobalShell title="Spaces" active="spaces">
+              <p>Content</p>
+            </GlobalShell>
+          )}
+        />
+      </MemoryRouter>
+    ));
+
+    const currentLinks = screen.getAllByRole("link").filter((link) =>
+      link.getAttribute("aria-current") === "page"
+    );
+    expect(currentLinks).toHaveLength(1);
+    expect(currentLinks[0]).toHaveAttribute("href", "/spaces");
+  });
+});

--- a/frontend/src/components/GlobalShell.navigation.test.tsx
+++ b/frontend/src/components/GlobalShell.navigation.test.tsx
@@ -14,7 +14,7 @@ describe("GlobalShell router navigation", () => {
         <Route
           path="/spaces"
           component={() => (
-            <GlobalShell title="Spaces" active="spaces">
+            <GlobalShell title="Spaces">
               <p>Content</p>
             </GlobalShell>
           )}
@@ -27,5 +27,29 @@ describe("GlobalShell router navigation", () => {
     );
     expect(currentLinks).toHaveLength(1);
     expect(currentLinks[0]).toHaveAttribute("href", "/spaces");
+  });
+
+  it("uses the exact About match for the About footer link", () => {
+    const history = createMemoryHistory();
+    history.set({ value: "/about", replace: true, scroll: false });
+
+    render(() => (
+      <MemoryRouter history={history}>
+        <Route
+          path="/about"
+          component={() => (
+            <GlobalShell title="About">
+              <p>Content</p>
+            </GlobalShell>
+          )}
+        />
+      </MemoryRouter>
+    ));
+
+    const currentLinks = screen.getAllByRole("link").filter((link) =>
+      link.getAttribute("aria-current") === "page"
+    );
+    expect(currentLinks).toHaveLength(1);
+    expect(currentLinks[0]).toHaveAttribute("href", "/about");
   });
 });

--- a/frontend/src/components/GlobalShell.test.tsx
+++ b/frontend/src/components/GlobalShell.test.tsx
@@ -11,6 +11,14 @@ vi.mock("~/lib/ugoite-client", () => ({
   },
 }));
 
+vi.mock("@solidjs/router", () => ({
+  A: (props: Record<string, unknown>) => {
+    const { children, ...rest } = props;
+    return <a {...(rest as never)}>{children as never}</a>;
+  },
+  useNavigate: () => vi.fn(),
+}));
+
 describe("GlobalShell account menu", () => {
   beforeEach(() => {
     setLocale("en");

--- a/frontend/src/components/GlobalShell.test.tsx
+++ b/frontend/src/components/GlobalShell.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@solidjs/router", () => ({
     return <a {...(rest as never)}>{children as never}</a>;
   },
   useNavigate: () => vi.fn(),
+  useParams: () => ({}),
 }));
 
 describe("GlobalShell account menu", () => {

--- a/frontend/src/components/GlobalShell.tsx
+++ b/frontend/src/components/GlobalShell.tsx
@@ -1,3 +1,4 @@
+import { A, useNavigate } from "@solidjs/router";
 import { Show, type JSX } from "solid-js";
 import { UiIcon } from "~/components/UiIcon";
 import { AccountMenu } from "~/components/AccountMenu";
@@ -34,92 +35,96 @@ export function GlobalShell(
     authenticated?: boolean;
   },
 ) {
+  const navigate = useNavigate();
   const copy = () => labels[locale() === "ja" ? "ja" : "en"];
   return (
     <main class="app workspaceApp">
       <div class="desktopSidebar">
         <aside class="sidebar">
-          <a class="brand" href="/spaces">
+          <A class="brand" href="/spaces">
             <span class="brandMark">U</span>
             <span>Ugoite</span>
-          </a>
+          </A>
           <nav class="navGroup">
-            <a class="navItem" href="/spaces">
+            <A class="navItem" href="/spaces">
               <UiIcon name="home" />
               <span>{copy().home}</span>
-            </a>
-            <a class="navItem" href="/spaces">
+            </A>
+            <A class="navItem" href="/spaces">
               <UiIcon name="forms" />
               <span>{copy().forms}</span>
-            </a>
-            <a class="navItem" href="/spaces">
+            </A>
+            <A class="navItem" href="/spaces">
               <UiIcon name="search" />
               <span>{copy().search}</span>
-            </a>
-            <a class="navItem" href="/spaces">
+            </A>
+            <A class="navItem" href="/spaces">
               <UiIcon name="settings" />
               <span>{copy().settings}</span>
-            </a>
+            </A>
           </nav>
           <div class="sideFoot">
-            <a
+            <A
               class="navItem"
               classList={{ active: props.active === "spaces" }}
               href="/spaces"
             >
               <UiIcon name="spaces" />
               <span>{copy().spaces}</span>
-            </a>
-            <a
+            </A>
+            <A
               class="navItem"
               classList={{ active: props.active === "about" }}
               href="/about"
             >
               <UiIcon name="about" />
               <span>{copy().about}</span>
-            </a>
+            </A>
           </div>
         </aside>
       </div>
       <section class="main">
         <header class="topbar">
-          <a
+          <A
             class="btn iconBtn mobileMenu"
             href="/spaces"
             aria-label={copy().menu}
           >
             <UiIcon name="menu" />
-          </a>
+          </A>
           <select class="spaceSelect" aria-label="Space">
             <option>Ugoite</option>
           </select>
           <div class="crumbTop">{props.title}</div>
           <Show
             when={props.authenticated !== false}
-            fallback={<a class="btn" href="/login">{copy().signIn}</a>}
+            fallback={<A class="btn" href="/login">{copy().signIn}</A>}
           >
-            <AccountMenu />
+            <AccountMenu
+              settingsLink={(linkProps) => <A {...linkProps} />}
+              onSignOut={() => navigate("/login", { replace: true })}
+            />
           </Show>
         </header>
         <div class="content">{props.children}</div>
       </section>
       <nav class="bottomNav">
-        <a class="active" href="/spaces">
+        <A class="active" href="/spaces">
           <UiIcon name="home" />
           <span>{copy().home}</span>
-        </a>
-        <a href="/spaces">
+        </A>
+        <A href="/spaces">
           <UiIcon name="forms" />
           <span>{copy().forms}</span>
-        </a>
-        <a href="/spaces">
+        </A>
+        <A href="/spaces">
           <UiIcon name="search" />
           <span>{copy().search}</span>
-        </a>
-        <a href="/spaces">
+        </A>
+        <A href="/spaces">
           <UiIcon name="settings" />
           <span>{copy().settings}</span>
-        </a>
+        </A>
       </nav>
     </main>
   );

--- a/frontend/src/components/GlobalShell.tsx
+++ b/frontend/src/components/GlobalShell.tsx
@@ -1,5 +1,5 @@
 import { A, useNavigate } from "@solidjs/router";
-import { Show, type JSX } from "solid-js";
+import { type JSX, Show } from "solid-js";
 import { UiIcon } from "~/components/UiIcon";
 import { AccountMenu } from "~/components/AccountMenu";
 import { locale } from "~/lib/i18n";
@@ -37,38 +37,42 @@ export function GlobalShell(
 ) {
   const navigate = useNavigate();
   const copy = () => labels[locale() === "ja" ? "ja" : "en"];
+  const navigateLink = (href: string) => (event: MouseEvent) => {
+    event.preventDefault();
+    navigate(href);
+  };
   return (
     <main class="app workspaceApp">
       <div class="desktopSidebar">
         <aside class="sidebar">
-          <A class="brand" href="/spaces">
+          <a
+            class="brand"
+            href="/spaces"
+            onClick={navigateLink("/spaces")}
+          >
             <span class="brandMark">U</span>
             <span>Ugoite</span>
-          </A>
+          </a>
           <nav class="navGroup">
-            <A class="navItem" href="/spaces">
+            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
               <UiIcon name="home" />
               <span>{copy().home}</span>
-            </A>
-            <A class="navItem" href="/spaces">
+            </a>
+            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
               <UiIcon name="forms" />
               <span>{copy().forms}</span>
-            </A>
-            <A class="navItem" href="/spaces">
+            </a>
+            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
               <UiIcon name="search" />
               <span>{copy().search}</span>
-            </A>
-            <A class="navItem" href="/spaces">
+            </a>
+            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
               <UiIcon name="settings" />
               <span>{copy().settings}</span>
-            </A>
+            </a>
           </nav>
           <div class="sideFoot">
-            <A
-              class="navItem"
-              classList={{ active: props.active === "spaces" }}
-              href="/spaces"
-            >
+            <A class="navItem" href="/spaces">
               <UiIcon name="spaces" />
               <span>{copy().spaces}</span>
             </A>
@@ -85,13 +89,14 @@ export function GlobalShell(
       </div>
       <section class="main">
         <header class="topbar">
-          <A
+          <button
             class="btn iconBtn mobileMenu"
-            href="/spaces"
+            type="button"
             aria-label={copy().menu}
+            onClick={() => navigate("/spaces")}
           >
             <UiIcon name="menu" />
-          </A>
+          </button>
           <select class="spaceSelect" aria-label="Space">
             <option>Ugoite</option>
           </select>
@@ -100,31 +105,28 @@ export function GlobalShell(
             when={props.authenticated !== false}
             fallback={<A class="btn" href="/login">{copy().signIn}</A>}
           >
-            <AccountMenu
-              settingsLink={(linkProps) => <A {...linkProps} />}
-              onSignOut={() => navigate("/login", { replace: true })}
-            />
+            <AccountMenu />
           </Show>
         </header>
         <div class="content">{props.children}</div>
       </section>
       <nav class="bottomNav">
-        <A class="active" href="/spaces">
+        <a href="/spaces" onClick={navigateLink("/spaces")}>
           <UiIcon name="home" />
           <span>{copy().home}</span>
-        </A>
-        <A href="/spaces">
+        </a>
+        <a href="/spaces" onClick={navigateLink("/spaces")}>
           <UiIcon name="forms" />
           <span>{copy().forms}</span>
-        </A>
-        <A href="/spaces">
+        </a>
+        <a href="/spaces" onClick={navigateLink("/spaces")}>
           <UiIcon name="search" />
           <span>{copy().search}</span>
-        </A>
-        <A href="/spaces">
+        </a>
+        <a href="/spaces" onClick={navigateLink("/spaces")}>
           <UiIcon name="settings" />
           <span>{copy().settings}</span>
-        </A>
+        </a>
       </nav>
     </main>
   );

--- a/frontend/src/components/GlobalShell.tsx
+++ b/frontend/src/components/GlobalShell.tsx
@@ -1,4 +1,4 @@
-import { A, useNavigate } from "@solidjs/router";
+import { A } from "@solidjs/router";
 import { type JSX, Show } from "solid-js";
 import { UiIcon } from "~/components/UiIcon";
 import { AccountMenu } from "~/components/AccountMenu";
@@ -31,56 +31,42 @@ export function GlobalShell(
   props: {
     title: string;
     children: JSX.Element;
-    active?: "spaces" | "about";
     authenticated?: boolean;
   },
 ) {
-  const navigate = useNavigate();
   const copy = () => labels[locale() === "ja" ? "ja" : "en"];
-  const navigateLink = (href: string) => (event: MouseEvent) => {
-    event.preventDefault();
-    navigate(href);
-  };
   return (
     <main class="app workspaceApp">
       <div class="desktopSidebar">
         <aside class="sidebar">
-          <a
-            class="brand"
-            href="/spaces"
-            onClick={navigateLink("/spaces")}
-          >
+          <a class="brand" href="/spaces">
             <span class="brandMark">U</span>
             <span>Ugoite</span>
           </a>
           <nav class="navGroup">
-            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
+            <a class="navItem" href="/spaces">
               <UiIcon name="home" />
               <span>{copy().home}</span>
             </a>
-            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
+            <a class="navItem" href="/spaces">
               <UiIcon name="forms" />
               <span>{copy().forms}</span>
             </a>
-            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
+            <a class="navItem" href="/spaces">
               <UiIcon name="search" />
               <span>{copy().search}</span>
             </a>
-            <a class="navItem" href="/spaces" onClick={navigateLink("/spaces")}>
+            <a class="navItem" href="/spaces">
               <UiIcon name="settings" />
               <span>{copy().settings}</span>
             </a>
           </nav>
           <div class="sideFoot">
-            <A class="navItem" href="/spaces">
+            <A class="navItem" href="/spaces" end>
               <UiIcon name="spaces" />
               <span>{copy().spaces}</span>
             </A>
-            <A
-              class="navItem"
-              classList={{ active: props.active === "about" }}
-              href="/about"
-            >
+            <A class="navItem" href="/about" end>
               <UiIcon name="about" />
               <span>{copy().about}</span>
             </A>
@@ -89,21 +75,20 @@ export function GlobalShell(
       </div>
       <section class="main">
         <header class="topbar">
-          <button
+          <a
             class="btn iconBtn mobileMenu"
-            type="button"
+            href="/spaces"
             aria-label={copy().menu}
-            onClick={() => navigate("/spaces")}
           >
             <UiIcon name="menu" />
-          </button>
+          </a>
           <select class="spaceSelect" aria-label="Space">
             <option>Ugoite</option>
           </select>
           <div class="crumbTop">{props.title}</div>
           <Show
             when={props.authenticated !== false}
-            fallback={<A class="btn" href="/login">{copy().signIn}</A>}
+            fallback={<a class="btn" href="/login">{copy().signIn}</a>}
           >
             <AccountMenu />
           </Show>
@@ -111,19 +96,19 @@ export function GlobalShell(
         <div class="content">{props.children}</div>
       </section>
       <nav class="bottomNav">
-        <a href="/spaces" onClick={navigateLink("/spaces")}>
+        <a href="/spaces">
           <UiIcon name="home" />
           <span>{copy().home}</span>
         </a>
-        <a href="/spaces" onClick={navigateLink("/spaces")}>
+        <a href="/spaces">
           <UiIcon name="forms" />
           <span>{copy().forms}</span>
         </a>
-        <a href="/spaces" onClick={navigateLink("/spaces")}>
+        <a href="/spaces">
           <UiIcon name="search" />
           <span>{copy().search}</span>
         </a>
-        <a href="/spaces" onClick={navigateLink("/spaces")}>
+        <a href="/spaces">
           <UiIcon name="settings" />
           <span>{copy().settings}</span>
         </a>

--- a/frontend/src/components/SpaceShell.test.tsx
+++ b/frontend/src/components/SpaceShell.test.tsx
@@ -6,6 +6,14 @@ import { setLocale } from "~/lib/i18n";
 import { loadingState } from "~/lib/loading";
 import { SpaceShell } from "./SpaceShell";
 
+vi.mock("@solidjs/router", () => ({
+  A: (props: Record<string, unknown>) => {
+    const { children, ...rest } = props;
+    return <a {...(rest as never)}>{children as never}</a>;
+  },
+  useNavigate: () => vi.fn(),
+}));
+
 vi.mock("~/lib/space-store", () => ({
   createSpaceStore: () => ({
     spaces: () => [

--- a/frontend/src/components/SpaceShell.test.tsx
+++ b/frontend/src/components/SpaceShell.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@solidjs/router", () => ({
     return <a {...(rest as never)}>{children as never}</a>;
   },
   useNavigate: () => vi.fn(),
+  useParams: () => ({ space_id: "my-space" }),
 }));
 
 vi.mock("~/lib/space-store", () => ({
@@ -78,7 +79,7 @@ describe("v5 SpaceShell", () => {
   });
   it("offers the other available spaces in the workspace selector", () => {
     render(() => (
-      <SpaceShell spaceId="my-space">
+      <SpaceShell spaceId="my-space" activeNavigation="home">
         <p>Content</p>
       </SpaceShell>
     ));
@@ -95,7 +96,7 @@ describe("v5 SpaceShell", () => {
   it("localizes navigation", () => {
     setLocale("ja");
     render(() => (
-      <SpaceShell spaceId="my-space">
+      <SpaceShell spaceId="my-space" activeNavigation="home">
         <p>Content</p>
       </SpaceShell>
     ));
@@ -105,7 +106,7 @@ describe("v5 SpaceShell", () => {
   it("shows the v5 loading indicator", () => {
     loadingState.start();
     const { container } = render(() => (
-      <SpaceShell spaceId="my-space">
+      <SpaceShell spaceId="my-space" activeNavigation="home">
         <p>Content</p>
       </SpaceShell>
     ));
@@ -115,7 +116,9 @@ describe("v5 SpaceShell", () => {
   it("keeps the route space selected when the route changes", () => {
     const [spaceId, setSpaceId] = createSignal("my-space");
     render(() => (
-      <SpaceShell spaceId={spaceId()}><p>Space content</p></SpaceShell>
+      <SpaceShell spaceId={spaceId()} activeNavigation="home">
+        <p>Space content</p>
+      </SpaceShell>
     ));
     setSpaceId("other-space");
     expect(screen.getByRole("combobox", { name: "Space" })).toHaveValue(

--- a/frontend/src/components/SpaceShell.tsx
+++ b/frontend/src/components/SpaceShell.tsx
@@ -1,3 +1,4 @@
+import { A, useNavigate } from "@solidjs/router";
 import type { JSX } from "solid-js";
 import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 import { locale } from "~/lib/i18n";
@@ -54,6 +55,7 @@ const labels = {
 
 export function SpaceShell(props: SpaceShellProps) {
   const spaceStore = createSpaceStore();
+  const navigate = useNavigate();
   const [drawerOpen, setDrawerOpen] = createSignal(false);
   onMount(() => {
     void spaceStore.loadSpaces().catch(() => undefined);
@@ -86,9 +88,7 @@ export function SpaceShell(props: SpaceShellProps) {
   const switchSpace = (spaceId: string) => {
     if (!spaceId || spaceId === props.spaceId) return;
     spaceStore.selectSpace(spaceId);
-    if (typeof window !== "undefined") {
-      window.location.assign(`/spaces/${spaceId}/${activePath()}`);
-    }
+    navigate(`/spaces/${spaceId}/${activePath()}`);
   };
 
   const navigation = (mobile = false) => (
@@ -97,7 +97,7 @@ export function SpaceShell(props: SpaceShellProps) {
       aria-label="Space navigation"
     >
       {navItems.map((item) => (
-        <a
+        <A
           href={`/spaces/${props.spaceId}/${item.path}`}
           class={mobile ? "" : "navItem"}
           classList={{ active: active() === item.id }}
@@ -106,7 +106,7 @@ export function SpaceShell(props: SpaceShellProps) {
         >
           <UiIcon name={item.icon} />
           <span>{copy()[item.id]}</span>
-        </a>
+        </A>
       ))}
     </nav>
   );
@@ -139,6 +139,8 @@ export function SpaceShell(props: SpaceShellProps) {
           <div class="crumbTop">{crumb()}</div>
           <AccountMenu
             settingsHref={`/spaces/${props.spaceId}/settings?section=credentials`}
+            settingsLink={(linkProps) => <A {...linkProps} />}
+            onSignOut={() => navigate("/login", { replace: true })}
           />
         </header>
         <div class="content">{props.children}</div>
@@ -150,10 +152,10 @@ export function SpaceShell(props: SpaceShellProps) {
   function sidebar() {
     return (
       <aside class="sidebar">
-        <a class="brand" href={`/spaces/${props.spaceId}/dashboard`}>
+        <A class="brand" href={`/spaces/${props.spaceId}/dashboard`}>
           <span class="brandMark">U</span>
           <span>Ugoite</span>
-        </a>
+        </A>
         <label class="sidebarSpaceSelect">
           <span class="ui-sr-only">Space</span>
           <select
@@ -175,14 +177,14 @@ export function SpaceShell(props: SpaceShellProps) {
         </label>
         {navigation()}
         <div class="sideFoot">
-          <a class="navItem" href="/spaces">
+          <A class="navItem" href="/spaces">
             <UiIcon name="spaces" />
             <span>{copy().spaces}</span>
-          </a>
-          <a class="navItem" href="/about">
+          </A>
+          <A class="navItem" href="/about">
             <UiIcon name="about" />
             <span>{copy().about}</span>
-          </a>
+          </A>
         </div>
       </aside>
     );

--- a/frontend/src/components/SpaceShell.tsx
+++ b/frontend/src/components/SpaceShell.tsx
@@ -7,18 +7,12 @@ import { UiIcon, type UiIconName } from "~/components/UiIcon";
 import { AccountMenu } from "~/components/AccountMenu";
 import { createSpaceStore } from "~/lib/space-store";
 
-export type SpaceTopTab = "dashboard" | "search";
-export type SpaceBottomTab = "object" | "grid";
 export type SpaceNavigation = "home" | "forms" | "search" | "settings";
 
 interface SpaceShellProps {
   spaceId: string;
-  activeTopTab?: SpaceTopTab;
-  activeBottomTab?: SpaceBottomTab;
-  activeNavigation?: SpaceNavigation;
+  activeNavigation: SpaceNavigation;
   title?: string;
-  showBottomTabs?: boolean;
-  bottomTabHrefSuffix?: string;
   children: JSX.Element;
 }
 
@@ -61,25 +55,7 @@ export function SpaceShell(props: SpaceShellProps) {
     void spaceStore.loadSpaces().catch(() => undefined);
   });
   const copy = () => labels[locale() === "ja" ? "ja" : "en"];
-  const active = createMemo<SpaceNavigation>(() => {
-    if (props.activeNavigation) return props.activeNavigation;
-    if (props.activeTopTab === "dashboard") return "home";
-    if (props.activeTopTab === "search") return "search";
-    if (props.activeBottomTab === "grid") return "forms";
-    const pathname = typeof window === "undefined"
-      ? ""
-      : window.location.pathname;
-    if (pathname.includes("/settings")) return "settings";
-    if (
-      pathname.includes("/search") || pathname.includes("/sql") ||
-      pathname.includes("/queries")
-    ) return "search";
-    if (
-      pathname.includes("/forms") || pathname.includes("/entries") ||
-      pathname.includes("/assets")
-    ) return "forms";
-    return "home";
-  });
+  const active = () => props.activeNavigation;
   const crumb = createMemo(() => props.title ?? copy()[active()]);
   const activePath = createMemo(() =>
     navItems.find((item) => item.id === active())?.path ?? "dashboard"
@@ -100,6 +76,8 @@ export function SpaceShell(props: SpaceShellProps) {
         <A
           href={`/spaces/${props.spaceId}/${item.path}`}
           class={mobile ? "" : "navItem"}
+          activeClass=""
+          inactiveClass=""
           classList={{ active: active() === item.id }}
           aria-current={active() === item.id ? "page" : undefined}
           onClick={() => setDrawerOpen(false)}
@@ -137,11 +115,7 @@ export function SpaceShell(props: SpaceShellProps) {
             <UiIcon name="menu" />
           </button>
           <div class="crumbTop">{crumb()}</div>
-          <AccountMenu
-            settingsHref={`/spaces/${props.spaceId}/settings?section=credentials`}
-            settingsLink={(linkProps) => <A {...linkProps} />}
-            onSignOut={() => navigate("/login", { replace: true })}
-          />
+          <AccountMenu />
         </header>
         <div class="content">{props.children}</div>
       </section>
@@ -163,7 +137,11 @@ export function SpaceShell(props: SpaceShellProps) {
             value={props.spaceId}
             onChange={(event) => switchSpace(event.currentTarget.value)}
           >
-            <Show when={!spaceStore.spaces().some((space) => space.id === props.spaceId)}>
+            <Show
+              when={!spaceStore.spaces().some((space) =>
+                space.id === props.spaceId
+              )}
+            >
               <option value={props.spaceId}>{props.spaceId}</option>
             </Show>
             <For each={spaceStore.spaces()}>

--- a/frontend/src/components/SpaceShell.tsx
+++ b/frontend/src/components/SpaceShell.tsx
@@ -126,10 +126,10 @@ export function SpaceShell(props: SpaceShellProps) {
   function sidebar() {
     return (
       <aside class="sidebar">
-        <A class="brand" href={`/spaces/${props.spaceId}/dashboard`}>
+        <a class="brand" href={`/spaces/${props.spaceId}/dashboard`}>
           <span class="brandMark">U</span>
           <span>Ugoite</span>
-        </A>
+        </a>
         <label class="sidebarSpaceSelect">
           <span class="ui-sr-only">Space</span>
           <select
@@ -155,14 +155,14 @@ export function SpaceShell(props: SpaceShellProps) {
         </label>
         {navigation()}
         <div class="sideFoot">
-          <A class="navItem" href="/spaces">
+          <a class="navItem" href="/spaces">
             <UiIcon name="spaces" />
             <span>{copy().spaces}</span>
-          </A>
-          <A class="navItem" href="/about">
+          </a>
+          <a class="navItem" href="/about">
             <UiIcon name="about" />
             <span>{copy().about}</span>
-          </A>
+          </a>
         </div>
       </aside>
     );

--- a/frontend/src/lib/space-shell-route.ts
+++ b/frontend/src/lib/space-shell-route.ts
@@ -1,0 +1,28 @@
+import type { RouteDefinition } from "@solidjs/router";
+import type { SpaceNavigation } from "~/components/SpaceShell";
+
+export type SpaceShellTitle =
+  | "asset"
+  | "assets"
+  | "entryHistory"
+  | "newEntry"
+  | "restore"
+  | "revision"
+  | "savedSql"
+  | "savedSqlDetail"
+  | "settings"
+  | "settingsStorage"
+  | "sqlNew"
+  | "sqlVariables"
+  | "formTypes";
+
+export type SpaceShellRouteInfo = {
+  navigation: SpaceNavigation;
+  title?: SpaceShellTitle;
+};
+
+export const spaceRoute = (
+  info: SpaceShellRouteInfo,
+): Pick<RouteDefinition, "info"> => ({
+  info: { spaceShell: info },
+});

--- a/frontend/src/routes/[...404].test.tsx
+++ b/frontend/src/routes/[...404].test.tsx
@@ -10,6 +10,7 @@ vi.mock("@solidjs/router", () => ({
     </a>
   ),
   useNavigate: () => vi.fn(),
+  useParams: () => ({}),
 }));
 
 describe("404 route", () => {

--- a/frontend/src/routes/[...404].test.tsx
+++ b/frontend/src/routes/[...404].test.tsx
@@ -9,6 +9,7 @@ vi.mock("@solidjs/router", () => ({
       {props.children}
     </a>
   ),
+  useNavigate: () => vi.fn(),
 }));
 
 describe("404 route", () => {

--- a/frontend/src/routes/[...404].tsx
+++ b/frontend/src/routes/[...404].tsx
@@ -1,4 +1,3 @@
-import { A } from "@solidjs/router";
 import { GlobalShell } from "~/components/GlobalShell";
 
 export default function NotFound() {
@@ -15,18 +14,18 @@ export default function NotFound() {
           </p>
         </div>
         <div class="actions">
-          <A href="/spaces" class="btn primary">
+          <a href="/spaces" class="btn primary">
             Open Spaces
-          </A>
-          <A href="/login" class="btn">
+          </a>
+          <a href="/login" class="btn">
             Go to Login
-          </A>
-          <A href="/" class="btn">
+          </a>
+          <a href="/" class="btn">
             Back to Home
-          </A>
-          <A href="/about" class="btn">
+          </a>
+          <a href="/about" class="btn">
             About Ugoite
-          </A>
+          </a>
         </div>
       </div>
       <p class="ui-muted">

--- a/frontend/src/routes/[...404].tsx
+++ b/frontend/src/routes/[...404].tsx
@@ -1,3 +1,4 @@
+import { A } from "@solidjs/router";
 import { GlobalShell } from "~/components/GlobalShell";
 
 export default function NotFound() {
@@ -14,18 +15,18 @@ export default function NotFound() {
           </p>
         </div>
         <div class="actions">
-          <a href="/spaces" class="btn primary">
+          <A href="/spaces" class="btn primary">
             Open Spaces
-          </a>
-          <a href="/login" class="btn">
+          </A>
+          <A href="/login" class="btn">
             Go to Login
-          </a>
-          <a href="/" class="btn">
+          </A>
+          <A href="/" class="btn">
             Back to Home
-          </a>
-          <a href="/about" class="btn">
+          </A>
+          <A href="/about" class="btn">
             About Ugoite
-          </a>
+          </A>
         </div>
       </div>
       <p class="ui-muted">

--- a/frontend/src/routes/about.test.tsx
+++ b/frontend/src/routes/about.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@solidjs/router", () => ({
     </a>
   ),
   useNavigate: () => vi.fn(),
+  useParams: () => ({}),
 }));
 
 vi.mock("~/lib/ugoite-client", () => ({

--- a/frontend/src/routes/about.test.tsx
+++ b/frontend/src/routes/about.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@solidjs/router", () => ({
       {props.children}
     </a>
   ),
+  useNavigate: () => vi.fn(),
 }));
 
 vi.mock("~/lib/ugoite-client", () => ({

--- a/frontend/src/routes/about.tsx
+++ b/frontend/src/routes/about.tsx
@@ -1,4 +1,3 @@
-import { A } from "@solidjs/router";
 import { createMemo, createSignal, onMount } from "solid-js";
 import { authApi } from "~/lib/ugoite-client";
 import { t } from "~/lib/i18n";
@@ -57,7 +56,6 @@ export default function About() {
   return (
     <GlobalShell
       title="About"
-      active="about"
       authenticated={authSession().authenticated}
     >
       <div>
@@ -68,12 +66,12 @@ export default function About() {
             <p class="ui-muted">{copy().subtitle}</p>
           </div>
           <div class="actions">
-            <A href={openSpacesHref()} class="btn primary">
+            <a href={openSpacesHref()} class="btn primary">
               {copy().openSpaces}
-            </A>
-            <A href="/" class="btn">
+            </a>
+            <a href="/" class="btn">
               {copy().backHome}
-            </A>
+            </a>
           </div>
         </div>
         <h2 class="sr-only">{copy().whatMakesDifferent}</h2>

--- a/frontend/src/routes/about.tsx
+++ b/frontend/src/routes/about.tsx
@@ -1,3 +1,4 @@
+import { A } from "@solidjs/router";
 import { createMemo, createSignal, onMount } from "solid-js";
 import { authApi } from "~/lib/ugoite-client";
 import { t } from "~/lib/i18n";
@@ -67,12 +68,12 @@ export default function About() {
             <p class="ui-muted">{copy().subtitle}</p>
           </div>
           <div class="actions">
-            <a href={openSpacesHref()} class="btn primary">
+            <A href={openSpacesHref()} class="btn primary">
               {copy().openSpaces}
-            </a>
-            <a href="/" class="btn">
+            </A>
+            <A href="/" class="btn">
               {copy().backHome}
-            </a>
+            </A>
           </div>
         </div>
         <h2 class="sr-only">{copy().whatMakesDifferent}</h2>

--- a/frontend/src/routes/public-pages.test.tsx
+++ b/frontend/src/routes/public-pages.test.tsx
@@ -3,6 +3,14 @@ import { render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setLocale } from "~/lib/i18n";
 import AboutRoute from "./about";
+vi.mock("@solidjs/router", () => ({
+  A: (props: Record<string, unknown>) => {
+    const { children, ...rest } = props;
+    return <a {...(rest as never)}>{children as never}</a>;
+  },
+  useNavigate: () => vi.fn(),
+}));
+
 vi.mock(
   "~/lib/ugoite-client",
   () => ({

--- a/frontend/src/routes/spaces/[space_id].test.tsx
+++ b/frontend/src/routes/spaces/[space_id].test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import SpaceLayout, {
+  routeNavigation,
+  routeTitle,
+} from "./[space_id]";
+
+vi.mock("@solidjs/router", () => ({
+  useLocation: () => ({
+    pathname: "/spaces/demo/entries/new",
+    search: "?form=Notes",
+  }),
+  useParams: () => ({ space_id: "demo" }),
+}));
+vi.mock("~/components/SpaceShell", () => ({
+  SpaceShell: (props: {
+    activeNavigation?: string;
+    title?: string;
+    children: unknown;
+  }) => (
+    <section
+      data-active-navigation={props.activeNavigation}
+      data-title={props.title}
+    >
+      {props.children}
+    </section>
+  ),
+}));
+
+describe("SpaceLayout", () => {
+  it("keeps the shared shell around entry creation", () => {
+    render(() => (
+      <SpaceLayout>
+        <p>Entry editor</p>
+      </SpaceLayout>
+    ));
+
+    const shell = screen.getByText("Entry editor").parentElement;
+    expect(shell).toHaveAttribute("data-active-navigation", "forms");
+    expect(shell).toHaveAttribute("data-title", "New Entry");
+  });
+
+  it("maps space routes to the persistent navigation", () => {
+    expect(routeNavigation("/spaces/demo/forms")).toBe("forms");
+    expect(routeNavigation("/spaces/demo/queries/new")).toBe("search");
+    expect(routeNavigation("/spaces/demo/settings")).toBe("settings");
+  });
+
+  it("retains route-specific topbar titles", () => {
+    expect(routeTitle("/spaces/demo/entries/one/history", ""))
+      .toBe("Entry / History");
+    expect(routeTitle("/spaces/demo/settings", "?section=storage"))
+      .toBe("Settings / Storage");
+  });
+});

--- a/frontend/src/routes/spaces/[space_id].test.tsx
+++ b/frontend/src/routes/spaces/[space_id].test.tsx
@@ -24,6 +24,7 @@ vi.mock("~/lib/space-store", () => ({
 }));
 
 const formsRoute = spaceRoute({ navigation: "forms" });
+const dashboardRoute = spaceRoute({ navigation: "home" });
 const newEntryRoute = spaceRoute({ navigation: "forms", title: "newEntry" });
 const testConnectionRoute = spaceRoute({
   navigation: "settings",
@@ -40,6 +41,10 @@ function FormsPage() {
   );
 }
 
+function DashboardPage() {
+  return <p>Dashboard route</p>;
+}
+
 function NewEntryPage() {
   return <p>New Entry route</p>;
 }
@@ -53,6 +58,7 @@ const routes: RouteDefinition[] = [{
   component: SpaceLayout,
   info: spaceLayoutRoute.info,
   children: [
+    { path: "/dashboard", component: DashboardPage, ...dashboardRoute },
     { path: "/forms", component: FormsPage, ...formsRoute },
     { path: "/entries/new", component: NewEntryPage, ...newEntryRoute },
     {
@@ -68,6 +74,13 @@ function renderAt(path: string) {
   history.set({ value: path, replace: true, scroll: false });
   render(() => <MemoryRouter history={history}>{routes}</MemoryRouter>);
   return history;
+}
+
+function expectNotCurrent(name: string) {
+  for (const link of screen.getAllByRole("link", { name })) {
+    expect(link).not.toHaveClass("active");
+    expect(link).not.toHaveAttribute("aria-current", "page");
+  }
 }
 
 describe("/spaces/:space_id persistent layout", () => {
@@ -94,8 +107,20 @@ describe("/spaces/:space_id persistent layout", () => {
         .toHaveClass("active");
       expect(screen.getAllByRole("link", { name: "Forms" })[0])
         .toHaveAttribute("aria-current", "page");
+      expectNotCurrent("Spaces");
     });
     expect(screen.getByRole("main")).toBe(shell);
+  });
+
+  it("does not mark the Spaces action current on the dashboard", async () => {
+    renderAt("/spaces/demo/dashboard");
+
+    await waitFor(() => {
+      expect(screen.getByText("Dashboard route")).toBeInTheDocument();
+      expect(document.querySelector(".crumbTop")).toHaveTextContent("Home");
+    });
+
+    expectNotCurrent("Spaces");
   });
 
   it("derives Settings navigation from the matched route metadata", async () => {

--- a/frontend/src/routes/spaces/[space_id].test.tsx
+++ b/frontend/src/routes/spaces/[space_id].test.tsx
@@ -1,55 +1,130 @@
-import { render, screen } from "@solidjs/testing-library";
-import { describe, expect, it, vi } from "vitest";
-import SpaceLayout, {
-  routeNavigation,
-  routeTitle,
-} from "./[space_id]";
+import "@testing-library/jest-dom/vitest";
+import {
+  A,
+  createMemoryHistory,
+  MemoryRouter,
+  type RouteDefinition,
+} from "@solidjs/router";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setLocale } from "~/lib/i18n";
+import { spaceRoute } from "~/lib/space-shell-route";
+import SpaceLayout, { route as spaceLayoutRoute } from "./[space_id]";
 
-vi.mock("@solidjs/router", () => ({
-  useLocation: () => ({
-    pathname: "/spaces/demo/entries/new",
-    search: "?form=Notes",
+const { loadSpacesMock } = vi.hoisted(() => ({
+  loadSpacesMock: vi.fn(),
+}));
+
+vi.mock("~/lib/space-store", () => ({
+  createSpaceStore: () => ({
+    spaces: () => [{ id: "demo", name: "Demo", created_at: "" }],
+    loadSpaces: loadSpacesMock,
+    selectSpace: vi.fn(),
   }),
-  useParams: () => ({ space_id: "demo" }),
-}));
-vi.mock("~/components/SpaceShell", () => ({
-  SpaceShell: (props: {
-    activeNavigation?: string;
-    title?: string;
-    children: unknown;
-  }) => (
-    <section
-      data-active-navigation={props.activeNavigation}
-      data-title={props.title}
-    >
-      {props.children}
-    </section>
-  ),
 }));
 
-describe("SpaceLayout", () => {
-  it("keeps the shared shell around entry creation", () => {
-    render(() => (
-      <SpaceLayout>
-        <p>Entry editor</p>
-      </SpaceLayout>
-    ));
+const formsRoute = spaceRoute({ navigation: "forms" });
+const newEntryRoute = spaceRoute({ navigation: "forms", title: "newEntry" });
+const testConnectionRoute = spaceRoute({
+  navigation: "settings",
+  title: "settingsStorage",
+});
 
-    const shell = screen.getByText("Entry editor").parentElement;
-    expect(shell).toHaveAttribute("data-active-navigation", "forms");
-    expect(shell).toHaveAttribute("data-title", "New Entry");
+function FormsPage() {
+  return (
+    <>
+      <p>Forms route</p>
+      <A href="/spaces/demo/entries/new">New Entry</A>
+      <A href="/spaces/demo/test-connection">Test connection</A>
+    </>
+  );
+}
+
+function NewEntryPage() {
+  return <p>New Entry route</p>;
+}
+
+function TestConnectionPage() {
+  return <p>Test connection route</p>;
+}
+
+const routes: RouteDefinition[] = [{
+  path: "/spaces/:space_id",
+  component: SpaceLayout,
+  info: spaceLayoutRoute.info,
+  children: [
+    { path: "/forms", component: FormsPage, ...formsRoute },
+    { path: "/entries/new", component: NewEntryPage, ...newEntryRoute },
+    {
+      path: "/test-connection",
+      component: TestConnectionPage,
+      ...testConnectionRoute,
+    },
+  ],
+}];
+
+function renderAt(path: string) {
+  const history = createMemoryHistory();
+  history.set({ value: path, replace: true, scroll: false });
+  render(() => <MemoryRouter history={history}>{routes}</MemoryRouter>);
+  return history;
+}
+
+describe("/spaces/:space_id persistent layout", () => {
+  beforeEach(() => {
+    setLocale("en");
+    loadSpacesMock.mockReset();
+    loadSpacesMock.mockResolvedValue(undefined);
   });
 
-  it("maps space routes to the persistent navigation", () => {
-    expect(routeNavigation("/spaces/demo/forms")).toBe("forms");
-    expect(routeNavigation("/spaces/demo/queries/new")).toBe("search");
-    expect(routeNavigation("/spaces/demo/settings")).toBe("settings");
+  it("keeps the same shell instance and loads spaces once across child navigation", async () => {
+    renderAt("/spaces/demo/forms");
+    const shell = screen.getByRole("main");
+
+    expect(document.querySelector(".crumbTop")).toHaveTextContent("Forms");
+    fireEvent.click(screen.getByRole("link", { name: "New Entry" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("New Entry route")).toBeInTheDocument();
+      expect(document.querySelector(".crumbTop")).toHaveTextContent(
+        "New Entry",
+      );
+      expect(loadSpacesMock).toHaveBeenCalledOnce();
+      expect(screen.getAllByRole("link", { name: "Forms" })[0])
+        .toHaveClass("active");
+      expect(screen.getAllByRole("link", { name: "Forms" })[0])
+        .toHaveAttribute("aria-current", "page");
+    });
+    expect(screen.getByRole("main")).toBe(shell);
   });
 
-  it("retains route-specific topbar titles", () => {
-    expect(routeTitle("/spaces/demo/entries/one/history", ""))
-      .toBe("Entry / History");
-    expect(routeTitle("/spaces/demo/settings", "?section=storage"))
-      .toBe("Settings / Storage");
+  it("derives Settings navigation from the matched route metadata", async () => {
+    renderAt("/spaces/demo/test-connection");
+
+    await waitFor(() => {
+      expect(document.querySelector(".crumbTop")).toHaveTextContent(
+        "Settings / Storage",
+      );
+    });
+    expect(screen.getAllByRole("link", { name: "Settings" })[0])
+      .toHaveClass("active");
+    expect(screen.getAllByRole("link", { name: "Home" })[0])
+      .not.toHaveClass("active");
+  });
+
+  it("keeps Forms localized when the shell uses the route fallback title", () => {
+    setLocale("ja");
+    renderAt("/spaces/demo/forms");
+
+    expect(document.querySelector(".crumbTop")).toHaveTextContent("フォーム");
+  });
+
+  it("uses route metadata when the space id contains navigation names", () => {
+    renderAt("/spaces/search/forms");
+
+    expect(screen.getAllByRole("link", { name: "Forms" })[0])
+      .toHaveClass("active");
+    expect(screen.getAllByRole("link", { name: "Search" })[0])
+      .not.toHaveClass("active");
   });
 });

--- a/frontend/src/routes/spaces/[space_id].tsx
+++ b/frontend/src/routes/spaces/[space_id].tsx
@@ -1,0 +1,73 @@
+import { useLocation, useParams } from "@solidjs/router";
+import type { RouteSectionProps } from "@solidjs/router";
+import { createMemo } from "solid-js";
+import {
+  SpaceShell,
+  type SpaceNavigation,
+} from "~/components/SpaceShell";
+
+export const routeTitle = (
+  pathname: string,
+  search: string,
+): string | undefined => {
+  if (pathname.endsWith("/entries/new")) return "New Entry";
+  if (/\/entries\/[^/]+\/history\/[^/]+$/.test(pathname)) return "Revision";
+  if (/\/entries\/[^/]+\/history$/.test(pathname)) return "Entry / History";
+  if (/\/entries\/[^/]+\/restore$/.test(pathname)) return "Restore";
+  if (/\/assets\/[^/]+$/.test(pathname)) return "Asset";
+  if (pathname.endsWith("/assets")) return "Assets";
+  if (pathname.endsWith("/sql")) return "Saved SQL";
+  if (/\/sql\/[^/]+$/.test(pathname)) return "Saved SQL detail";
+  if (pathname.endsWith("/queries/new")) return "SQL / New";
+  if (/\/queries\/[^/]+\/variables$/.test(pathname)) {
+    return "SQL / Variables";
+  }
+  if (pathname.endsWith("/test-connection")) return "Settings / Storage";
+  if (pathname.endsWith("/settings")) {
+    const section = new URLSearchParams(search).get("section");
+    const sectionTitle: Record<string, string> = {
+      general: "General",
+      members: "Members",
+      agents: "Agents",
+      credentials: "Credentials",
+      storage: "Storage",
+    };
+    return `Settings / ${sectionTitle[section ?? ""] ?? "General"}`;
+  }
+  if (pathname.endsWith("/search")) return "Search";
+  if (pathname.endsWith("/forms/types")) return "Forms / Field Types";
+  if (pathname.endsWith("/forms")) return "Forms";
+  return undefined;
+};
+
+export const routeNavigation = (pathname: string): SpaceNavigation => {
+  if (pathname.includes("/settings")) return "settings";
+  if (
+    pathname.includes("/search") || pathname.includes("/sql") ||
+    pathname.includes("/queries") || pathname.includes("/query")
+  ) return "search";
+  if (
+    pathname.includes("/forms") || pathname.includes("/entries") ||
+    pathname.includes("/assets")
+  ) return "forms";
+  return "home";
+};
+
+export default function SpaceLayout(props: RouteSectionProps) {
+  const params = useParams<{ space_id: string }>();
+  const location = useLocation();
+  const spaceId = () => params.space_id;
+  const pathname = () => location.pathname;
+  const activeNavigation = createMemo(() => routeNavigation(pathname()));
+  const title = createMemo(() => routeTitle(pathname(), location.search));
+
+  return (
+    <SpaceShell
+      spaceId={spaceId()}
+      activeNavigation={activeNavigation()}
+      title={title()}
+    >
+      {props.children}
+    </SpaceShell>
+  );
+}

--- a/frontend/src/routes/spaces/[space_id].tsx
+++ b/frontend/src/routes/spaces/[space_id].tsx
@@ -1,70 +1,97 @@
-import { useLocation, useParams } from "@solidjs/router";
+import { useCurrentMatches, useLocation, useParams } from "@solidjs/router";
 import type { RouteSectionProps } from "@solidjs/router";
 import { createMemo } from "solid-js";
-import {
-  SpaceShell,
-  type SpaceNavigation,
-} from "~/components/SpaceShell";
+import { locale } from "~/lib/i18n";
+import { spaceRoute, type SpaceShellRouteInfo } from "~/lib/space-shell-route";
+import { SpaceShell } from "~/components/SpaceShell";
 
-export const routeTitle = (
-  pathname: string,
-  search: string,
-): string | undefined => {
-  if (pathname.endsWith("/entries/new")) return "New Entry";
-  if (/\/entries\/[^/]+\/history\/[^/]+$/.test(pathname)) return "Revision";
-  if (/\/entries\/[^/]+\/history$/.test(pathname)) return "Entry / History";
-  if (/\/entries\/[^/]+\/restore$/.test(pathname)) return "Restore";
-  if (/\/assets\/[^/]+$/.test(pathname)) return "Asset";
-  if (pathname.endsWith("/assets")) return "Assets";
-  if (pathname.endsWith("/sql")) return "Saved SQL";
-  if (/\/sql\/[^/]+$/.test(pathname)) return "Saved SQL detail";
-  if (pathname.endsWith("/queries/new")) return "SQL / New";
-  if (/\/queries\/[^/]+\/variables$/.test(pathname)) {
-    return "SQL / Variables";
-  }
-  if (pathname.endsWith("/test-connection")) return "Settings / Storage";
-  if (pathname.endsWith("/settings")) {
-    const section = new URLSearchParams(search).get("section");
-    const sectionTitle: Record<string, string> = {
-      general: "General",
-      members: "Members",
-      agents: "Agents",
-      credentials: "Credentials",
-      storage: "Storage",
-    };
-    return `Settings / ${sectionTitle[section ?? ""] ?? "General"}`;
-  }
-  if (pathname.endsWith("/search")) return "Search";
-  if (pathname.endsWith("/forms/types")) return "Forms / Field Types";
-  if (pathname.endsWith("/forms")) return "Forms";
-  return undefined;
-};
+export const route = spaceRoute({ navigation: "home" });
 
-export const routeNavigation = (pathname: string): SpaceNavigation => {
-  if (pathname.includes("/settings")) return "settings";
-  if (
-    pathname.includes("/search") || pathname.includes("/sql") ||
-    pathname.includes("/queries") || pathname.includes("/query")
-  ) return "search";
-  if (
-    pathname.includes("/forms") || pathname.includes("/entries") ||
-    pathname.includes("/assets")
-  ) return "forms";
-  return "home";
+const titleCopy = {
+  en: {
+    asset: "Asset",
+    assets: "Assets",
+    entryHistory: "Entry / History",
+    newEntry: "New Entry",
+    restore: "Restore",
+    revision: "Revision",
+    savedSql: "Saved SQL",
+    savedSqlDetail: "Saved SQL detail",
+    settings: "Settings",
+    settingsStorage: "Settings / Storage",
+    sqlNew: "SQL / New",
+    sqlVariables: "SQL / Variables",
+    formTypes: "Forms / Field Types",
+  },
+  ja: {
+    asset: "アセット",
+    assets: "アセット",
+    entryHistory: "エントリー / 履歴",
+    newEntry: "新しいエントリー",
+    restore: "復元",
+    revision: "リビジョン",
+    savedSql: "保存済みSQL",
+    savedSqlDetail: "保存済みSQL詳細",
+    settings: "設定",
+    settingsStorage: "設定 / ストレージ",
+    sqlNew: "SQL / 新規",
+    sqlVariables: "SQL / 変数",
+    formTypes: "フォーム / フィールドタイプ",
+  },
+} as const;
+
+const settingsSectionCopy = {
+  en: {
+    general: "General",
+    members: "Members",
+    agents: "Agents",
+    credentials: "Credentials",
+    storage: "Storage",
+  },
+  ja: {
+    general: "一般",
+    members: "メンバー",
+    agents: "エージェント",
+    credentials: "認証情報",
+    storage: "ストレージ",
+  },
+} as const;
+
+const getRouteInfo = (matches: ReturnType<typeof useCurrentMatches>) => {
+  for (const match of [...matches()].reverse()) {
+    const info = match.route.info?.spaceShell as
+      | SpaceShellRouteInfo
+      | undefined;
+    if (info) return info;
+  }
+  return { navigation: "home" as const };
 };
 
 export default function SpaceLayout(props: RouteSectionProps) {
   const params = useParams<{ space_id: string }>();
+  const matches = useCurrentMatches();
   const location = useLocation();
   const spaceId = () => params.space_id;
-  const pathname = () => location.pathname;
-  const activeNavigation = createMemo(() => routeNavigation(pathname()));
-  const title = createMemo(() => routeTitle(pathname(), location.search));
+  const routeInfo = createMemo(() => getRouteInfo(matches));
+  const title = createMemo(() => {
+    const info = routeInfo();
+    if (!info.title) return undefined;
+    const language = locale() === "ja" ? "ja" : "en";
+    const copy = titleCopy[language];
+    if (info.title !== "settings") return copy[info.title];
+
+    const section = new URLSearchParams(location.search).get("section") ??
+      "general";
+    const sectionCopy = settingsSectionCopy[language];
+    return `${copy.settings} / ${
+      sectionCopy[section as keyof typeof sectionCopy] ?? sectionCopy.general
+    }`;
+  });
 
   return (
     <SpaceShell
       spaceId={spaceId()}
-      activeNavigation={activeNavigation()}
+      activeNavigation={routeInfo().navigation}
       title={title()}
     >
       {props.children}

--- a/frontend/src/routes/spaces/[space_id]/assets.tsx
+++ b/frontend/src/routes/spaces/[space_id]/assets.tsx
@@ -1,4 +1,7 @@
 import type { RouteSectionProps } from "@solidjs/router";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceAssetsLayout(props: RouteSectionProps) {
   return props.children;

--- a/frontend/src/routes/spaces/[space_id]/assets/[asset_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/assets/[asset_id].tsx
@@ -4,6 +4,9 @@ import { assetApi } from "~/lib/ugoite-client";
 import { AccessPolicyEditor } from "~/components/AccessPolicyEditor";
 import { t } from "~/lib/i18n";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms", title: "asset" });
 
 export default function SpaceAssetDetailRoute() {
   const navigate = useNavigate();

--- a/frontend/src/routes/spaces/[space_id]/assets/[asset_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/assets/[asset_id].tsx
@@ -2,7 +2,6 @@ import { A, useNavigate, useParams } from "@solidjs/router";
 import { createMemo, createSignal, Show } from "solid-js";
 import { assetApi } from "~/lib/ugoite-client";
 import { AccessPolicyEditor } from "~/components/AccessPolicyEditor";
-import { SpaceShell } from "~/components/SpaceShell";
 import { t } from "~/lib/i18n";
 import { createResource } from "~/lib/recoverable-resource";
 
@@ -38,7 +37,7 @@ export default function SpaceAssetDetailRoute() {
   };
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="forms" title="Asset">
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">Forms / Assets</div>
@@ -94,6 +93,6 @@ export default function SpaceAssetDetailRoute() {
           )}
         </Show>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/assets/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/assets/index.tsx
@@ -1,7 +1,6 @@
 import { A, useParams } from "@solidjs/router";
 import { createSignal, Show } from "solid-js";
 import { AssetUploader } from "~/components/AssetUploader";
-import { SpaceShell } from "~/components/SpaceShell";
 import { assetApi } from "~/lib/ugoite-client";
 import { t } from "~/lib/i18n";
 import { createResource } from "~/lib/recoverable-resource";
@@ -33,7 +32,7 @@ export default function SpaceAssetsRoute() {
   };
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="forms" title="Assets">
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">Forms</div>
@@ -59,6 +58,6 @@ export default function SpaceAssetsRoute() {
           <p class="ui-alert ui-alert-error">{t("assetsPage.failedLoad")}</p>
         </Show>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/assets/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/assets/index.tsx
@@ -4,6 +4,9 @@ import { AssetUploader } from "~/components/AssetUploader";
 import { assetApi } from "~/lib/ugoite-client";
 import { t } from "~/lib/i18n";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms", title: "assets" });
 import type { Asset } from "~/lib/types";
 
 export default function SpaceAssetsRoute() {

--- a/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
-import { createSignal, Show } from "solid-js";
+import { createMemo, createSignal, Show } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setLocale } from "~/lib/i18n";
 import { formApi, spaceApi } from "~/lib/ugoite-client";
@@ -9,8 +9,7 @@ import SpaceDashboardRoute from "./dashboard";
 const navigate = vi.fn();
 const { entryStoreMock } = vi.hoisted(() => ({ entryStoreMock: { entries: vi.fn(), loadEntries: vi.fn(), error: vi.fn() } }));
 vi.mock("@solidjs/router", () => ({ useNavigate: () => navigate, useParams: () => ({ space_id: "default" }), A: (props: { href: string; class?: string; children: unknown }) => <a href={props.href} class={props.class}>{props.children}</a> }));
-vi.mock("~/components/SpaceShell", () => ({ SpaceShell: (props: { children: unknown }) => <div>{props.children}</div> }));
-vi.mock("~/components/create-dialogs", () => ({ CreateFormDialog: (props: { open: boolean }) => <Show when={props.open}><div>Create Form Dialog</div></Show> }));
+vi.mock("~/components/create-dialogs", () => ({ CreateFormDialog: (props: { open: boolean }) => { const open = createMemo(() => props.open); return <Show when={open()}><div>Create Form Dialog</div></Show>; } }));
 vi.mock("~/lib/entry-store", () => ({ createEntryStore: () => entryStoreMock }));
 vi.mock("~/lib/ugoite-client", () => ({ formApi: { list: vi.fn(), listTypes: vi.fn(), create: vi.fn() }, spaceApi: { get: vi.fn() } }));
 

--- a/frontend/src/routes/spaces/[space_id]/dashboard.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.tsx
@@ -1,7 +1,6 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import { createMemo, createSignal, For, onMount, Show } from "solid-js";
 import { CreateFormDialog } from "~/components/create-dialogs";
-import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { createEntryStore } from "~/lib/entry-store";
 import { getDocsiteHref } from "~/lib/docsite-links";
@@ -64,7 +63,7 @@ export default function SpaceDashboardRoute() {
   };
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="home" title={c().home}>
+    <>
       <div class="screenHead">
         <div class="screenTitle"><div class="eyebrow">{spaceName()}</div><h1>{c().home}</h1></div>
         <button class="btn primary" type="button" disabled={!formsAvailable()} onClick={startNewEntry}>
@@ -118,6 +117,6 @@ export default function SpaceDashboardRoute() {
       </section>
 
       <CreateFormDialog open={showFormDialog()} columnTypes={columnTypes() ?? []} formNames={(forms() ?? []).map((form) => form.name)} onClose={() => setShowFormDialog(false)} onSubmit={createForm} />
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/dashboard.tsx
+++ b/frontend/src/routes/spaces/[space_id]/dashboard.tsx
@@ -9,6 +9,9 @@ import { createResource } from "~/lib/recoverable-resource";
 import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { formApi, spaceApi } from "~/lib/ugoite-client";
 import type { FormCreatePayload } from "~/lib/types";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "home" });
 
 const copy = {
   en: { home: "Home", newEntry: "Entry", continue: "Continue", pinned: "Pinned", recent: "Recent", forms: "Forms", search: "Search", assets: "Assets", savedSql: "SQL", noRecent: "Create an entry to start building this Space.", walkthrough: "Create your first entry with the browser walkthrough", form: "Form", entry: "Entry", searchMeta: "Entries · Forms · Assets" },

--- a/frontend/src/routes/spaces/[space_id]/entries.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries.tsx
@@ -6,6 +6,9 @@ import { formApi } from "~/lib/ugoite-client";
 import { createEntryStore } from "~/lib/entry-store";
 import { createSpaceStore } from "~/lib/space-store";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceEntriesRoute(props: RouteSectionProps) {
   const params = useParams<{ space_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id].tsx
@@ -1,4 +1,7 @@
 import type { RouteSectionProps } from "@solidjs/router";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceEntryLayout(props: RouteSectionProps) {
   return props.children;

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history.tsx
@@ -1,4 +1,7 @@
 import type { RouteSectionProps } from "@solidjs/router";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceEntryHistoryLayout(props: RouteSectionProps) {
   return props.children;

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/[revision_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/[revision_id].tsx
@@ -2,6 +2,9 @@ import { A, useParams } from "@solidjs/router";
 import { Show } from "solid-js";
 import { entryApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms", title: "revision" });
 
 export default function SpaceEntryRevisionRoute() {
   const params = useParams<

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/[revision_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/[revision_id].tsx
@@ -1,7 +1,6 @@
 import { A, useParams } from "@solidjs/router";
 import { Show } from "solid-js";
 import { entryApi } from "~/lib/ugoite-client";
-import { SpaceShell } from "~/components/SpaceShell";
 import { createResource } from "~/lib/recoverable-resource";
 
 export default function SpaceEntryRevisionRoute() {
@@ -17,7 +16,7 @@ export default function SpaceEntryRevisionRoute() {
   });
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="forms" title="Revision">
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">{entryId()} / History</div>
@@ -54,6 +53,6 @@ export default function SpaceEntryRevisionRoute() {
           </div>
         )}
       </Show>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.tsx
@@ -1,6 +1,5 @@
 import { A, useParams } from "@solidjs/router";
 import { For, Show } from "solid-js";
-import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { entryApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
@@ -15,11 +14,7 @@ export default function SpaceEntryHistoryRoute() {
   );
 
   return (
-    <SpaceShell
-      spaceId={spaceId()}
-      activeNavigation="forms"
-      title="Entry / History"
-    >
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">{entryId()}</div>
@@ -63,6 +58,6 @@ export default function SpaceEntryHistoryRoute() {
           </div>
         )}
       </Show>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.tsx
@@ -3,6 +3,9 @@ import { For, Show } from "solid-js";
 import { UiIcon } from "~/components/UiIcon";
 import { entryApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms", title: "entryHistory" });
 
 export default function SpaceEntryHistoryRoute() {
   const params = useParams<{ space_id: string; entry_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/index.tsx
@@ -3,7 +3,6 @@ import { Show } from "solid-js";
 import { EntryDetailPane } from "~/components/EntryDetailPane";
 import { useEntriesRouteContext } from "~/lib/entries-route-context";
 import { t } from "~/lib/i18n";
-import { SpaceShell } from "~/components/SpaceShell";
 
 export default function SpaceEntryDetailRoute() {
   const navigate = useNavigate();
@@ -14,7 +13,7 @@ export default function SpaceEntryDetailRoute() {
   const entryId = () => params.entry_id ?? "";
 
   return (
-    <SpaceShell spaceId={spaceId()}>
+    <>
       <div class="mx-auto max-w-6xl">
         <Show
           when={!ctx.loadingForms() && !ctx.formsError?.()}
@@ -54,6 +53,6 @@ export default function SpaceEntryDetailRoute() {
           />
         </Show>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/index.tsx
@@ -3,6 +3,9 @@ import { Show } from "solid-js";
 import { EntryDetailPane } from "~/components/EntryDetailPane";
 import { useEntriesRouteContext } from "~/lib/entries-route-context";
 import { t } from "~/lib/i18n";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceEntryDetailRoute() {
   const navigate = useNavigate();

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.tsx
@@ -2,6 +2,9 @@ import { A, useNavigate, useParams } from "@solidjs/router";
 import { createSignal, For, Show } from "solid-js";
 import { entryApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms", title: "restore" });
 
 export default function SpaceEntryRestoreRoute() {
   const navigate = useNavigate();

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.tsx
@@ -1,7 +1,6 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import { createSignal, For, Show } from "solid-js";
 import { entryApi } from "~/lib/ugoite-client";
-import { SpaceShell } from "~/components/SpaceShell";
 import { createResource } from "~/lib/recoverable-resource";
 
 export default function SpaceEntryRestoreRoute() {
@@ -38,7 +37,7 @@ export default function SpaceEntryRestoreRoute() {
   };
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="forms" title="Restore">
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">{entryId()} / History</div>
@@ -95,6 +94,6 @@ export default function SpaceEntryRestoreRoute() {
           </div>
         )}
       </Show>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/entries/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.tsx
@@ -8,7 +8,6 @@ import {
   Show,
 } from "solid-js";
 import { CreateFormDialog } from "~/components/create-dialogs";
-import { SpaceShell } from "~/components/SpaceShell";
 import { formatDateLabel } from "~/lib/date-format";
 import { useEntriesRouteContext } from "~/lib/entries-route-context";
 import { formApi } from "~/lib/ugoite-client";
@@ -145,14 +144,7 @@ export default function SpaceEntriesIndexPane() {
   };
 
   return (
-    <SpaceShell
-      spaceId={spaceId()}
-      showBottomTabs
-      activeBottomTab="object"
-      bottomTabHrefSuffix={sessionId().trim()
-        ? `?session=${encodeURIComponent(sessionId())}`
-        : ""}
-    >
+    <>
       <div class="mx-auto max-w-6xl">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div>
@@ -302,6 +294,6 @@ export default function SpaceEntriesIndexPane() {
         onClose={() => setShowCreateFormDialog(false)}
         onSubmit={handleCreateForm}
       />
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/entries/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/index.tsx
@@ -16,6 +16,9 @@ import { createResource } from "~/lib/recoverable-resource";
 import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { sqlSessionApi, sqlSessionRowToEntryRecord } from "~/lib/ugoite-client";
 import type { EntryRecord, FormCreatePayload } from "~/lib/types";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceEntriesIndexPane() {
   const navigate = useNavigate();

--- a/frontend/src/routes/spaces/[space_id]/entries/new.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/new.tsx
@@ -6,7 +6,6 @@ import {
   Show,
 } from "solid-js";
 import { EntryDetailPane } from "~/components/EntryDetailPane";
-import { SpaceShell } from "~/components/SpaceShell";
 import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { formApi, spaceApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
@@ -55,7 +54,7 @@ export default function NewEntryRoute() {
   );
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="forms" title="New Entry">
+    <>
       <Show
         when={!space.loading && !forms.loading}
         fallback={
@@ -117,6 +116,6 @@ export default function NewEntryRoute() {
           </Show>
         </Show>
       </Show>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/entries/new.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/new.tsx
@@ -9,6 +9,9 @@ import { EntryDetailPane } from "~/components/EntryDetailPane";
 import { filterCreatableEntryForms } from "~/lib/metadata-forms";
 import { formApi, spaceApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms", title: "newEntry" });
 
 export default function NewEntryRoute() {
   const params = useParams<{ space_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/forms.tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms.tsx
@@ -6,6 +6,9 @@ import { EntriesRouteContext } from "~/lib/entries-route-context";
 import { createEntryStore } from "~/lib/entry-store";
 import { createSpaceStore } from "~/lib/space-store";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceFormsRoute(props: RouteSectionProps) {
   const params = useParams<{ space_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/forms/[form_name].tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms/[form_name].tsx
@@ -1,5 +1,8 @@
 import { useNavigate, useParams } from "@solidjs/router";
 import { onMount } from "solid-js";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 export default function SpaceFormDetailRoute() {
   const params = useParams<{ space_id: string; form_name: string }>();

--- a/frontend/src/routes/spaces/[space_id]/forms/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms/index.tsx
@@ -2,7 +2,6 @@ import { useNavigate, useSearchParams } from "@solidjs/router";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
 import { CreateFormDialog, EditFormDialog } from "~/components/create-dialogs";
 import { FormTable } from "~/components/FormTable";
-import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { useEntriesRouteContext } from "~/lib/entries-route-context";
 import { locale } from "~/lib/i18n";
@@ -82,11 +81,7 @@ export default function SpaceFormsIndexPane() {
   };
 
   return (
-    <SpaceShell
-      spaceId={ctx.spaceId()}
-      activeNavigation="forms"
-      title={c().forms}
-    >
+    <>
       <Show
         when={!ctx.formsError?.()}
         fallback={
@@ -229,6 +224,6 @@ export default function SpaceFormsIndexPane() {
           onSubmit={createForm}
         />
       </Show>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/forms/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms/index.tsx
@@ -11,6 +11,9 @@ import {
 } from "~/lib/metadata-forms";
 import { formApi } from "~/lib/ugoite-client";
 import type { FormCreatePayload } from "~/lib/types";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms" });
 
 const copy = {
   en: {

--- a/frontend/src/routes/spaces/[space_id]/forms/types.tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms/types.tsx
@@ -2,6 +2,9 @@ import { A, useParams } from "@solidjs/router";
 import { For, Show } from "solid-js";
 import { formApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "forms", title: "formTypes" });
 
 export default function SpaceFormTypesRoute() {
   const params = useParams<{ space_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/forms/types.tsx
+++ b/frontend/src/routes/spaces/[space_id]/forms/types.tsx
@@ -1,7 +1,6 @@
 import { A, useParams } from "@solidjs/router";
 import { For, Show } from "solid-js";
 import { formApi } from "~/lib/ugoite-client";
-import { SpaceShell } from "~/components/SpaceShell";
 import { createResource } from "~/lib/recoverable-resource";
 
 export default function SpaceFormTypesRoute() {
@@ -13,11 +12,7 @@ export default function SpaceFormTypesRoute() {
   });
 
   return (
-    <SpaceShell
-      spaceId={spaceId()}
-      activeNavigation="forms"
-      title="Forms / Field Types"
-    >
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">Forms</div>
@@ -51,6 +46,6 @@ export default function SpaceFormTypesRoute() {
           </div>
         )}
       </Show>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.tsx
@@ -2,6 +2,9 @@ import { A, useNavigate, useParams } from "@solidjs/router";
 import { createMemo, createSignal, For, Show } from "solid-js";
 import { sqlApi, sqlSessionApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "search", title: "sqlVariables" });
 
 export default function SpaceQueryVariablesRoute() {
   const params = useParams<{ space_id: string; query_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.tsx
@@ -1,6 +1,5 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import { createMemo, createSignal, For, Show } from "solid-js";
-import { SpaceShell } from "~/components/SpaceShell";
 import { sqlApi, sqlSessionApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
 
@@ -65,11 +64,7 @@ export default function SpaceQueryVariablesRoute() {
   };
 
   return (
-    <SpaceShell
-      spaceId={spaceId()}
-      activeNavigation="search"
-      title="SQL / Variables"
-    >
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">Search / Saved SQL</div>
@@ -128,6 +123,6 @@ export default function SpaceQueryVariablesRoute() {
           </div>
         )}
       </Show>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/queries/new.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/new.tsx
@@ -1,7 +1,6 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import type { Diagnostic } from "@codemirror/lint";
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
-import { SpaceShell } from "~/components/SpaceShell";
 import { SqlQueryEditor } from "~/components";
 import { formApi } from "~/lib/ugoite-client";
 import { buildSqlSchema } from "~/lib/sql";
@@ -78,7 +77,7 @@ export default function SpaceQueryCreateRoute() {
   };
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="search" title="SQL / New">
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">Search / Saved SQL</div>
@@ -132,6 +131,6 @@ export default function SpaceQueryCreateRoute() {
           {isSaving() ? "Saving..." : "Save"}
         </button>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/queries/new.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/new.tsx
@@ -7,6 +7,9 @@ import { buildSqlSchema } from "~/lib/sql";
 import { sqlApi } from "~/lib/ugoite-client";
 import type { Form, SqlVariable } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "search", title: "sqlNew" });
 
 const VARIABLE_REGEX = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
 

--- a/frontend/src/routes/spaces/[space_id]/query.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/query.test.tsx
@@ -12,16 +12,6 @@ vi.mock("@solidjs/router", () => ({
   useParams: () => ({ space_id: "default" }),
 }));
 
-vi.mock("~/components/SpaceShell", () => ({
-  SpaceShell: (
-    props: { children: unknown; spaceId: string; activeTopTab?: string },
-  ) => (
-    <div data-space-id={props.spaceId} data-active-top-tab={props.activeTopTab}>
-      {props.children}
-    </div>
-  ),
-}));
-
 describe("/spaces/:space_id/query", () => {
   it("REQ-FE-063: legacy query route explains the supported search path", () => {
     const { container } = render(() => <SpaceQueryRoute />);
@@ -46,13 +36,5 @@ describe("/spaces/:space_id/query", () => {
         "href",
         "/spaces/default/dashboard",
       );
-    expect(container.firstElementChild).toHaveAttribute(
-      "data-space-id",
-      "default",
-    );
-    expect(container.firstElementChild).toHaveAttribute(
-      "data-active-top-tab",
-      "search",
-    );
   });
 });

--- a/frontend/src/routes/spaces/[space_id]/query.tsx
+++ b/frontend/src/routes/spaces/[space_id]/query.tsx
@@ -1,12 +1,11 @@
 import { A, useParams } from "@solidjs/router";
-import { SpaceShell } from "~/components/SpaceShell";
 
 export default function SpaceQueryRoute() {
   const params = useParams<{ space_id: string }>();
   const spaceId = () => params.space_id;
 
   return (
-    <SpaceShell spaceId={spaceId()} activeTopTab="search">
+    <>
       <div class="mx-auto max-w-4xl ui-stack">
         <section class="ui-card ui-stack">
           <div class="ui-stack-sm">
@@ -54,6 +53,6 @@ export default function SpaceQueryRoute() {
           </div>
         </section>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/query.tsx
+++ b/frontend/src/routes/spaces/[space_id]/query.tsx
@@ -1,4 +1,7 @@
 import { A, useParams } from "@solidjs/router";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "search" });
 
 export default function SpaceQueryRoute() {
   const params = useParams<{ space_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -8,6 +8,9 @@ import { sqlSessionApi } from "~/lib/ugoite-client";
 import { sqlApi } from "~/lib/ugoite-client";
 import type { KeywordSearchResult, SqlEntry } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "search" });
 
 type SearchMode = "keyword" | "advanced";
 type FieldMatchOperator = "equals" | "contains" | "lt" | "lte" | "gt" | "gte";

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -1,6 +1,5 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import { createMemo, createSignal, For, Index, Show } from "solid-js";
-import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { formatDateLabel } from "~/lib/date-format";
 import { formApi } from "~/lib/ugoite-client";
@@ -607,7 +606,7 @@ export default function SpaceSearchRoute() {
   };
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="search" title="Search">
+    <>
       <div>
         <div class="screenHead">
           <div class="screenTitle">
@@ -1071,6 +1070,6 @@ export default function SpaceSearchRoute() {
           </main>
         </div>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/settings.tsx
+++ b/frontend/src/routes/spaces/[space_id]/settings.tsx
@@ -1,7 +1,6 @@
 import { useParams, useSearchParams } from "@solidjs/router";
 import { createMemo, createSignal, For, Show } from "solid-js";
 import { SpaceSettings } from "~/components/SpaceSettings";
-import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon, type UiIconName } from "~/components/UiIcon";
 import { CredentialSettings } from "~/routes/settings/security";
 import { locale } from "~/lib/i18n";
@@ -147,13 +146,7 @@ export default function SpaceSettingsRoute() {
   };
 
   return (
-    <SpaceShell
-      spaceId={spaceId()}
-      activeNavigation="settings"
-      title={`Settings / ${
-        sections.find((section) => section.id === active())?.en ?? "General"
-      }`}
-    >
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">{space()?.name || spaceId()}</div>
@@ -432,6 +425,6 @@ export default function SpaceSettingsRoute() {
 
         </main>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/settings.tsx
+++ b/frontend/src/routes/spaces/[space_id]/settings.tsx
@@ -13,6 +13,9 @@ import type {
   StorageConnectionConfig,
 } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "settings", title: "settings" });
 
 type Section =
   | "general"

--- a/frontend/src/routes/spaces/[space_id]/sql.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql.tsx
@@ -1,4 +1,7 @@
 import type { RouteSectionProps } from "@solidjs/router";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "search" });
 
 export default function SpaceSqlRoute(props: RouteSectionProps) {
   return props.children;

--- a/frontend/src/routes/spaces/[space_id]/sql/[sql_id].test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/[sql_id].test.tsx
@@ -21,19 +21,6 @@ vi.mock("@solidjs/router", () => ({
   useParams: () => ({ space_id: "default", sql_id: "saved-query" }),
 }));
 
-vi.mock("~/components/SpaceShell", () => ({
-  SpaceShell: (
-    props: { children: unknown; spaceId: string; activeNavigation?: string },
-  ) => (
-    <div
-      data-space-id={props.spaceId}
-      data-active-navigation={props.activeNavigation}
-    >
-      {props.children}
-    </div>
-  ),
-}));
-
 vi.mock("~/components", () => ({
   SqlQueryEditor: (props: { value: string; disabled?: boolean }) => (
     <pre
@@ -74,7 +61,7 @@ describe("/spaces/:space_id/sql/:sql_id", () => {
       revision_id: "rev-1",
     });
 
-    const { container } = render(() => <SpaceSqlDetailRoute />);
+    render(() => <SpaceSqlDetailRoute />);
 
     expect(await screen.findByRole("heading", { name: "Recent Search" }))
       .toBeInTheDocument();
@@ -100,14 +87,6 @@ describe("/spaces/:space_id/sql/:sql_id", () => {
     expect(screen.getByRole("link", { name: "Open Search" })).toHaveAttribute(
       "href",
       "/spaces/default/search",
-    );
-    expect(container.firstElementChild).toHaveAttribute(
-      "data-space-id",
-      "default",
-    );
-    expect(container.firstElementChild).toHaveAttribute(
-      "data-active-navigation",
-      "search",
     );
   });
 

--- a/frontend/src/routes/spaces/[space_id]/sql/[sql_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/[sql_id].tsx
@@ -13,6 +13,9 @@ import { buildSqlSchema } from "~/lib/sql";
 import { sqlApi } from "~/lib/ugoite-client";
 import { sqlSessionApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "search", title: "savedSqlDetail" });
 
 const READ_ONLY_SQL_SCHEMA = buildSqlSchema([]);
 

--- a/frontend/src/routes/spaces/[space_id]/sql/[sql_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/[sql_id].tsx
@@ -8,7 +8,6 @@ import {
   Switch,
 } from "solid-js";
 import { SqlQueryEditor } from "~/components";
-import { SpaceShell } from "~/components/SpaceShell";
 import { formatDateLabel } from "~/lib/date-format";
 import { buildSqlSchema } from "~/lib/sql";
 import { sqlApi } from "~/lib/ugoite-client";
@@ -57,11 +56,7 @@ export default function SpaceSqlDetailRoute() {
   };
 
   return (
-    <SpaceShell
-      spaceId={spaceId()}
-      activeNavigation="search"
-      title="Saved SQL detail"
-    >
+    <>
       <div class="screenHead">
         <div class="ui-stack-sm">
           <p class="eyebrow">Search / Saved SQL</p>
@@ -210,6 +205,6 @@ export default function SpaceSqlDetailRoute() {
           </A>
         </div>
       </section>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/sql/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/index.test.tsx
@@ -12,39 +12,19 @@ vi.mock("@solidjs/router", () => ({
   useParams: () => ({ space_id: "default" }),
 }));
 
-vi.mock("~/components/SpaceShell", () => ({
-  SpaceShell: (
-    props: { children: unknown; spaceId: string; activeNavigation?: string },
-  ) => (
-    <div
-      data-space-id={props.spaceId}
-      data-active-navigation={props.activeNavigation}
-    >
-      {props.children}
-    </div>
-  ),
-}));
 vi.mock("~/lib/ugoite-client", () => ({
   sqlApi: { list: vi.fn().mockResolvedValue([]) },
 }));
 
 describe("/spaces/:space_id/sql", () => {
   it("REQ-FE-061: saved SQL route provides the v5 list and create action", async () => {
-    const { container } = render(() => <SpaceSqlRoute />);
+    render(() => <SpaceSqlRoute />);
 
     expect(screen.getByRole("heading", { name: "Saved SQL" }))
       .toBeInTheDocument();
     expect(screen.getByRole("link", { name: "SQL" })).toHaveAttribute(
       "href",
       "/spaces/default/queries/new",
-    );
-    expect(container.firstElementChild).toHaveAttribute(
-      "data-space-id",
-      "default",
-    );
-    expect(container.firstElementChild).toHaveAttribute(
-      "data-active-navigation",
-      "search",
     );
   });
 });

--- a/frontend/src/routes/spaces/[space_id]/sql/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/index.tsx
@@ -1,6 +1,5 @@
 import { A, useParams } from "@solidjs/router";
 import { For, Show } from "solid-js";
-import { SpaceShell } from "~/components/SpaceShell";
 import { UiIcon } from "~/components/UiIcon";
 import { sqlApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
@@ -11,7 +10,7 @@ export default function SpaceSqlIndexRoute() {
   const [queries] = createResource(spaceId, sqlApi.list);
 
   return (
-    <SpaceShell spaceId={spaceId()} activeNavigation="search" title="Saved SQL">
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">Search</div>
@@ -59,6 +58,6 @@ export default function SpaceSqlIndexRoute() {
           )}
         </For>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/sql/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/index.tsx
@@ -3,6 +3,9 @@ import { For, Show } from "solid-js";
 import { UiIcon } from "~/components/UiIcon";
 import { sqlApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "search", title: "savedSql" });
 
 export default function SpaceSqlIndexRoute() {
   const params = useParams<{ space_id: string }>();

--- a/frontend/src/routes/spaces/[space_id]/test-connection.tsx
+++ b/frontend/src/routes/spaces/[space_id]/test-connection.tsx
@@ -2,7 +2,6 @@ import { A, useParams } from "@solidjs/router";
 import { createSignal, Show } from "solid-js";
 import { spaceApi } from "~/lib/ugoite-client";
 import type { StorageConnectionConfig } from "~/lib/types";
-import { SpaceShell } from "~/components/SpaceShell";
 import { createResource } from "~/lib/recoverable-resource";
 
 export default function SpaceTestConnectionRoute() {
@@ -50,11 +49,7 @@ export default function SpaceTestConnectionRoute() {
   };
 
   return (
-    <SpaceShell
-      spaceId={spaceId()}
-      activeNavigation="settings"
-      title="Settings / Storage"
-    >
+    <>
       <div class="screenHead">
         <div class="screenTitle">
           <div class="eyebrow">Settings / Storage</div>
@@ -114,6 +109,6 @@ export default function SpaceTestConnectionRoute() {
           <p class="ui-alert ui-alert-error">{error()}</p>
         </Show>
       </div>
-    </SpaceShell>
+    </>
   );
 }

--- a/frontend/src/routes/spaces/[space_id]/test-connection.tsx
+++ b/frontend/src/routes/spaces/[space_id]/test-connection.tsx
@@ -3,6 +3,9 @@ import { createSignal, Show } from "solid-js";
 import { spaceApi } from "~/lib/ugoite-client";
 import type { StorageConnectionConfig } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
+import { spaceRoute } from "~/lib/space-shell-route";
+
+export const route = spaceRoute({ navigation: "settings", title: "settingsStorage" });
 
 export default function SpaceTestConnectionRoute() {
   const params = useParams<{ space_id: string }>();

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -19,6 +19,7 @@ const navigateMock = vi.fn();
 
 vi.mock("@solidjs/router", () => ({
   useNavigate: () => navigateMock,
+  useParams: () => ({}),
   A: (props: { href: string; class?: string; children: unknown }) => (
     <a href={props.href} class={props.class}>
       {props.children}

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -192,7 +192,7 @@ export default function SpacesIndexRoute() {
   });
 
   return (
-    <GlobalShell title="Spaces" active="spaces">
+    <GlobalShell title="Spaces">
       <div class="ui-stack">
         <div class="screenHead">
           <div class="screenTitle">

--- a/frontend/src/routes/spaces/join.tsx
+++ b/frontend/src/routes/spaces/join.tsx
@@ -45,7 +45,6 @@ export default function SpaceInvitationJoinRoute() {
   return (
     <GlobalShell
       title="Join a Space"
-      active="spaces"
       authenticated={session()?.authenticated ?? false}
     >
       <div class="screenHead">

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
     // across otherwise isolated tests.
     fileParallelism: false,
     testTimeout: 10000,
+    server: {
+      deps: {
+        inline: ["@solidjs/router"],
+      },
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,10 +1,30 @@
 import { defineConfig } from "vitest/config";
 import solidPlugin from "vite-plugin-solid";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const frontendRoot = fileURLToPath(new URL(".", import.meta.url));
 const frontendTestOrigin = process.env.FRONTEND_TEST_ORIGIN ??
   "http://localhost:3000";
+const materializedSolidJs = fileURLToPath(
+  new URL("./node_modules/solid-js/dist/dev.js", import.meta.url),
+);
+const materializedSolidJsWeb = fileURLToPath(
+  new URL("./node_modules/solid-js/web/dist/dev.js", import.meta.url),
+);
+const materializedSolidJsStore = fileURLToPath(
+  new URL("./node_modules/solid-js/store/dist/dev.js", import.meta.url),
+);
+
+// The production build materializes Solid under frontend/node_modules. Keep
+// npm dependencies on that same runtime when tests run after the build.
+const solidAliases = existsSync(materializedSolidJs)
+  ? [
+    { find: "solid-js/web", replacement: materializedSolidJsWeb },
+    { find: "solid-js/store", replacement: materializedSolidJsStore },
+    { find: "solid-js", replacement: materializedSolidJs },
+  ]
+  : [];
 
 export default defineConfig({
   root: frontendRoot,
@@ -28,7 +48,7 @@ export default defineConfig({
     testTimeout: 10000,
     server: {
       deps: {
-        inline: ["@solidjs/router"],
+        inline: ["@solidjs/router", "@solidjs/testing-library"],
       },
     },
     coverage: {
@@ -61,9 +81,7 @@ export default defineConfig({
   },
   resolve: {
     conditions: ["development", "browser"],
-    alias: {
-      "~": "/src",
-    },
+    alias: [{ find: "~", replacement: "/src" }, ...solidAliases],
     dedupe: [
       "@solidjs/router",
       "@solidjs/start",


### PR DESCRIPTION
## Summary

- Keep the `/spaces/:space_id` SpaceShell mounted while child routes change, so Forms → New Entry replaces only route content.
- Derive shell title and active navigation from Solid Router route metadata and `useCurrentMatches()`, including the Settings / Storage connection route.
- Keep Forms title localization and remove pathname classification, legacy shell props, browser-location fallbacks, and duplicated AccountMenu navigation adapters.
- Restrict `<A>` to links that need active/current semantics, use exact matches for global footer links, and keep shell/action links as native Router-intercepted anchors.
- Remove GlobalShell's manual `preventDefault() + navigate()` adapter and its obsolete `active` prop.
- Inline Solid Router in Vitest so tests remain stable after the frontend build creates its local dependency links.

## Related Issue (required)

closes #1875

## Testing

- [x] frontend Vitest / 521 tests passed
- [x] `deno lint frontend/src`
- [x] `mise run lint`
- [x] `mise run check`
- [x] `UGOITE_STATIC_SPA=true deno task frontend:build`
- [x] `mise run fmt:check`
