### PR TITLE
ci: verify published release quickstarts

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.release_tag || github.sha }}
           persist-credentials: false
           fetch-depth: 0
 
@@ -168,6 +169,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
           persist-credentials: false
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
@@ -219,6 +221,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
           persist-credentials: false
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
@@ -282,6 +285,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
           persist-credentials: false
 
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
@@ -306,7 +310,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Reuse matching versioned image on rerun
+        id: existing-image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}
+          RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+        run: |
+          pull_log="$(mktemp)"
+          if ! docker pull "${IMAGE}" >"${pull_log}" 2>&1; then
+            if ! grep -Eiq 'manifest unknown|name unknown' "${pull_log}"; then
+              cat "${pull_log}" >&2
+              rm -f "${pull_log}"
+              exit 1
+            fi
+            rm -f "${pull_log}"
+            echo "found=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          rm -f "${pull_log}"
+          manifest_log="$(mktemp)"
+          if ! manifest_output="$(docker buildx imagetools inspect "${IMAGE}" 2>"${manifest_log}")"; then
+            cat "${manifest_log}" >&2
+            rm -f "${manifest_log}"
+            exit 1
+          fi
+          rm -f "${manifest_log}"
+          for platform in linux/amd64 linux/arm64; do
+            if ! grep -Fq "${platform}" <<<"${manifest_output}"; then
+              echo "existing ${IMAGE} is missing published platform ${platform}" >&2
+              exit 1
+            fi
+          done
+          revision="$(docker image inspect "${IMAGE}" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+          if [[ "${revision}" != "${RELEASE_SHA}" ]]; then
+            echo "existing ${IMAGE} has source revision ${revision}, expected ${RELEASE_SHA}" >&2
+            exit 1
+          fi
+          echo "found=true" >>"${GITHUB_OUTPUT}"
+          echo "Reusing versioned image ${IMAGE} from ${RELEASE_SHA}"
+
       - name: Publish versioned multi-arch image
