### PR TITLE
fix(frontend): render entry history timestamps

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -156,7 +156,7 @@ export interface EntryRevisionContent {
 /** Entry history entry */
 export interface EntryRevision {
   revision_id: string;
-  created_at: string;
+  timestamp: string | number;
   checksum: string;
 }
 

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.test.tsx
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setLocale } from "~/lib/i18n";
+import { formatDateTimeLabel } from "~/lib/date-format";
+import { entryApi } from "~/lib/ugoite-client";
+import SpaceEntryHistoryRoute from "./index";
+
+vi.mock("@solidjs/router", () => ({
+  A: (props: { href: string; class?: string; children: unknown }) => (
+    <a href={props.href} class={props.class}>{props.children}</a>
+  ),
+  useParams: () => ({ space_id: "default", entry_id: "entry-1" }),
+}));
+
+vi.mock("~/lib/ugoite-client", () => ({
+  entryApi: { history: vi.fn() },
+}));
+
+describe("entry history route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setLocale("en");
+  });
+
+  it("renders the backend revision timestamp", async () => {
+    const timestamp = 1767225600;
+    vi.mocked(entryApi.history).mockResolvedValue({
+      revisions: [{
+        revision_id: "rev-1",
+        timestamp,
+        checksum: "checksum",
+      }],
+    });
+
+    render(() => <SpaceEntryHistoryRoute />);
+
+    expect(await screen.findByText(formatDateTimeLabel(timestamp)))
+      .toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/history/index.tsx
@@ -1,6 +1,7 @@
 import { A, useParams } from "@solidjs/router";
 import { For, Show } from "solid-js";
 import { UiIcon } from "~/components/UiIcon";
+import { formatDateTimeLabel } from "~/lib/date-format";
 import { entryApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
 import { spaceRoute } from "~/lib/space-shell-route";
@@ -52,7 +53,7 @@ export default function SpaceEntryHistoryRoute() {
                   </span>
                   <span>
                     <b>{revision.revision_id}</b>
-                    <small>{revision.created_at}</small>
+                    <small>{formatDateTimeLabel(revision.timestamp)}</small>
                   </span>
                   <span>›</span>
                 </A>

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.test.tsx
@@ -1,0 +1,44 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { formatDateTimeLabel } from "~/lib/date-format";
+import { setLocale } from "~/lib/i18n";
+import { entryApi } from "~/lib/ugoite-client";
+import SpaceEntryRestoreRoute from "./restore";
+
+const navigate = vi.fn();
+
+vi.mock("@solidjs/router", () => ({
+  A: (props: { href: string; class?: string; children: unknown }) => (
+    <a href={props.href} class={props.class}>{props.children}</a>
+  ),
+  useNavigate: () => navigate,
+  useParams: () => ({ space_id: "default", entry_id: "entry-1" }),
+}));
+
+vi.mock("~/lib/ugoite-client", () => ({
+  entryApi: { history: vi.fn(), restore: vi.fn() },
+}));
+
+describe("entry restore route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setLocale("en");
+  });
+
+  it("renders a string revision timestamp", async () => {
+    const timestamp = "2026-01-01T00:00:00Z";
+    vi.mocked(entryApi.history).mockResolvedValue({
+      revisions: [{
+        revision_id: "rev-1",
+        timestamp,
+        checksum: "checksum",
+      }],
+    });
+
+    render(() => <SpaceEntryRestoreRoute />);
+
+    expect(await screen.findByText(formatDateTimeLabel(timestamp)))
+      .toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.tsx
+++ b/frontend/src/routes/spaces/[space_id]/entries/[entry_id]/restore.tsx
@@ -1,5 +1,6 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import { createSignal, For, Show } from "solid-js";
+import { formatDateTimeLabel } from "~/lib/date-format";
 import { entryApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
 import { spaceRoute } from "~/lib/space-shell-route";
@@ -77,7 +78,7 @@ export default function SpaceEntryRestoreRoute() {
                     />
                     <span>
                       <b>{revision.revision_id}</b>
-                      <small>{revision.created_at}</small>
+                      <small>{formatDateTimeLabel(revision.timestamp)}</small>
                     </span>
                   </li>
                 )}

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -685,9 +685,9 @@ export const handlers = [
     }
     return HttpResponse.json({
       revisions: [{
-        id: entry.revision_id,
-        created_at: entry.updated_at,
-        author: null,
+        revision_id: entry.revision_id,
+        timestamp: entry.updated_at,
+        checksum: "mock-checksum",
       }],
     });
   }),


### PR DESCRIPTION
## Summary

- Align `EntryRevision` and the History/Restore routes with the current `{ timestamp, checksum }` history response.
- Render numeric Unix-second and string timestamps through the shared localized date/time formatter.
- Update the MSW history fixture and add focused visible-date regression coverage for both routes.

## Related Issue (required)

closes #1899

## Testing

- [x] Focused frontend Vitest: History and Restore route tests
- [x] Frontend TypeScript/config check: `deno task --cwd frontend check`
- [x] Codex review with `gpt-5.6-luna` / `xhigh`: no actionable findings
