### PR TITLE
fix(frontend): ignore deprecated required fields on entry creation

### DIFF
--- a/e2e/entries.test.ts
+++ b/e2e/entries.test.ts
@@ -516,9 +516,14 @@ test.describe("Entries CRUD", () => {
 			);
 			entryIds.push(mediaEntryId);
 
-			let mediaEntryResponse = await request.get(
-				getBackendUrl(`/spaces/${spaceId}/entries/${mediaEntryId}`),
+			const mediaEntryUrl = getBackendUrl(
+				`/spaces/${spaceId}/entries/${mediaEntryId}`,
 			);
+			let mediaEntryResponse = await request.get(mediaEntryUrl);
+			for (let attempt = 0; attempt < 10 && !mediaEntryResponse.ok(); attempt++) {
+				await new Promise((resolve) => setTimeout(resolve, 500));
+				mediaEntryResponse = await request.get(mediaEntryUrl);
+			}
 			expect(mediaEntryResponse.ok()).toBeTruthy();
 			let mediaEntry = await mediaEntryResponse.json() as { content: string };
 			expect(mediaEntry.content).toContain('"name":"thumbnail.txt"');

--- a/frontend/src/components/EntryDetailPane.test.tsx
+++ b/frontend/src/components/EntryDetailPane.test.tsx
@@ -152,6 +152,45 @@ describe("EntryDetailPane", () => {
     });
   });
 
