### PR TITLE
fix(frontend): redirect logged-out routes to login

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -2,6 +2,7 @@ import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import { type JSXElement, Suspense } from "solid-js";
 import { AppErrorBoundary } from "~/components/AppErrorBoundary";
+import { AuthGate } from "~/components/AuthGate";
 import Nav from "~/components/Nav";
 import { primePortablePreferencesFromLocal } from "~/lib/preferences-store";
 import "./app.css";
@@ -24,7 +25,9 @@ export default function App() {
       root={(props) => (
         <>
           <Nav />
-          <AppErrorBoundary>{props.children}</AppErrorBoundary>
+          <AuthGate>
+            <AppErrorBoundary>{props.children}</AppErrorBoundary>
+          </AuthGate>
         </>
       )}
     >

--- a/frontend/src/components/AuthGate.test.tsx
+++ b/frontend/src/components/AuthGate.test.tsx
@@ -1,0 +1,137 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthGate } from "./AuthGate";
+import { authApi } from "~/lib/auth-api";
+
+const navigateMock = vi.fn();
+const [pathname, setPathname] = createSignal("/spaces/demo/dashboard");
+const [search, setSearch] = createSignal("?tab=recent");
+const locationMock = {
+  get pathname() {
+    return pathname();
+  },
+  get search() {
+    return search();
+  },
+};
+
+vi.mock("@solidjs/router", () => ({
+  useLocation: () => locationMock,
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("~/lib/auth-api", () => ({
+  authApi: {
+    getSession: vi.fn(),
+  },
+}));
+
+describe("AuthGate", () => {
+  beforeEach(() => {
+    setPathname("/spaces/demo/dashboard");
+    setSearch("?tab=recent");
+    sessionStorage.clear();
+    navigateMock.mockReset();
+    vi.mocked(authApi.getSession).mockReset();
+  });
+
+  it("does not render protected content while the session is pending", async () => {
+    let resolveSession: (value: { authenticated: boolean }) => void = () => {};
+    vi.mocked(authApi.getSession).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+
+    render(() => (
+      <AuthGate>
+        <p>Protected dashboard</p>
+      </AuthGate>
+    ));
+
+    expect(screen.queryByText("Protected dashboard")).not.toBeInTheDocument();
+    expect(screen.getByText("Checking authentication…")).toBeInTheDocument();
+
+    resolveSession({ authenticated: false });
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/login?next=%2Fspaces%2Fdemo%2Fdashboard%3Ftab%3Drecent",
+        { replace: true },
+      );
+    });
+    expect(screen.queryByText("Protected dashboard")).not.toBeInTheDocument();
+  });
+
+  it("renders protected content only after an authenticated session", async () => {
+    vi.mocked(authApi.getSession).mockResolvedValue({ authenticated: true });
+
+    render(() => (
+      <AuthGate>
+        <p>Protected dashboard</p>
+      </AuthGate>
+    ));
+
+    expect(screen.queryByText("Protected dashboard")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Protected dashboard")).toBeInTheDocument()
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the session request is rejected", async () => {
+    vi.mocked(authApi.getSession).mockRejectedValue(new Error("offline"));
+
+    render(() => (
+      <AuthGate>
+        <p>Protected dashboard</p>
+      </AuthGate>
+    ));
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/login?next=%2Fspaces%2Fdemo%2Fdashboard%3Ftab%3Drecent",
+        { replace: true },
+      );
+    });
+  });
+
+  it("does not let a stale protected check redirect after a public navigation", async () => {
+    let resolveSession: (value: { authenticated: boolean }) => void = () => {};
+    vi.mocked(authApi.getSession).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+
+    render(() => (
+      <AuthGate>
+        <p>Invitation join</p>
+      </AuthGate>
+    ));
+
+    setPathname("/about");
+    setSearch("");
+    expect(screen.getByText("Invitation join")).toBeInTheDocument();
+
+    resolveSession({ authenticated: false });
+    await Promise.resolve();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves public routes available without a session request", () => {
+    setPathname("/spaces/join");
+    setSearch("");
+
+    render(() => (
+      <AuthGate>
+        <p>Invitation join</p>
+      </AuthGate>
+    ));
+
+    expect(screen.getByText("Invitation join")).toBeInTheDocument();
+    expect(authApi.getSession).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,0 +1,68 @@
+import { useLocation, useNavigate } from "@solidjs/router";
+import type { JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, Show } from "solid-js";
+import { authApi } from "~/lib/auth-api";
+import {
+  buildLoginPath,
+  consumePendingLoginPath,
+  isProtectedRoute,
+} from "~/lib/auth-route";
+
+type AuthState = "checking" | "authenticated";
+
+const checkingView = (
+  <main class="publicShell">
+    <section class="publicCard ui-muted">Checking authentication…</section>
+  </main>
+);
+
+export function AuthGate(props: { children: JSX.Element }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [authState, setAuthState] = createSignal<AuthState>("checking");
+  const [authorizedPath, setAuthorizedPath] = createSignal<string>();
+  let requestId = 0;
+
+  onCleanup(() => ++requestId);
+
+  createEffect(() => {
+    const pathname = location.pathname;
+    const search = location.search;
+    const currentPath = `${pathname}${search}`;
+
+    if (!isProtectedRoute(pathname)) {
+      ++requestId;
+      setAuthorizedPath(undefined);
+      return;
+    }
+
+    const currentRequestId = ++requestId;
+    setAuthState("checking");
+    setAuthorizedPath(undefined);
+
+    void authApi.getSession().then((session) => {
+      if (currentRequestId !== requestId) return;
+      if (session.authenticated) {
+        const pendingLoginPath = consumePendingLoginPath();
+        if (pendingLoginPath && pendingLoginPath !== currentPath) {
+          navigate(pendingLoginPath, { replace: true });
+          return;
+        }
+        setAuthState("authenticated");
+        setAuthorizedPath(currentPath);
+        return;
+      }
+      navigate(buildLoginPath(pathname, search), { replace: true });
+    }).catch(() => {
+      if (currentRequestId !== requestId) return;
+      navigate(buildLoginPath(pathname, search), { replace: true });
+    });
+  });
+
+  const isReady = () =>
+    !isProtectedRoute(location.pathname) ||
+    (authState() === "authenticated" &&
+      authorizedPath() === `${location.pathname}${location.search}`);
+
+  return <Show when={isReady()} fallback={checkingView}>{props.children}</Show>;
+}

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -1,4 +1,5 @@
 import { UgoiteApiError } from "./ugoite-client/protocol";
+import { clearPendingLoginPath, rememberPendingLoginPath } from "./auth-route";
 
 export type AuthConfig = {
   status: "uninitialized" | "active";
@@ -187,11 +188,19 @@ export const authApi = {
   async listOidcProviders(): Promise<OidcProvider[]> {
     return await request("/auth/oidc/providers", { method: "GET" });
   },
-  loginWithOidc(providerId: string, invitationToken?: string): void {
+  loginWithOidc(
+    providerId: string,
+    invitationToken?: string,
+    nextPath?: string,
+  ): void {
+    if (nextPath) rememberPendingLoginPath(nextPath);
+    else clearPendingLoginPath();
     const query = invitationToken
       ? `?invitation_token=${encodeURIComponent(invitationToken)}`
       : "";
-    location.assign(`/api/auth/oidc/${encodeURIComponent(providerId)}/start${query}`);
+    location.assign(
+      `/api/auth/oidc/${encodeURIComponent(providerId)}/start${query}`,
+    );
   },
   linkOidc(providerId: string): void {
     location.assign(`/api/auth/oidc/${encodeURIComponent(providerId)}/link`);
@@ -343,14 +352,17 @@ export const authApi = {
       }),
     });
     const credential = await createPasskey(challenge);
-    return await request<{ recovery_codes: string[] }>("/auth/recovery/finish", {
-      method: "POST",
-      body: JSON.stringify({
-        account_id: accountId,
-        challenge_id: challenge.challenge_id,
-        credential,
-      }),
-    });
+    return await request<{ recovery_codes: string[] }>(
+      "/auth/recovery/finish",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          account_id: accountId,
+          challenge_id: challenge.challenge_id,
+          credential,
+        }),
+      },
+    );
   },
   async clearSession(): Promise<void> {
     await request("/auth/session", { method: "DELETE" });

--- a/frontend/src/lib/auth-route.test.ts
+++ b/frontend/src/lib/auth-route.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLoginPath,
+  clearPendingLoginPath,
+  consumePendingLoginPath,
+  getCurrentPath,
+  getSafeNextPath,
+  isProtectedRoute,
+  isPublicRoute,
+  rememberPendingLoginPath,
+} from "./auth-route";
+
+describe("frontend authentication routes", () => {
+  it("keeps the public route allowlist explicit", () => {
+    expect(isPublicRoute("/")).toBe(true);
+    expect(isPublicRoute("/login")).toBe(true);
+    expect(isPublicRoute("/recover")).toBe(true);
+    expect(isPublicRoute("/setup")).toBe(true);
+    expect(isPublicRoute("/about")).toBe(true);
+    expect(isPublicRoute("/spaces/join")).toBe(true);
+    expect(isPublicRoute("/spaces/demo/dashboard")).toBe(false);
+    expect(isPublicRoute("/device")).toBe(false);
+    expect(isPublicRoute("/settings/security")).toBe(false);
+    expect(isPublicRoute("/LOGIN/")).toBe(true);
+    expect(isPublicRoute("/spaces//join/")).toBe(true);
+    expect(isProtectedRoute("/spaces")).toBe(true);
+    expect(isProtectedRoute("/spaces/demo/dashboard")).toBe(true);
+    expect(isProtectedRoute("/settings/security")).toBe(true);
+    expect(isProtectedRoute("/device")).toBe(true);
+    expect(isProtectedRoute("/SPACES/")).toBe(true);
+    expect(isProtectedRoute("/spaces//demo/dashboard/")).toBe(true);
+    expect(isProtectedRoute("/SETTINGS/SECURITY/")).toBe(true);
+    expect(isProtectedRoute("/device/")).toBe(true);
+    expect(isProtectedRoute("/does-not-exist")).toBe(false);
+  });
+
+  it("preserves the requested path and query in the login redirect", () => {
+    expect(getCurrentPath("/spaces/demo/dashboard", "?tab=recent")).toBe(
+      "/spaces/demo/dashboard?tab=recent",
+    );
+    expect(buildLoginPath("/spaces/demo/dashboard", "?tab=recent")).toBe(
+      "/login?next=%2Fspaces%2Fdemo%2Fdashboard%3Ftab%3Drecent",
+    );
+  });
+
+  it("accepts only root-relative next paths", () => {
+    expect(getSafeNextPath("/spaces/demo/dashboard?tab=recent")).toBe(
+      "/spaces/demo/dashboard?tab=recent",
+    );
+    expect(getSafeNextPath("https://attacker.invalid/steal")).toBe("/spaces");
+    expect(getSafeNextPath("//attacker.invalid/steal")).toBe("/spaces");
+    expect(getSafeNextPath("spaces/demo")).toBe("/spaces");
+    expect(getSafeNextPath(undefined)).toBe("/spaces");
+  });
+
+  it("stores and consumes a safe OIDC continuation path once", () => {
+    sessionStorage.clear();
+    rememberPendingLoginPath("/spaces/demo/dashboard?tab=recent");
+
+    expect(consumePendingLoginPath()).toBe(
+      "/spaces/demo/dashboard?tab=recent",
+    );
+    expect(consumePendingLoginPath()).toBeUndefined();
+  });
+
+  it("can clear a stale OIDC continuation before a new login method", () => {
+    rememberPendingLoginPath("/spaces/demo/dashboard");
+    clearPendingLoginPath();
+
+    expect(consumePendingLoginPath()).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/auth-route.ts
+++ b/frontend/src/lib/auth-route.ts
@@ -1,0 +1,88 @@
+const publicRoutePaths = new Set([
+  "/",
+  "/login",
+  "/recover",
+  "/setup",
+  "/about",
+  "/spaces/join",
+]);
+
+const normalizeRoutePath = (pathname: string): string => {
+  const normalized = pathname.toLowerCase().replace(/\/+/g, "/").replace(
+    /\/+$/,
+    "",
+  );
+  return normalized || "/";
+};
+
+export const isProtectedRoute = (pathname: string): boolean => {
+  const normalized = normalizeRoutePath(pathname);
+  if (publicRoutePaths.has(normalized)) return false;
+  return normalized === "/spaces" ||
+    normalized.startsWith("/spaces/") ||
+    normalized === "/settings/security" ||
+    normalized === "/device";
+};
+
+export const isPublicRoute = (pathname: string): boolean =>
+  publicRoutePaths.has(normalizeRoutePath(pathname));
+
+export const getCurrentPath = (pathname: string, search = ""): string =>
+  `${pathname || "/"}${search}`;
+
+export const buildLoginPath = (pathname: string, search = "") =>
+  `/login?next=${encodeURIComponent(getCurrentPath(pathname, search))}`;
+
+const defaultNextPath = "/spaces";
+
+export const getSafeNextPath = (value: unknown): string => {
+  if (
+    typeof value !== "string" ||
+    !value.startsWith("/") ||
+    value.startsWith("//")
+  ) {
+    return defaultNextPath;
+  }
+
+  try {
+    const parsed = new URL(value, "https://ugoite.invalid");
+    if (parsed.origin !== "https://ugoite.invalid") return defaultNextPath;
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return defaultNextPath;
+  }
+};
+
+const pendingLoginPathKey = "ugoite.pending-login-path";
+
+export const clearPendingLoginPath = (): void => {
+  if (typeof sessionStorage === "undefined") return;
+
+  try {
+    sessionStorage.removeItem(pendingLoginPathKey);
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+};
+
+export const rememberPendingLoginPath = (value: unknown): void => {
+  if (typeof sessionStorage === "undefined") return;
+
+  try {
+    sessionStorage.setItem(pendingLoginPathKey, getSafeNextPath(value));
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+};
+
+export const consumePendingLoginPath = (): string | undefined => {
+  if (typeof sessionStorage === "undefined") return undefined;
+
+  try {
+    const value = sessionStorage.getItem(pendingLoginPathKey);
+    clearPendingLoginPath();
+    return value ? getSafeNextPath(value) : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/frontend/src/routes/device.test.tsx
+++ b/frontend/src/routes/device.test.tsx
@@ -1,0 +1,40 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DeviceApprovalRoute from "./device";
+import { spaceApi } from "~/lib/ugoite-client";
+import { UgoiteApiError } from "~/lib/ugoite-client/protocol";
+
+vi.mock("@solidjs/router", () => ({
+  useSearchParams: () => [{ user_code: "ABCD" }],
+}));
+
+vi.mock("~/lib/ugoite-client", () => ({
+  spaceApi: {
+    list: vi.fn(),
+  },
+}));
+
+describe("/device", () => {
+  beforeEach(() => {
+    vi.mocked(spaceApi.list).mockReset();
+  });
+
+  it("keeps authenticated permission errors distinguishable", async () => {
+    vi.mocked(spaceApi.list).mockRejectedValue(
+      new UgoiteApiError({
+        kind: "forbidden",
+        code: "FORBIDDEN",
+        status: 403,
+        message: "forbidden",
+        detail: { request_id: "device-space-list-1" },
+      }),
+    );
+
+    render(() => <DeviceApprovalRoute />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("You do not have permission to do that.");
+    expect(alert).toHaveTextContent("device-space-list-1");
+  });
+});

--- a/frontend/src/routes/device.tsx
+++ b/frontend/src/routes/device.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, onMount, Show } from "solid-js";
 import { useSearchParams } from "@solidjs/router";
 import { spaceApi } from "~/lib/ugoite-client";
+import { formatUserFacingError } from "~/lib/user-facing-error";
 
 export default function DeviceApprovalRoute() {
   const [params] = useSearchParams();
@@ -16,10 +17,10 @@ export default function DeviceApprovalRoute() {
       const values = await spaceApi.list();
       setSpaces(values);
       setSpaceId(values[0]?.id ?? "");
-    } catch {
-      location.href = `/login?next=${
-        encodeURIComponent(location.pathname + location.search)
-      }`;
+    } catch (cause) {
+      setError(
+        formatUserFacingError(cause, "spacesPage.failedLoad", "space.list"),
+      );
     }
   });
   const approve = async (event: Event) => {
@@ -101,7 +102,7 @@ export default function DeviceApprovalRoute() {
           </form>
         </Show>
         <Show when={error()}>
-          <p class="ui-alert ui-alert-error">{error()}</p>
+          <p class="ui-alert ui-alert-error" role="alert">{error()}</p>
         </Show>
       </section>
     </main>

--- a/frontend/src/routes/index.test.tsx
+++ b/frontend/src/routes/index.test.tsx
@@ -4,9 +4,43 @@ import IndexRoute from "./index";
 const navigate = vi.fn();
 const getSession = vi.fn();
 vi.mock("@solidjs/router", () => ({ useNavigate: () => navigate }));
-vi.mock("~/lib/ugoite-client", () => ({ authApi: { getSession: (...args: unknown[]) => getSession(...args) } }));
+vi.mock(
+  "~/lib/ugoite-client",
+  () => ({
+    authApi: { getSession: (...args: unknown[]) => getSession(...args) },
+  }),
+);
 describe("root route", () => {
-  beforeEach(() => { navigate.mockReset(); getSession.mockReset(); });
-  it("opens Spaces for an authenticated session", async () => { getSession.mockResolvedValue({ authenticated: true }); render(() => <IndexRoute />); await waitFor(() => expect(navigate).toHaveBeenCalledWith("/spaces", { replace: true })); });
-  it("opens Login for a signed-out or unavailable session", async () => { getSession.mockResolvedValue({ authenticated: false }); render(() => <IndexRoute />); await waitFor(() => expect(navigate).toHaveBeenCalledWith("/login", { replace: true })); });
+  beforeEach(() => {
+    navigate.mockReset();
+    getSession.mockReset();
+  });
+  it("opens Spaces for an authenticated session", async () => {
+    getSession.mockResolvedValue({ authenticated: true });
+    render(() => <IndexRoute />);
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("/spaces", { replace: true })
+    );
+  });
+  it("opens Login for a signed-out or unavailable session", async () => {
+    getSession.mockResolvedValue({ authenticated: false });
+    render(() => <IndexRoute />);
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("/login", { replace: true })
+    );
+  });
+  it("does not navigate after the route is unmounted while checking", async () => {
+    let resolveSession: (value: { authenticated: boolean }) => void = () => {};
+    getSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSession = resolve;
+      }),
+    );
+    const { unmount } = render(() => <IndexRoute />);
+
+    unmount();
+    resolveSession({ authenticated: false });
+    await Promise.resolve();
+    expect(navigate).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,13 +1,22 @@
 import { useNavigate } from "@solidjs/router";
-import { onMount } from "solid-js";
+import { onCleanup, onMount } from "solid-js";
 import { authApi } from "~/lib/ugoite-client";
 
 export default function IndexRoute() {
   const navigate = useNavigate();
+  let cancelled = false;
+  onCleanup(() => cancelled = true);
   onMount(() => {
     void authApi.getSession().then((session) => {
+      if (cancelled) return;
       navigate(session.authenticated ? "/spaces" : "/login", { replace: true });
-    }).catch(() => navigate("/login", { replace: true }));
+    }).catch(() => {
+      if (!cancelled) navigate("/login", { replace: true });
+    });
   });
-  return <main class="publicShell"><section class="publicCard ui-muted">Opening Ugoite…</section></main>;
+  return (
+    <main class="publicShell">
+      <section class="publicCard ui-muted">Opening Ugoite…</section>
+    </main>
+  );
 }

--- a/frontend/src/routes/login.test.tsx
+++ b/frontend/src/routes/login.test.tsx
@@ -1,0 +1,83 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LoginRoute from "./login";
+import { authApi } from "~/lib/auth-api";
+
+const navigateMock = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+  A: (props: { children: unknown }) => <>{props.children}</>,
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [{ next: "/spaces/demo/dashboard?tab=recent" }],
+}));
+
+vi.mock("~/lib/auth-api", () => ({
+  authApi: {
+    getConfig: vi.fn(),
+    listOidcProviders: vi.fn(),
+    loginWithPasskey: vi.fn(),
+    loginWithOidc: vi.fn(),
+  },
+}));
+
+describe("/login continuation", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    vi.mocked(authApi.getConfig).mockResolvedValue({
+      status: "active",
+      nodeId: "node",
+      issuer: "http://localhost:3000",
+      rpId: "localhost",
+      passkey: true,
+      oidc: false,
+    });
+    vi.mocked(authApi.listOidcProviders).mockResolvedValue([]);
+    vi.mocked(authApi.loginWithPasskey).mockResolvedValue();
+    vi.mocked(authApi.loginWithOidc).mockReset();
+  });
+
+  it("keeps the requested route after Passkey login", async () => {
+    render(() => <LoginRoute />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Sign in with a passkey" }),
+    );
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/spaces/demo/dashboard?tab=recent",
+        { replace: true },
+      )
+    );
+  });
+
+  it("passes the requested route to OIDC login", async () => {
+    vi.mocked(authApi.getConfig).mockResolvedValue({
+      status: "active",
+      nodeId: "node",
+      issuer: "http://localhost:3000",
+      rpId: "localhost",
+      passkey: true,
+      oidc: true,
+    });
+    vi.mocked(authApi.listOidcProviders).mockResolvedValue([{
+      provider_id: "provider",
+      issuer: "https://issuer.example",
+    }]);
+
+    render(() => <LoginRoute />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Sign in with https://issuer.example",
+      }),
+    );
+
+    expect(authApi.loginWithOidc).toHaveBeenCalledWith(
+      "provider",
+      undefined,
+      "/spaces/demo/dashboard?tab=recent",
+    );
+  });
+});

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -1,6 +1,7 @@
 import { A, useNavigate, useSearchParams } from "@solidjs/router";
 import { createSignal, For, onMount, Show } from "solid-js";
 import { authApi, type AuthConfig, type OidcProvider } from "~/lib/auth-api";
