### PR TITLE
fix(frontend): make saved SQL starters runnable

### DIFF
--- a/e2e/lib/client.ts
+++ b/e2e/lib/client.ts
@@ -4,113 +4,122 @@ const frontendUrl = process.env.FRONTEND_URL ?? "http://localhost:3000";
 const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8000";
 
 export function getFrontendUrl(path: string): string {
-	return new URL(path, frontendUrl).toString();
+  return new URL(path, frontendUrl).toString();
 }
 
 export function getBackendUrl(path: string): string {
-	return new URL(`/api${path}`, frontendUrl).toString();
+  return new URL(`/api${path}`, frontendUrl).toString();
 }
 
 function getDirectBackendUrl(path: string): string {
-	return new URL(path, backendUrl).toString();
+  return new URL(path, backendUrl).toString();
 }
 
 async function waitForOk(
-	request: APIRequestContext,
-	url: string,
-	timeoutMs: number,
+  request: APIRequestContext,
+  url: string,
+  timeoutMs: number,
 ): Promise<void> {
-	const start = Date.now();
-	while (Date.now() - start < timeoutMs) {
-		try {
-			const response = await request.get(url);
-			if (response.ok()) {
-				return;
-			}
-		} catch {
-			// Ignore transient errors while waiting.
-		}
-		await new Promise((resolve) => setTimeout(resolve, 500));
-	}
-	throw new Error(`Timed out waiting for ${url}`);
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await request.get(url);
+      if (response.ok()) {
+        return;
+      }
+    } catch {
+      // Ignore transient errors while waiting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
 }
 
 async function waitForReachable(
-	request: APIRequestContext,
-	url: string,
-	timeoutMs: number,
+  request: APIRequestContext,
+  url: string,
+  timeoutMs: number,
 ): Promise<void> {
-	const start = Date.now();
-	while (Date.now() - start < timeoutMs) {
-		try {
-			const response = await request.get(url);
-			if (response.status() < 500) {
-				return;
-			}
-		} catch {
-			// Ignore transient errors while waiting.
-		}
-		await new Promise((resolve) => setTimeout(resolve, 500));
-	}
-	throw new Error(`Timed out waiting for ${url}`);
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await request.get(url);
+      if (response.status() < 500) {
+        return;
+      }
+    } catch {
+      // Ignore transient errors while waiting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
 }
 
 export async function waitForServers(
-	request: APIRequestContext,
-	options: { timeoutMs?: number } = {},
+  request: APIRequestContext,
+  options: { timeoutMs?: number } = {},
 ): Promise<void> {
-	const timeoutMs = options.timeoutMs ?? 60_000;
-	await waitForReachable(request, getDirectBackendUrl("/spaces"), timeoutMs);
-	await waitForOk(request, getFrontendUrl("/"), timeoutMs);
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  await waitForReachable(request, getDirectBackendUrl("/spaces"), timeoutMs);
+  await waitForOk(request, getFrontendUrl("/"), timeoutMs);
 }
 
 export async function ensureDefaultForm(
-	request: APIRequestContext,
+  request: APIRequestContext,
 ): Promise<void> {
-	const spaceId = await getDefaultSpaceId(request);
-	const response = await request.post(getBackendUrl(`/spaces/${spaceId}/forms`), {
-		data: {
-			name: "Entry",
-			version: 1,
-			template: "# Entry\n\n## Body\n",
-			fields: { Body: { type: "markdown", required: false } },
-		},
-	});
-	if (![200, 201, 409].includes(response.status())) {
-		const body = await response.text();
-		throw new Error(`Failed to ensure default form: ${response.status()} ${body}`);
-	}
+  const spaceId = await getDefaultSpaceId(request);
+  const response = await request.post(
+    getBackendUrl(`/spaces/${spaceId}/forms`),
+    {
+      data: {
+        name: "Entry",
+        version: 1,
+        template: "# Entry\n\n## Body\n",
+        fields: { Body: { type: "markdown", required: false } },
+      },
+    },
+  );
+  if (![200, 201, 409].includes(response.status())) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to ensure default form: ${response.status()} ${body}`,
+    );
+  }
 }
 
 export async function getDefaultFormRelation(
-	request: APIRequestContext,
-	spaceId?: string,
+  request: APIRequestContext,
+  spaceId?: string,
 ): Promise<string> {
-	const resolvedSpaceId = spaceId ?? await getDefaultSpaceId(request);
-	const response = await request.get(
-		getBackendUrl(`/spaces/${resolvedSpaceId}/forms`),
-	);
-	if (!response.ok()) {
-		throw new Error(`Failed to list default Forms: ${response.status()}`);
-	}
-	const forms = await response.json() as Array<{
-		name?: string;
-		sql_relation?: string;
-	}>;
-	const relation = forms.find((form) => form.name === "Entry")?.sql_relation;
-	if (!relation) throw new Error("Default Entry Form has no SQL relation");
-	return relation;
+  const resolvedSpaceId = spaceId ?? await getDefaultSpaceId(request);
+  const response = await request.get(
+    getBackendUrl(`/spaces/${resolvedSpaceId}/forms`),
+  );
+  if (!response.ok()) {
+    throw new Error(`Failed to list default Forms: ${response.status()}`);
+  }
+  const forms = await response.json() as Array<{
+    name?: string;
+    sql_relation?: string;
+  }>;
+  const relation = forms.find((form) => form.name === "Entry")?.sql_relation;
+  if (!relation) throw new Error("Default Entry Form has no SQL relation");
+  return relation;
 }
 
 export async function getDefaultSpaceId(
-	request: APIRequestContext,
+  request: APIRequestContext,
 ): Promise<string> {
-	const response = await request.get(getBackendUrl("/spaces"));
-	if (!response.ok()) throw new Error(`Failed to list Spaces: ${response.status()}`);
-	const spaces = await response.json() as Array<{ id: string; slug?: string; name: string }>;
-	const space = spaces.find((candidate) =>
-		candidate.slug === "default" || candidate.name === "default"
-	);
-	if (!space) throw new Error("Default Space was not created during setup");
-	return space.id;
+  const response = await request.get(getBackendUrl("/spaces"));
+  if (!response.ok()) {
+    throw new Error(`Failed to list Spaces: ${response.status()}`);
+  }
+  const spaces = await response.json() as Array<
+    { id: string; slug?: string; name: string }
+  >;
+  const space = spaces.find((candidate) =>
+    candidate.slug === "default" || candidate.name === "default"
+  );
+  if (!space) throw new Error("Default Space was not created during setup");
+  return space.id;
 }

--- a/e2e/saved-sql-route.test.ts
+++ b/e2e/saved-sql-route.test.ts
@@ -1,73 +1,123 @@
 import { expect, test } from "@playwright/test";
 import {
-	ensureDefaultForm,
-	getBackendUrl,
-	getDefaultFormRelation,
-	getFrontendUrl,
-	waitForServers,
+  ensureDefaultForm,
+  getBackendUrl,
+  getDefaultFormRelation,
+  getFrontendUrl,
+  waitForServers,
 } from "./lib/client.ts";
 
 const spaceId = "default";
 
 test.describe("Saved SQL route", () => {
-	test.beforeAll(async ({ request }) => {
-		await waitForServers(request);
-	});
+  test.beforeAll(async ({ request }) => {
+    await waitForServers(request);
+  });
 
-	test("REQ-FE-061: saved SQL route provides recovery links instead of a dead end", async ({
-		page,
-	}) => {
-		await page.goto(getFrontendUrl(`/spaces/${spaceId}/sql`), {
-			waitUntil: "domcontentloaded",
-		});
+  test("REQ-FE-061: saved SQL route provides recovery links instead of a dead end", async ({ page }) => {
+    await page.goto(getFrontendUrl(`/spaces/${spaceId}/sql`), {
+      waitUntil: "domcontentloaded",
+    });
 
-		await expect(page.getByRole("heading", { level: 1, name: "Saved SQL" })).toBeVisible();
-		await expect(page.getByText(/named-query management/i)).toBeVisible();
-		await expect(page.getByRole("link", { name: "Open Search" })).toHaveAttribute(
-			"href",
-			`/spaces/${spaceId}/search`,
-		);
-		await expect(page.getByRole("link", { name: "Back to Dashboard" })).toHaveAttribute(
-			"href",
-			`/spaces/${spaceId}/dashboard`,
-		);
-		await expect(page.getByRole("link", { name: "Browse Entries" })).toHaveAttribute(
-			"href",
-			`/spaces/${spaceId}/entries`,
-		);
-		await expect(page.getByText("Saved SQL management is not yet in the UI.")).toHaveCount(0);
-	});
+    await expect(page.getByRole("heading", { level: 1, name: "Saved SQL" }))
+      .toBeVisible();
+    await expect(page.getByText(/named-query management/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: "Open Search" }))
+      .toHaveAttribute(
+        "href",
+        `/spaces/${spaceId}/search`,
+      );
+    await expect(page.getByRole("link", { name: "Back to Dashboard" }))
+      .toHaveAttribute(
+        "href",
+        `/spaces/${spaceId}/dashboard`,
+      );
+    await expect(page.getByRole("link", { name: "Browse Entries" }))
+      .toHaveAttribute(
+        "href",
+        `/spaces/${spaceId}/entries`,
+      );
+    await expect(page.getByText("Saved SQL management is not yet in the UI."))
+      .toHaveCount(0);
+  });
 
-	test("REQ-FE-062: saved SQL detail loads query text and routes variable-free runs to entries", async ({
-		page,
-		request,
-	}) => {
-		await ensureDefaultForm(request);
-		const relation = await getDefaultFormRelation(request);
-		const sqlCreate = await request.post(getBackendUrl(`/spaces/${spaceId}/sql`), {
-			data: {
-				name: `Saved Detail Query ${Date.now()}`,
-				kind: "user-query",
-				sql: `SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
-				variables: [],
-			},
-		});
-		expect([200, 201]).toContain(sqlCreate.status());
-		const savedSql = (await sqlCreate.json()) as { id: string };
+  test("REQ-FE-062: saved SQL detail loads query text and routes variable-free runs to entries", async ({ page, request }) => {
+    await ensureDefaultForm(request);
+    const relation = await getDefaultFormRelation(request, spaceId);
+    const sqlCreate = await request.post(
+      getBackendUrl(`/spaces/${spaceId}/sql`),
+      {
+        data: {
+          name: `Saved Detail Query ${Date.now()}`,
+          kind: "user-query",
+          sql:
+            `SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
+          variables: [],
+        },
+      },
+    );
+    expect([200, 201]).toContain(sqlCreate.status());
+    const savedSql = (await sqlCreate.json()) as { id: string };
 
-		try {
-			await page.goto(getFrontendUrl(`/spaces/${spaceId}/sql/${savedSql.id}`), {
-				waitUntil: "domcontentloaded",
-			});
+    try {
+      await page.goto(getFrontendUrl(`/spaces/${spaceId}/sql/${savedSql.id}`), {
+        waitUntil: "domcontentloaded",
+      });
 
-			await expect(page.getByRole("heading", { level: 1, name: /Saved Detail Query/ })).toBeVisible();
-			await expect(page.locator(".ui-sql-editor")).toContainText(
-				`SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
-			);
-			await page.getByRole("button", { name: "Run Query" }).click();
-			await expect(page).toHaveURL(new RegExp(`/spaces/${spaceId}/entries\\?session=`));
-		} finally {
-			await request.delete(getBackendUrl(`/spaces/${spaceId}/sql/${savedSql.id}`));
-		}
-	});
+      await expect(
+        page.getByRole("heading", { level: 1, name: /Saved Detail Query/ }),
+      ).toBeVisible();
+      await expect(page.locator(".ui-sql-editor")).toContainText(
+        `SELECT * FROM "${relation}" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 1`,
+      );
+      await page.getByRole("button", { name: "Run Query" }).click();
+      await expect(page).toHaveURL(
+        new RegExp(`/spaces/${spaceId}/entries\\?session=`),
+      );
+    } finally {
+      await request.delete(
+        getBackendUrl(`/spaces/${spaceId}/sql/${savedSql.id}`),
+      );
+    }
+  });
+
+  test("REQ-FE-063: new saved SQL starts with a runnable total-ordered query", async ({ page, request }) => {
+    await ensureDefaultForm(request);
+    const queryName = `Runnable starter ${Date.now()}`;
+    let savedSqlId: string | undefined;
+
+    try {
+      await page.goto(getFrontendUrl(`/spaces/${spaceId}/queries/new`), {
+        waitUntil: "domcontentloaded",
+      });
+
+      await expect(page.locator(".ui-sql-editor")).toContainText(
+        /SELECT \* FROM "[^"]+" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50/,
+      );
+      await page.getByLabel("Query name").fill(queryName);
+      const createResponsePromise = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return response.request().method() === "POST" &&
+          url.pathname === `/api/spaces/${spaceId}/sql`;
+      });
+      await page.getByRole("button", { name: "Save" }).click();
+      const createResponse = await createResponsePromise;
+      expect([200, 201]).toContain(createResponse.status());
+      savedSqlId = (await createResponse.json() as { id: string }).id;
+
+      await page.goto(getFrontendUrl(`/spaces/${spaceId}/sql/${savedSqlId}`), {
+        waitUntil: "domcontentloaded",
+      });
+      await page.getByRole("button", { name: "Run Query" }).click();
+      await expect(page).toHaveURL(
+        new RegExp(`/spaces/${spaceId}/entries\\?session=`),
+      );
+    } finally {
+      if (savedSqlId) {
+        await request.delete(
+          getBackendUrl(`/spaces/${spaceId}/sql/${savedSqlId}`),
+        );
+      }
+    }
+  });
 });