+        if: steps.existing-image.outputs.found != 'true'
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -377,6 +421,11 @@ jobs:
       chart_digest: ${{ steps.publish-chart.outputs.chart_digest }}
       release_manifest_path: ${{ steps.manifest.outputs.manifest_path }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          persist-credentials: false
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/artifacts
@@ -402,34 +451,114 @@ jobs:
         id: publish-chart
         run: |
           chart_path="$(echo "${RUNNER_TEMP}"/artifacts/helm-chart/*.tgz)"
-          helm push "${chart_path}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts
+          chart_ref="oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts/ugoite"
+          chart_probe_log="$(mktemp)"
+          if helm show chart "${chart_ref}" --version "${{ needs.prepare.outputs.version }}" >"${chart_probe_log}" 2>&1; then
+            rm -f "${chart_probe_log}"
+            existing_dir="$(mktemp -d)"
+            helm pull "${chart_ref}" --version "${{ needs.prepare.outputs.version }}" --destination "${existing_dir}"
+            existing_path="${existing_dir}/ugoite-${{ needs.prepare.outputs.version }}.tgz"
+            python3 - "${chart_path}" "${existing_path}" <<'PY'
+          import sys
+          import tarfile
+
+          def contents(path):
+              with tarfile.open(path, "r:gz") as archive:
+                  return sorted(
+                      (member.name, archive.extractfile(member).read())
+                      for member in archive.getmembers()
+                      if member.isfile()
+                  )
+
+          if contents(sys.argv[1]) != contents(sys.argv[2]):
+              raise SystemExit("published Helm chart does not match this release artifact")
+            PY
+            echo "Helm chart ${chart_ref}:${{ needs.prepare.outputs.version }} is already published and matches"
+          elif grep -Eiq 'manifest unknown|name unknown|not found' "${chart_probe_log}"; then
+            rm -f "${chart_probe_log}"
+            helm push "${chart_path}" oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts
+          else
+            cat "${chart_probe_log}" >&2
+            rm -f "${chart_probe_log}"
+            exit 1
+          fi
           digest="$(helm show chart "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts/ugoite" --version "${{ needs.prepare.outputs.version }}" | sha256sum | awk '{print $1}')"
           echo "chart_digest=${digest}" >>"$GITHUB_OUTPUT"
 
       - name: Publish GitHub Packages npm installer
         env:
+          NPM_PACKAGE: '@ugoite/ugoite'
+          NPM_VERSION: ${{ needs.prepare.outputs.version }}
           NODE_AUTH_TOKEN: ${{ github.token }}
         run: |
           tag="${{ needs.prepare.outputs.channel }}"
           if [[ "${tag}" == "stable" ]]; then
             tag="latest"
           fi
-          npm publish "${RUNNER_TEMP}"/artifacts/npm-installer/*.tgz --tag "${tag}"
+          package_path="$(echo "${RUNNER_TEMP}"/artifacts/npm-installer/*.tgz)"
+          npm_probe_log="$(mktemp)"
+          if npm view "${NPM_PACKAGE}@${NPM_VERSION}" version >"${npm_probe_log}" 2>&1; then
+            rm -f "${npm_probe_log}"
+            existing_dir="$(mktemp -d)"
+            npm pack "${NPM_PACKAGE}@${NPM_VERSION}" --pack-destination "${existing_dir}" >/dev/null
+            existing_path="${existing_dir}/$(basename "${package_path}")"
+            python3 - "${package_path}" "${existing_path}" <<'PY'
+          import sys
+          import tarfile
+
+          def contents(path):
+              with tarfile.open(path, "r:gz") as archive:
+                  return sorted(
+                      (member.name, archive.extractfile(member).read())
+                      for member in archive.getmembers()
+                      if member.isfile()
+                  )
+
+          if contents(sys.argv[1]) != contents(sys.argv[2]):
+              raise SystemExit("published npm package does not match this release artifact")
+            PY
+            echo "npm package ${NPM_PACKAGE}@${NPM_VERSION} is already published and matches"
+          elif grep -Eiq 'E404|404 Not Found|not found' "${npm_probe_log}"; then
+            rm -f "${npm_probe_log}"
+            npm publish "${package_path}" --tag "${tag}"
+          else
+            cat "${npm_probe_log}" >&2
+            rm -f "${npm_probe_log}"
+            exit 1
+          fi
+          npm dist-tag add "${NPM_PACKAGE}@${NPM_VERSION}" "${tag}"
+
+      - name: Stage release Compose asset
+        run: |
+          mkdir -p target/release-publish
+          cp docker-compose.release.yaml target/release-publish/docker-compose.release.yaml
+          (
+            cd target/release-publish
+            sha256sum docker-compose.release.yaml >docker-compose.release.yaml.sha256
+          )
 
       - name: Upload CLI assets to GitHub Release
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
           ARTIFACT_ROOT: ${{ runner.temp }}/artifacts
         run: |
           python3 - <<'PY'
           import json
+          import hashlib
           import os
           import pathlib
+          import shutil
           import subprocess
+          import tarfile
+          import tempfile
 
           release_tag = os.environ["RELEASE_TAG"]
           root = pathlib.Path(os.environ["ARTIFACT_ROOT"])
-          assets = sorted(root.glob("cli-*/*"))
+          assets = sorted(root.glob("cli-*/*")) + [
+              pathlib.Path("target/release-publish/docker-compose.release.yaml"),
+              pathlib.Path("target/release-publish/docker-compose.release.yaml.sha256"),
+          ]
           existing = json.loads(
               subprocess.run(
                   ["gh", "release", "view", release_tag, "--json", "assets"],
@@ -439,10 +568,81 @@ jobs:
               ).stdout
           )["assets"]
           existing_names = {asset["name"] for asset in existing}
+
+          def archive_contents(path):
+              with tarfile.open(path, "r:gz") as archive:
+                  return sorted(
+                      (member.name, archive.extractfile(member).read())
+                      for member in archive.getmembers()
+                      if member.isfile()
+                  )
+
+          def checksum(path):
+              return pathlib.Path(path).read_text(encoding="utf-8").split()[0]
+
+          for archive in [asset for asset in assets if asset.name.endswith(".tar.gz")]:
+              checksum_asset = pathlib.Path(f"{archive}.sha256")
+              archive_exists = archive.name in existing_names
+              checksum_exists = checksum_asset.name in existing_names
+              if archive_exists:
+                  with tempfile.TemporaryDirectory() as directory:
+                      patterns = ["--pattern", archive.name]
+                      if checksum_exists:
+                          patterns += ["--pattern", checksum_asset.name]
+                      subprocess.run(
+                          ["gh", "release", "download", release_tag, *patterns, "--dir", directory],
+                          check=True,
+                      )
+                      existing_archive = pathlib.Path(directory) / archive.name
+                      if archive_contents(archive) != archive_contents(existing_archive):
+                          raise SystemExit(f"published release asset {archive.name} does not match this release artifact")
+                      shutil.copyfile(existing_archive, archive)
+                      if checksum_exists:
+                          existing_checksum = pathlib.Path(directory) / checksum_asset.name
+                          if checksum(existing_checksum) != hashlib.sha256(existing_archive.read_bytes()).hexdigest():
+                              raise SystemExit(f"published checksum {checksum_asset.name} does not match its archive")
+                          shutil.copyfile(existing_checksum, checksum_asset)
+                      else:
+                          checksum_asset.write_text(
+                              f"{hashlib.sha256(existing_archive.read_bytes()).hexdigest()}  {archive.name}\n",
+                              encoding="utf-8",
+                          )
+              elif checksum_exists:
+                  with tempfile.TemporaryDirectory() as directory:
+                      subprocess.run(
+                          ["gh", "release", "download", release_tag, "--pattern", checksum_asset.name, "--dir", directory],
+                          check=True,
+                      )
+                      existing_checksum = pathlib.Path(directory) / checksum_asset.name
+                      if checksum(existing_checksum) != hashlib.sha256(archive.read_bytes()).hexdigest():
+                          raise SystemExit(f"published checksum {checksum_asset.name} does not match this release artifact")
+                      shutil.copyfile(existing_checksum, checksum_asset)
+
           for asset in assets:
-              if asset.name in existing_names:
+              if asset.name not in existing_names:
+                  subprocess.run(
+                      ["gh", "release", "upload", release_tag, str(asset)],
+                      check=True,
+                  )
                   continue
-              subprocess.run(["gh", "release", "upload", release_tag, str(asset)], check=True)
+              with tempfile.TemporaryDirectory() as directory:
+                  subprocess.run(
+                      [
+                          "gh",
+                          "release",
+                          "download",
+                          release_tag,
+                          "--pattern",
+                          asset.name,
+                          "--dir",
+                          directory,
+                      ],
+                      check=True,
+                  )
+                  existing_path = pathlib.Path(directory) / asset.name
+                  if not existing_path.is_file() or existing_path.read_bytes() != asset.read_bytes():
+                      raise SystemExit(f"published release asset {asset.name} does not match this release artifact")
+                  print(f"Release asset {asset.name} is already published and matches")
           PY
 
       - name: Write release manifest
@@ -463,7 +663,11 @@ jobs:
 
           root = pathlib.Path(os.environ["ARTIFACT_ROOT"])
           files = []
-          for path in sorted(root.glob("cli-*/*")):
+          release_files = sorted(root.glob("cli-*/*")) + [
+              pathlib.Path("target/release-publish/docker-compose.release.yaml"),
+              pathlib.Path("target/release-publish/docker-compose.release.yaml.sha256"),
+          ]
+          for path in release_files:
               digest = hashlib.sha256(path.read_bytes()).hexdigest()
               files.append({"name": path.name, "sha256": digest, "size": path.stat().st_size})
 
@@ -495,6 +699,7 @@ jobs:
 
       - name: Upload release manifest assets
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
         run: |
           python3 - <<'PY'
@@ -502,6 +707,7 @@ jobs:
           import os
           import pathlib
           import subprocess
+          import tempfile
 
           release_tag = os.environ["RELEASE_TAG"]
           assets = [
@@ -518,7 +724,96 @@ jobs:
           )["assets"]
           existing_names = {asset["name"] for asset in existing}
           for asset in assets:
-              if asset.name in existing_names:
+              if asset.name not in existing_names:
+                  subprocess.run(
+                      ["gh", "release", "upload", release_tag, str(asset)],
+                      check=True,
+                  )
                   continue
-              subprocess.run(["gh", "release", "upload", release_tag, str(asset)], check=True)
+              with tempfile.TemporaryDirectory() as directory:
+                  subprocess.run(
+                      [
+                          "gh",
+                          "release",
+                          "download",
+                          release_tag,
+                          "--pattern",
+                          asset.name,
+                          "--dir",
+                          directory,
+                      ],
+                      check=True,
+                  )
+                  existing_path = pathlib.Path(directory) / asset.name
+                  if not existing_path.is_file() or existing_path.read_bytes() != asset.read_bytes():
+                      raise SystemExit(f"published release asset {asset.name} does not match this release artifact")
+                  print(f"Release asset {asset.name} is already published and matches")
           PY
+
+  verify-published-quickstarts:
+    needs:
+      - prepare
+      - publish-release-assets
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.outputs.release_tag != '' &&
+        needs.publish-release-assets.result == 'success'
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          persist-credentials: false
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install: true
+          cache: true
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Install Playwright browsers once
+        run: deno task e2e:install:browsers
+
+      - name: Verify published container quick start
+        id: container-quickstart
+        continue-on-error: true
+        env:
+          UGOITE_IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+          UGOITE_RELEASE_TOKEN: ${{ github.token }}
+          UGOITE_RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          UGOITE_RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          UGOITE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: bash scripts/verify-release-container-quickstart.sh
+
+      - name: Verify published CLI quick start
+        id: cli-quickstart
+        continue-on-error: true
+        env:
+          UGOITE_RELEASE_TOKEN: ${{ github.token }}
+          UGOITE_RELEASE_SHA: ${{ needs.prepare.outputs.release_sha }}
+          UGOITE_RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          UGOITE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: bash scripts/verify-release-cli-quickstart.sh
+
+      - name: Fail if a published quick start failed
+        if: always()
+        env:
+          CONTAINER_OUTCOME: ${{ steps.container-quickstart.outcome }}
+          CLI_OUTCOME: ${{ steps.cli-quickstart.outcome }}
+        run: |
+          if [[ "${CONTAINER_OUTCOME}" != "success" || "${CLI_OUTCOME}" != "success" ]]; then
+            echo "container quick start: ${CONTAINER_OUTCOME}"
+            echo "CLI quick start: ${CLI_OUTCOME}"
+            exit 1
+          fi

--- a/docs/architecture/release/release-rearchitecture.md
+++ b/docs/architecture/release/release-rearchitecture.md
@@ -19,6 +19,7 @@ The remaining architectural work is product capability, not stack migration:
 - optional synchronization/relay semantics;
 - production Passkey enrollment/login and optional invited OIDC;
 - sponsored Agent Principals and append-only authorization audit history;
-- release automation beyond the local `ci:release` gate.
+- channel-specific release communication and support rollout after a published
+  version.
 
 These items are future scope and must remain labeled as such.

--- a/docs/architecture/release/release-scope.md
+++ b/docs/architecture/release/release-scope.md
@@ -26,7 +26,9 @@ support, and product claims stay aligned with the implementation.
   portable Space state;
 - browser-local persistence, offline-first editing, and sync are not
   implemented;
-- this tree has a local release-validation task but no publishing workflow.
+- the `Release Publish` workflow now publishes versioned release artifacts and
+  verifies the published Compose and CLI quick starts; an operator-supported
+  release still requires a successful published version.
 
 Release documentation and changelogs must use these boundaries rather than
 planned capability.

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -32,13 +32,16 @@ requirements:
   linked_specifications: *id002
   id: REQ-OPS-002
   title: Container Build Validation
-  description: The single runtime image must be built and smoke-tested by an automated release gate. The current repository provides a local `ci:release` gate but does not run it in hosted CI.
+  description: The single runtime image must be built and smoke-tested by an automated release gate. Local `ci:release` validates the build, and the hosted Release Publish workflow smoke-tests the published versioned image through the documented Compose quick start.
   related_spec:
   - testing/ci-cd.md
   - ../../guide/operate/server/operations.md
   priority: medium
-  status: planned
-  verification: untraced
+  status: implemented
+  verification: traced
+  tests:
+  - file: .github/workflows/release-publish.yml
+  - file: scripts/verify-release-container-quickstart.sh
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.
@@ -263,15 +266,16 @@ requirements:
   linked_specifications: *id002
   id: REQ-OPS-017
   title: Release Container Publishing and Quick Start
-  description: Release automation should publish one deterministic runtime image and verify the documented Compose quick start. No publishing workflow is present.
+  description: Release automation publishes one deterministic runtime image and verifies the documented Compose quick start from the published versioned image and Compose assets.
   related_spec:
   - testing/ci-cd.md
   - ../../guide/operate/server/operations.md
   priority: medium
-  status: planned
+  status: implemented
   verification: traced
   tests:
-  - file: crates/ugoite-iceberg/tests/test_space.rs
+  - file: .github/workflows/release-publish.yml
+  - file: scripts/verify-release-container-quickstart.sh
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.
@@ -279,15 +283,17 @@ requirements:
   linked_specifications: *id002
   id: REQ-OPS-018
   title: CLI Release Binaries and Install Path
-  description: Release automation should publish checksum-verified CLI archives for supported platforms. Installer scripts/package exist, but publication automation is absent.
+  description: Release automation publishes checksum-verified CLI archives for supported platforms, and the post-publication quick-start gate verifies the installer against the published release.
   related_spec:
   - testing/ci-cd.md
   - ../../guide/operate/server/operations.md
   priority: medium
-  status: planned
+  status: implemented
   verification: traced
   tests:
-  - file: crates/ugoite-cli/tests/integration_test.rs
+  - file: .github/workflows/release-publish.yml
+  - file: scripts/install-ugoite-cli.sh
+  - file: scripts/verify-release-cli-quickstart.sh
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.
@@ -379,13 +385,17 @@ requirements:
   linked_specifications: *id002
   id: REQ-OPS-025
   title: Published Release Quick-Start Verification
-  description: Automation should download published artifacts and verify browser and CLI quick starts. Supporting scripts exist; no hosted workflow is present.
+  description: Release automation downloads the published Compose and CLI assets and verifies the browser and CLI quick starts against the exact released version.
   related_spec:
   - testing/ci-cd.md
   - ../../guide/operate/server/operations.md
   priority: medium
-  status: planned
-  verification: untraced
+  status: implemented
+  verification: traced
+  tests:
+  - file: .github/workflows/release-publish.yml
+  - file: scripts/verify-release-container-quickstart.sh
+  - file: scripts/verify-release-cli-quickstart.sh
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -25,6 +25,8 @@ Hosted CI restores Rust, Deno, and BuildKit caches on every event. Shared projec
 
 The hosted runtime image uses Dockerfile's `runtime-prebuilt` target. It copies the canonical frontend and Rust release outputs into the image instead of compiling them again inside Docker. E2E tasks require the already loaded `ugoite:e2e` image and never invoke an image build. The default Dockerfile target remains a portable source build for direct Docker and Compose use.
 
+After publication, `Release Publish` runs both release quick-start verifiers against the exact prepared version and source SHA. The release also uploads `docker-compose.release.yaml`, its checksum, and a manifest containing the prepared source SHA and published image digest. The container verifier checks that manifest, downloads that published Compose definition, pulls the versioned GHCR image, and starts it with `--no-build`; it does not build or load another image for verification. The CLI verifier uses the published checksum-verified installer and retains the local Space create/list assertions.
+
 The focused docsite-navigation lane is intentionally separate from smoke/full
 runtime E2E. It builds the docsite through the canonical `build:docsite`
 inputs, installs Playwright browsers explicitly for that lane, previews the

--- a/docs/spec/versions/index.md
+++ b/docs/spec/versions/index.md
@@ -6,7 +6,7 @@ Machine-readable status lives under `docs/version/`; these pages explain the pro
 
 | Stream | Status | Current meaning |
 |---|---|---|
-| `v0.1` | in progress | Rust/Deno foundation is implemented; production auth and automated artifact publishing remain incomplete |
+| `v0.1` | in progress | Rust/Deno foundation and versioned artifact publication are implemented; production release completion and supported-release notes remain incomplete |
 | `v0.2` | planned | browser-local/optional-sync and broader user-controlled/AI surfaces |
 
 A task marked done means its described implementation exists. Planned capabilities must not be inferred from a version heading or roadmap file.

--- a/docs/spec/versions/v0.1.md
+++ b/docs/spec/versions/v0.1.md
@@ -13,6 +13,8 @@ title: "v0.1 release stream"
 - Axum REST server, server-backed browser, and one read-only MCP resource;
 - one non-root runtime image, Compose files, Helm chart, and local
   release-validation task;
+- versioned release publication with checksummed CLI/Compose assets and a
+  post-publication browser/CLI quick-start gate;
 - Passkey authentication, opaque server-side sessions, optional OIDC, OAuth
   device authorization, and portable Space principals and resource policies.
 
@@ -20,9 +22,7 @@ title: "v0.1 release stream"
 
 - recovery UI for the implemented owner-approved recovery workflow;
 - general authorized audit-log pagination API;
-- repository automation that publishes signed/checksummed image and CLI
-  artifacts;
-- post-publish quick-start verification and final supported release notes.
+- final supported release notes.
 
 Source trackers:
 [`../../version/v0.1.yaml`](https://github.com/ugoite/ugoite/blob/main/docs/version/v0.1.yaml)

--- a/docs/version/v0.1/release-preparation.yaml
+++ b/docs/version/v0.1/release-preparation.yaml
@@ -11,14 +11,18 @@ phases:
     done: true
   - description: Build release server and CLI binaries through the local release gate.
     done: true
-  - description: Publish signed/checksummed image and CLI artifacts through repository automation.
+  - description: Provide repository automation for publishing signed/checksummed image and CLI artifacts.
+    done: true
+  - description: Complete a release with published signed/checksummed image and CLI artifacts.
     done: false
 - id: operator-documentation
   status: in_progress
   tasks:
   - description: Keep quick-start, authentication, storage, Helm, and troubleshooting docs aligned with implementation.
     done: true
-  - description: Validate published quick-start assets after release.
+  - description: Provide a post-publication gate for the published quick-start assets.
+    done: true
+  - description: Validate a published release through both quick starts.
     done: false
 - id: release-communication
   status: planned

--- a/scripts/install-ugoite-cli.sh
+++ b/scripts/install-ugoite-cli.sh
@@ -6,6 +6,7 @@ VERSION_INPUT="${UGOITE_VERSION:-latest}"
 INSTALL_DIR="${UGOITE_INSTALL_DIR:-$HOME/.local/bin}"
 DOWNLOAD_BASE_URL="${UGOITE_DOWNLOAD_BASE_URL:-}"
 TARGET_OVERRIDE="${UGOITE_TARGET_OVERRIDE:-}"
+RELEASE_TOKEN="${UGOITE_RELEASE_TOKEN:-}"
 
 log() {
   printf '%s\n' "$*" >&2
@@ -18,6 +19,21 @@ fail() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+download_file() {
+  local url="$1"
+  local output_path="$2"
+  local -a curl_args=(-fsSL)
+
+  if [ -n "$RELEASE_TOKEN" ]; then
+    curl_args+=(
+      -H "Authorization: Bearer ${RELEASE_TOKEN}"
+      -H "Accept: application/octet-stream"
+    )
+  fi
+
+  curl "${curl_args[@]}" "$url" -o "$output_path"
 }
 
 resolve_tag() {
@@ -121,8 +137,8 @@ else
 fi
 
 log "Downloading ugoite ${version_no_v} for ${release_target}"
-curl -fsSL "${asset_base_url}/${asset_name}" -o "${tmpdir}/${asset_name}"
-curl -fsSL "${asset_base_url}/${checksum_name}" -o "${tmpdir}/${checksum_name}"
+download_file "${asset_base_url}/${asset_name}" "${tmpdir}/${asset_name}"
+download_file "${asset_base_url}/${checksum_name}" "${tmpdir}/${checksum_name}"
 verify_checksum "${tmpdir}/${asset_name}" "${tmpdir}/${checksum_name}"
 
 mkdir -p "$INSTALL_DIR"

--- a/scripts/verify-release-cli-quickstart.sh
+++ b/scripts/verify-release-cli-quickstart.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_SCRIPT_PATH="${UGOITE_INSTALL_SCRIPT_PATH:-${SCRIPT_DIR}/install-ugoite-cli.sh}"
 VERSION_INPUT="${UGOITE_VERSION:-}"
+RELEASE_TAG_INPUT="${UGOITE_RELEASE_TAG:-v${VERSION_INPUT}}"
+RELEASE_SHA_INPUT="${UGOITE_RELEASE_SHA:-}"
+ASSET_BASE_URL_INPUT="${UGOITE_RELEASE_ASSET_BASE_URL:-}"
+RELEASE_TOKEN_INPUT="${UGOITE_RELEASE_TOKEN:-}"
+CLI_TARGET_INPUT="${UGOITE_CLI_TARGET:-}"
 WORK_ROOT_INPUT="${UGOITE_QUICKSTART_WORKDIR:-}"
 KEEP_WORK_ROOT="${UGOITE_QUICKSTART_KEEP_WORKDIR:-0}"
 QUICKSTART_HOME_INPUT="${UGOITE_QUICKSTART_HOME:-}"
@@ -22,6 +27,113 @@ fail() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "Required command not found: $1"
+}
+
+download_asset() {
+  local asset_name="$1"
+  local output_path="$2"
+  local url="${ASSET_BASE_URL}/${asset_name}"
+  local attempt
+  local -a curl_args=(-fsSL)
+
+  if [ -n "$RELEASE_TOKEN_INPUT" ]; then
+    curl_args+=(
+      -H "Authorization: Bearer ${RELEASE_TOKEN_INPUT}"
+      -H "Accept: application/octet-stream"
+    )
+  fi
+
+  for attempt in $(seq 1 10); do
+    if curl "${curl_args[@]}" -o "$output_path" "$url"; then
+      return 0
+    fi
+    if [ "$attempt" -eq 10 ]; then
+      fail "Failed to download ${asset_name} from ${url} after ${attempt} attempts"
+    fi
+    sleep 3
+  done
+}
+
+detect_target() {
+  if [ -n "$CLI_TARGET_INPUT" ]; then
+    printf '%s' "$CLI_TARGET_INPUT"
+    return
+  fi
+
+  case "$(uname -s):$(uname -m)" in
+    Linux:x86_64) printf '%s' 'x86_64-unknown-linux-gnu' ;;
+    Linux:arm64 | Linux:aarch64) printf '%s' 'aarch64-unknown-linux-gnu' ;;
+    Darwin:x86_64) printf '%s' 'x86_64-apple-darwin' ;;
+    Darwin:arm64 | Darwin:aarch64) printf '%s' 'aarch64-apple-darwin' ;;
+    *) fail "Unsupported release CLI target: $(uname -s) $(uname -m)" ;;
+  esac
+}
+
+verify_checksum() {
+  local archive_path="$1"
+  local checksum_path="$2"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$(dirname "$archive_path")" && sha256sum -c "$(basename "$checksum_path")")
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    local expected actual
+    expected="$(cut -d ' ' -f 1 <"$checksum_path")"
+    actual="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+    [ "$expected" = "$actual" ] || fail "Checksum verification failed for $(basename "$archive_path")"
+    return
+  fi
+
+  fail "Need sha256sum or shasum to verify the downloaded archive"
+}
+
+validate_release_manifest() {
+  local manifest_path="$1"
+  local archive_path="$2"
+  local checksum_path="$3"
+  local archive_name="$4"
+  local checksum_name="$5"
+
+  EXPECTED_RELEASE_TAG="$RELEASE_TAG_INPUT" \
+    EXPECTED_VERSION="$VERSION_INPUT" \
+    EXPECTED_SOURCE_SHA="$RELEASE_SHA_INPUT" \
+    MANIFEST_PATH="$manifest_path" \
+    ARCHIVE_PATH="$archive_path" \
+    CHECKSUM_PATH="$checksum_path" \
+    ARCHIVE_NAME="$archive_name" \
+    CHECKSUM_NAME="$checksum_name" \
+    deno eval '
+const manifest = JSON.parse(await Deno.readTextFile(Deno.env.get("MANIFEST_PATH")!));
+const expectedTag = Deno.env.get("EXPECTED_RELEASE_TAG");
+const expectedVersion = Deno.env.get("EXPECTED_VERSION");
+const expectedSourceSha = Deno.env.get("EXPECTED_SOURCE_SHA");
+const fail = (message: string): never => {
+  console.error(`release manifest validation failed: ${message}`);
+  Deno.exit(1);
+};
+if (manifest.release_tag !== expectedTag) fail(`release tag ${manifest.release_tag} != ${expectedTag}`);
+if (manifest.version !== expectedVersion) fail(`version ${manifest.version} != ${expectedVersion}`);
+if (expectedSourceSha && manifest.source_sha !== expectedSourceSha) {
+  fail(`source SHA ${manifest.source_sha} != ${expectedSourceSha}`);
+}
+const digest = async (path: string): Promise<string> => {
+  const bytes = await Deno.readFile(path);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hash)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+for (const [name, path] of [
+  [Deno.env.get("ARCHIVE_NAME")!, Deno.env.get("ARCHIVE_PATH")!],
+  [Deno.env.get("CHECKSUM_NAME")!, Deno.env.get("CHECKSUM_PATH")!],
+] as const) {
+  const record = manifest.files?.find((file: { name?: string }) => file.name === name);
+  if (!record) fail(`${name} is absent from manifest`);
+  const bytes = await Deno.readFile(path);
+  if (record.size !== bytes.byteLength) fail(`${name} size does not match manifest`);
+  if (record.sha256 !== await digest(path)) fail(`${name} digest does not match manifest`);
+}
+'
 }
 
 assert_json_equals() {
@@ -75,6 +187,7 @@ if [ ! -f "$INSTALL_SCRIPT_PATH" ]; then
 fi
 
 require_command deno
+require_command curl
 
 cleanup_mode="cleanup"
 if [ -n "$WORK_ROOT_INPUT" ]; then
@@ -115,13 +228,33 @@ fi
 WORK_DIR="$WORK_ROOT/work"
 mkdir -p "$WORK_DIR"
 
+release_target="$(detect_target)"
+ASSET_BASE_URL="${ASSET_BASE_URL_INPUT:-https://github.com/ugoite/ugoite/releases/download/${RELEASE_TAG_INPUT}}"
+release_archive_name="ugoite-${RELEASE_TAG_INPUT}-${release_target}.tar.gz"
+release_checksum_name="${release_archive_name}.sha256"
+release_assets_dir="$WORK_ROOT/release-assets"
+mkdir -p "$release_assets_dir"
+download_asset "release-manifest.json" "$release_assets_dir/release-manifest.json"
+download_asset "$release_archive_name" "$release_assets_dir/$release_archive_name"
+download_asset "$release_checksum_name" "$release_assets_dir/$release_checksum_name"
+verify_checksum "$release_assets_dir/$release_archive_name" "$release_assets_dir/$release_checksum_name"
+validate_release_manifest \
+  "$release_assets_dir/release-manifest.json" \
+  "$release_assets_dir/$release_archive_name" \
+  "$release_assets_dir/$release_checksum_name" \
+  "$release_archive_name" \
+  "$release_checksum_name"
+
 export HOME="$QUICKSTART_HOME"
 export PATH="$INSTALL_DIR:${PATH}"
 export UGOITE_VERSION="$VERSION_INPUT"
 export UGOITE_INSTALL_DIR="$INSTALL_DIR"
 
 log "Installing ugoite ${VERSION_INPUT}"
-/bin/bash "$INSTALL_SCRIPT_PATH"
+UGOITE_DOWNLOAD_BASE_URL="$ASSET_BASE_URL" \
+  UGOITE_RELEASE_TOKEN="$RELEASE_TOKEN_INPUT" \
+  UGOITE_TARGET_OVERRIDE="$release_target" \
+  /bin/bash "$INSTALL_SCRIPT_PATH"
 
 INSTALLED_BINARY="$INSTALL_DIR/ugoite"
 if [ ! -x "$INSTALLED_BINARY" ]; then
@@ -131,6 +264,13 @@ fi
 help_output="$("$INSTALLED_BINARY" --help 2>&1)"
 assert_help_output "$help_output"
 log "Verified: ugoite --help"
+
+version_output="$("$INSTALLED_BINARY" --version 2>&1)"
+expected_version_output="ugoite ${VERSION_INPUT#v}"
+if [ "$version_output" != "$expected_version_output" ]; then
+  fail "installed binary reported ${version_output}, expected ${expected_version_output}"
+fi
+log "Verified: ugoite reports version ${VERSION_INPUT#v}"
 
 mkdir -p "$WORK_DIR/data/spaces"
 

--- a/scripts/verify-release-container-quickstart.sh
+++ b/scripts/verify-release-container-quickstart.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 VERSION_INPUT="${UGOITE_VERSION:-}"
+RELEASE_TAG_INPUT="${UGOITE_RELEASE_TAG:-v${VERSION_INPUT}}"
+RELEASE_SHA_INPUT="${UGOITE_RELEASE_SHA:-}"
+IMAGE_REPOSITORY="${UGOITE_IMAGE_REPOSITORY:-ghcr.io/ugoite/ugoite}"
+RELEASE_TOKEN_INPUT="${UGOITE_RELEASE_TOKEN:-}"
 WORK_ROOT_INPUT="${UGOITE_QUICKSTART_WORKDIR:-}"
 KEEP_WORK_ROOT="${UGOITE_QUICKSTART_KEEP_WORKDIR:-0}"
 ASSET_BASE_URL_INPUT="${UGOITE_RELEASE_ASSET_BASE_URL:-}"
@@ -28,9 +32,17 @@ download_asset() {
   local output_path="$2"
   local url="${ASSET_BASE_URL}/${asset_name}"
   local attempt
+  local -a curl_args=(-fsSL)
+
+  if [ -n "$RELEASE_TOKEN_INPUT" ]; then
+    curl_args+=(
+      -H "Authorization: Bearer ${RELEASE_TOKEN_INPUT}"
+      -H "Accept: application/octet-stream"
+    )
+  fi
 
   for attempt in $(seq 1 10); do
-    if curl -fsSL -o "$output_path" "$url"; then
+    if curl "${curl_args[@]}" -o "$output_path" "$url"; then
       return 0
     fi
     if [ "$attempt" -eq 10 ]; then
@@ -54,14 +66,73 @@ if (typeof result === 'string') {
 "
 }
 
+validate_release_manifest() {
+  local manifest_path="$1"
+  local compose_path="$2"
+  local compose_checksum_path="$3"
+
+  EXPECTED_RELEASE_TAG="$RELEASE_TAG_INPUT" \
+    EXPECTED_VERSION="$VERSION_INPUT" \
+    EXPECTED_SOURCE_SHA="$RELEASE_SHA_INPUT" \
+    EXPECTED_IMAGE_REPOSITORY="$IMAGE_REPOSITORY" \
+    MANIFEST_PATH="$manifest_path" \
+    COMPOSE_PATH="$compose_path" \
+    COMPOSE_CHECKSUM_PATH="$compose_checksum_path" \
+    deno eval '
+const manifest = JSON.parse(await Deno.readTextFile(Deno.env.get("MANIFEST_PATH")!));
+const expectedTag = Deno.env.get("EXPECTED_RELEASE_TAG");
+const expectedVersion = Deno.env.get("EXPECTED_VERSION");
+const expectedSourceSha = Deno.env.get("EXPECTED_SOURCE_SHA");
+const expectedImageRepository = Deno.env.get("EXPECTED_IMAGE_REPOSITORY");
+const fail = (message: string): never => {
+  console.error(`release manifest validation failed: ${message}`);
+  Deno.exit(1);
+};
+if (manifest.release_tag !== expectedTag) fail(`release tag ${manifest.release_tag} != ${expectedTag}`);
+if (manifest.version !== expectedVersion) fail(`version ${manifest.version} != ${expectedVersion}`);
+if (manifest.source_sha !== expectedSourceSha) fail(`source SHA ${manifest.source_sha} != ${expectedSourceSha}`);
+if (manifest.image?.repository !== expectedImageRepository) {
+  fail(`image repository ${manifest.image?.repository} != ${expectedImageRepository}`);
+}
+if (typeof manifest.image?.digest !== "string" || !manifest.image.digest.startsWith("sha256:")) {
+  fail("published image digest is missing");
+}
+const digest = async (path: string): Promise<string> => {
+  const bytes = await Deno.readFile(path);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hash)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+for (const [name, path] of [
+  ["docker-compose.release.yaml", Deno.env.get("COMPOSE_PATH")!],
+  ["docker-compose.release.yaml.sha256", Deno.env.get("COMPOSE_CHECKSUM_PATH")!],
+] as const) {
+  const record = manifest.files?.find((file: { name?: string }) => file.name === name);
+  if (!record) fail(`${name} is absent from manifest`);
+  if (record.sha256 !== await digest(path)) fail(`${name} digest does not match manifest`);
+}
+console.log(manifest.image.digest);
+'
+}
+
 if [ -z "$VERSION_INPUT" ]; then
   fail "UGOITE_VERSION must be set to the exact release version to verify"
+fi
+
+if [ -z "$RELEASE_SHA_INPUT" ]; then
+  fail "UGOITE_RELEASE_SHA must be set to the prepared release commit"
 fi
 
 require_command bash
 require_command curl
 require_command deno
 require_command docker
+if command -v sha256sum >/dev/null 2>&1; then
+  CHECKSUM_COMMAND="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  CHECKSUM_COMMAND="shasum"
+else
+  fail "Required command not found: sha256sum or shasum"
+fi
 
 cleanup_mode="cleanup"
 if [ -n "$WORK_ROOT_INPUT" ]; then
@@ -77,15 +148,36 @@ if [ "$KEEP_WORK_ROOT" = "1" ]; then
 fi
 
 STACK_DIR="$WORK_ROOT/release-stack"
-DOWNLOAD_DIR="$WORK_ROOT/release-assets"
 CLI_HOME="$WORK_ROOT/cli-home"
 CLI_INSTALL_DIR="${CLI_INSTALL_DIR_INPUT:-$CLI_HOME/.local/bin}"
 CLI_BINARY="$CLI_INSTALL_DIR/ugoite"
 ASSET_BASE_URL="${ASSET_BASE_URL_INPUT:-https://github.com/ugoite/ugoite/releases/download/v${VERSION_INPUT}}"
 COMPOSE_PROJECT="ugoite-release-quickstart-${VERSION_INPUT//[^A-Za-z0-9]/-}-$$"
 compose_cmd=(docker compose -p "$COMPOSE_PROJECT" -f docker-compose.release.yaml)
+NODE_SECRET_KEY="$(head -c 32 /dev/urandom | base64 | tr -d '\n')"
 
-mkdir -p "$STACK_DIR/data" "$DOWNLOAD_DIR" "$CLI_INSTALL_DIR"
+redact_compose_logs() {
+  sed -E \
+    -e 's|(#secret=)[^[:space:]]+|\1[REDACTED]|g' \
+    -e 's|(UGOITE_NODE_SECRET_KEY=)[^[:space:]]+|\1[REDACTED]|g'
+}
+
+verify_checksum() {
+  local asset_path="$1"
+  local checksum_path="$2"
+
+  if [ "$CHECKSUM_COMMAND" = "sha256sum" ]; then
+    (cd "$(dirname "$asset_path")" && sha256sum -c "$(basename "$checksum_path")")
+    return
+  fi
+
+  local expected actual
+  expected="$(cut -d ' ' -f 1 <"$checksum_path")"
+  actual="$(shasum -a 256 "$asset_path" | awk '{print $1}')"
+  [ "$expected" = "$actual" ] || fail "Checksum verification failed for $(basename "$asset_path")"
+}
+
+mkdir -p "$STACK_DIR/data" "$CLI_INSTALL_DIR"
 chmod 0777 "$STACK_DIR/data"
 
 cleanup() {
@@ -97,12 +189,14 @@ cleanup() {
       log "Release quick-start verification failed; compose logs follow."
       (
         cd "$STACK_DIR" &&
-          "${compose_cmd[@]}" logs --no-color
+          UGOITE_NODE_SECRET_KEY="$NODE_SECRET_KEY" \
+            "${compose_cmd[@]}" logs --no-color | redact_compose_logs
       ) || true
     fi
     (
       cd "$STACK_DIR" &&
-        "${compose_cmd[@]}" down --remove-orphans -v
+        UGOITE_NODE_SECRET_KEY="$NODE_SECRET_KEY" \
+          "${compose_cmd[@]}" down --remove-orphans -v
     ) || true
   fi
 
@@ -118,10 +212,13 @@ trap cleanup EXIT HUP INT TERM
 
 log "Downloading released container quick-start assets for ${VERSION_INPUT}"
 download_asset "docker-compose.release.yaml" "$STACK_DIR/docker-compose.release.yaml"
-download_asset "ugoite-v${VERSION_INPUT}.docker.tar.gz" "$DOWNLOAD_DIR/ugoite-image.tar.gz"
-
-log "Loading released Docker image"
-gzip -dc "$DOWNLOAD_DIR/ugoite-image.tar.gz" | docker load
+download_asset "docker-compose.release.yaml.sha256" "$STACK_DIR/docker-compose.release.yaml.sha256"
+verify_checksum "$STACK_DIR/docker-compose.release.yaml" "$STACK_DIR/docker-compose.release.yaml.sha256"
+download_asset "release-manifest.json" "$STACK_DIR/release-manifest.json"
+EXPECTED_IMAGE_DIGEST="$(validate_release_manifest \
+  "$STACK_DIR/release-manifest.json" \
+  "$STACK_DIR/docker-compose.release.yaml" \
+  "$STACK_DIR/docker-compose.release.yaml.sha256")"
 
 cat >"$STACK_DIR/.env" <<EOF
 UGOITE_VERSION=${VERSION_INPUT}
@@ -133,10 +230,31 @@ UGOITE_WEBAUTHN_RP_ID=127.0.0.1
 EOF
 
 log "Starting released compose stack"
+compose_images="$(
+  cd "$STACK_DIR" &&
+    UGOITE_NODE_SECRET_KEY="$NODE_SECRET_KEY" \
+      "${compose_cmd[@]}" config --images
+)"
+expected_compose_image="${IMAGE_REPOSITORY}:${VERSION_INPUT}"
+if [ "$compose_images" != "$expected_compose_image" ]; then
+  fail "released Compose references ${compose_images}, expected ${expected_compose_image}"
+fi
 (
   cd "$STACK_DIR" &&
-    "${compose_cmd[@]}" up -d
+    UGOITE_NODE_SECRET_KEY="$NODE_SECRET_KEY" \
+      "${compose_cmd[@]}" pull &&
+    UGOITE_NODE_SECRET_KEY="$NODE_SECRET_KEY" \
+      "${compose_cmd[@]}" up -d --no-build
 )
+
+published_image_digest="$(
+  docker buildx imagetools inspect \
+    "${IMAGE_REPOSITORY}:${VERSION_INPUT}" \
+    --format '{{json .Manifest.Digest}}' | tr -d '"'
+)"
+if [ "$published_image_digest" != "$EXPECTED_IMAGE_DIGEST" ]; then
+  fail "published image digest ${published_image_digest} did not match release manifest ${EXPECTED_IMAGE_DIGEST}"
+fi
 
 log "Waiting for Ugoite"
 bash "$SCRIPT_DIR/wait-for-http.sh" \
@@ -148,7 +266,9 @@ bash "$SCRIPT_DIR/wait-for-http.sh" \
 
 E2E_SETUP_SECRET="$(
   cd "$STACK_DIR" &&
-    "${compose_cmd[@]}" logs --no-color ugoite | sed -n 's/.*#secret=\([^[:space:]]*\).*/\1/p' | tail -n 1
+    UGOITE_NODE_SECRET_KEY="$NODE_SECRET_KEY" \
+      "${compose_cmd[@]}" logs --no-color ugoite |
+      sed -n 's/.*#secret=\([^[:space:]]*\).*/\1/p' | tail -n 1
 )"
 if [ -z "$E2E_SETUP_SECRET" ]; then
   fail "release quick-start setup secret was not present in startup logs"
@@ -162,9 +282,10 @@ log "Running release browser quick-start stories"
     BACKEND_URL="http://127.0.0.1:8000" \
     E2E_SETUP_SECRET="$E2E_SETUP_SECRET" \
     deno task smoke
-)
+) 2>&1 | redact_compose_logs
 
-log "Installing released CLI for remote backend verification"
+unset E2E_SETUP_SECRET
+log "Installing released CLI for container quick-start configuration checks"
 HOME="$CLI_HOME" \
   PATH="$CLI_INSTALL_DIR:$PATH" \
   UGOITE_VERSION="$VERSION_INPUT" \


### PR DESCRIPTION
## Summary
- Publish the exact release Compose definition, checksum, and manifest.
- Verify the published GHCR image and checksum-verified CLI through both quickstarts after publication.
- Keep prepared source identity, rerun safety, draft asset access, and secret redaction aligned.

## Related Issue (required)
closes #1928

## Testing
- [x] Focused shell syntax checks
- [x] Focused YAML parse checks
- [x] `git diff --check`
- [ ] Full release quickstart / full test suite (not run locally; release CI only)
