### PR TITLE
fix(frontend): send canonical markdown from FormTable

### DIFF
--- a/frontend/src/components/FormTable.test.tsx
+++ b/frontend/src/components/FormTable.test.tsx
@@ -198,6 +198,7 @@ describe("FormTable", () => {
   it("REQ-FE-030: Add Row button creates a new entry", async () => {
     const entryForm = {
       name: "Test",
+      template: "---\ntitle: Preserved\nform: Old\n---\n\n# New Test\n",
       fields: { col: { type: "string" } },
     } as any;
     const entries = [];
@@ -221,9 +222,14 @@ describe("FormTable", () => {
       expect(createSpy).toHaveBeenCalledWith(
         "ws",
         expect.objectContaining({
-          content: expect.stringContaining("form: Test"),
+          markdown: expect.stringContaining("form: Test"),
         }),
       );
+    });
+
+    const [, payload] = createSpy.mock.calls[0];
+    expect(payload).toEqual({
+      markdown: "---\ntitle: Preserved\nform: Test\n---\n\n# New Test\n",
     });
     createSpy.mockRestore();
   });

--- a/frontend/src/components/FormTable.tsx
+++ b/frontend/src/components/FormTable.tsx
@@ -342,7 +342,7 @@ export function FormTable(props: FormTableProps) {
       content = ensureFormFrontmatter(content, props.entryForm.name);
 
       await entryApi.create(props.spaceId, {
-        content,
+        markdown: content,
       });
       refetch();
     } catch (err) {


### PR DESCRIPTION
## Summary

- Make FormTable Add Row send the canonical `markdown` entry-create payload.
- Extend the Add Row test to verify frontmatter preservation while updating the form name.

## Related Issue (required)

closes #1909

## Testing

- [x] `deno fmt --check src/components/FormTable.tsx src/components/FormTable.test.tsx`
- [x] `deno lint frontend/src/components/FormTable.tsx frontend/src/components/FormTable.test.tsx`
- [x] `deno task --cwd frontend test src/components/FormTable.test.tsx` (15 passed)
- [x] `deno task --cwd frontend check`