--- a/frontend/src/components/SqlQueryEditor.test.tsx
+++ b/frontend/src/components/SqlQueryEditor.test.tsx
@@ -15,6 +15,17 @@ vi.mock("@codemirror/lint", () => ({
 
 vi.mock("@codemirror/lang-sql", () => ({
   sql: (config: unknown) => ({ type: "sql", config }),
+  StandardSQL: {
+    language: {
+      parser: {
+        parse: () => ({
+          cursor: () => ({
+            firstChild: () => false,
+          }),
+        }),
+      },
+    },
+  },
 }));
 
 vi.mock("@codemirror/state", () => {

--- a/frontend/src/lib/sql.test.ts
+++ b/frontend/src/lib/sql.test.ts
@@ -1,5 +1,10 @@
 // REQ-FE-036: SQL Query Editor
-import { buildSqlSchema, sqlLintDiagnostics } from "./sql";
+import {
+  buildSqlSchema,
+  buildSqlStarterQuery,
+  normalizeSqlVariables,
+  sqlLintDiagnostics,
+} from "./sql";
 import type { Form } from "./types";
 
 describe("sql helpers", () => {
@@ -17,6 +22,28 @@ describe("sql helpers", () => {
       'SELECT * FROM "form_00000000000000000000000000000001" LIMIT 10',
     );
     expect(diagnostics).toHaveLength(0);
+  });
+
+  it("builds a starter query with the SQL session total order", () => {
+    expect(buildSqlStarterQuery("form_entry")).toBe(
+      'SELECT * FROM "form_entry" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50',
+    );
+  });
+
+  it("does not extract placeholders from SQL literals or comments", () => {
+    expect(normalizeSqlVariables(
+      "SELECT * FROM form_entry WHERE title = '$literal' AND title = $actual -- $comment\n/* {{block}} */",
+    )).toEqual({
+      sql:
+        "SELECT * FROM form_entry WHERE title = '$literal' AND title = $actual -- $comment\n/* {{block}} */",
+      variables: [{ type: "string", name: "actual", description: "" }],
+    });
+    expect(normalizeSqlVariables(
+      "SELECT * FROM form_entry WHERE title = {{title}}",
+    )).toEqual({
+      sql: "SELECT * FROM form_entry WHERE title = $title",
+      variables: [{ type: "string", name: "title", description: "" }],
+    });
   });
 
   it("should expose no SQL schema without backend Form metadata", () => {
@@ -70,10 +97,17 @@ describe("sql helpers", () => {
       .toBe(true);
   });
 
-  it("should flag invalid LIMIT value", () => {
-    const diagnostics = sqlLintDiagnostics(
-      'SELECT * FROM "form_00000000000000000000000000000001" LIMIT abc',
-    );
-    expect(diagnostics.some((d) => d.message.includes("LIMIT"))).toBe(true);
+  it("keeps LIMIT lint advisory for native and template parameters", () => {
+    expect(
+      sqlLintDiagnostics(
+        'SELECT * FROM "form_entry" LIMIT abc',
+      ).some((diagnostic) => diagnostic.message.includes("LIMIT")),
+    ).toBe(true);
+    expect(sqlLintDiagnostics(
+      "SELECT * FROM form_entry LIMIT $page_size",
+    )).toHaveLength(0);
+    expect(sqlLintDiagnostics(
+      "SELECT * FROM form_entry LIMIT {{page_size}}",
+    )).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/sql.ts
+++ b/frontend/src/lib/sql.ts
@@ -1,9 +1,13 @@
-import type { Diagnostic } from "@codemirror/lint";
+import { StandardSQL } from "@codemirror/lang-sql";
 import type { SQLConfig } from "@codemirror/lang-sql";
+import type { Diagnostic } from "@codemirror/lint";
 import sqlRules from "../../../shared/sql/ugoite-sql-rules.json";
-import type { Form } from "./types";
+import type { Form, SqlVariable } from "./types";
 
 export type SqlSchema = NonNullable<SQLConfig["schema"]>;
+
+export const SQL_SESSION_DEFAULT_LIMIT = 50;
+export const SQL_SESSION_ORDER = "ORDER BY _ugoite_updated_at DESC, _ugoite_id";
 
 const SQL_SYSTEM_COLUMNS = [
   "_ugoite_id",
@@ -11,7 +15,6 @@ const SQL_SYSTEM_COLUMNS = [
   "_ugoite_created_at",
   "_ugoite_updated_at",
 ];
-
 export function buildSqlSchema(forms: Form[]): SqlSchema {
   const tables: Record<string, string[]> = {};
   for (const item of forms) {
@@ -26,6 +29,112 @@ export function buildSqlSchema(forms: Form[]): SqlSchema {
   }
 
   return { tables };
+}
+
+function quoteSqlIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+/** Build the runnable query shown when a user creates Saved SQL. */
+export function buildSqlStarterQuery(sqlRelation: string): string {
+  return `SELECT * FROM ${
+    quoteSqlIdentifier(sqlRelation)
+  } ${SQL_SESSION_ORDER} LIMIT ${SQL_SESSION_DEFAULT_LIMIT}`;
+}
+
+const SQL_LITERAL_OR_COMMENT_NODES = new Set([
+  "BlockComment",
+  "LineComment",
+  "String",
+]);
+const SQL_QUOTED_IDENTIFIER_NODE = "QuotedIdentifier";
+
+type ParsedSql = {
+  code: string;
+  variableCode: string;
+};
+
+function parseSql(sql: string): ParsedSql {
+  const ignoredRanges: Array<[number, number]> = [];
+  const quotedIdentifierRanges: Array<[number, number]> = [];
+  const cursor = StandardSQL.language.parser.parse(sql).cursor();
+
+  const visit = (): void => {
+    if (SQL_LITERAL_OR_COMMENT_NODES.has(cursor.type.name)) {
+      ignoredRanges.push([cursor.from, cursor.to]);
+      return;
+    }
+    if (cursor.type.name === SQL_QUOTED_IDENTIFIER_NODE) {
+      quotedIdentifierRanges.push([cursor.from, cursor.to]);
+      return;
+    }
+    if (cursor.firstChild()) {
+      do visit(); while (cursor.nextSibling());
+      cursor.parent();
+    }
+  };
+  if (cursor.firstChild()) {
+    do {
+      visit();
+    } while (cursor.nextSibling());
+    cursor.parent();
+  }
+
+  const maskRanges = (ranges: Array<[number, number]>): string => {
+    const masked = sql.split("");
+    for (const [from, to] of ranges) {
+      for (let offset = from; offset < to; offset += 1) masked[offset] = " ";
+    }
+    return masked.join("");
+  };
+  const code = maskRanges(ignoredRanges);
+  return {
+    code,
+    variableCode: maskRanges([...ignoredRanges, ...quotedIdentifierRanges]),
+  };
+}
+
+/**
+ * Normalize the editor's template variables to DataFusion placeholders.
+ * CodeMirror's SQL parser keeps strings, quoted identifiers, and comments out
+ * of the placeholder scan, so `$name` in user text is not mistaken for a
+ * session parameter.
+ */
+export function normalizeSqlVariables(sql: string): {
+  sql: string;
+  variables: SqlVariable[];
+} {
+  const names = new Set<string>();
+  const parsed = parseSql(sql);
+  const variablePattern =
+    /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+  const normalizedSql = sql.replace(
+    variablePattern,
+    (
+      match,
+      templatedName: string | undefined,
+      nativeName: string | undefined,
+      offset: number,
+    ) => {
+      if (parsed.variableCode[offset] === " ") return match;
+      if (nativeName && /[A-Za-z0-9_$]/.test(sql[offset - 1] ?? "")) {
+        return match;
+      }
+      const name = templatedName ?? nativeName;
+      if (!name) return match;
+      names.add(name);
+      return `$${name}`;
+    },
+  );
+
+  return {
+    sql: normalizedSql,
+    variables: Array.from(names).map((name) => ({
+      type: "string",
+      name,
+      description: "",
+    })),
+  };
 }
 
 export function sqlLintDiagnostics(query: string): Diagnostic[] {
@@ -45,7 +154,8 @@ export function sqlLintDiagnostics(query: string): Diagnostic[] {
     return diagnostics;
   }
 
-  const selectMatch = /\bselect\b/i.exec(trimmed);
+  const parsedQuery = parseSql(query);
+  const selectMatch = /\bselect\b/i.exec(parsedQuery.code);
   if (lintRules.require_select !== false && !selectMatch) {
     diagnostics.push({
       from: leadingWhitespace,
@@ -55,7 +165,7 @@ export function sqlLintDiagnostics(query: string): Diagnostic[] {
     });
   }
 
-  const fromMatch = /\bfrom\b/i.exec(trimmed);
+  const fromMatch = /\bfrom\b/i.exec(parsedQuery.code);
   if (lintRules.require_from !== false && !fromMatch) {
     diagnostics.push({
       from: Math.max(0, query.length - 1),
@@ -65,7 +175,7 @@ export function sqlLintDiagnostics(query: string): Diagnostic[] {
     });
   }
 
-  const semicolonIndex = query.indexOf(";");
+  const semicolonIndex = parsedQuery.code.indexOf(";");
   /* v8 ignore start */
   if (lintRules.single_statement_only !== false) {
     /* v8 ignore stop */
@@ -81,17 +191,20 @@ export function sqlLintDiagnostics(query: string): Diagnostic[] {
   }
   /* v8 ignore stop */
 
-  const limitMatch = /\blimit\b\s+([^\s;]+)/i.exec(query);
+  const limitMatch = /\blimit\b\s+([^\s;]+)/i.exec(parsedQuery.code);
   /* v8 ignore start */
-  if (lintRules.limit_requires_number !== false) {
+  if (lintRules.limit_requires_number !== false && limitMatch) {
     /* v8 ignore stop */
-    if (limitMatch && Number.isNaN(Number(limitMatch[1]))) {
-      const from = limitMatch.index + limitMatch[0].indexOf(limitMatch[1]);
+    const limitValue = limitMatch[1];
+    const isPlaceholder = /^\$[A-Za-z_][A-Za-z0-9_]*$/.test(limitValue) ||
+      /^\{\{\s*[A-Za-z_][A-Za-z0-9_]*\s*\}\}$/.test(limitValue);
+    if (Number.isNaN(Number(limitValue)) && !isPlaceholder) {
+      const from = limitMatch.index + limitMatch[0].indexOf(limitValue);
       diagnostics.push({
         from,
-        to: from + limitMatch[1].length,
-        severity: "error",
-        message: "LIMIT value must be a number",
+        to: from + limitValue.length,
+        severity: "warning",
+        message: "LIMIT value should be a number or parameter",
       });
     }
     /* v8 ignore start */

--- a/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.test.tsx
@@ -1,0 +1,99 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SpaceQueryVariablesRoute from "./variables";
+
+const { navigateMock, sqlGetMock, sessionCreateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  sqlGetMock: vi.fn(),
+  sessionCreateMock: vi.fn(),
+}));
+
+vi.mock("@solidjs/router", () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ space_id: "default", query_id: "saved-vars" }),
+}));
+
+vi.mock("~/lib/ugoite-client", () => ({
+  sqlApi: { get: sqlGetMock },
+  sqlSessionApi: { create: sessionCreateMock },
+}));
+
+describe("/spaces/:space_id/queries/:query_id/variables", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    sqlGetMock.mockResolvedValue({
+      id: "saved-vars",
+      name: "Needs variables",
+      kind: "user-query",
+      sql:
+        "SELECT * FROM form_entry WHERE _ugoite_title = {{title}} AND enabled = $enabled AND count = $count AND score = $score AND day = $day AND happened = $happened AND optional = $optional ORDER BY _ugoite_id",
+      variables: [
+        { type: "string", name: "title", description: "Title" },
+        { type: "boolean", name: "enabled", description: "Enabled" },
+        { type: "integer", name: "count", description: "Count" },
+        { type: "float", name: "score", description: "Score" },
+        { type: "date", name: "day", description: "Day" },
+        { type: "timestamp", name: "happened", description: "Happened" },
+        { type: "string", name: "optional", description: "Optional" },
+      ],
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      revision_id: "rev-1",
+    });
+    sessionCreateMock.mockResolvedValue({
+      id: "variable-session",
+      status: "ready",
+      error: null,
+    });
+  });
+
+  it("runs with typed parameters and opens the shared result surface", async () => {
+    render(() => <SpaceQueryVariablesRoute />);
+
+    await screen.findByPlaceholderText("Title");
+    for (
+      const [placeholder, value] of [
+        ["Title", "Alpha"],
+        ["Enabled", "true"],
+        ["Count", "3"],
+        ["Score", "1.5"],
+        ["Day", "2026-08-10"],
+        ["Happened", "2026-08-10T12:34:56Z"],
+      ]
+    ) {
+      fireEvent.input(screen.getByPlaceholderText(placeholder), {
+        target: { value },
+      });
+    }
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+
+    await waitFor(() => {
+      expect(sessionCreateMock).toHaveBeenCalledWith(
+        "default",
+        "SELECT * FROM form_entry WHERE _ugoite_title = $title AND enabled = $enabled AND count = $count AND score = $score AND day = $day AND happened = $happened AND optional = $optional ORDER BY _ugoite_id",
+        {
+          title: "Alpha",
+          enabled: true,
+          count: 3,
+          score: 1.5,
+          day: "2026-08-10",
+          happened: "2026-08-10T12:34:56Z",
+          optional: null,
+        },
+        {
+          title: "string",
+          enabled: "boolean",
+          count: "integer",
+          score: "float",
+          day: "date",
+          happened: "timestamp",
+          optional: "string",
+        },
+      );
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/spaces/default/entries?session=variable-session",
+      );
+    });
+  });
+});

--- a/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/[query_id]/variables.tsx
@@ -1,13 +1,17 @@
-import { A, useNavigate, useParams } from "@solidjs/router";
+import { useNavigate, useParams } from "@solidjs/router";
 import { createMemo, createSignal, For, Show } from "solid-js";
 import { sqlApi, sqlSessionApi } from "~/lib/ugoite-client";
+import { normalizeSqlVariables } from "~/lib/sql";
 import { createResource } from "~/lib/recoverable-resource";
 import { t } from "~/lib/i18n";
 import { displaySqlName } from "~/lib/sql-metadata";
 import { formatUserFacingError } from "~/lib/user-facing-error";
 import { spaceRoute } from "~/lib/space-shell-route";
 
-export const route = spaceRoute({ navigation: "search", title: "sqlVariables" });
+export const route = spaceRoute({
+  navigation: "search",
+  title: "sqlVariables",
+});
 
 export default function SpaceQueryVariablesRoute() {
   const params = useParams<{ space_id: string; query_id: string }>();
@@ -59,7 +63,7 @@ export default function SpaceQueryVariablesRoute() {
       );
       const session = await sqlSessionApi.create(
         spaceId(),
-        current.sql,
+        normalizeSqlVariables(current.sql).sql,
         parameters,
         parameterTypes,
       );

--- a/frontend/src/routes/spaces/[space_id]/queries/new.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/new.test.tsx
@@ -1,0 +1,186 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SpaceQueryCreateRoute from "./new";
+
+const { navigateMock, formApiListMock, sqlCreateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  formApiListMock: vi.fn(),
+  sqlCreateMock: vi.fn(),
+}));
+
+vi.mock("@solidjs/router", () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ space_id: "default" }),
+}));
+
+vi.mock("~/components", () => ({
+  SqlQueryEditor: (props: {
+    id?: string;
+    value: string;
+    onChange: (value: string) => void;
+    onDiagnostics?: (
+      diagnostics: Array<{
+        from: number;
+        to: number;
+        severity: "error";
+        message: string;
+      }>,
+    ) => void;
+  }) => {
+    const emitBackendDiagnostic = (value: string) => {
+      props.onDiagnostics?.(
+        value.includes("missing_relation")
+          ? [{
+            from: 0,
+            to: value.length,
+            severity: "error",
+            message: "Backend rejected the relation",
+          }]
+          : [],
+      );
+    };
+    return (
+      <textarea
+        id={props.id}
+        aria-label="SQL"
+        value={props.value}
+        onInput={(event) => {
+          const value = event.currentTarget.value;
+          props.onChange(value);
+          emitBackendDiagnostic(value);
+        }}
+      />
+    );
+  },
+}));
+
+vi.mock("~/lib/ugoite-client", () => ({
+  formApi: { list: formApiListMock },
+  sqlApi: { create: sqlCreateMock },
+}));
+
+describe("/spaces/:space_id/queries/new", () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    formApiListMock.mockResolvedValue([
+      {
+        id: "sql-form",
+        name: "SQL",
+        sql_relation: "form_sql",
+        version: 1,
+        template: "",
+        fields: {},
+      },
+      {
+        id: "user-form",
+        name: "User",
+        sql_relation: "form_user",
+        version: 1,
+        template: "",
+        fields: {},
+      },
+      {
+        id: "group-form",
+        name: "UserGroup",
+        sql_relation: "form_group",
+        version: 1,
+        template: "",
+        fields: {},
+      },
+      {
+        id: "form-1",
+        name: "Entry",
+        sql_relation: "form_entry",
+        version: 1,
+        template: "# Entry\n",
+        fields: {},
+      },
+    ]);
+    sqlCreateMock.mockResolvedValue({ id: "query-1", revisionId: "rev-1" });
+  });
+
+  it("REQ-FE-063: uses a runnable Form relation starter with session ordering", async () => {
+    render(() => <SpaceQueryCreateRoute />);
+
+    const editor = await screen.findByRole("textbox", { name: "SQL" });
+    await waitFor(() => {
+      expect(editor).toHaveValue(
+        'SELECT * FROM "form_entry" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50',
+      );
+    });
+    fireEvent.input(screen.getByLabelText("Query name"), {
+      target: { value: "Runnable starter" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(sqlCreateMock).toHaveBeenCalledWith("default", {
+        name: "Runnable starter",
+        kind: "user-query",
+        metadata: undefined,
+        sql:
+          'SELECT * FROM "form_entry" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50',
+        variables: [],
+      });
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/spaces/default/search");
+  });
+
+  it("normalizes template variables to the native SQL session placeholder", async () => {
+    render(() => <SpaceQueryCreateRoute />);
+    const editor = await screen.findByRole("textbox", { name: "SQL" });
+    await waitFor(() => {
+      expect(editor).toHaveValue(
+        'SELECT * FROM "form_entry" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50',
+      );
+    });
+    fireEvent.input(editor, {
+      target: {
+        value:
+          'SELECT * FROM "form_entry" WHERE _ugoite_title = {{title}} ORDER BY _ugoite_id',
+      },
+    });
+    fireEvent.input(screen.getByLabelText("Query name"), {
+      target: { value: "Variable query" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(sqlCreateMock).toHaveBeenCalledWith("default", {
+        name: "Variable query",
+        kind: "user-query",
+        metadata: undefined,
+        sql:
+          'SELECT * FROM "form_entry" WHERE _ugoite_title = $title ORDER BY _ugoite_id',
+        variables: [{ type: "string", name: "title", description: "" }],
+      });
+    });
+  });
+
+  it("leaves session semantic validation to the backend", async () => {
+    render(() => <SpaceQueryCreateRoute />);
+    const editor = await screen.findByRole("textbox", { name: "SQL" });
+    await waitFor(() => {
+      expect(editor).toHaveValue(
+        'SELECT * FROM "form_entry" ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT 50',
+      );
+    });
+    fireEvent.input(editor, {
+      target: { value: "SELECT * FROM missing_relation LIMIT $page_size" },
+    });
+    expect(await screen.findByText("Backend rejected the relation"))
+      .toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(sqlCreateMock).toHaveBeenCalledWith("default", {
+        name: null,
+        kind: "user-query",
+        metadata: { generatedName: "untitled" },
+        sql: "SELECT * FROM missing_relation LIMIT $page_size",
+        variables: [{ type: "string", name: "page_size", description: "" }],
+      });
+    });
+  });
+});

--- a/frontend/src/routes/spaces/[space_id]/queries/new.tsx
+++ b/frontend/src/routes/spaces/[space_id]/queries/new.tsx
@@ -1,11 +1,16 @@
 import { A, useNavigate, useParams } from "@solidjs/router";
 import type { Diagnostic } from "@codemirror/lint";
-import { createSignal, For, Show } from "solid-js";
+import { createEffect, createSignal, For, Show } from "solid-js";
 import { SqlQueryEditor } from "~/components";
 import { formApi } from "~/lib/ugoite-client";
-import { buildSqlSchema } from "~/lib/sql";
+import {
+  buildSqlSchema,
+  buildSqlStarterQuery,
+  normalizeSqlVariables,
+} from "~/lib/sql";
 import { sqlApi } from "~/lib/ugoite-client";
-import type { Form, SqlVariable } from "~/lib/types";
+import { filterCreatableEntryForms } from "~/lib/metadata-forms";
+import type { Form } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
 import { t } from "~/lib/i18n";
 import { formatUserFacingError } from "~/lib/user-facing-error";
@@ -13,37 +18,27 @@ import { spaceRoute } from "~/lib/space-shell-route";
 
 export const route = spaceRoute({ navigation: "search", title: "sqlNew" });
 
-const VARIABLE_REGEX = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
-
-function extractVariables(sql: string): SqlVariable[] {
-  const names = new Set<string>();
-  VARIABLE_REGEX.lastIndex = 0;
-  let match = VARIABLE_REGEX.exec(sql);
-  while (match !== null) {
-    names.add(match[1]);
-    match = VARIABLE_REGEX.exec(sql);
-  }
-  return Array.from(names).map((name) => ({
-    type: "string",
-    name,
-    description: "",
-  }));
-}
-
 export default function SpaceQueryCreateRoute() {
   const params = useParams<{ space_id: string }>();
   const navigate = useNavigate();
   const spaceId = () => params.space_id;
   const [queryName, setQueryName] = createSignal("");
-  const [sqlInput, setSqlInput] = createSignal(
-    "SELECT * FROM entries LIMIT 50",
-  );
+  const [sqlInput, setSqlInput] = createSignal("");
+  const [hasUserEditedSql, setHasUserEditedSql] = createSignal(false);
   const [diagnostics, setDiagnostics] = createSignal<Diagnostic[]>([]);
   const [error, setError] = createSignal<string | null>(null);
   const [isSaving, setIsSaving] = createSignal(false);
 
   const [forms] = createResource(async () => {
     return await formApi.list(spaceId());
+  });
+
+  createEffect(() => {
+    if (hasUserEditedSql()) return;
+    const relation = filterCreatableEntryForms(forms() ?? [])
+      .find((form) => form.sql_relation?.trim())
+      ?.sql_relation?.trim();
+    if (relation) setSqlInput(buildSqlStarterQuery(relation));
   });
 
   const schema = () => buildSqlSchema((forms() || []) as Form[]);
@@ -56,6 +51,7 @@ export default function SpaceQueryCreateRoute() {
       setError(t("sqlPage.sqlRequired"));
       return;
     }
+    const normalized = normalizeSqlVariables(sql);
 
     setIsSaving(true);
     try {
@@ -63,8 +59,8 @@ export default function SpaceQueryCreateRoute() {
         name: name || null,
         kind: "user-query",
         metadata: name ? undefined : { generatedName: "untitled" },
-        sql,
-        variables: extractVariables(sql),
+        sql: normalized.sql,
+        variables: normalized.variables,
       });
       navigate(`/spaces/${spaceId()}/search`);
     } catch (err) {
@@ -101,7 +97,10 @@ export default function SpaceQueryCreateRoute() {
           <SqlQueryEditor
             id="query-sql"
             value={sqlInput()}
-            onChange={setSqlInput}
+            onChange={(value) => {
+              setHasUserEditedSql(true);
+              setSqlInput(value);
+            }}
             schema={schema()}
             onDiagnostics={setDiagnostics}
             disabled={isSaving()}

--- a/frontend/src/routes/spaces/[space_id]/search.test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.test.tsx
@@ -292,10 +292,19 @@ describe("/spaces/:space_id/search", () => {
   });
 
   it("REQ-SRCH-005: saved history entries rerun directly or open variable input when needed", async () => {
+    const relation = "form_entry";
+    seedForm("default", {
+      name: "Entry",
+      sql_relation: relation,
+      version: 1,
+      template: "# Entry\n",
+      fields: {},
+    });
     seedSqlEntry("default", {
       id: "saved-ready",
       name: "Ready history",
-      sql: "SELECT * FROM entries WHERE title = 'Alpha'",
+      sql:
+        `SELECT * FROM "${relation}" WHERE _ugoite_title = 'Alpha' ORDER BY _ugoite_id`,
       variables: [],
       created_at: "2025-01-01T00:00:00Z",
       updated_at: "2025-01-02T00:00:00Z",
@@ -304,7 +313,8 @@ describe("/spaces/:space_id/search", () => {
     seedSqlEntry("default", {
       id: "saved-vars",
       name: "Needs variables",
-      sql: "SELECT * FROM entries WHERE title = {{title}}",
+      sql:
+        `SELECT * FROM "${relation}" WHERE _ugoite_title = $title ORDER BY _ugoite_id`,
       variables: [{ type: "string", name: "title", description: "Title" }],
       created_at: "2025-01-01T00:00:00Z",
       updated_at: "2025-01-03T00:00:00Z",
@@ -332,7 +342,7 @@ describe("/spaces/:space_id/search", () => {
     );
     await waitFor(() => {
       expect(sessionSqlBody?.sql).toBe(
-        "SELECT * FROM entries WHERE title = 'Alpha'",
+        `SELECT * FROM "${relation}" WHERE _ugoite_title = 'Alpha' ORDER BY _ugoite_id`,
       );
       expect(navigateMock).toHaveBeenCalledWith(
         "/spaces/default/entries?session=history-session",

--- a/frontend/src/routes/spaces/[space_id]/search.tsx
+++ b/frontend/src/routes/spaces/[space_id]/search.tsx
@@ -6,6 +6,11 @@ import { formApi } from "~/lib/ugoite-client";
 import { searchApi } from "~/lib/ugoite-client";
 import { sqlSessionApi } from "~/lib/ugoite-client";
 import { sqlApi } from "~/lib/ugoite-client";
+import {
+  normalizeSqlVariables,
+  SQL_SESSION_DEFAULT_LIMIT,
+  SQL_SESSION_ORDER,
+} from "~/lib/sql";
 import type { KeywordSearchResult, SqlEntry } from "~/lib/types";
 import { createResource } from "~/lib/recoverable-resource";
 import { t, type TranslationKey } from "~/lib/i18n";
@@ -65,7 +70,7 @@ type AdvancedSearchQuery = {
   parameterTypes: Record<string, string>;
 };
 
-const ADVANCED_SEARCH_LIMIT = 50;
+const ADVANCED_SEARCH_LIMIT = SQL_SESSION_DEFAULT_LIMIT;
 
 function escapeSqlLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
@@ -347,7 +352,7 @@ function buildAdvancedSearchQuery(
   const render = (where: string) =>
     `SELECT * FROM ${
       quoteSqlIdentifier(criteria.sqlRelation)
-    }${where} ORDER BY _ugoite_updated_at DESC, _ugoite_id LIMIT ${ADVANCED_SEARCH_LIMIT}`;
+    }${where} ${SQL_SESSION_ORDER} LIMIT ${ADVANCED_SEARCH_LIMIT}`;
   return {
     sql: render(sessionWhere),
     historySql: render(historyWhere),
@@ -535,7 +540,10 @@ export default function SpaceSearchRoute() {
     setActionError(null);
     setRunningSearchId(entry.id);
     try {
-      const session = await sqlSessionApi.create(spaceId(), entry.sql);
+      const session = await sqlSessionApi.create(
+        spaceId(),
+        normalizeSqlVariables(entry.sql).sql,
+      );
       if (session.status === "failed") {
         setActionError(
           formatUserFacingError(

--- a/frontend/src/routes/spaces/[space_id]/sql/[sql_id].test.tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/[sql_id].test.tsx
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { http, HttpResponse } from "msw";
 import SpaceSqlDetailRoute from "./[sql_id]";
-import { resetMockData, seedSpace, seedSqlEntry } from "~/test/mocks/handlers";
+import {
+  resetMockData,
+  seedForm,
+  seedSpace,
+  seedSqlEntry,
+} from "~/test/mocks/handlers";
 import { server } from "~/test/mocks/server";
 import type { Space } from "~/lib/types";
 import { testApiUrl } from "~/test/http-origin";
@@ -91,6 +96,13 @@ describe("/spaces/:space_id/sql/:sql_id", () => {
   });
 
   it("REQ-FE-062: saved SQL detail runs variable-free queries through SQL sessions", async () => {
+    seedForm("default", {
+      name: "Entry",
+      sql_relation: entryRelation,
+      version: 1,
+      template: "# Entry\n",
+      fields: {},
+    });
     seedSqlEntry("default", {
       id: "saved-query",
       name: "Runnable Query",

--- a/frontend/src/routes/spaces/[space_id]/sql/[sql_id].tsx
+++ b/frontend/src/routes/spaces/[space_id]/sql/[sql_id].tsx
@@ -3,17 +3,19 @@ import { createMemo, createSignal, For, Match, Show, Switch } from "solid-js";
 import { SqlQueryEditor } from "~/components";
 import { formatDateLabel } from "~/lib/date-format";
 import { buildSqlSchema } from "~/lib/sql";
-import { sqlApi } from "~/lib/ugoite-client";
+import { formApi, sqlApi } from "~/lib/ugoite-client";
 import { sqlSessionApi } from "~/lib/ugoite-client";
 import { createResource } from "~/lib/recoverable-resource";
 import { t } from "~/lib/i18n";
 import { displaySqlName } from "~/lib/sql-metadata";
 import { formatUserFacingError } from "~/lib/user-facing-error";
 import { spaceRoute } from "~/lib/space-shell-route";
+import type { Form } from "~/lib/types";
 
-export const route = spaceRoute({ navigation: "search", title: "savedSqlDetail" });
-
-const READ_ONLY_SQL_SCHEMA = buildSqlSchema([]);
+export const route = spaceRoute({
+  navigation: "search",
+  title: "savedSqlDetail",
+});
 
 export default function SpaceSqlDetailRoute() {
   const params = useParams<{ space_id: string; sql_id: string }>();
@@ -24,6 +26,7 @@ export default function SpaceSqlDetailRoute() {
   const [running, setRunning] = createSignal(false);
 
   const [entry] = createResource(async () => sqlApi.get(spaceId(), sqlId()));
+  const [forms] = createResource(async () => formApi.list(spaceId()));
   const variableCount = createMemo(() => entry()?.variables.length ?? 0);
   const queryVariablesHref = () =>
     `/spaces/${spaceId()}/queries/${encodeURIComponent(sqlId())}/variables`;
@@ -132,7 +135,7 @@ export default function SpaceSqlDetailRoute() {
                   <SqlQueryEditor
                     value={data().sql}
                     onChange={() => undefined}
-                    schema={READ_ONLY_SQL_SCHEMA}
+                    schema={buildSqlSchema((forms() || []) as Form[])}
                     disabled
                   />
                 </div>


### PR DESCRIPTION
## Summary

- Make new Saved SQL use a backend-provided creatable Form relation and a deterministic SQL-session ordering.
- Keep frontend SQL feedback advisory, normalize DataFusion variables, and route variable queries through the variables editor.
- Add focused frontend and E2E coverage for starter, save, variable execution, and result routing behavior.

## Related Issue (required)

closes #1895

## Testing

- [x] Focused Vitest suite: 6 files, 27 tests
- [x] `deno task check`
- [x] Changed-file `deno lint`
- [x] `deno check --config e2e/deno.json e2e/saved-sql-route.test.ts`
- [x] `git diff --check`
- [x] `gpt-5.6-luna` (`xhigh` / extra high) review: `REVIEW PASS`
