### PR TITLE
feat(server): add deployment-aware security headers

### DIFF
--- a/crates/ugoite-server/Cargo.toml
+++ b/crates/ugoite-server/Cargo.toml
@@ -11,7 +11,7 @@ http = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7"
-tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "signal", "sync"] }
 tower-http = { version = "0.7", features = ["cors", "fs", "request-id", "trace"] }
 ugoite-core = { path = "../ugoite-core" }
 ugoite-iceberg = { path = "../ugoite-iceberg" }

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -21,6 +21,7 @@ use serde_json::{json, Value};
 use std::{
     collections::{BTreeMap, BTreeSet},
     env,
+    net::IpAddr,
 };
 use tower_http::{
     cors::{AllowOrigin, CorsLayer},
@@ -54,11 +55,66 @@ use webauthn_rs::prelude::{PublicKeyCredential, RegisterPublicKeyCredential};
 pub const OPENAPI_JSON: &str = include_str!("openapi.json");
 const OAUTH_RESOURCE_DOCUMENTATION_URL: &str =
     "https://ugoite.github.io/ugoite/docs/guide/operate/auth/auth-overview/";
+const SECURITY_HEADERS_CSP: &str = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self'; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; worker-src 'self' blob:; manifest-src 'self'";
+const HSTS_VALUE: &str = "max-age=31536000; includeSubDomains";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SecurityHeadersPolicy {
+    hsts: bool,
+}
+
+impl SecurityHeadersPolicy {
+    fn from_public_origin(public_origin: &str) -> Self {
+        let hsts = url::Url::parse(public_origin).is_ok_and(|origin| {
+            origin.scheme() == "https"
+                && !origin.host_str().is_some_and(|host| {
+                    let host = host.trim_start_matches('[').trim_end_matches(']');
+                    host.trim_end_matches('.').eq_ignore_ascii_case("localhost")
+                        || host
+                            .parse::<IpAddr>()
+                            .is_ok_and(|address| address.is_loopback())
+                })
+        });
+        Self { hsts }
+    }
+
+    fn apply(self, headers: &mut HeaderMap) {
+        headers.insert(
+            HeaderName::from_static("content-security-policy"),
+            HeaderValue::from_static(SECURITY_HEADERS_CSP),
+        );
+        headers.insert(
+            HeaderName::from_static("x-content-type-options"),
+            HeaderValue::from_static("nosniff"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-frame-options"),
+            HeaderValue::from_static("DENY"),
+        );
+        headers.insert(
+            HeaderName::from_static("referrer-policy"),
+            HeaderValue::from_static("strict-origin-when-cross-origin"),
+        );
+        headers.insert(
+            HeaderName::from_static("permissions-policy"),
+            HeaderValue::from_static("camera=(), microphone=(), geolocation=()"),
+        );
+        if self.hsts {
+            headers.insert(
+                HeaderName::from_static("strict-transport-security"),
+                HeaderValue::from_static(HSTS_VALUE),
+            );
+        } else {
+            headers.remove("strict-transport-security");
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct AppState {
     service: UgoiteService,
     identity: NodeIdentityService,
+    security_headers: SecurityHeadersPolicy,
 }
 
 impl AppState {
@@ -78,8 +134,10 @@ impl AppState {
                 .context("configure UGOITE_NODE_CONTROL_URI")?,
             Err(_) => service.operator().clone(),
         };
+        let identity = NodeIdentityService::new(control_operator, rp_id, public_origin)?;
         Ok(Self {
-            identity: NodeIdentityService::new(control_operator, rp_id, public_origin)?,
+            security_headers: SecurityHeadersPolicy::from_public_origin(identity.public_origin()),
+            identity,
             service,
         })
     }
@@ -89,6 +147,7 @@ impl AppState {
         let service = UgoiteService::new(root_uri.into())?;
         Ok(Self {
             identity: NodeIdentityService::new_for_tests("localhost", "http://localhost:8000")?,
+            security_headers: SecurityHeadersPolicy::from_public_origin("http://localhost:8000"),
             service,
         })
     }
@@ -393,7 +452,21 @@ fn app_layers(router: Router<AppState>, state: AppState) -> Router {
             );
         }
     }
+    router = router.layer(middleware::from_fn_with_state(
+        state.clone(),
+        add_security_headers,
+    ));
     router.with_state(state)
+}
+
+async fn add_security_headers(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let mut response = next.run(request).await;
+    state.security_headers.apply(response.headers_mut());
+    response
 }
 
 async fn validate_unsafe_origin(
@@ -4542,6 +4615,55 @@ fn strip_html_tags(input: &str) -> String {
 
 pub fn openapi_snapshot() -> Value {
     serde_json::from_str(OPENAPI_JSON).expect("embedded OpenAPI snapshot must be valid JSON")
+}
+
+#[cfg(test)]
+mod security_headers_tests {
+    use super::*;
+
+    #[test]
+    fn req_sec_002_omits_hsts_for_local_origins() {
+        for origin in [
+            "http://localhost:8000",
+            "https://localhost:8000",
+            "https://127.0.0.1:8000",
+            "https://[::1]:8000",
+        ] {
+            assert!(
+                !SecurityHeadersPolicy::from_public_origin(origin).hsts,
+                "local origin must not receive HSTS: {origin}"
+            );
+        }
+        assert!(SecurityHeadersPolicy::from_public_origin("https://ugoite.example").hsts);
+    }
+
+    #[test]
+    fn req_sec_002_adds_the_common_header_contract() {
+        let mut headers = HeaderMap::new();
+        SecurityHeadersPolicy { hsts: true }.apply(&mut headers);
+
+        assert_eq!(
+            headers.get("content-security-policy").unwrap(),
+            SECURITY_HEADERS_CSP
+        );
+        assert!(SECURITY_HEADERS_CSP.contains("script-src 'self'"));
+        assert!(!SECURITY_HEADERS_CSP.contains("script-src 'unsafe-inline'"));
+        assert!(SECURITY_HEADERS_CSP.contains("img-src 'self' blob:"));
+        assert_eq!(headers.get("x-content-type-options").unwrap(), "nosniff");
+        assert_eq!(headers.get("x-frame-options").unwrap(), "DENY");
+        assert_eq!(
+            headers.get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+        assert_eq!(
+            headers.get("permissions-policy").unwrap(),
+            "camera=(), microphone=(), geolocation=()"
+        );
+        assert_eq!(
+            headers.get("strict-transport-security").unwrap(),
+            HSTS_VALUE
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -1,10 +1,13 @@
 use axum::{
     body::Body,
-    http::{Request, StatusCode},
+    http::{Method, Request, StatusCode},
 };
 use serde_json::Value;
+use std::sync::{Mutex, OnceLock};
 use tower::ServiceExt;
 use ugoite_server::{app, AppState};
+
+static APP_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 async fn initialized_app(name: &str) -> axum::Router {
     let state = AppState::new_for_tests(format!("memory://server-contract-{name}")).expect("state");
@@ -20,6 +23,128 @@ async fn json(response: axum::response::Response) -> Value {
         .await
         .expect("body");
     serde_json::from_slice(&bytes).expect("json")
+}
+
+fn assert_common_security_headers(response: &axum::response::Response, hsts: bool) {
+    let headers = response.headers();
+    assert_eq!(
+        headers.get("x-content-type-options"),
+        Some(&"nosniff".parse().unwrap())
+    );
+    assert_eq!(
+        headers.get("x-frame-options"),
+        Some(&"DENY".parse().unwrap())
+    );
+    assert_eq!(
+        headers.get("referrer-policy"),
+        Some(&"strict-origin-when-cross-origin".parse().unwrap())
+    );
+    assert_eq!(
+        headers.get("permissions-policy"),
+        Some(&"camera=(), microphone=(), geolocation=()".parse().unwrap())
+    );
+    let csp = headers
+        .get("content-security-policy")
+        .and_then(|value| value.to_str().ok())
+        .expect("CSP header");
+    assert!(csp.contains("default-src 'self'"));
+    assert!(csp.contains("script-src 'self'"));
+    assert!(csp.contains("img-src 'self' blob:"));
+    assert_eq!(headers.contains_key("strict-transport-security"), hsts);
+}
+
+#[tokio::test]
+async fn req_sec_002_covers_metadata_api_error_and_middleware_responses() {
+    let app = initialized_app("security-headers").await;
+    for uri in [
+        "/",
+        "/health",
+        "/.well-known/oauth-protected-resource",
+        "/missing",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(Request::get(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_common_security_headers(&response, false);
+    }
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/auth/setup/start")
+                .header("cookie", "ugoite_session=present")
+                .header("origin", "https://attacker.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_common_security_headers(&response, false);
+}
+
+#[tokio::test]
+async fn req_sec_002_covers_the_static_browser_root() {
+    let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let static_dir = std::env::temp_dir().join(format!(
+        "ugoite-security-headers-static-{}",
+        uuid::Uuid::now_v7()
+    ));
+    std::fs::create_dir_all(&static_dir).unwrap();
+    std::fs::write(static_dir.join("index.html"), "<!doctype html>").unwrap();
+    let previous = std::env::var_os("UGOITE_STATIC_DIR");
+    std::env::set_var("UGOITE_STATIC_DIR", &static_dir);
+    let app = initialized_app("security-headers-static").await;
+    let response = app
+        .oneshot(Request::get("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    match previous {
+        Some(value) => std::env::set_var("UGOITE_STATIC_DIR", value),
+        None => std::env::remove_var("UGOITE_STATIC_DIR"),
+    }
+    std::fs::remove_dir_all(static_dir).unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_common_security_headers(&response, false);
+}
+
+#[tokio::test]
+async fn req_sec_002_keeps_security_headers_on_cors_preflight() {
+    let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let previous = std::env::var_os("UGOITE_CORS_ALLOWED_ORIGINS");
+    std::env::set_var("UGOITE_CORS_ALLOWED_ORIGINS", "https://frontend.example");
+    let app = initialized_app("security-headers-cors").await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::OPTIONS)
+                .uri("/health")
+                .header("origin", "https://frontend.example")
+                .header("access-control-request-method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    match previous {
+        Some(value) => std::env::set_var("UGOITE_CORS_ALLOWED_ORIGINS", value),
+        None => std::env::remove_var("UGOITE_CORS_ALLOWED_ORIGINS"),
+    }
+
+    assert!(response.status().is_success());
+    assert_eq!(
+        response.headers().get("access-control-allow-origin"),
+        Some(&"https://frontend.example".parse().unwrap())
+    );
+    assert_eq!(
+        response.headers().get("access-control-allow-credentials"),
+        Some(&"true".parse().unwrap())
+    );
+    assert_common_security_headers(&response, false);
 }
 
 #[tokio::test]

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -3,7 +3,8 @@ use axum::{
     http::{Method, Request, StatusCode},
 };
 use serde_json::Value;
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
 use tower::ServiceExt;
 use ugoite_server::{app, AppState};
 
@@ -88,7 +89,7 @@ async fn req_sec_002_covers_metadata_api_error_and_middleware_responses() {
 
 #[tokio::test]
 async fn req_sec_002_covers_the_static_browser_root() {
-    let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
     let static_dir = std::env::temp_dir().join(format!(
         "ugoite-security-headers-static-{}",
         uuid::Uuid::now_v7()
@@ -114,7 +115,7 @@ async fn req_sec_002_covers_the_static_browser_root() {
 
 #[tokio::test]
 async fn req_sec_002_keeps_security_headers_on_cors_preflight() {
-    let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
     let previous = std::env::var_os("UGOITE_CORS_ALLOWED_ORIGINS");
     std::env::set_var("UGOITE_CORS_ALLOWED_ORIGINS", "https://frontend.example");
     let app = initialized_app("security-headers-cors").await;

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -3,6 +3,7 @@ use axum::{
     http::{Method, Request, StatusCode},
 };
 use serde_json::Value;
+use std::ffi::{OsStr, OsString};
 use std::sync::OnceLock;
 use tokio::sync::Mutex;
 use tower::ServiceExt;
@@ -10,7 +11,34 @@ use ugoite_server::{app, AppState};
 
 static APP_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+struct EnvVarGuard {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 async fn initialized_app(name: &str) -> axum::Router {
+    let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    initialized_app_without_env_lock(name).await
+}
+
+async fn initialized_app_without_env_lock(name: &str) -> axum::Router {
     let state = AppState::new_for_tests(format!("memory://server-contract-{name}")).expect("state");
     state
         .initialize_node()
@@ -96,17 +124,12 @@ async fn req_sec_002_covers_the_static_browser_root() {
     ));
     std::fs::create_dir_all(&static_dir).unwrap();
     std::fs::write(static_dir.join("index.html"), "<!doctype html>").unwrap();
-    let previous = std::env::var_os("UGOITE_STATIC_DIR");
-    std::env::set_var("UGOITE_STATIC_DIR", &static_dir);
-    let app = initialized_app("security-headers-static").await;
+    let _static_dir = EnvVarGuard::set("UGOITE_STATIC_DIR", &static_dir);
+    let app = initialized_app_without_env_lock("security-headers-static").await;
     let response = app
         .oneshot(Request::get("/").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    match previous {
-        Some(value) => std::env::set_var("UGOITE_STATIC_DIR", value),
-        None => std::env::remove_var("UGOITE_STATIC_DIR"),
-    }
     std::fs::remove_dir_all(static_dir).unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
@@ -116,9 +139,8 @@ async fn req_sec_002_covers_the_static_browser_root() {
 #[tokio::test]
 async fn req_sec_002_keeps_security_headers_on_cors_preflight() {
     let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
-    let previous = std::env::var_os("UGOITE_CORS_ALLOWED_ORIGINS");
-    std::env::set_var("UGOITE_CORS_ALLOWED_ORIGINS", "https://frontend.example");
-    let app = initialized_app("security-headers-cors").await;
+    let _cors_origins = EnvVarGuard::set("UGOITE_CORS_ALLOWED_ORIGINS", "https://frontend.example");
+    let app = initialized_app_without_env_lock("security-headers-cors").await;
     let response = app
         .oneshot(
             Request::builder()
@@ -131,10 +153,6 @@ async fn req_sec_002_keeps_security_headers_on_cors_preflight() {
         )
         .await
         .unwrap();
-    match previous {
-        Some(value) => std::env::set_var("UGOITE_CORS_ALLOWED_ORIGINS", value),
-        None => std::env::remove_var("UGOITE_CORS_ALLOWED_ORIGINS"),
-    }
 
     assert!(response.status().is_success());
     assert_eq!(

--- a/docs/spec/requirements/security.yaml
+++ b/docs/spec/requirements/security.yaml
@@ -36,13 +36,18 @@ requirements:
   - SPEC-ARCH-INTERFACE
   id: REQ-SEC-002
   title: Security Headers
-  description: The server should add an explicit production security-header policy. Current middleware provides
-    request IDs, tracing, body limits, and CORS but does not set the full header set described here.
+  description: The server adds an explicit response security-header policy to every application response. CSP is
+    same-origin by default and supports the static browser's external manifest boot script, WebAssembly, and blob
+    asset previews. HSTS is added only for non-loopback HTTPS public origins; localhost and IPv4/IPv6 loopback
+    origins omit HSTS for local development.
   related_spec:
   - security/overview.md
   priority: medium
-  status: planned
-  verification: untraced
+  status: implemented
+  verification: traced
+  tests:
+  - file: crates/ugoite-server/src/lib.rs
+  - file: crates/ugoite-server/tests/api_contract.rs
 - set_id: REQCAT-SECURITY
   source_file: requirements/security.yaml
   scope: Security controls, integrity protections, and isolation requirements.

--- a/docs/spec/security/overview.md
+++ b/docs/spec/security/overview.md
@@ -38,3 +38,26 @@ invariants are:
 `UGOITE_PUBLIC_ORIGIN` must be HTTPS except on loopback. The WebAuthn RP ID must
 be a registrable suffix of that origin host and must be configured before
 credential registration.
+
+## HTTP response security policy
+
+`ugoite-server` adds the following headers to every response, including static
+browser responses, metadata, API success and error responses, CORS preflight
+responses, and middleware-generated responses:
+
+- `Content-Security-Policy` restricts scripts and connections to the same
+  origin, disallows framing and plugins, permits the static browser's
+  same-origin WebAssembly and external manifest boot script, and permits
+  `blob:` previews for user-selected assets. The script policy has no
+  `unsafe-inline`; the limited CSS inline-style exception supports the
+  existing interactive layout.
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
+
+`Strict-Transport-Security: max-age=31536000; includeSubDomains` is added only
+when `UGOITE_PUBLIC_ORIGIN` is HTTPS on a non-loopback host. HTTP origins and
+localhost, IPv4-loopback, and IPv6-loopback HTTPS origins intentionally do not
+receive HSTS, so local development does not create browser state that assumes
+TLS.

--- a/frontend/scripts/generate-static-index.ts
+++ b/frontend/scripts/generate-static-index.ts
@@ -1,3 +1,5 @@
+import { dirname, join } from "node:path";
+
 const [manifestPath, outputPath] = Deno.args;
 
 if (!manifestPath || !outputPath) {
@@ -44,6 +46,11 @@ const stylesheetLinks = (clientEntry.css ?? [])
   .map((file) => `\t\t<link rel="stylesheet" href="${toBuildPath(file)}">`)
   .join("\n");
 const manifestScript = JSON.stringify(inputs);
+const manifestScriptPath = join(
+  dirname(outputPath),
+  "_build",
+  "ugoite-manifest.js",
+);
 
 const html = `<!doctype html>
 <html lang="en">
@@ -54,7 +61,7 @@ const html = `<!doctype html>
 		<link rel="icon" href="/favicon.ico">
 ${preloadLinks}
 ${stylesheetLinks}
-		<script>window.manifest = ${manifestScript};</script>
+		<script src="/_build/ugoite-manifest.js"></script>
 	</head>
 	<body>
 		<div id="app"></div>
@@ -63,4 +70,9 @@ ${stylesheetLinks}
 </html>
 `;
 
+await Deno.mkdir(dirname(manifestScriptPath), { recursive: true });
+await Deno.writeTextFile(
+  manifestScriptPath,
+  `window.manifest = ${manifestScript};\n`,
+);
 await Deno.writeTextFile(outputPath, html);

--- a/mise.toml
+++ b/mise.toml
@@ -102,7 +102,10 @@ sources = [
   "shared/**/*",
   "scripts/activate-ugoite-wasm.sh",
 ]
-outputs = ["frontend/.output/public/index.html"]
+outputs = [
+  "frontend/.output/public/index.html",
+  "frontend/.output/public/_build/ugoite-manifest.js",
+]
 run = [
   "bash scripts/activate-ugoite-wasm.sh release",
   "UGOITE_STATIC_SPA=true deno task frontend:build",


### PR DESCRIPTION
## Summary

- Add one outer Axum security-header middleware for CSP, nosniff, frame denial, referrer policy, permissions policy, and deployment-aware HSTS.
- Keep HSTS off for HTTP and localhost/IPv4/IPv6 loopback origins, while deriving the policy from `UGOITE_PUBLIC_ORIGIN`.
- Replace the static browser's inline manifest boot script with an external same-origin build asset and trace the contract in the security specification.
- Add focused response-surface, CORS preflight, HSTS profile, and static-root tests.

## Related Issue (required)

closes #1920

## Testing

- [x] `cargo test -p ugoite-server --locked`
- [x] `cargo fmt --all --check`
- [x] `deno check frontend/scripts/generate-static-index.ts`