+import { clearPendingLoginPath, getSafeNextPath } from "~/lib/auth-route";
 
 const message = (error: unknown) =>
   error instanceof Error ? error.message : "Authentication failed.";
@@ -12,6 +13,10 @@ export default function LoginRoute() {
   const [oidcProviders, setOidcProviders] = createSignal<OidcProvider[]>([]);
   const [error, setError] = createSignal("");
   const [busy, setBusy] = createSignal(false);
+
+  const nextPath = () => getSafeNextPath(params.next);
+  const nextQuery = () =>
+    params.next ? `?next=${encodeURIComponent(nextPath())}` : "";
 
   onMount(async () => {
     try {
@@ -29,11 +34,12 @@ export default function LoginRoute() {
     setBusy(true);
     setError("");
     try {
+      clearPendingLoginPath();
       await authApi.loginWithPasskey();
       navigate(
         config()?.status === "uninitialized"
-          ? "/setup"
-          : params.next || "/spaces",
+          ? `/setup${nextQuery()}`
+          : nextPath(),
         { replace: true },
       );
     } catch (cause) {
@@ -71,7 +77,12 @@ export default function LoginRoute() {
               <button
                 type="button"
                 class="ui-button ui-button-secondary"
-                onClick={() => authApi.loginWithOidc(provider.provider_id)}
+                onClick={() =>
+                  authApi.loginWithOidc(
+                    provider.provider_id,
+                    undefined,
+                    params.next ? nextPath() : undefined,
+                  )}
               >
                 Sign in with {provider.issuer}
               </button>
@@ -81,7 +92,10 @@ export default function LoginRoute() {
         <Show when={error()}>
           <p class="ui-alert ui-alert-error text-sm">{error()}</p>
         </Show>
-        <A href="/recover" class="ui-button ui-button-secondary">
+        <A
+          href={`/recover${nextQuery()}`}
+          class="ui-button ui-button-secondary"
+        >
           Recover a Passkey
         </A>
       </section>

--- a/frontend/src/routes/recover.test.tsx
+++ b/frontend/src/routes/recover.test.tsx
@@ -1,0 +1,55 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RecoverRoute from "./recover";
+import { authApi } from "~/lib/auth-api";
+
+const navigateMock = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [{ next: "/spaces/demo/dashboard?tab=recent" }],
+}));
+
+vi.mock("~/lib/auth-api", () => ({
+  authApi: {
+    recoverPasskey: vi.fn(),
+  },
+}));
+
+describe("/recover continuation", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    vi.mocked(authApi.recoverPasskey).mockResolvedValue({
+      recovery_codes: ["replacement-code"],
+    });
+  });
+
+  it("keeps the requested route after recovery", async () => {
+    render(() => <RecoverRoute />);
+
+    fireEvent.input(screen.getByLabelText("Account ID"), {
+      target: { value: "account" },
+    });
+    fireEvent.input(screen.getByLabelText("Recovery code"), {
+      target: { value: "recovery" },
+    });
+    fireEvent.input(screen.getByLabelText("TOTP code"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Register replacement Passkey" }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "I saved the codes" }),
+    );
+
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/spaces/demo/dashboard?tab=recent",
+        { replace: true },
+      )
+    );
+  });
+});

--- a/frontend/src/routes/recover.tsx
+++ b/frontend/src/routes/recover.tsx
@@ -1,15 +1,18 @@
-import { useNavigate } from "@solidjs/router";
+import { useNavigate, useSearchParams } from "@solidjs/router";
 import { createSignal, For, Show } from "solid-js";
 import { authApi } from "~/lib/auth-api";
+import { getSafeNextPath } from "~/lib/auth-route";
 
 export default function RecoverRoute() {
   const navigate = useNavigate();
+  const [params] = useSearchParams();
   const [accountId, setAccountId] = createSignal("");
   const [recoveryCode, setRecoveryCode] = createSignal("");
   const [totpCode, setTotpCode] = createSignal("");
   const [error, setError] = createSignal("");
   const [busy, setBusy] = createSignal(false);
   const [replacementCodes, setReplacementCodes] = createSignal<string[]>([]);
+  const nextPath = () => getSafeNextPath(params.next);
 
   const submit = async (event: Event) => {
     event.preventDefault();
@@ -39,49 +42,50 @@ export default function RecoverRoute() {
         </p>
         <Show when={replacementCodes().length === 0}>
           <form class="ui-stack-sm" onSubmit={submit}>
-          <label class="ui-stack-sm">
-            <span>Account ID</span>
-            <input
-              class="ui-input"
-              value={accountId()}
-              onInput={(event) => setAccountId(event.currentTarget.value)}
-              required
-            />
-          </label>
-          <label class="ui-stack-sm">
-            <span>Recovery code</span>
-            <input
-              class="ui-input font-mono"
-              value={recoveryCode()}
-              onInput={(event) => setRecoveryCode(event.currentTarget.value)}
-              required
-            />
-          </label>
-          <label class="ui-stack-sm">
-            <span>TOTP code</span>
-            <input
-              class="ui-input"
-              inputmode="numeric"
-              autocomplete="one-time-code"
-              value={totpCode()}
-              onInput={(event) => setTotpCode(event.currentTarget.value)}
-              required
-            />
-          </label>
-          <button
-            type="submit"
-            class="ui-button ui-button-primary"
-            disabled={busy()}
-          >
-            {busy() ? "Verifying…" : "Register replacement Passkey"}
-          </button>
+            <label class="ui-stack-sm">
+              <span>Account ID</span>
+              <input
+                class="ui-input"
+                value={accountId()}
+                onInput={(event) => setAccountId(event.currentTarget.value)}
+                required
+              />
+            </label>
+            <label class="ui-stack-sm">
+              <span>Recovery code</span>
+              <input
+                class="ui-input font-mono"
+                value={recoveryCode()}
+                onInput={(event) => setRecoveryCode(event.currentTarget.value)}
+                required
+              />
+            </label>
+            <label class="ui-stack-sm">
+              <span>TOTP code</span>
+              <input
+                class="ui-input"
+                inputmode="numeric"
+                autocomplete="one-time-code"
+                value={totpCode()}
+                onInput={(event) => setTotpCode(event.currentTarget.value)}
+                required
+              />
+            </label>
+            <button
+              type="submit"
+              class="ui-button ui-button-primary"
+              disabled={busy()}
+            >
+              {busy() ? "Verifying…" : "Register replacement Passkey"}
+            </button>
           </form>
         </Show>
         <Show when={replacementCodes().length > 0}>
           <section class="ui-stack-sm" aria-label="Replacement recovery codes">
             <h2>Save your replacement recovery codes</h2>
             <p class="ui-muted">
-              The code used for recovery has been replaced. These values are shown only once.
+              The code used for recovery has been replaced. These values are
+              shown only once.
             </p>
             <ul class="font-mono">
               <For each={replacementCodes()}>{(code) => <li>{code}</li>}</For>
@@ -89,7 +93,7 @@ export default function RecoverRoute() {
             <button
               type="button"
               class="ui-button ui-button-primary"
-              onClick={() => navigate("/spaces", { replace: true })}
+              onClick={() => navigate(nextPath(), { replace: true })}
             >
               I saved the codes
             </button>

--- a/frontend/src/routes/setup.test.tsx
+++ b/frontend/src/routes/setup.test.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SetupRoute from "./setup";
+import { authApi } from "~/lib/auth-api";
+
+const navigateMock = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [{ next: "/spaces/demo/dashboard?tab=recent" }],
+}));
+
+vi.mock("~/lib/auth-api", () => ({
+  authApi: {
+    getConfig: vi.fn(),
+    getSession: vi.fn(),
+    setup: vi.fn(),
+    addPasskey: vi.fn(),
+  },
+}));
+
+describe("/setup continuation", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    vi.mocked(authApi.getConfig).mockResolvedValue({
+      status: "uninitialized",
+      nodeId: "node",
+      issuer: "http://localhost:3000",
+      rpId: "localhost",
+      passkey: true,
+      oidc: false,
+    });
+    vi.mocked(authApi.getSession).mockResolvedValue({ authenticated: false });
+    vi.mocked(authApi.setup).mockResolvedValue({
+      recovery_codes: ["recovery-code"],
+      account: { account_id: "account", display_name: "Admin" },
+    });
+    vi.mocked(authApi.addPasskey).mockResolvedValue();
+  });
+
+  it("keeps the protected route after setup strengthening", async () => {
+    render(() => <SetupRoute />);
+
+    fireEvent.input(screen.getByLabelText("Setup secret"), {
+      target: { value: "setup-secret" },
+    });
+    fireEvent.input(screen.getByLabelText("Display name"), {
+      target: { value: "Admin" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Create administrator passkey",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Register second Passkey" }))
+        .toBeInTheDocument()
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Register second Passkey" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" }))
+        .toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/spaces/demo/dashboard?tab=recent",
+      { replace: true },
+    );
+  });
+});

