### PR TITLE
[e2e] Resolve Space routes with UUID fixture IDs

### DIFF
--- a/e2e/entries.test.ts
+++ b/e2e/entries.test.ts
@@ -9,7 +9,13 @@
 
 import { expect, test, type Page } from "@playwright/test";
 import { Buffer } from "node:buffer";
-import { ensureDefaultForm, getBackendUrl, getFrontendUrl, waitForServers } from "./lib/client.ts";
+import {
+	ensureDefaultForm,
+	getBackendUrl,
+	getDefaultSpaceId,
+	getFrontendUrl,
+	waitForServers,
+} from "./lib/client.ts";
 
 async function settleUiLoading(page: Page): Promise<void> {
 	await page.waitForTimeout(150);
@@ -22,15 +28,18 @@ async function settleUiLoading(page: Page): Promise<void> {
 }
 
 test.describe("Entries CRUD", () => {
+	let spaceId = "";
+
 	test.beforeAll(async ({ request }) => {
 		await waitForServers(request);
-		await ensureDefaultForm(request);
+		spaceId = await getDefaultSpaceId(request);
+		await ensureDefaultForm(request, spaceId);
 	});
 
-	test("POST /spaces/default/entries creates a new entry", async ({ request }) => {
+	test("POST /spaces/:space_id/entries creates a new entry", async ({ request }) => {
 		const timestamp = Date.now();
 		const res = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown: `---\nform: Entry\n---\n# E2E Test Entry ${timestamp}\n\n## Body\nCreated at ${new Date().toISOString()}`,
@@ -42,12 +51,12 @@ test.describe("Entries CRUD", () => {
 		const entry = (await res.json()) as { id: string };
 		expect(entry).toHaveProperty("id");
 
-		await request.delete(getBackendUrl(`/spaces/default/entries/${entry.id}`));
+		await request.delete(getBackendUrl(`/spaces/${spaceId}/entries/${entry.id}`));
 	});
 
-	test("GET /spaces/default/entries returns entry list", async ({ request }) => {
+	test("GET /spaces/:space_id/entries returns entry list", async ({ request }) => {
 		const res = await request.get(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 		);
 		expect(res.ok()).toBeTruthy();
 
@@ -57,7 +66,7 @@ test.describe("Entries CRUD", () => {
 
 	test("consecutive PUT should succeed with updated revision_id", async ({ request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown:
@@ -69,7 +78,7 @@ test.describe("Entries CRUD", () => {
 		const created = (await createRes.json()) as { id: string; revision_id: string };
 
 		const firstUpdateRes = await request.put(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 			{
 				data: {
 					markdown:
@@ -84,7 +93,7 @@ test.describe("Entries CRUD", () => {
 		};
 
 		const secondUpdateRes = await request.put(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 			{
 				data: {
 					markdown:
@@ -96,13 +105,13 @@ test.describe("Entries CRUD", () => {
 		expect(secondUpdateRes.ok()).toBeTruthy();
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
 	test("PUT with stale revision_id should return 409 conflict", async ({ request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown:
@@ -114,7 +123,7 @@ test.describe("Entries CRUD", () => {
 		const created = (await createRes.json()) as { id: string; revision_id: string };
 
 		const firstUpdateRes = await request.put(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 			{
 				data: {
 					markdown:
@@ -126,7 +135,7 @@ test.describe("Entries CRUD", () => {
 		expect(firstUpdateRes.ok()).toBeTruthy();
 
 		const conflictRes = await request.put(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 			{
 				data: {
 					markdown:
@@ -138,13 +147,13 @@ test.describe("Entries CRUD", () => {
 		expect(conflictRes.status()).toBe(409);
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
 	test("saved content should persist after reload (REQ-FE-010)", async ({ page, request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown:
@@ -156,7 +165,7 @@ test.describe("Entries CRUD", () => {
 		const created = (await createRes.json()) as { id: string; revision_id: string };
 
 		const updateRes = await request.put(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 			{
 				data: {
 					markdown:
@@ -167,14 +176,14 @@ test.describe("Entries CRUD", () => {
 		);
 		expect(updateRes.ok()).toBeTruthy();
 
-		await page.goto(`/spaces/default/entries/${created.id}`);
+		await page.goto(`/spaces/${spaceId}/entries/${created.id}`);
 		await page.waitForLoadState("networkidle");
 		const html = await page.content();
 		expect(html).toContain("Updated content that should persist");
 		expect(html).not.toContain("Original content");
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
@@ -216,7 +225,7 @@ test.describe("Entries CRUD", () => {
 		const formName = `EntryCreateFields-${timestamp}`;
 		const title = `Entry create boundary ${timestamp}`;
 		const formResponse = await request.post(
-			getBackendUrl("/spaces/default/forms"),
+			getBackendUrl(`/spaces/${spaceId}/forms`),
 			{
 				data: {
 					name: formName,
@@ -238,17 +247,17 @@ test.describe("Entries CRUD", () => {
 			const url = new URL(requestEvent.url());
 			if (
 				requestEvent.method() === "POST" &&
-				url.pathname === "/api/spaces/default/entries"
+				url.pathname === `/api/spaces/${spaceId}/entries`
 			) entryPostCount += 1;
 			if (
 				requestEvent.method() === "PUT" &&
-				/^\/api\/spaces\/default\/entries\/[^/]+$/.test(url.pathname)
+				new RegExp(`^/api/spaces/${spaceId}/entries/[^/]+$`).test(url.pathname)
 			) entryPutCount += 1;
 		});
 
 		await page.goto(
 			getFrontendUrl(
-				`/spaces/default/entries/new?form=${encodeURIComponent(formName)}`,
+				`/spaces/${spaceId}/entries/new?form=${encodeURIComponent(formName)}`,
 			),
 			{ waitUntil: "domcontentloaded" },
 		);
@@ -261,12 +270,12 @@ test.describe("Entries CRUD", () => {
 		const createResponsePromise = page.waitForResponse((response) => {
 			const url = new URL(response.url());
 			return response.request().method() === "POST" &&
-				url.pathname === "/api/spaces/default/entries";
+				url.pathname === `/api/spaces/${spaceId}/entries`;
 		});
 		const detailResponsePromise = page.waitForResponse((response) => {
 			const url = new URL(response.url());
 			return response.request().method() === "GET" &&
-				/^\/api\/spaces\/default\/entries\/[^/]+$/.test(url.pathname);
+				new RegExp(`^/api/spaces/${spaceId}/entries/[^/]+$`).test(url.pathname);
 		});
 		await page.getByRole("button", { name: "Save" }).click();
 		const createResponse = await createResponsePromise;
@@ -280,7 +289,7 @@ test.describe("Entries CRUD", () => {
 		const detail = (await detailResponse.json()) as { revision_id: string };
 
 		await expect(page).toHaveURL(
-			new RegExp(`/spaces/default/entries/${created.id}$`),
+			new RegExp(`/spaces/${spaceId}/entries/${created.id}$`),
 		);
 		await expect(page.getByText("All changes saved")).toBeVisible();
 		await expect(page.getByText("Unsaved changes")).toHaveCount(0);
@@ -290,7 +299,7 @@ test.describe("Entries CRUD", () => {
 		expect(detail.revision_id).toBe(created.revision_id);
 
 		const historyResponse = await request.get(
-			getBackendUrl(`/spaces/default/entries/${created.id}/history`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}/history`),
 		);
 		expect(historyResponse.ok()).toBeTruthy();
 		const history = (await historyResponse.json()) as {
@@ -300,7 +309,7 @@ test.describe("Entries CRUD", () => {
 		expect(history.revisions[0]?.revision_id).toBe(created.revision_id);
 
 		const entryResponse = await request.get(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 		expect(entryResponse.ok()).toBeTruthy();
 		const entry = (await entryResponse.json()) as { content: string };
@@ -308,7 +317,7 @@ test.describe("Entries CRUD", () => {
 		expect(entry.content).toContain("## ts\n2026-08-21T10:48:00");
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
@@ -676,7 +685,7 @@ test.describe("Entries CRUD", () => {
 
 	test("REQ-FE-033: frontend entry detail route renders (not SolidJS Not Found)", async ({ page, request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown:
@@ -687,20 +696,20 @@ test.describe("Entries CRUD", () => {
 		expect(createRes.status()).toBe(201);
 		const created = (await createRes.json()) as { id: string };
 
-		await page.goto(`/spaces/default/entries/${created.id}`);
+		await page.goto(`/spaces/${spaceId}/entries/${created.id}`);
 		await page.waitForLoadState("networkidle");
 		const html = await page.content();
 		expect(html).not.toContain("Visit solidjs.com");
 		expect(html).not.toContain("NOT FOUND");
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
 	test("REQ-FE-005: entry detail preview escapes raw HTML in markdown content", async ({ page, request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					content:
@@ -711,7 +720,7 @@ test.describe("Entries CRUD", () => {
 		expect(createRes.status()).toBe(201);
 		const created = (await createRes.json()) as { id: string };
 
-		await page.goto(`/spaces/default/entries/${created.id}`);
+		await page.goto(`/spaces/${spaceId}/entries/${created.id}`);
 		await page.waitForLoadState("networkidle");
 		await settleUiLoading(page);
 
@@ -728,7 +737,7 @@ test.describe("Entries CRUD", () => {
 		expect(marker).toBeNull();
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
@@ -736,7 +745,7 @@ test.describe("Entries CRUD", () => {
 		const timestamp = Date.now();
 		const title = `Special Entry @ ${timestamp} % &`;
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown: `---\nform: Entry\n---\n# ${title}\n\n## Body\nTesting special chars in title.`,
@@ -746,29 +755,29 @@ test.describe("Entries CRUD", () => {
 		expect(createRes.status()).toBe(201);
 		const created = (await createRes.json()) as { id: string };
 
-		await page.goto(`/spaces/default/entries/${encodeURIComponent(created.id)}`);
+		await page.goto(`/spaces/${spaceId}/entries/${encodeURIComponent(created.id)}`);
 		await page.waitForLoadState("networkidle");
 		const html = await page.content();
 		expect(html).toContain(title);
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
 	test("REQ-FE-034: Multi-entry navigation should not get stuck in loading state", async ({ page, request }) => {
 		const formEntries = await Promise.all([
-			request.post(getBackendUrl("/spaces/default/entries"), {
+			request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
 				data: {
 					markdown: "---\nform: Entry\n---\n# Entry A\n\n## Body\nContent A",
 				},
 			}),
-			request.post(getBackendUrl("/spaces/default/entries"), {
+			request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
 				data: {
 					markdown: "---\nform: Entry\n---\n# Entry B\n\n## Body\nContent B",
 				},
 			}),
-			request.post(getBackendUrl("/spaces/default/entries"), {
+			request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
 				data: {
 					markdown: "---\nform: Entry\n---\n# Entry C\n\n## Body\nContent C",
 				},
@@ -780,7 +789,7 @@ test.describe("Entries CRUD", () => {
 		)) as Array<{ id: string }>;
 
 		for (const entry of entries) {
-			await page.goto(`/spaces/default/entries/${encodeURIComponent(entry.id)}`);
+			await page.goto(`/spaces/${spaceId}/entries/${encodeURIComponent(entry.id)}`);
 			await page.waitForLoadState("networkidle");
 			const entryHtml = await page.content();
 			expect(entryHtml).not.toContain("Loading entry...");
@@ -788,7 +797,7 @@ test.describe("Entries CRUD", () => {
 		}
 
 		for (const entry of entries) {
-			await page.goto(`/spaces/default/entries/${encodeURIComponent(entry.id)}`);
+			await page.goto(`/spaces/${spaceId}/entries/${encodeURIComponent(entry.id)}`);
 			await page.waitForLoadState("networkidle");
 			const html = await page.content();
 			expect(html).not.toContain("Loading entry...");
@@ -798,7 +807,7 @@ test.describe("Entries CRUD", () => {
 		await Promise.all(
 			entries.map((entry) =>
 				request.delete(
-					getBackendUrl(`/spaces/default/entries/${entry.id}`),
+					getBackendUrl(`/spaces/${spaceId}/entries/${entry.id}`),
 				),
 			),
 		);
@@ -806,7 +815,7 @@ test.describe("Entries CRUD", () => {
 
 	test("REQ-FE-035: Navigation timeout handling and recovery", async ({ page, request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown:
@@ -817,19 +826,19 @@ test.describe("Entries CRUD", () => {
 		expect(createRes.status()).toBe(201);
 		const created = (await createRes.json()) as { id: string };
 
-		await page.goto(`/spaces/default/entries/${created.id}`);
+		await page.goto(`/spaces/${spaceId}/entries/${created.id}`);
 		await page.waitForLoadState("networkidle");
 		const html = await page.content();
 		expect(html).not.toContain("Loading...");
 
 		await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 	});
 
-	test("PUT /spaces/default/entries/:id updates entry", async ({ request }) => {
+	test("PUT /spaces/:space_id/entries/:id updates entry", async ({ request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown:
@@ -841,12 +850,12 @@ test.describe("Entries CRUD", () => {
 		const created = (await createRes.json()) as { id: string };
 
 		const getRes = await request.get(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 		const current = (await getRes.json()) as { revision_id: string };
 
 		const updateRes = await request.put(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 			{
 				data: {
 					markdown:
@@ -857,12 +866,12 @@ test.describe("Entries CRUD", () => {
 		);
 		expect(updateRes.ok()).toBeTruthy();
 
-		await request.delete(getBackendUrl(`/spaces/default/entries/${created.id}`));
+		await request.delete(getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`));
 	});
 
-	test("DELETE /spaces/default/entries/:id removes entry", async ({ request }) => {
+	test("DELETE /spaces/:space_id/entries/:id removes entry", async ({ request }) => {
 		const createRes = await request.post(
-			getBackendUrl("/spaces/default/entries"),
+			getBackendUrl(`/spaces/${spaceId}/entries`),
 			{
 				data: {
 					markdown:
@@ -874,12 +883,12 @@ test.describe("Entries CRUD", () => {
 		const created = (await createRes.json()) as { id: string };
 
 		const deleteRes = await request.delete(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 		expect([200, 204]).toContain(deleteRes.status());
 
 		const fetchRes = await request.get(
-			getBackendUrl(`/spaces/default/entries/${created.id}`),
+			getBackendUrl(`/spaces/${spaceId}/entries/${created.id}`),
 		);
 		expect(fetchRes.status()).toBe(404);
 	});

--- a/e2e/forms.test.ts
+++ b/e2e/forms.test.ts
@@ -1,11 +1,12 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-import { getBackendUrl, waitForServers } from "./lib/client.ts";
-
-const spaceId = "default";
+import { getBackendUrl, getDefaultSpaceId, waitForServers } from "./lib/client.ts";
 
 test.describe("Form", () => {
+	let spaceId = "";
+
 	test.beforeAll(async ({ request }) => {
 		await waitForServers(request);
+		spaceId = await getDefaultSpaceId(request);
 	});
 
 	const waitForForm = async (request: APIRequestContext, formName: string) => {

--- a/e2e/lib/client.ts
+++ b/e2e/lib/client.ts
@@ -66,8 +66,8 @@ export async function waitForServers(
 
 export async function ensureDefaultForm(
 	request: APIRequestContext,
+	spaceId: string,
 ): Promise<void> {
-	const spaceId = await getDefaultSpaceId(request);
 	const response = await request.post(getBackendUrl(`/spaces/${spaceId}/forms`), {
 		data: {
 			name: "Entry",
@@ -84,11 +84,10 @@ export async function ensureDefaultForm(
 
 export async function getDefaultFormRelation(
 	request: APIRequestContext,
-	spaceId?: string,
+	spaceId: string,
 ): Promise<string> {
-	const resolvedSpaceId = spaceId ?? await getDefaultSpaceId(request);
 	const response = await request.get(
-		getBackendUrl(`/spaces/${resolvedSpaceId}/forms`),
+		getBackendUrl(`/spaces/${spaceId}/forms`),
 	);
 	if (!response.ok()) {
 		throw new Error(`Failed to list default Forms: ${response.status()}`);
@@ -105,11 +104,13 @@ export async function getDefaultFormRelation(
 export async function getDefaultSpaceId(
 	request: APIRequestContext,
 ): Promise<string> {
+	// The display name/slug are only fixture-discovery keys. All callers must use
+	// the returned immutable ID for subsequent routes and API requests.
 	const response = await request.get(getBackendUrl("/spaces"));
 	if (!response.ok()) throw new Error(`Failed to list Spaces: ${response.status()}`);
 	const spaces = await response.json() as Array<{ id: string; slug?: string; name: string }>;
 	const space = spaces.find((candidate) =>
-		candidate.slug === "default" || candidate.name === "default"
+		candidate.name === "default" || candidate.slug === "default"
 	);
 	if (!space) throw new Error("Default Space was not created during setup");
 	return space.id;

--- a/e2e/navigation.test.ts
+++ b/e2e/navigation.test.ts
@@ -1,13 +1,20 @@
 import { expect, test, type Page } from "@playwright/test";
-import { ensureDefaultForm, getBackendUrl, waitForServers } from "./lib/client.ts";
+import {
+	ensureDefaultForm,
+	getBackendUrl,
+	getDefaultSpaceId,
+	waitForServers,
+} from "./lib/client.ts";
 
-const spaceId = "default";
 const maxVisitedPages = 16;
 
 test.describe("Dynamic navigation traversal", () => {
+	let spaceId = "";
+
 	test.beforeAll(async ({ request }) => {
 		await waitForServers(request);
-		await ensureDefaultForm(request);
+		spaceId = await getDefaultSpaceId(request);
+		await ensureDefaultForm(request, spaceId);
 	});
 
 	test("REQ-E2E-004: dynamic traversal has no console or SolidJS errors", async ({

--- a/e2e/saved-sql-route.test.ts
+++ b/e2e/saved-sql-route.test.ts
@@ -3,15 +3,17 @@ import {
 	ensureDefaultForm,
 	getBackendUrl,
 	getDefaultFormRelation,
+	getDefaultSpaceId,
 	getFrontendUrl,
 	waitForServers,
 } from "./lib/client.ts";
 
-const spaceId = "default";
-
 test.describe("Saved SQL route", () => {
+	let spaceId = "";
+
 	test.beforeAll(async ({ request }) => {
 		await waitForServers(request);
+		spaceId = await getDefaultSpaceId(request);
 	});
 
 	test("REQ-FE-061: saved SQL route provides recovery links instead of a dead end", async ({
@@ -42,8 +44,8 @@ test.describe("Saved SQL route", () => {
 		page,
 		request,
 	}) => {
-		await ensureDefaultForm(request);
-		const relation = await getDefaultFormRelation(request);
+		await ensureDefaultForm(request, spaceId);
+		const relation = await getDefaultFormRelation(request, spaceId);
 		const sqlCreate = await request.post(getBackendUrl(`/spaces/${spaceId}/sql`), {
 			data: {
 				name: `Saved Detail Query ${Date.now()}`,

--- a/e2e/search-ui.test.ts
+++ b/e2e/search-ui.test.ts
@@ -1,12 +1,19 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
-import { ensureDefaultForm, getBackendUrl, getFrontendUrl, waitForServers } from "./lib/client.ts";
-
-const spaceId = "default";
+import {
+	ensureDefaultForm,
+	getBackendUrl,
+	getDefaultSpaceId,
+	getFrontendUrl,
+	waitForServers,
+} from "./lib/client.ts";
 
 test.describe("Search UI", () => {
+	let spaceId = "";
+
 	test.beforeAll(async ({ request }) => {
 		await waitForServers(request);
-		await ensureDefaultForm(request);
+		spaceId = await getDefaultSpaceId(request);
+		await ensureDefaultForm(request, spaceId);
 	});
 
 	test("REQ-SRCH-004: search page starts with direct keyword search", async ({ page, request }) => {
@@ -18,9 +25,9 @@ test.describe("Search UI", () => {
 		let entryId: string | null = null;
 
 		try {
-			await ensureSearchForm(request, formName);
-			entryId = await createEntry(request, entryContent);
-			await waitForKeywordMatch(request, "keyword-first", entryId);
+			await ensureSearchForm(request, formName, spaceId);
+			entryId = await createEntry(request, entryContent, spaceId);
+			await waitForKeywordMatch(request, "keyword-first", entryId, spaceId);
 
 			await page.goto(getFrontendUrl(`/spaces/${spaceId}/search`), {
 				waitUntil: "domcontentloaded",
@@ -54,12 +61,17 @@ test.describe("Search UI", () => {
 		const entryContent = `---\nform: ${formName}\ntags:\n  - release\n  - search-ui\n---\n# ${entryTitle}\n\n## Owner Name\nalice\n\n## Body\nAdvanced search history should stay reusable.\n`;
 		let entryId: string | null = null;
 
-		await cleanupSavedSearchesByForm(request, formName);
+		await cleanupSavedSearchesByForm(request, formName, spaceId);
 
 		try {
-			await ensureSearchForm(request, formName);
-			entryId = await createEntry(request, entryContent);
-			await waitForKeywordMatch(request, "Advanced search history should stay reusable.", entryId);
+			await ensureSearchForm(request, formName, spaceId);
+			entryId = await createEntry(request, entryContent, spaceId);
+			await waitForKeywordMatch(
+				request,
+				"Advanced search history should stay reusable.",
+				entryId,
+				spaceId,
+			);
 
 			await page.goto(getFrontendUrl(`/spaces/${spaceId}/search`), {
 				waitUntil: "domcontentloaded",
@@ -72,7 +84,7 @@ test.describe("Search UI", () => {
 			await page.getByLabel("Value").fill("alice");
 			await page.getByRole("button", { name: "Run advanced search" }).click();
 
-			await expect(page).toHaveURL(/\/spaces\/default\/entries\?session=/);
+			await expect(page).toHaveURL(new RegExp(`/spaces/${spaceId}/entries\\?session=`));
 			await expect(page.getByRole("button", { name: new RegExp(entryTitle) })).toBeVisible();
 
 			await page.goto(getFrontendUrl(`/spaces/${spaceId}/search`), {
@@ -80,17 +92,21 @@ test.describe("Search UI", () => {
 			});
 			await expect(page.getByRole("button", { name: new RegExp(historyName) })).toBeVisible();
 			await page.getByRole("button", { name: new RegExp(historyName) }).click();
-			await expect(page).toHaveURL(/\/spaces\/default\/entries\?session=/);
+			await expect(page).toHaveURL(new RegExp(`/spaces/${spaceId}/entries\\?session=`));
 		} finally {
 			if (entryId) {
 				await request.delete(getBackendUrl(`/spaces/${spaceId}/entries/${entryId}`));
 			}
-			await cleanupSavedSearchesByForm(request, formName);
+			await cleanupSavedSearchesByForm(request, formName, spaceId);
 		}
 	});
 });
 
-async function ensureSearchForm(request: APIRequestContext, formName: string): Promise<void> {
+async function ensureSearchForm(
+	request: APIRequestContext,
+	formName: string,
+	spaceId: string,
+): Promise<void> {
 	const response = await request.post(getBackendUrl(`/spaces/${spaceId}/forms`), {
 		data: {
 			name: formName,
@@ -107,7 +123,11 @@ async function ensureSearchForm(request: APIRequestContext, formName: string): P
 	}
 }
 
-async function createEntry(request: APIRequestContext, markdown: string): Promise<string> {
+async function createEntry(
+	request: APIRequestContext,
+	markdown: string,
+	spaceId: string,
+): Promise<string> {
 	const response = await request.post(getBackendUrl(`/spaces/${spaceId}/entries`), {
 		data: { markdown },
 	});
@@ -120,6 +140,7 @@ async function waitForKeywordMatch(
 	request: APIRequestContext,
 	query: string,
 	entryId: string,
+	spaceId: string,
 ): Promise<void> {
 	await expect
 		.poll(
@@ -139,6 +160,7 @@ async function waitForKeywordMatch(
 async function cleanupSavedSearchesByForm(
 	request: APIRequestContext,
 	formName: string,
+	spaceId: string,
 ): Promise<void> {
 	const response = await request.get(getBackendUrl(`/spaces/${spaceId}/sql`));
 	if (!response.ok()) {

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -15,9 +15,12 @@ import {
 } from "./lib/client.ts";
 
 test.describe("Smoke Tests", () => {
+  let spaceId = "";
+
   test.beforeAll(async ({ request }) => {
     await waitForServers(request);
-    await ensureDefaultForm(request);
+    spaceId = await getDefaultSpaceId(request);
+    await ensureDefaultForm(request, spaceId);
   });
 
   test("GET / returns HTML with DOCTYPE", async ({ page }) => {
@@ -42,7 +45,6 @@ test.describe("Smoke Tests", () => {
   });
 
   test("GET /spaces/:space_id/entries/:id returns HTML", async ({ page, request }) => {
-    const spaceId = await getDefaultSpaceId(request);
     const createRes = await request.post(
       getBackendUrl(`/spaces/${spaceId}/entries`),
       {
@@ -78,7 +80,6 @@ test.describe("Smoke Tests", () => {
   });
 
   test("plain Entries list is integrated into the Forms workspace", async ({ page, request }) => {
-    const spaceId = await getDefaultSpaceId(request);
     await page.goto(`/spaces/${spaceId}/entries`);
     await expect(page).toHaveURL(`/spaces/${spaceId}/forms?form=Entry`);
     await expect(page.getByRole("tab")).toHaveCount(0);
@@ -118,15 +119,14 @@ test.describe("Smoke Tests", () => {
     expect(Array.isArray(json)).toBe(true);
   });
 
-  test("GET /spaces includes default space", async ({ request }) => {
+  test("GET /spaces includes the resolved fixture Space", async ({ request }) => {
     const res = await request.get(getBackendUrl("/spaces"));
-    const spaces = (await res.json()) as Array<{ name: string }>;
-    const defaultWs = spaces.find((ws) => ws.name === "default");
-    expect(defaultWs).toBeDefined();
+    const spaces = (await res.json()) as Array<{ id: string; name: string }>;
+    expect(spaces.some((space) => space.id === spaceId && space.name === "default"))
+      .toBe(true);
   });
 
   test("GET /spaces/:space_id/entries returns list", async ({ request }) => {
-    const spaceId = await getDefaultSpaceId(request);
     const res = await request.get(getBackendUrl(`/spaces/${spaceId}/entries`));
     expect(res.ok()).toBeTruthy();
 

--- a/e2e/space-settings-storage-guidance.test.ts
+++ b/e2e/space-settings-storage-guidance.test.ts
@@ -1,13 +1,16 @@
 import { expect, test } from "@playwright/test";
-import { getFrontendUrl, waitForServers } from "./lib/client.ts";
+import { getDefaultSpaceId, getFrontendUrl, waitForServers } from "./lib/client.ts";
 
 test.describe("Space settings storage guidance", () => {
+	let spaceId = "";
+
   test.beforeAll(async ({ request }) => {
     await waitForServers(request);
+		spaceId = await getDefaultSpaceId(request);
   });
 
   test("REQ-FE-017: storage settings explain that configuration does not move the current Space", async ({ page }) => {
-    await page.goto(getFrontendUrl("/spaces/default/settings"), {
+    await page.goto(getFrontendUrl(`/spaces/${spaceId}/settings`), {
       waitUntil: "networkidle",
     });
 

--- a/e2e/ui-pages-screenshots.test.ts
+++ b/e2e/ui-pages-screenshots.test.ts
@@ -5,6 +5,7 @@ import {
   ensureDefaultForm,
   getBackendUrl,
   getDefaultFormRelation,
+  getDefaultSpaceId,
   waitForServers,
 } from "./lib/client.ts";
 
@@ -13,18 +14,20 @@ type UiPageSpec = {
   route: string;
 };
 
-const spaceId = "default";
 const screenshotDir = path.resolve(process.cwd(), "../target/ui-screenshots");
 
 test.describe("UI page screenshot export @screenshot", () => {
+  let spaceId = "";
+
   test.beforeAll(async ({ request }) => {
     await waitForServers(request);
-    await ensureDefaultForm(request);
+    spaceId = await getDefaultSpaceId(request);
+    await ensureDefaultForm(request, spaceId);
   });
 
   test("REQ-E2E-004: export screenshots for all UI page specs", async ({ page, request }) => {
     test.setTimeout(180_000);
-    const relation = await getDefaultFormRelation(request);
+    const relation = await getDefaultFormRelation(request, spaceId);
 
     const entryTitle = `E2E Screenshot Entry ${Date.now()}`;
     const entryRes = await request.post(

--- a/e2e/ui-themes.test.ts
+++ b/e2e/ui-themes.test.ts
@@ -3,10 +3,10 @@ import {
   ensureDefaultForm,
   getBackendUrl,
   getDefaultFormRelation,
+  getDefaultSpaceId,
   waitForServers,
 } from "./lib/client.ts";
 
-const spaceId = "default";
 const themes = ["materialize", "classic", "pop"] as const;
 const themeTestTitles: Record<(typeof themes)[number], string> = {
 	materialize: "REQ-E2E-003: UI flows work in materialize theme",
@@ -15,15 +15,18 @@ const themeTestTitles: Record<(typeof themes)[number], string> = {
 };
 
 test.describe("UI theme flows", () => {
-	test.beforeAll(async ({ request }) => {
-		await waitForServers(request);
-		await ensureDefaultForm(request);
+  let spaceId = "";
+
+  test.beforeAll(async ({ request }) => {
+    await waitForServers(request);
+    spaceId = await getDefaultSpaceId(request);
+    await ensureDefaultForm(request, spaceId);
 	});
 
 	for (const theme of themes) {
 		test(themeTestTitles[theme], async ({ page, request }) => {
 			test.setTimeout(120_000);
-			const relation = await getDefaultFormRelation(request);
+      const relation = await getDefaultFormRelation(request, spaceId);
 			const runId = Date.now();
 			const entryTitle = `E2E Theme Entry ${theme} ${runId}`;
 			const variableQueryName = `E2E Variables ${theme}`;


### PR DESCRIPTION
## Summary

- Resolve the authenticated E2E fixture Space to its immutable UUID during suite setup.
- Use the resolved UUID for every Space route and API request, removing executable `default` route aliases.
- Update route-oriented test names and shared helpers to document that names are only fixture-discovery keys.

## Related Issue (required)

closes #1908

## Testing

- [x] `deno check --config e2e/deno.json e2e/*.test.ts e2e/global-setup.ts e2e/lib/*.ts e2e/playwright.config.ts`
- [x] `deno lint e2e`
- [x] `git diff --check` and no hard-coded `/spaces/default` routes in executable E2E
