### PR TITLE
docs: synchronize roadmap and requirement status

### DIFF
--- a/docs/version/unknown/roadmap.yaml
+++ b/docs/version/unknown/roadmap.yaml
@@ -1,6 +1,6 @@
 id: roadmap
 version: "unknown"
-status: planned
+status: in_progress
 title: "Development Roadmap"
 goal: >
   Outline major milestones for Ugoite development from MVP through native app,
@@ -9,7 +9,7 @@ goal: >
   baseline.
 phases:
   - id: design
-    status: in_progress
+    status: completed
     tasks:
       - description: "Define milestone overview table covering milestones 1-7"
         done: true
@@ -27,7 +27,7 @@ phases:
       - description: "Milestone 3 Markdown as Table - Iceberg storage + SQL (v0.1)"
         done: true
       - description: "Milestone 4 User Management - auth/authz/collaboration (v0.1)"
-        done: false
+        done: true
       - description: "Milestone 5 User Controlled View - query-driven UI views (v0.2)"
         done: false
       - description: "Milestone 6 AI-Enabled & AI-Used - broader MCP resources/tools + vector search (v0.2)"

--- a/docsite/src/spec-integrity.test.ts
+++ b/docsite/src/spec-integrity.test.ts
@@ -16,6 +16,7 @@ describe("executable documentation sources", () => {
         await fs.readFile(path.join(requirementDir, filename), "utf8"),
       ) as { requirements?: Requirement[] };
       for (const requirement of source.requirements ?? []) {
+        assertRequirementStatusIntegrity(requirement);
         expect(
           ids.has(requirement.id),
           `duplicate requirement ${requirement.id}`,
@@ -43,6 +44,57 @@ describe("executable documentation sources", () => {
       }
     }
     expect(ids.size).toBeGreaterThan(40);
+  });
+
+  test("REQ-OPS-004: version statuses agree with their tasks and canonical sources", async () => {
+    const versionRoot = path.join(repoRoot, "docs/version");
+
+    for (const filename of await yamlFilesRecursively(versionRoot)) {
+      const filePath = path.join(versionRoot, filename);
+      const document = parse(
+        await fs.readFile(filePath, "utf8"),
+      ) as VersionDocument;
+
+      // Changelog entries are historical records, not status-bearing plans.
+      if (document.status === undefined) continue;
+
+      assertVersionStatus(document.status, filename);
+      const phaseStatuses = [] as VersionStatus[];
+      for (const phase of document.phases ?? []) {
+        assertVersionStatus(phase.status, `${filename}:${phase.id}`);
+        phaseStatuses.push(phase.status);
+        expect(
+          Array.isArray(phase.tasks),
+          `${filename}:${phase.id}: status must be supported by tasks`,
+        ).toBe(true);
+        const tasks = phase.tasks ?? [];
+        for (const [index, task] of tasks.entries()) {
+          expect(
+            typeof task.done,
+            `${filename}:${phase.id}: task ${index} must declare done`,
+          ).toBe("boolean");
+        }
+        expect(phase.status, `${filename}:${phase.id}: stale status`).toBe(
+          statusFromTasks(tasks),
+        );
+      }
+
+      const milestoneStatuses = [] as VersionStatus[];
+      for (const milestone of document.milestones ?? []) {
+        assertVersionStatus(milestone.status, `${filename}:${milestone.id}`);
+        milestoneStatuses.push(milestone.status);
+        await assertMilestoneSourceIntegrity(milestone, filename);
+      }
+
+      const childStatuses = document.milestones
+        ? milestoneStatuses
+        : phaseStatuses;
+      expect(childStatuses, `${filename}: status has no children`).not
+        .toHaveLength(0);
+      expect(document.status, `${filename}: stale top-level status`).toBe(
+        statusFromStatuses(childStatuses),
+      );
+    }
   });
 
   test("REQ-API-004: feature registry files and implementation paths resolve", async () => {
@@ -74,14 +126,148 @@ describe("executable documentation sources", () => {
 
 type Requirement = {
   id: string;
+  status: string;
+  verification: string;
   related_spec?: string[];
-  tests?: Array<{ file: string }>;
+  tests?: Array<{ file: string; cases?: string[] }>;
 };
+
+type VersionStatus = "planned" | "in_progress" | "completed";
+
+type VersionTask = { done?: boolean };
+
+type VersionPhase = {
+  id: string;
+  status: VersionStatus;
+  tasks?: VersionTask[];
+};
+
+type VersionMilestone = {
+  id: string;
+  status: VersionStatus;
+  source: string[];
+  phases: Array<{ id: string; status: VersionStatus }>;
+};
+
+type VersionDocument = {
+  status?: string;
+  phases?: VersionPhase[];
+  milestones?: VersionMilestone[];
+};
+
+const requirementStatuses = new Set(["implemented", "planned", "superseded"]);
+const verificationStatuses = new Set(["traced", "untraced"]);
+const versionStatuses = new Set<VersionStatus>([
+  "planned",
+  "in_progress",
+  "completed",
+]);
+
+function assertRequirementStatusIntegrity(requirement: Requirement): void {
+  expect(
+    requirementStatuses.has(requirement.status),
+    `${requirement.id}: invalid requirement status`,
+  ).toBe(true);
+  expect(
+    verificationStatuses.has(requirement.verification),
+    `${requirement.id}: invalid verification status`,
+  ).toBe(true);
+
+  const tests = requirement.tests ?? [];
+  if (requirement.verification === "traced") {
+    expect(
+      tests,
+      `${requirement.id}: traced requirements need test references`,
+    ).not.toHaveLength(0);
+  } else {
+    expect(
+      tests,
+      `${requirement.id}: untraced requirements cannot claim test references`,
+    ).toHaveLength(0);
+  }
+}
+
+function assertVersionStatus(
+  status: string,
+  owner: string,
+): asserts status is VersionStatus {
+  expect(
+    versionStatuses.has(status as VersionStatus),
+    `${owner}: invalid version status`,
+  ).toBe(
+    true,
+  );
+}
+
+function statusFromTasks(tasks: VersionTask[]): VersionStatus {
+  return statusFromStatuses(
+    tasks.map((task) => (task.done === true ? "completed" : "planned")),
+  );
+}
+
+function statusFromStatuses(statuses: VersionStatus[]): VersionStatus {
+  if (statuses.every((status) => status === "completed")) return "completed";
+  if (statuses.every((status) => status === "planned")) return "planned";
+  return "in_progress";
+}
+
+async function assertMilestoneSourceIntegrity(
+  milestone: VersionMilestone,
+  owner: string,
+): Promise<void> {
+  expect(milestone.source, `${owner}:${milestone.id}: missing source`).not
+    .toHaveLength(0);
+  for (const source of milestone.source) {
+    await expectPath(
+      path.resolve(repoRoot, source),
+      `${owner}:${milestone.id}`,
+    );
+  }
+
+  const yamlSource = milestone.source.find((source) =>
+    source.endsWith(".yaml")
+  );
+  expect(yamlSource, `${owner}:${milestone.id}: missing canonical YAML source`)
+    .toBeDefined();
+  const canonical = parse(
+    await fs.readFile(path.resolve(repoRoot, yamlSource as string), "utf8"),
+  ) as VersionDocument;
+  expect(milestone.status, `${owner}:${milestone.id}: stale milestone status`)
+    .toBe(
+      canonical.status,
+    );
+  expect(
+    milestone.phases.map(({ id, status }) => ({ id, status })),
+    `${owner}:${milestone.id}: stale phase status summary`,
+  ).toEqual(canonical.phases?.map(({ id, status }) => ({ id, status })));
+}
 
 async function yamlFiles(directory: string): Promise<string[]> {
   return (await fs.readdir(directory))
     .filter((filename) => filename.endsWith(".yaml"))
     .sort();
+}
+
+async function yamlFilesRecursively(
+  directory: string,
+  prefix = "",
+): Promise<string[]> {
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relativePath = path.join(prefix, entry.name);
+    if (entry.isDirectory()) {
+      files.push(
+        ...await yamlFilesRecursively(
+          path.join(directory, entry.name),
+          relativePath,
+        ),
+      );
+    } else if (entry.name.endsWith(".yaml")) {
+      files.push(relativePath);
+    }
+  }
+  return files.sort();
 }
 
 async function expectPath(filePath: string, owner: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Synchronize the unknown roadmap with completed design and User Management milestones.
- Extend executable spec-integrity checks to validate requirement verification status, version task/phase/document status derivation, and canonical milestone summaries.

## Related Issue (required)

closes #1946

## Testing

- [x] `mise exec -- deno task --cwd docsite test src/spec-integrity.test.ts`
- [ ] `mise run test`