--- a/frontend/src/routes/setup.tsx
+++ b/frontend/src/routes/setup.tsx
@@ -1,12 +1,19 @@
-import { useNavigate } from "@solidjs/router";
-import { createSignal, onMount, Show } from "solid-js";
+import { useNavigate, useSearchParams } from "@solidjs/router";
+import { createSignal, onCleanup, onMount, Show } from "solid-js";
 import { authApi } from "~/lib/auth-api";
+import { getSafeNextPath } from "~/lib/auth-route";
 
 const message = (error: unknown) =>
   error instanceof Error ? error.message : "Setup failed.";
 
 export default function SetupRoute() {
   const navigate = useNavigate();
+  const [params] = useSearchParams();
+  let cancelled = false;
+  onCleanup(() => cancelled = true);
+  const nextPath = () => getSafeNextPath(params.next);
+  const nextQuery = () =>
+    params.next ? `?next=${encodeURIComponent(nextPath())}` : "";
   const initialSecret = typeof location === "undefined"
     ? ""
     : new URLSearchParams(location.hash.slice(1)).get("secret") ?? "";
@@ -26,9 +33,13 @@ export default function SetupRoute() {
 
   onMount(async () => {
     const config = await authApi.getConfig().catch(() => undefined);
-    if (config?.status === "active") navigate("/login", { replace: true });
+    if (cancelled) return;
+    if (config?.status === "active") {
+      navigate(`/login${nextQuery()}`, { replace: true });
+      return;
+    }
     const session = await authApi.getSession().catch(() => undefined);
-    if (session?.authenticated) {
+    if (!cancelled && session?.authenticated) {
       setHasInitialPasskey(true);
       setAccountId(session.account?.account_id ?? "");
     }
@@ -40,7 +51,8 @@ export default function SetupRoute() {
     setError("");
     try {
       const result = await authApi.setup(secret(), displayName());
-      history.replaceState(null, "", location.pathname);
+      if (cancelled) return;
+      history.replaceState(null, "", `${location.pathname}${nextQuery()}`);
       setRecoveryCodes(result.recovery_codes);
       setAccountId(result.account.account_id);
       setHasInitialPasskey(true);
@@ -176,7 +188,7 @@ export default function SetupRoute() {
                 <button
                   type="button"
                   class="ui-button ui-button-primary"
-                  onClick={() => navigate("/spaces", { replace: true })}
+                  onClick={() => navigate(nextPath(), { replace: true })}
                 >
                   Continue
                 </button>

--- a/frontend/src/routes/spaces/index.test.tsx
+++ b/frontend/src/routes/spaces/index.test.tsx
@@ -266,7 +266,9 @@ describe("/spaces", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("You do not have permission to do that. (Details: Forbidden)"),
+        screen.getByText(
+          "You do not have permission to do that. (Details: Forbidden)",
+        ),
       ).toBeInTheDocument();
     });
 
@@ -310,22 +312,5 @@ describe("/spaces", () => {
         "href",
         localDevAuthGuideUrl,
       );
-  });
-
-  it("REQ-OPS-015: redirects unauthenticated users to the explicit login route", async () => {
-    (spaceApi.list as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new UgoiteApiError({
-        kind: "forbidden",
-        code: "AUTHENTICATION_FAILED",
-        status: 401,
-        message: "Unauthorized",
-      }),
-    );
-
-    render(() => <SpacesIndexRoute />);
-
-    await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith("/login?next=%2Fspaces");
-    });
   });
 });

--- a/frontend/src/routes/spaces/index.tsx
+++ b/frontend/src/routes/spaces/index.tsx
@@ -1,6 +1,6 @@
 import { A, useNavigate } from "@solidjs/router";
 import { GlobalShell } from "~/components/GlobalShell";
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { createMemo, createSignal, For, Show } from "solid-js";
 import { getDocsiteHref } from "~/lib/docsite-links";
 import { authApi, spaceApi } from "~/lib/ugoite-client";
 import { sortSpaces } from "~/lib/space-list";
@@ -83,7 +83,6 @@ export default function SpacesIndexRoute() {
       return [];
     }
   });