+  it("does not require deprecated fields when creating an entry", async () => {
+    const createMock = entryApi.create as ReturnType<typeof vi.fn>;
+    createMock.mockResolvedValue({
+      id: "created-entry",
+      revision_id: "created-revision",
+    });
+    const form: Form = {
+      name: "LegacyForm",
+      version: 1,
+      template: "# LegacyForm\n\n## Active\n\n## Retired\n",
+      fields: {
+        Active: { type: "string", required: true },
+        Retired: { type: "string", required: true, deprecated: true },
+      },
+    };
+
+    render(() => (
+      <EntryDetailPane
+        spaceId={() => "default"}
+        forms={() => [form]}
+        createForm={() => form}
+        onCreated={vi.fn()}
+        onDeleted={vi.fn()}
+      />
+    ));
+
+    expect(await screen.findByText("This field is required."))
+      .toBeInTheDocument();
+    expect(screen.getByLabelText("Retired")).toBeInTheDocument();
+    expect(screen.getAllByText("Optional").length).toBeGreaterThan(0);
+
+    fireEvent.input(screen.getByLabelText("Active"), {
+      target: { value: "active value" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalled());
+  });
+
   it("serializes a selected date from the native date input", async () => {
     const form: Form = {
       name: "Meeting",

--- a/frontend/src/components/EntryDetailPane.tsx
+++ b/frontend/src/components/EntryDetailPane.tsx
@@ -71,6 +71,9 @@ const NUMERIC_FIELD_TYPES = new Set([
 ]);
 const ROW_REFERENCE_SUGGESTION_LIMIT = 8;
 
+const isActiveRequiredField = (field: FormField) =>
+  field.required && !field.deprecated;
+
 function parseEntryValidationError(error: unknown) {
   if (!(error instanceof UgoiteApiError)) return null;
   const detail = error.detail && typeof error.detail === "object" &&
@@ -159,7 +162,7 @@ function buildEditorGuidance(form: Form | null, markdown: string) {
 
   const missingRequired = formFields
     .filter(([fieldName, fieldDef]) => {
-      if (!fieldDef.required) return false;
+      if (!isActiveRequiredField(fieldDef)) return false;
       const section = sectionMap.get(normalizeFieldName(fieldName));
       if (!section || !section.content.trim()) return true;
       if (fieldDef.type === "asset_reference") {
@@ -661,7 +664,7 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
           issues.push(
             t("entryDetail.validation.assetInvalid", { field: fieldName }),
           );
-        } else if (fieldDef.required && !reference) {
+        } else if (isActiveRequiredField(fieldDef) && !reference) {
           issues.push(
             t("entryDetail.validation.assetRequired", { field: fieldName }),
           );
@@ -686,7 +689,10 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
           issues.push(
             t("entryDetail.validation.assetDuplicate", { field: fieldName }),
           );
-        } else if (fieldDef.required && references.length === 0) {
+        } else if (
+          isActiveRequiredField(fieldDef) &&
+          references.length === 0
+        ) {
           issues.push(
             t("entryDetail.validation.assetListRequired", {
               field: fieldName,
@@ -1216,11 +1222,11 @@ export function EntryDetailPane(props: EntryDetailPaneProps) {
                                       </p>
                                     </div>
                                     <span
-                                      class={fieldDef.required
+                                      class={isActiveRequiredField(fieldDef)
                                         ? "ui-entry-required"
                                         : "ui-pill"}
                                     >
-                                      {fieldDef.required
+                                      {isActiveRequiredField(fieldDef)
                                         ? t("entryDetail.required")
                                         : t("entryDetail.optional")}
                                     </span>

--- a/frontend/src/components/create-dialogs.test.tsx
+++ b/frontend/src/components/create-dialogs.test.tsx
@@ -611,6 +611,102 @@ describe("CreateEntryDialog", () => {
     expect((countInput as HTMLInputElement).value).toBe("0");
   });
 
+  it("REQ-FE-037: does not default or require deprecated fields in webform mode", async () => {
+    const onSubmit = vi.fn();
+    const forms = [
+      {
+        name: "Task",
+        version: 1,
+        fields: {
+          Summary: { type: "string", required: true },
+          RetiredAt: { type: "date", required: true, deprecated: true },
+        },
+        template: "",
+      },
+    ];
+
+    render(() => (
+      <CreateEntryDialog
+        open={true}
+        forms={forms}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("Enter entry title..."), {
+      target: { value: "Task Entry" },
+    });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "Task" },
+    });
+
+    expect(screen.getByLabelText(/RetiredAt/)).toHaveValue("");
+    fireEvent.input(screen.getByLabelText(/Summary/), {
+      target: { value: "Active summary" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      "Task Entry",
+      "Task",
+      { Summary: "Active summary" },
+      "webform",
+    );
+  });
+
+  it("REQ-FE-037: does not block webform submission on a deprecated row reference", async () => {
+    const onSubmit = vi.fn();
+    vi.spyOn(searchApi, "rowReferenceOptions").mockResolvedValue([]);
+    const forms = [
+      {
+        name: "Task",
+        version: 1,
+        fields: {
+          Summary: { type: "string", required: true },
+          Retired: {
+            type: "row_reference",
+            required: true,
+            deprecated: true,
+            target_form: "Legacy",
+          },
+        },
+        template: "",
+      },
+    ];
+
+    render(() => (
+      <CreateEntryDialog
+        open={true}
+        forms={forms}
+        spaceId="default"
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("Enter entry title..."), {
+      target: { value: "Task Entry" },
+    });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "Task" },
+    });
+    fireEvent.input(screen.getByLabelText(/Summary/), {
+      target: { value: "Active summary" },
+    });
+    fireEvent.input(screen.getByLabelText(/Retired/), {
+      target: { value: "legacy" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      "Task Entry",
+      "Task",
+      { Summary: "Active summary" },
+      "webform",
+    );
+  });
+
   it("REQ-FE-037: keeps numeric and temporal fields writable while editing", async () => {
     const onSubmit = vi.fn();
     const forms = [
@@ -1767,6 +1863,75 @@ describe("CreateEntryDialog", () => {
     expect(screen.getByLabelText(/Notes/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Skip optional field" }))
       .toBeInTheDocument();
+  });
+
+  it("REQ-FE-057: chat mode treats deprecated required fields as optional", async () => {
+    const onSubmit = vi.fn();
+    vi.spyOn(searchApi, "rowReferenceOptions").mockResolvedValue([]);
+    const forms = [
+      {
+        name: "Task",
+        version: 1,
+        fields: {
+          Summary: { type: "string", required: true },
+          Retired: {
+            type: "row_reference",
+            required: true,
+            deprecated: true,
+            target_form: "Legacy",
+          },
+          Notes: { type: "markdown", required: false },
+        },
+        template: "# Task\n\n## Summary\n",
+      },
+    ];
+
+    render(() => (
+      <CreateEntryDialog
+        open={true}
+        forms={forms}
+        spaceId="default"
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("Enter entry title..."), {
+      target: { value: "Chat Task" },
+    });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "Task" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Chat" }));
+
+    fireEvent.input(screen.getByLabelText(/Summary/), {
+      target: { value: "Conversation summary" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next question" }));
+
+    expect(screen.getByRole("button", { name: "Retired (optional)" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Skip optional field" }))
+      .toBeInTheDocument();
+    fireEvent.input(screen.getByLabelText(/Retired/), {
+      target: { value: "legacy" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next question" }));
+    expect(screen.getByText("Question 3 / 3")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retired (optional)" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Skip optional field" }),
+    );
+
+    expect(screen.getByText("Question 3 / 3")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      "Chat Task",
+      "Task",
+      { Summary: "Conversation summary" },
+      "chat",
+    );
   });
   it("REQ-FE-057: chat step pills react to answers and current step", async () => {
     const onSubmit = vi.fn();

--- a/frontend/src/components/create-dialogs.test.tsx
+++ b/frontend/src/components/create-dialogs.test.tsx
@@ -2515,6 +2515,40 @@ describe("EditFormDialog", () => {
     }));
   });
 
+  it("preserves deprecated fields on a no-op edit", () => {
+    const onSubmit = vi.fn();
+    const formWithDeprecatedField: Form = {
+      name: "LegacyForm",
+      version: 1,
+      template: "# LegacyForm\n\n## retired\n\n",
+      fields: {
+        retired: { type: "string", required: true, deprecated: true },
+      },
+    };
+
+    render(() => (
+      <EditFormDialog
+        open={true}
+        entryForm={formWithDeprecatedField}
+        columnTypes={columnTypes}
+        formNames={["LegacyForm"]}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    ));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      fields: expect.objectContaining({
+        retired: expect.objectContaining({
+          required: true,
+          deprecated: true,
+        }),
+      }),
+    }));
+  });
+
   it("REQ-FE-055: keeps edit-form column inputs readable on narrow layouts", async () => {
     const onSubmit = vi.fn();
     const onClose = vi.fn();

--- a/frontend/src/components/create-dialogs.tsx
+++ b/frontend/src/components/create-dialogs.tsx
@@ -85,6 +85,9 @@ const isLongTextField = (name: string, def: Form["fields"][string]) =>
 const isTextareaField = (name: string, def: Form["fields"][string]) =>
   isLongTextField(name, def) || def.type === "object_list";
 
+const isActiveRequiredField = (def: Form["fields"][string]) =>
+  def.required && !def.deprecated;
+
 const createFieldInputId = (prefix: string, name: string, index: number) => {
   const normalized = name
     .trim()
@@ -437,7 +440,9 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
     const form = selectedFormDef();
     if (!form) return [] as Array<[string, Form["fields"][string]]>;
     /* v8 ignore start */
-    return Object.entries(form.fields || {}).filter(([, def]) => def.required);
+    return Object.entries(form.fields || {}).filter(([, def]) =>
+      isActiveRequiredField(def)
+    );
     /* v8 ignore stop */
   });
 
@@ -580,7 +585,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
     const defaults: Record<string, string> = {};
     /* v8 ignore start */
     for (const [name, def] of Object.entries(form.fields || {})) {
-      if (!def.required) continue;
+      if (!isActiveRequiredField(def)) continue;
       defaults[name] = buildDefaultValue(name, def);
     }
     /* v8 ignore stop */
@@ -664,6 +669,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
     name: string,
     def: Form["fields"][string],
   ) =>
+    !def.deprecated &&
     hasRowReferencePicker(def) &&
     (rowReferenceQueries()[name] ?? "").trim() !== "" &&
     !(fieldValues()[name] ?? "").trim();
@@ -773,7 +779,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
       );
       return;
     }
-    if (def.required && !(fieldValues()[name] || "").trim()) {
+    if (isActiveRequiredField(def) && !(fieldValues()[name] || "").trim()) {
       setErrorMessage(
         t("createDialog.entry.error.answerRequired", { field: name }),
       );
@@ -787,7 +793,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
     const current = currentChatField();
     if (!current) return;
     const [name, def] = current;
-    if (def.required) {
+    if (isActiveRequiredField(def)) {
       setErrorMessage(
         t("createDialog.entry.error.skipRequired", { field: name }),
       );
@@ -975,7 +981,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
                               <span class="ui-pill gap-1">
                                 <span class="font-medium">{name}</span>
                                 <span class="ui-muted">({def.type})</span>
-                                <Show when={def.required}>
+                                <Show when={isActiveRequiredField(def)}>
                                   <span class="ui-text-danger">*</span>
                                 </Show>
                               </span>
@@ -1081,7 +1087,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
                             {name}
                             <span class="ui-muted ml-2 text-xs">
                               {t(
-                                def.required
+                                isActiveRequiredField(def)
                                   ? "createDialog.entry.fieldMeta.required"
                                   : "createDialog.entry.fieldMeta.optional",
                                 { type: def.type },
@@ -1130,7 +1136,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
                           {name} (
                           {answered()
                             ? t("createDialog.entry.chatStatus.answered")
-                            : def.required
+                            : isActiveRequiredField(def)
                             ? t("createDialog.entry.chatStatus.required")
                             : t("createDialog.entry.chatStatus.optional")}
                           )
@@ -1156,7 +1162,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
                           {name}
                           <span class="ui-muted ml-2 text-xs">
                             {t(
-                              def.required
+                              isActiveRequiredField(def)
                                 ? "createDialog.entry.chatFieldMeta.required"
                                 : "createDialog.entry.chatFieldMeta.optional",
                               { type: def.type },
@@ -1185,7 +1191,7 @@ export function CreateEntryDialog(props: CreateEntryDialogProps) {
                               onClick={handleSkipChatField}
                             >
                               {t(
-                                def.required
+                                isActiveRequiredField(def)
                                   ? "createDialog.entry.chatSkip"
                                   : "createDialog.entry.chatSkipOptional",
                               )}

--- a/frontend/src/components/create-dialogs.tsx
+++ b/frontend/src/components/create-dialogs.tsx
@@ -1704,6 +1704,7 @@ function processFields(
     name: string;
     type: string;
     required: boolean;
+    deprecated?: boolean;
     targetForm?: string;
     itemsType?: string;
     itemsTargetForm?: string;
@@ -1714,6 +1715,7 @@ function processFields(
     {
       type: string;
       required: boolean;
+      deprecated?: boolean;
       target_form?: string;
       items?: { type: string; target_form?: string };
     }
@@ -1737,6 +1739,7 @@ function processFields(
       fieldRecord[trimmedName] = {
         type: f.type,
         required: f.required,
+        ...(f.deprecated ? { deprecated: true } : {}),
         target_form,
         items,
       };
@@ -1796,6 +1799,7 @@ export function EditFormDialog(props: EditFormDialogProps) {
       name: string;
       type: string;
       required: boolean;
+      deprecated?: boolean;
       targetForm?: string;
       itemsType?: string;
       itemsTargetForm?: string;
@@ -1870,6 +1874,7 @@ export function EditFormDialog(props: EditFormDialogProps) {
         name,
         type: def.type,
         required: def.required,
+        deprecated: def.deprecated,
         targetForm: def.target_form,
         itemsType: def.items?.type,
         itemsTargetForm: def.items?.target_form,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -178,6 +178,8 @@ export interface FormField {
   id?: number;
   type: string;
   required: boolean;
+  /** Deprecated fields remain readable but are not required for new entries. */
+  deprecated?: boolean;
   target_form?: string;
   items?: {
     type: string;


### PR DESCRIPTION
## Summary

- Treat `deprecated: true` Form fields as inactive for New Entry required defaults, Web Form submission validation, and Chat required/skip behavior.
- Keep deprecated fields visible for historical context and cover Web Form/Chat regressions, including row-reference picker paths.

## Related Issue (required)

closes #1900

## Testing

- [x] `deno task --cwd frontend test src/components/create-dialogs.test.tsx --reporter=dot` (62 passed)
- [x] `deno fmt --check frontend/src/components/create-dialogs.tsx frontend/src/components/create-dialogs.test.tsx frontend/src/lib/types.ts`
- [x] `deno lint frontend/src/components/create-dialogs.tsx frontend/src/components/create-dialogs.test.tsx frontend/src/lib/types.ts`
