### PR TITLE
ci: reuse caches for E2E and release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           echo "epoch=$(date +%s)" >>"$GITHUB_OUTPUT"
           echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >>"$GITHUB_ENV"
+          echo "PLAYWRIGHT_BROWSERS_PATH=${RUNNER_TEMP}/playwright-browsers" >>"$GITHUB_ENV"
 
       - name: Free runner disk space
         run: |
@@ -77,6 +78,15 @@ jobs:
           key: deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-${{ hashFiles('deno.lock') }}
           restore-keys: |
             deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-
+
+      - name: Restore Playwright browser cache
+        id: playwright-cache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/playwright-browsers
+          key: playwright-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('e2e/deno.json', 'deno.lock') }}
+          restore-keys: |
+            playwright-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -295,6 +305,14 @@ jobs:
           path: ${{ runner.temp }}/deno-cache
           key: ${{ steps.deno-cache-restore.outputs.cache-primary-key }}
 
+      - name: Save Playwright browser cache
+        id: playwright-cache-save
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/playwright-browsers
+          key: ${{ steps.playwright-cache-restore.outputs.cache-primary-key }}
+
       - name: Summarize CI cache and artifact state
         if: always()
         env:
@@ -309,6 +327,9 @@ jobs:
           DENO_CACHE_HIT: ${{ steps.deno-cache-restore.outputs.cache-hit }}
           DENO_CACHE_PRIMARY_KEY: ${{ steps.deno-cache-restore.outputs.cache-primary-key }}
           DENO_CACHE_MATCHED_KEY: ${{ steps.deno-cache-restore.outputs.cache-matched-key }}
+          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache-restore.outputs.cache-hit }}
+          PLAYWRIGHT_CACHE_PRIMARY_KEY: ${{ steps.playwright-cache-restore.outputs.cache-primary-key }}
+          PLAYWRIGHT_CACHE_MATCHED_KEY: ${{ steps.playwright-cache-restore.outputs.cache-matched-key }}
           DOCSITE_ARTIFACT_DIGEST: ${{ steps.upload-docsite.outputs.artifact-digest }}
           IMAGE_ARTIFACT_DIGEST: ${{ steps.upload-image.outputs.artifact-digest }}
           CLI_ARTIFACT_DIGEST: ${{ steps.upload-cli.outputs.artifact-digest }}
@@ -316,10 +337,16 @@ jobs:
           MANIFEST_ARTIFACT_DIGEST: ${{ steps.upload-manifest.outputs.artifact-digest }}
           WORKFLOW_START_EPOCH: ${{ steps.workflow-start.outputs.epoch }}
           DENO_DIR_PATH: ${{ runner.temp }}/deno-cache
+          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/playwright-browsers
         run: |
           deno_cache_fallback="false"
           if [[ -n "${DENO_CACHE_MATCHED_KEY}" && "${DENO_CACHE_MATCHED_KEY}" != "${DENO_CACHE_PRIMARY_KEY}" ]]; then
             deno_cache_fallback="true"
+          fi
+
+          playwright_cache_fallback="false"
+          if [[ -n "${PLAYWRIGHT_CACHE_MATCHED_KEY}" && "${PLAYWRIGHT_CACHE_MATCHED_KEY}" != "${PLAYWRIGHT_CACHE_PRIMARY_KEY}" ]]; then
+            playwright_cache_fallback="true"
           fi
 
           total_duration_seconds="n/a"
@@ -335,6 +362,11 @@ jobs:
           deno_cache_size_bytes="0"
           if [[ -d "${DENO_DIR_PATH}" ]]; then
             deno_cache_size_bytes="$(du -sk "${DENO_DIR_PATH}" | awk '{print $1 * 1024}')"
+          fi
+
+          playwright_cache_size_bytes="0"
+          if [[ -d "${PLAYWRIGHT_BROWSERS_PATH}" ]]; then
+            playwright_cache_size_bytes="$(du -sk "${PLAYWRIGHT_BROWSERS_PATH}" | awk '{print $1 * 1024}')"
           fi
 
           rust_target_size_bytes="0"