-  const [redirected, setRedirected] = createSignal(false);
   const [showCreateForm, setShowCreateForm] = createSignal(false);
   const [newSpaceId, setNewSpaceId] = createSignal("");
   const [createError, setCreateError] = createSignal<string | null>(null);
@@ -170,16 +169,6 @@ export default function SpacesIndexRoute() {
       setIsCreating(false);
     }
   };
-
-  createEffect(() => {
-    if (!spacesError() || redirected()) {
-      return;
-    }
-    if (isAuthenticationError(spacesError())) {
-      setRedirected(true);
-      navigate("/login?next=%2Fspaces");
-    }
-  });
 
   return (
     <GlobalShell title={t("spacesPage.title")} active="spaces">


### PR DESCRIPTION
## Summary

- Add a shared frontend auth gate for known protected routes.
- Redirect logged-out visitors to login while preserving a safe same-origin destination.
- Carry the destination through passkey, OIDC, recovery, and setup flows.
- Keep public entry routes and the public catch-all 404 available, while retaining permission errors for authenticated users.

## Related Issue (required)

closes #1889

## Testing

- [x] `deno run -A npm:vitest run src/lib/auth-route.test.ts src/lib/auth-api.test.ts src/components/AuthGate.test.tsx src/routes/index.test.tsx src/routes/login.test.tsx src/routes/recover.test.tsx src/routes/setup.test.tsx src/routes/device.test.tsx src/routes/spaces/index.test.tsx src/routes/spaces/join.test.tsx`
- [x] `deno fmt --check` on changed frontend files
- [x] `deno lint` on changed frontend files
- [x] `deno task check` from `frontend`
