### PR TITLE
feat(cli): support remote asset uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,6 +4996,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/crates/ugoite-cli/Cargo.toml
+++ b/crates/ugoite-cli/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-reqwest = { version = "0.13", default-features = false, features = ["json", "blocking", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "blocking", "multipart", "rustls"] }
 opendal = { version = "0.57", default-features = false, features = ["executors-tokio", "services-fs", "services-memory"] }
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
 base64 = "0.23"

--- a/crates/ugoite-cli/src/commands/asset.rs
+++ b/crates/ugoite-cli/src/commands/asset.rs
@@ -57,8 +57,19 @@ pub async fn run(cmd: AssetCmd) -> Result<()> {
                     .unwrap_or("asset")
                     .to_string()
             });
-            if validated_base_url(&config)?.is_some() {
-                anyhow::bail!("asset upload in remote mode not yet supported via CLI");
+            if let Some(base) = validated_base_url(&config)? {
+                let result = http::execute_multipart(
+                    &base,
+                    "asset.upload",
+                    serde_json::json!({"space_id": space_id}),
+                    "file",
+                    &name,
+                    data,
+                    "application/octet-stream",
+                )
+                .await?;
+                print_json(&result);
+                return Ok(());
             }
             let service = UgoiteService::new(&root)?;
             let asset = service.save_asset(&space_id, &name, &data).await?;

--- a/crates/ugoite-cli/src/http.rs
+++ b/crates/ugoite-cli/src/http.rs
@@ -20,17 +20,48 @@ pub async fn execute(
     execute_prepared(base_url, prepared).await
 }
 
+/// Execute a multipart operation while keeping path, authentication, and
+/// response decoding in the same native transport as JSON operations.
+pub async fn execute_multipart(
+    base_url: &str,
+    operation: &str,
+    arguments: Value,
+    field_name: &str,
+    filename: &str,
+    data: Vec<u8>,
+    media_type: &str,
+) -> Result<Value> {
+    let prepared = prepare_request(operation, &arguments, None)?;
+    if prepared.body_kind != RequestBodyKind::Multipart {
+        bail!("operation {operation} does not require a multipart body");
+    }
+    let operation_name = prepared.operation.clone();
+    let (_, request) = authenticated_request(base_url, &prepared).await?;
+    let part = reqwest::multipart::Part::bytes(data)
+        .file_name(filename.to_string())
+        .mime_str(media_type)?;
+    let form = reqwest::multipart::Form::new().part(field_name.to_string(), part);
+    send_and_decode(&operation_name, request.multipart(form)).await
+}
+
 async fn execute_prepared(base_url: &str, prepared: PreparedRequest) -> Result<Value> {
     let operation = prepared.operation.clone();
+    let (_, mut request) = authenticated_request(base_url, &prepared).await?;
+    request = match (prepared.body_kind, prepared.body) {
+        (RequestBodyKind::Multipart, _) => bail!("operation {operation} requires multipart"),
+        (RequestBodyKind::Json, Some(body)) => request.body(body),
+        (RequestBodyKind::Json, None) => bail!("operation {operation} requires a JSON body"),
+        (RequestBodyKind::None, _) => request,
+    };
+    send_and_decode(&operation, request).await
+}
+
+async fn authenticated_request(
+    base_url: &str,
+    prepared: &PreparedRequest,
+) -> Result<(String, reqwest::RequestBuilder)> {
     let url = join_base_and_path(base_url, &prepared.path);
     crate::config::validate_server_endpoint_url(&url, "Remote request")?;
-    let method_name = match prepared.method {
-        HttpMethod::Get => "GET",
-        HttpMethod::Post => "POST",
-        HttpMethod::Put => "PUT",
-        HttpMethod::Patch => "PATCH",
-        HttpMethod::Delete => "DELETE",
-    };
     let mut request = match prepared.method {
         HttpMethod::Get => client().get(&url),
         HttpMethod::Post => client().post(&url),
@@ -46,15 +77,13 @@ async fn execute_prepared(base_url: &str, prepared: PreparedRequest) -> Result<V
             .header("Authorization", format!("DPoP {}", session.access_token))
             .header(
                 "DPoP",
-                crate::commands::auth::dpop_proof(&session, method_name, &url)?,
+                crate::commands::auth::dpop_proof(&session, prepared.method.as_str(), &url)?,
             );
     }
-    request = match (prepared.body_kind, prepared.body) {
-        (RequestBodyKind::Multipart, _) => bail!("operation {operation} requires multipart"),
-        (RequestBodyKind::Json, Some(body)) => request.body(body),
-        (RequestBodyKind::Json, None) => bail!("operation {operation} requires a JSON body"),
-        (RequestBodyKind::None, _) => request,
-    };
+    Ok((url, request))
+}
+
+async fn send_and_decode(operation: &str, request: reqwest::RequestBuilder) -> Result<Value> {
     let response = request
         .send()
         .await
@@ -73,7 +102,7 @@ async fn execute_prepared(base_url: &str, prepared: PreparedRequest) -> Result<V
         .collect();
     let body = response.text().await?;
     decode_response(
-        &operation,
+        operation,
         ApiResponse {
             status: status.as_u16(),
             status_text,

--- a/crates/ugoite-cli/tests/test_assets.rs
+++ b/crates/ugoite-cli/tests/test_assets.rs
@@ -4,6 +4,17 @@
 use std::path::Path;
 use std::process::Command;
 
+use base64::Engine;
+use p256::ecdsa::SigningKey;
+use p256::elliptic_curve::rand_core::OsRng;
+use p256::pkcs8::EncodePrivateKey;
+use ugoite_cli::config::AuthSession;
+
+#[path = "support/mod.rs"]
+mod support;
+
+use support::spawn_recording_server;
+
 fn ugoite_bin() -> String {
     let mut path = std::env::current_exe().unwrap();
     path.pop();
@@ -21,6 +32,34 @@ fn immutable_space_path(root: &str) -> std::path::PathBuf {
         .map(|entry| entry.path())
         .find(|path| path.join("meta.json").is_file())
         .expect("UUID Space directory")
+}
+
+fn write_test_auth_session(config_path: &Path, base_url: &str) {
+    let signing_key = SigningKey::random(&mut OsRng);
+    let point = signing_key.verifying_key().to_encoded_point(false);
+    let encode = |value: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(value);
+    let session = AuthSession {
+        credential_id: uuid::Uuid::now_v7(),
+        device_name: "asset-upload-test".to_string(),
+        public_key_jwk: serde_json::json!({
+            "kty": "EC",
+            "crv": "P-256",
+            "x": encode(point.x().unwrap()),
+            "y": encode(point.y().unwrap()),
+        }),
+        private_key_pkcs8: Some(encode(signing_key.to_pkcs8_der().unwrap().as_bytes())),
+        access_token: "test-access-token".to_string(),
+        refresh_token: "test-refresh-token".to_string(),
+        expires_at: i64::MAX,
+        base_url: base_url.to_string(),
+        space_uid: uuid::Uuid::now_v7(),
+    };
+    let credentials_path = config_path.parent().unwrap().join("cli-credentials.json");
+    std::fs::write(
+        credentials_path,
+        serde_json::to_vec_pretty(&session).unwrap(),
+    )
+    .unwrap();
 }
 
 /// REQ-ASSET-001: Asset upload and exact-key lifecycle.
@@ -151,4 +190,156 @@ fn test_asset_req_asset_001_upload_normalizes_markdown_heading_filename() {
         .join("assets")
         .join(asset["asset_id"].as_str().expect("asset id"))
         .exists());
+}
+
+/// REQ-ASSET-001: Remote upload uses the portable multipart operation in both endpoint modes.
+#[test]
+fn test_asset_req_asset_001_remote_upload_sends_file_part_and_returns_metadata() {
+    for (mode, endpoint_flag, expected_path, filename) in [
+        (
+            "backend",
+            "--backend-url",
+            "/spaces/remote-space/assets",
+            "test-asset.txt",
+        ),
+        (
+            "api",
+            "--api-url",
+            "/api/spaces/remote-space/assets",
+            "nested/../../outside.txt",
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("cli-config.json");
+        let asset_file = dir.path().join("test-asset.txt");
+        std::fs::write(&asset_file, b"remote asset content").unwrap();
+        let (base_url, request_rx, server_handle) = spawn_recording_server(
+            "HTTP/1.1 201 Created",
+            r#"{"asset_id":"asset-remote-1","name":"outside.txt","media_type":"application/octet-stream","size_bytes":20,"sha256":"remote-sha256"}"#,
+        );
+        let endpoint_url = if mode == "api" {
+            format!("{base_url}/api")
+        } else {
+            base_url.clone()
+        };
+
+        let set_output = Command::new(ugoite_bin())
+            .args([
+                "config",
+                "set",
+                "--mode",
+                mode,
+                endpoint_flag,
+                &endpoint_url,
+            ])
+            .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+            .output()
+            .expect("configure remote endpoint");
+        assert!(
+            set_output.status.success(),
+            "config stderr: {}",
+            String::from_utf8_lossy(&set_output.stderr)
+        );
+        write_test_auth_session(&config_path, &endpoint_url);
+
+        let mut upload_args = vec![
+            "asset",
+            "upload",
+            "remote-space",
+            asset_file.to_str().unwrap(),
+        ];
+        if mode == "api" {
+            upload_args.extend(["--filename", filename]);
+        }
+        let upload_output = Command::new(ugoite_bin())
+            .args(upload_args)
+            .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+            .output()
+            .expect("run remote asset upload");
+
+        server_handle.join().unwrap();
+        let request = request_rx.recv().unwrap();
+        assert!(
+            upload_output.status.success(),
+            "{mode} upload stderr: {}",
+            String::from_utf8_lossy(&upload_output.stderr)
+        );
+        assert!(
+            request.starts_with(&format!("POST {expected_path} HTTP/1.1\r\n")),
+            "{request}"
+        );
+        let request_lower = request.to_ascii_lowercase();
+        assert!(
+            request_lower.contains("content-type: multipart/form-data; boundary="),
+            "{request}"
+        );
+        assert!(
+            request.contains(&format!(
+                r#"Content-Disposition: form-data; name="file"; filename="{filename}""#
+            )),
+            "{request}"
+        );
+        assert!(
+            request_lower.contains("content-type: application/octet-stream"),
+            "{request}"
+        );
+        assert!(request.contains("remote asset content"), "{request}");
+        assert!(
+            request_lower.contains("authorization: dpop test-access-token"),
+            "{request}"
+        );
+        assert!(request_lower.contains("dpop: ey"), "{request}");
+
+        let asset: serde_json::Value =
+            serde_json::from_slice(&upload_output.stdout).expect("remote asset JSON");
+        assert_eq!(asset["asset_id"], "asset-remote-1");
+        assert_eq!(asset["name"], "outside.txt");
+        assert_eq!(asset["media_type"], "application/octet-stream");
+        assert_eq!(asset["size_bytes"], 20);
+        assert_eq!(asset["sha256"], "remote-sha256");
+    }
+}
+
+/// REQ-ASSET-001: Remote non-2xx responses use the shared API decoder.
+#[test]
+fn test_asset_req_asset_001_remote_upload_surfaces_api_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("cli-config.json");
+    let asset_file = dir.path().join("test-asset.txt");
+    std::fs::write(&asset_file, b"remote asset content").unwrap();
+    let (base_url, request_rx, server_handle) = spawn_recording_server(
+        "HTTP/1.1 413 Payload Too Large",
+        r#"{"detail":"Request payload is too large"}"#,
+    );
+
+    let set_output = Command::new(ugoite_bin())
+        .args([
+            "config",
+            "set",
+            "--mode",
+            "backend",
+            "--backend-url",
+            &base_url,
+        ])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("configure backend endpoint");
+    assert!(set_output.status.success());
+
+    let upload_output = Command::new(ugoite_bin())
+        .args([
+            "asset",
+            "upload",
+            "remote-space",
+            asset_file.to_str().unwrap(),
+        ])
+        .env("UGOITE_CLI_CONFIG_PATH", &config_path)
+        .output()
+        .expect("run remote asset upload");
+
+    server_handle.join().unwrap();
+    let _request = request_rx.recv().unwrap();
+    assert!(!upload_output.status.success());
+    let stderr = String::from_utf8_lossy(&upload_output.stderr);
+    assert!(stderr.contains("Failed to upload asset: Request payload is too large"));
 }

--- a/crates/ugoite-server/src/lib.rs
+++ b/crates/ugoite-server/src/lib.rs
@@ -64,6 +64,163 @@ struct SecurityHeadersPolicy {
     hsts: bool,
 }
 
+#[cfg(test)]
+mod remote_asset_upload_tests {
+    use super::*;
+    use axum::{body::Body, http::Request, routing::post};
+    use tower::ServiceExt;
+
+    fn test_identity(space_uid: Uuid, principal_id: Uuid) -> RequestIdentityContext {
+        RequestIdentityContext {
+            request_identity: RequestIdentity {
+                subject: AuthenticatedSubject::HumanAccount {
+                    account_id: principal_id,
+                },
+                actor: Actor::Human {
+                    account_id: principal_id,
+                },
+                credential_id: Uuid::now_v7(),
+                authentication_method: RequestAuthenticationMethod::DeviceProof,
+                assurance: AssuranceLevel::Possession,
+                constraints: CredentialConstraints::default(),
+                session_id: None,
+            },
+            account_id: principal_id,
+            display_name: "Asset upload test".to_string(),
+            node_admin: false,
+            token_principal_id: Some(principal_id),
+            token_actor_principal_id: None,
+            token_space_uid: Some(space_uid),
+            token_actions: Some(
+                ["read", "create", "update"]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
+            ),
+            recent_passkey: false,
+            credential_generation: 0,
+            session_token: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn asset_upload_app_layer_rejects_payloads_over_twenty_mib() {
+        let state =
+            AppState::new_for_tests("memory://server-asset-upload-limit").expect("test state");
+        let principal_id = Uuid::now_v7();
+        let space_uid = state
+            .service
+            .create_space_for_principal("remote-space", principal_id, "Asset upload test")
+            .await
+            .expect("create test Space");
+        let boundary = "asset-upload-limit-boundary";
+        let mut body = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"large.bin\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+        )
+        .into_bytes();
+        body.extend(std::iter::repeat_n(b'x', 20 * 1024 * 1024));
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+        let router = Router::new()
+            .route("/spaces/{space_id}/assets", post(upload_asset))
+            .layer(Extension(test_identity(space_uid, principal_id)));
+        let response = app_layers(router, state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/spaces/{space_uid}/assets"))
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    async fn upload_status(
+        state: AppState,
+        space_uid: Uuid,
+        principal_id: Uuid,
+        boundary: &str,
+        body: Vec<u8>,
+    ) -> StatusCode {
+        let router = Router::new()
+            .route("/spaces/{space_id}/assets", post(upload_asset))
+            .layer(Extension(test_identity(space_uid, principal_id)));
+        app_layers(router, state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/spaces/{space_uid}/assets"))
+                    .header(
+                        header::CONTENT_TYPE,
+                        format!("multipart/form-data; boundary={boundary}"),
+                    )
+                    .body(Body::from(body))
+                    .expect("request"),
+            )
+            .await
+            .expect("response")
+            .status()
+    }
+
+    fn multipart_body(boundary: &str, fields: &[(&str, &str)]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for (name, content) in fields {
+            body.extend_from_slice(
+                format!(
+                    "--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"; filename=\"asset.txt\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+                )
+                .as_bytes(),
+            );
+            body.extend_from_slice(content.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    #[tokio::test]
+    async fn asset_upload_rejects_wrong_and_additional_multipart_fields() {
+        let state =
+            AppState::new_for_tests("memory://server-asset-upload-fields").expect("test state");
+        let principal_id = Uuid::now_v7();
+        let space_uid = state
+            .service
+            .create_space_for_principal("remote-space", principal_id, "Asset upload test")
+            .await
+            .expect("create test Space");
+
+        let wrong_field = upload_status(
+            state.clone(),
+            space_uid,
+            principal_id,
+            "wrong-field-boundary",
+            multipart_body("wrong-field-boundary", &[("other", "content")]),
+        )
+        .await;
+        assert_eq!(wrong_field, StatusCode::BAD_REQUEST);
+
+        let additional_field = upload_status(
+            state,
+            space_uid,
+            principal_id,
+            "additional-field-boundary",
+            multipart_body(
+                "additional-field-boundary",
+                &[("file", "content"), ("extra", "content")],
+            ),
+        )
+        .await;
+        assert_eq!(additional_field, StatusCode::BAD_REQUEST);
+    }
+}
+
 impl SecurityHeadersPolicy {
     fn from_public_origin(public_origin: &str) -> Self {
         let hsts = url::Url::parse(public_origin).is_ok_and(|origin| {
@@ -6416,8 +6573,14 @@ async fn upload_asset(
     let field = multipart
         .next_field()
         .await
-        .map_err(|error| ApiError::new(StatusCode::BAD_REQUEST, error.to_string()))?
+        .map_err(|error| ApiError::new(error.status(), error.body_text()))?
         .ok_or_else(|| ApiError::new(StatusCode::BAD_REQUEST, "file is required"))?;
+    if field.name() != Some("file") {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "multipart field `file` is required",
+        ));
+    }
     let name = field.file_name().unwrap_or("asset").to_string();
     let media_type = field
         .content_type()
@@ -6426,7 +6589,18 @@ async fn upload_asset(
     let bytes = field
         .bytes()
         .await
-        .map_err(|error| ApiError::new(StatusCode::BAD_REQUEST, error.to_string()))?;
+        .map_err(|error| ApiError::new(error.status(), error.body_text()))?;
+    if multipart
+        .next_field()
+        .await
+        .map_err(|error| ApiError::new(error.status(), error.body_text()))?
+        .is_some()
+    {
+        return Err(ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "only the `file` multipart field is allowed",
+        ));
+    }
     let value = state
         .service
         .save_asset_with_media_type(&space_id, &name, &bytes, &media_type)

--- a/crates/ugoite-server/src/openapi.json
+++ b/crates/ugoite-server/src/openapi.json
@@ -3871,6 +3871,9 @@
           "400": {
             "description": "Invalid multipart payload"
           },
+          "413": {
+            "description": "Request payload is too large"
+          },
           "401": {
             "description": "Unauthorized"
           },
@@ -3944,6 +3947,11 @@
                   }
                 },
                 "additionalProperties": false
+              },
+              "encoding": {
+                "file": {
+                  "contentType": "application/octet-stream"
+                }
               }
             }
           }

--- a/crates/ugoite-server/tests/api_contract.rs
+++ b/crates/ugoite-server/tests/api_contract.rs
@@ -116,6 +116,29 @@ async fn req_sec_002_covers_metadata_api_error_and_middleware_responses() {
 }
 
 #[tokio::test]
+async fn asset_upload_route_is_not_public_before_authentication() {
+    let app = initialized_app("asset-upload-auth").await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/spaces/remote-space/assets")
+                .header(
+                    "content-type",
+                    "multipart/form-data; boundary=asset-auth-boundary",
+                )
+                .body(Body::from(
+                    "--asset-auth-boundary\r\nContent-Disposition: form-data; name=\"file\"; filename=\"asset.bin\"\r\nContent-Type: application/octet-stream\r\n\r\ncontent\r\n--asset-auth-boundary--\r\n",
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::LOCKED);
+}
+
+#[tokio::test]
 async fn req_sec_002_covers_the_static_browser_root() {
     let _lock = APP_ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
     let static_dir = std::env::temp_dir().join(format!(

--- a/docs/architecture/release/release-scope.md
+++ b/docs/architecture/release/release-scope.md
@@ -20,7 +20,8 @@ support, and product claims stay aligned with the implementation.
 
 ## Limited or unavailable
 
-- remote CLI asset upload is unavailable, although REST upload exists;
+- remote CLI asset upload is available in backend/API mode through the REST
+  asset operation;
 - index run/stats are local core-mode commands;
 - general audit-log listing APIs are not exposed; authorization events remain
   portable Space state;

--- a/docs/guide/automate/cli.md
+++ b/docs/guide/automate/cli.md
@@ -135,14 +135,24 @@ ugoite index stats /path/to/workspace/spaces/team-notes
 ugoite index run /path/to/workspace/spaces/team-notes
 ```
 
-The CLI reports that these commands are unavailable in backend/API mode. In core
-mode, asset upload and delete take a local Space path:
+The CLI reports that these commands are unavailable in backend/API mode. Asset
+upload and delete use the local Space path in core mode and the bare Space ID
+in backend/API mode:
 
 ```bash
+# Core mode
 ugoite asset upload /path/to/workspace/spaces/team-notes ./diagram.png
 ugoite asset delete /path/to/workspace/spaces/team-notes asset-id
+
+# Backend/API mode
+ugoite asset upload team-notes ./diagram.png
+ugoite asset delete team-notes asset-id
 ```
-Remote CLI asset upload is not available in this release.
+
+Remote upload sends the file as the REST `file` multipart part with
+`application/octet-stream` media type and prints the returned `AssetReference`
+as JSON. Use `--filename` to choose the logical filename; the server applies
+the same safe-basename rules as core mode.
 
 Every command has exhaustive, version-specific help. Use
 `ugoite <command> --help` or `ugoite <command> <subcommand> --help` before

--- a/docs/spec/api/openapi.yaml
+++ b/docs/spec/api/openapi.yaml
@@ -3871,6 +3871,9 @@
           "400": {
             "description": "Invalid multipart payload"
           },
+          "413": {
+            "description": "Request payload is too large"
+          },
           "401": {
             "description": "Unauthorized"
           },
@@ -3944,6 +3947,11 @@
                   }
                 },
                 "additionalProperties": false
+              },
+              "encoding": {
+                "file": {
+                  "contentType": "application/octet-stream"
+                }
               }
             }
           }

--- a/docs/spec/features/assets.yaml
+++ b/docs/spec/features/assets.yaml
@@ -20,7 +20,7 @@ apis:
     command: ugoite asset upload
     file: crates/ugoite-cli/src/commands/asset.rs
     function: run
-  notes: Upload returns an AssetReference and does not create an Entry. Remote CLI upload remains rejected in this release.
+  notes: Upload returns an AssetReference and does not create an Entry. Core and backend/API CLI modes use the same portable asset.upload operation; remote uploads send the file multipart part as application/octet-stream.
 - id: asset.delete
   method: DELETE
   status: implemented


### PR DESCRIPTION
## Summary

Add native CLI multipart transport for remote asset uploads in backend/API mode, preserving the shared endpoint, DPoP auth, response/error path, and core behavior. Update server OpenAPI and current docs.

## Related Issue (required)

closes #1925

## Testing

- [x] `cargo test -p ugoite-cli --test test_assets --locked`
- [x] `cargo test -p ugoite-server remote_asset_upload_tests --lib --locked`
- [x] `cargo test -p ugoite-server --test api_contract --locked`
- [x] `cargo test -p ugoite-api-client --locked`
- [x] `cargo test -p ugoite-cli --test test_cli_endpoint_routing --locked`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- openapi-check`