@@ -354,6 +386,8 @@ jobs:
             echo "- Rust cache fallback restore: \`n/a (rust-cache exposes exact-hit only)\`"
             echo "- Deno cache exact hit: \`${DENO_CACHE_HIT:-}\`"
             echo "- Deno cache fallback restore: \`${deno_cache_fallback}\`"
+            echo "- Playwright browser cache exact hit: \`${PLAYWRIGHT_CACHE_HIT:-}\`"
+            echo "- Playwright browser cache fallback restore: \`${playwright_cache_fallback}\`"
             echo "- Saving shared caches allowed: \`${CACHE_SAVE_ALLOWED}\`"
             echo "- Docker cache scope: \`${DOCKER_CACHE_SCOPE}\`"
             echo "- Docker cache export mode: \`${DOCKER_CACHE_MODE}\`"
@@ -408,6 +442,7 @@ jobs:
             echo
             echo "- target/rust: \`${rust_target_size_bytes}\` bytes"
             echo "- DENO_DIR: \`${deno_cache_size_bytes}\` bytes"
+            echo "- Playwright browsers: \`${playwright_cache_size_bytes}\` bytes"
             echo "- BuildKit cache: \`${buildx_cache_size_bytes}\`"
             echo "- target/artifacts: \`${artifact_size_bytes}\` bytes"
           } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -170,13 +170,37 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set Deno cache directory
+        run: echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >>"$GITHUB_ENV"
+
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install: true
           cache: true
 
+      - name: Resolve Deno version
+        id: deno-version
+        run: echo "version=$(deno --version | awk 'NR==1 { print $2 }')" >>"$GITHUB_OUTPUT"
+
+      - name: Restore Deno cache
+        id: deno-cache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/deno-cache
+          key: deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-
+
       - name: Install Rust CI components
         run: rustup component add rustfmt clippy
+
+      - name: Restore Rust cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b # v2.9.2
+        with:
+          workspaces: ". -> target/rust"
+          cache-bin: "false"
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build native CLI binary
         run: cargo build -p ugoite-cli --release --locked
@@ -205,6 +229,13 @@ jobs:
         with:
           subject-path: target/artifacts/cli/*.tar.gz
 
+      - name: Save Deno cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.runner != 'ubuntu-24.04'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/deno-cache
+          key: ${{ steps.deno-cache-restore.outputs.cache-primary-key }}
+
   build-npm-helm:
     needs:
       - prepare
@@ -221,10 +252,26 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set Deno cache directory
+        run: echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >>"$GITHUB_ENV"
+
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install: true
           cache: true
+
+      - name: Resolve Deno version
+        id: deno-version
+        run: echo "version=$(deno --version | awk 'NR==1 { print $2 }')" >>"$GITHUB_OUTPUT"
+
+      - name: Restore Deno cache
+        id: deno-cache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/deno-cache
+          key: deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -284,13 +331,37 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set Deno cache directory
+        run: echo "DENO_DIR=${RUNNER_TEMP}/deno-cache" >>"$GITHUB_ENV"
+
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install: true
           cache: true
 
+      - name: Resolve Deno version
+        id: deno-version
+        run: echo "version=$(deno --version | awk 'NR==1 { print $2 }')" >>"$GITHUB_OUTPUT"
+
+      - name: Restore Deno cache
+        id: deno-cache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/deno-cache
+          key: deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            deno-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.deno-version.outputs.version }}-
+
       - name: Install Rust build prerequisites
         run: rustup target add wasm32-unknown-unknown
+
+      - name: Restore Rust cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b # v2.9.2
+        with:
+          workspaces: ". -> target/rust"
+          cache-bin: "false"
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build release inputs
         run: |
@@ -315,6 +386,8 @@ jobs:
           provenance: true
           sbom: true
           push: true
+          cache-from: type=gha,scope=ugoite-runtime-release
+          cache-to: type=gha,scope=ugoite-runtime-release,mode=min
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ needs.prepare.outputs.release_sha }}
@@ -358,6 +431,13 @@ jobs:
         run: |
           digest="$(docker buildx imagetools inspect ghcr.io/${GITHUB_REPOSITORY}:${VERSION} --format '{{json .Manifest.Digest}}' | tr -d '\"')"
           echo "image_digest=${digest}" >>"$GITHUB_OUTPUT"
+
+      - name: Save Deno cache
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/deno-cache
+          key: ${{ steps.deno-cache-restore.outputs.cache-primary-key }}
 
   publish-release-assets:
     needs:

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -21,15 +21,16 @@ Root task composition:
 - `ci:merge`: `ci`, build/package/verify, a focused docsite-navigation E2E lane, and E2E smoke;
 - `ci:release`: `validate:release`, `ci:merge`, npm packaging/verification, and the full E2E suite.
 
-Hosted CI restores Rust, Deno, and BuildKit caches on every event. Shared project caches are refreshed only after successful pushes to `main`. Successful `main` runs also upload the verified artifact set using the logical names `ugoite-docsite-pages`, `ugoite-runtime-image`, `ugoite-cli-linux`, `ugoite-helm-chart`, and `ugoite-artifact-manifest`.
+Hosted CI restores Rust, Deno, Playwright browser, and BuildKit caches on every event. Shared project caches are refreshed only after successful pushes to `main`. Release build jobs use the same Rust/Deno dependency cache policy, with one Ubuntu release path writing the shared Deno key to avoid concurrent partial saves, and a separate release-image BuildKit scope. Successful `main` runs also upload the verified artifact set using the logical names `ugoite-docsite-pages`, `ugoite-runtime-image`, `ugoite-cli-linux`, `ugoite-helm-chart`, and `ugoite-artifact-manifest`.
 
 The hosted runtime image uses Dockerfile's `runtime-prebuilt` target. It copies the canonical frontend and Rust release outputs into the image instead of compiling them again inside Docker. E2E tasks require the already loaded `ugoite:e2e` image and never invoke an image build. The default Dockerfile target remains a portable source build for direct Docker and Compose use.
 
 The focused docsite-navigation lane is intentionally separate from smoke/full
 runtime E2E. It builds the docsite through the canonical `build:docsite`
-inputs, installs Playwright browsers explicitly for that lane, previews the
-static artifact, and verifies Starlight navigation semantics before the heavier
-runtime-backed smoke suite runs.
+inputs, restores the versioned Playwright browser cache, keeps the explicit
+browser-install step as a cache-miss fallback, previews the static artifact,
+and verifies Starlight navigation semantics before the heavier runtime-backed
+smoke suite runs.
 
 Deployable artifacts are staged below `target/artifacts/` with a machine-readable `manifest.json` and `SHA256SUMS`. The release workflow also emits installer-compatible CLI archives named `ugoite-v<version>-<target>.tar.gz` plus per-file checksums, publishes `@ugoite/ugoite` to GitHub Packages, publishes `ghcr.io/ugoite/ugoite:<version>`, and pushes the Helm chart to `oci://ghcr.io/ugoite/charts`.
 


### PR DESCRIPTION
## Summary

- Cache Playwright browser binaries for regular E2E gates with restore-only behavior on pull requests and merge groups.
- Restore Rust and Deno dependency caches in release build jobs and use a separate BuildKit cache scope for multi-arch release images.
- Keep existing build, test, packaging, provenance, publication commands, and artifact outputs unchanged; document the cache contract.

## Related Issue (required)

closes #1932
closes #1933

## Testing

- [x] `git diff --check`
- [x] `actionlint .github/workflows/ci.yml .github/workflows/release-publish.yml`
- [x] Ruby YAML parse for `.github/workflows/ci.yml` and `.github/workflows/release-publish.yml`
- [ ] Full `mise run test` (not run; the workflow-only change was validated with focused checks and full CI will run remotely)
