### PR TITLE
feat(release): publish channel-scoped release notes

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -897,3 +897,50 @@ jobs:
             echo "CLI quick start: ${CLI_OUTCOME}"
             exit 1
           fi
+
+  publish-channel-release-notes:
+    needs:
+      - prepare
+      - publish-release-assets
+      - verify-published-quickstarts
+    if: >-
+      ${{
+        needs.prepare.outputs.release_tag != '' &&
+        needs.publish-release-assets.result == 'success' &&
+        needs.verify-published-quickstarts.result == 'success'
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.release_sha }}
+          persist-credentials: false
+
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install: true
+          cache: false
+
+      - name: Publish repository-owned channel release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_CHANNEL: ${{ needs.prepare.outputs.channel }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          body_file="$(mktemp)"
+          notes_file="$(mktemp)"
+          cleanup() {
+            rm -f "${body_file}" "${notes_file}"
+          }
+          trap cleanup EXIT
+          gh release view "${RELEASE_TAG}" --json body --jq .body >"${body_file}"
+          deno run -A tools/release-notes.ts compose \
+            --channel "${RELEASE_CHANNEL}" \
+            --version "${RELEASE_VERSION}" \
+            --body-file "${body_file}" \
+            --output "${notes_file}"
+          gh release edit "${RELEASE_TAG}" --notes-file "${notes_file}"

--- a/deno.lock
+++ b/deno.lock
@@ -9295,7 +9295,8 @@
       },
       "tools": {
         "dependencies": [
-          "jsr:@std/assert@1"
+          "jsr:@std/assert@1",
+          "npm:yaml@2.9.0"
         ]
       }
     }

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -403,13 +403,16 @@ requirements:
   linked_specifications: *id002
   id: REQ-OPS-026
   title: Channel-Scoped Changelog Sources
-  description: Stable, beta, and alpha changelog sources must remain separate and must not imply unpublished artifacts exist.
+  description: Stable, beta, and alpha changelog sources must remain separate, must not imply unpublished artifacts exist, and must be rendered into the matching GitHub Release body after artifact and quick-start verification. Reruns replace one marked repository-owned section without duplicating generated notes.
   related_spec:
   - testing/ci-cd.md
   - ../../guide/operate/server/operations.md
   priority: medium
   status: implemented
-  verification: untraced
+  verification: traced
+  tests:
+  - file: tools/release-notes_test.ts
+  - file: .github/workflows/release-publish.yml
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/docs/spec/testing/ci-cd.md
+++ b/docs/spec/testing/ci-cd.md
@@ -27,6 +27,8 @@ The hosted runtime image uses Dockerfile's `runtime-prebuilt` target. It copies 
 
 After publication, `Release Publish` runs both release quick-start verifiers against the exact prepared version and source SHA. The release also uploads `docker-compose.release.yaml`, its checksum, and a manifest containing the prepared source SHA and published image digest. The container verifier checks that manifest, downloads that published Compose definition, pulls the versioned GHCR image, and starts it with `--no-build`; it does not build or load another image for verification. The CLI verifier uses the published checksum-verified installer and retains the local Space create/list assertions.
 
+Only after the artifact and quick-start gates succeed, `Release Publish` renders `docs/version/changelog/<channel>.yaml` into the GitHub Release body. The repository-owned section uses a versioned start/end marker so reruns replace the channel section and preserve GitHub's generated commit summary without duplication. Invalid, mismatched, or incomplete channel sources fail before the release body is changed.
+
 The focused docsite-navigation lane is intentionally separate from smoke/full
 runtime E2E. It builds the docsite through the canonical `build:docsite`
 inputs, restores the versioned Playwright browser cache, keeps the explicit

--- a/docs/spec/versions/changelog-alpha.md
+++ b/docs/spec/versions/changelog-alpha.md
@@ -2,6 +2,6 @@
 title: 'Alpha changelog'
 ---
 
-No alpha artifact publication is established by this repository snapshot. Alpha notes may describe validated preview behavior, but must keep unpublished artifacts and planned browser-local/auth/service-account/audit features clearly labeled.
+Alpha releases use the versioned GitHub Release assets, the alpha GHCR/npm aliases, the Helm chart, and the checksum-verified CLI/Compose assets. After those artifacts and their quick starts pass verification, `Release Publish` renders the repository-managed alpha source into the GitHub Release body. Alpha guidance remains explicit about preview risk and planned capability.
 
 Machine-readable source: [`../../version/changelog/alpha.yaml`](https://github.com/ugoite/ugoite/blob/main/docs/version/changelog/alpha.yaml).

--- a/docs/spec/versions/changelog-beta.md
+++ b/docs/spec/versions/changelog-beta.md
@@ -2,6 +2,6 @@
 title: 'Beta changelog'
 ---
 
-No beta artifact publication is established by this repository snapshot. A beta should validate the single image, CLI archives/installer verification, persistent Space compatibility, authentication/authorization, browser flows, and upgrade/rollback instructions.
+Beta releases use the versioned GitHub Release assets, the beta GHCR/npm aliases, the Helm chart, and the checksum-verified CLI/Compose assets. After those artifacts and their quick starts pass verification, `Release Publish` renders the repository-managed beta source into the GitHub Release body. Beta guidance remains separate from stable and alpha narratives.
 
 Machine-readable source: [`../../version/changelog/beta.yaml`](https://github.com/ugoite/ugoite/blob/main/docs/version/changelog/beta.yaml).

--- a/docs/spec/versions/changelog-stable.md
+++ b/docs/spec/versions/changelog-stable.md
@@ -2,6 +2,6 @@
 title: 'Stable changelog'
 ---
 
-Stable release publication uses the versioned GitHub Release assets, `ghcr.io/ugoite/ugoite:<version>`, `oci://ghcr.io/ugoite/charts/ugoite:<version>`, and the GitHub Packages installer `@ugoite/ugoite@<version>`. Stable releases may additionally refresh the `stable` and `latest` aliases after the exact version has been published.
+Stable release publication uses the versioned GitHub Release assets, `ghcr.io/ugoite/ugoite:<version>`, `oci://ghcr.io/ugoite/charts/ugoite:<version>`, and the GitHub Packages installer `@ugoite/ugoite@<version>`. Stable releases may additionally refresh the `stable` and `latest` aliases after the exact version has been published. The repository-managed stable source is rendered into the GitHub Release body after those artifacts and their quick starts pass verification.
 
 Machine-readable source: [`../../version/changelog/stable.yaml`](https://github.com/ugoite/ugoite/blob/main/docs/version/changelog/stable.yaml).

--- a/docs/spec/versions/changelog.md
+++ b/docs/spec/versions/changelog.md
@@ -2,7 +2,7 @@
 title: 'Changelog channels'
 ---
 
-The repository keeps separate stable, beta, and alpha source files. Release publication is orchestrated by `.github/workflows/release-publish.yml`: stable releases may refresh `latest`/`stable`, while prereleases refresh only their matching `alpha` or `beta` alias.
+The repository keeps separate stable, beta, and alpha source files. Release publication is orchestrated by `.github/workflows/release-publish.yml`: stable releases may refresh `latest`/`stable`, while prereleases refresh only their matching `alpha` or `beta` alias. After artifact publication and quick-start verification, the matching source is rendered into a marked section of the GitHub Release body; reruns replace that section without duplicating the generated notes.
 
 - [Stable](changelog-stable.md)
 - [Beta](changelog-beta.md)

--- a/docs/version/changelog/alpha.yaml
+++ b/docs/version/changelog/alpha.yaml
@@ -22,6 +22,6 @@ release_notes:
   - Documentation now distinguishes shipped behavior from browser-local sync and other planned capability.
   - Release notes no longer imply that unpublished artifacts or split frontend/backend images exist.
   planned:
-  - Published signed/checksummed container and CLI artifacts.
+  - A completed operator-supported release with its published artifacts and verified quick starts.
   - Production passkey/TOTP login, managed service accounts, audit APIs, and browser-local optional sync.
 updated: '2026-06-23'

--- a/docs/version/changelog/beta.yaml
+++ b/docs/version/changelog/beta.yaml
@@ -22,6 +22,6 @@ release_notes:
   - Documentation now distinguishes shipped behavior from browser-local sync and other planned capability.
   - Release notes no longer imply that unpublished artifacts or split frontend/backend images exist.
   planned:
-  - Published signed/checksummed container and CLI artifacts.
+  - A completed operator-supported release with its published artifacts and verified quick starts.
   - Production passkey/TOTP login, managed service accounts, audit APIs, and browser-local optional sync.
 updated: '2026-06-23'

--- a/docs/version/changelog/stable.yaml
+++ b/docs/version/changelog/stable.yaml
@@ -22,6 +22,6 @@ release_notes:
   - Documentation now distinguishes shipped behavior from browser-local sync and other planned capability.
   - Release notes no longer imply that unpublished artifacts or split frontend/backend images exist.
   planned:
-  - Published signed/checksummed container and CLI artifacts.
+  - A completed operator-supported release with its published artifacts and verified quick starts.
   - Production passkey/TOTP login, managed service accounts, audit APIs, and browser-local optional sync.
 updated: '2026-06-23'

--- a/docs/version/v0.1.yaml
+++ b/docs/version/v0.1.yaml
@@ -59,4 +59,4 @@ milestones:
   - id: operator-documentation
     status: in_progress
   - id: release-communication
-    status: planned
+    status: in_progress

--- a/docs/version/v0.1/release-preparation.yaml
+++ b/docs/version/v0.1/release-preparation.yaml
@@ -25,7 +25,9 @@ phases:
   - description: Validate a published release through both quick starts.
     done: false
 - id: release-communication
-  status: planned
+  status: in_progress
   tasks:
-  - description: Publish channel-specific stable, beta, and alpha release notes only when artifacts exist.
+  - description: Provide channel-specific stable, beta, and alpha release-note publication only after artifact and quick-start verification.
+    done: true
+  - description: Complete a release with published channel-specific notes.
     done: false

--- a/tools/deno.json
+++ b/tools/deno.json
@@ -6,6 +6,7 @@
     "create-pr": "deno run -A create_pr.ts"
   },
   "imports": {
-    "@std/assert/equals": "jsr:@std/assert@1/equals"
+    "@std/assert/equals": "jsr:@std/assert@1/equals",
+    "yaml": "npm:yaml@2.9.0"
   }
 }

--- a/tools/release-notes.ts
+++ b/tools/release-notes.ts
@@ -1,0 +1,290 @@
+import { parse } from "yaml";
+import { join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type ReleaseChannel = "stable" | "beta" | "alpha";
+
+export type ReleaseNotesOptions = {
+  channel: ReleaseChannel;
+  version: string;
+  repoRoot?: string;
+  sourcePath?: string;
+};
+
+export type ComposeReleaseNotesOptions = ReleaseNotesOptions & {
+  existingBody: string;
+  channelNotes?: string;
+};
+
+const RELEASE_VERSION = /^\d+\.\d+\.\d+(?:-(alpha|beta)\.\d+)?$/;
+const CHANNELS = ["stable", "beta", "alpha"] as const;
+const CHANNEL_NOTES_START = "<!-- UGOITE-CHANNEL-NOTES:v1:start";
+const CHANNEL_NOTES_END = "<!-- UGOITE-CHANNEL-NOTES:v1:end -->";
+const REPO_ROOT = fileURLToPath(new URL("../", import.meta.url));
+
+if (import.meta.main) {
+  await main(Deno.args);
+}
+
+export function channelForVersion(version: string): ReleaseChannel {
+  const match = RELEASE_VERSION.exec(version);
+  if (!match) {
+    throw new Error(`release version must be valid SemVer, got ${version}`);
+  }
+  return (match[1] ?? "stable") as ReleaseChannel;
+}
+
+export async function renderReleaseNotes(
+  options: ReleaseNotesOptions,
+): Promise<string> {
+  assertChannelMatchesVersion(options.channel, options.version);
+  const repoRoot = resolve(options.repoRoot ?? REPO_ROOT);
+  const sourcePath = resolve(
+    options.sourcePath ??
+      join(repoRoot, "docs/version/changelog", `${options.channel}.yaml`),
+  );
+  const source = await readFile(sourcePath, "channel changelog source");
+  const document = parseChannelDocument(source, sourcePath);
+  const context = relative(repoRoot, sourcePath) || sourcePath;
+  const configuredChannel = requiredString(document, "channel", context);
+  if (configuredChannel !== options.channel) {
+    throw new Error(
+      `${context} channel must be ${options.channel}, got ${configuredChannel}`,
+    );
+  }
+
+  const title = requiredString(document, "title", context);
+  const docPath = requiredString(document, "doc_path", context);
+  const fullDocPath = resolve(repoRoot, docPath);
+  if (relative(repoRoot, fullDocPath).startsWith("..")) {
+    throw new Error(`${context} doc_path escapes the repository: ${docPath}`);
+  }
+  await readFile(fullDocPath, "human-readable changelog document");
+  const summary = requiredString(document, "summary", context);
+  const releaseNotes = requiredMapping(document, "release_notes", context);
+  const releaseNotesContext = `${context}.release_notes`;
+  const intro = requiredString(releaseNotes, "intro", releaseNotesContext);
+  const expectations = requiredStringList(
+    releaseNotes,
+    "expectations",
+    releaseNotesContext,
+  );
+  const added = requiredStringList(releaseNotes, "added", releaseNotesContext);
+  const changed = requiredStringList(
+    releaseNotes,
+    "changed",
+    releaseNotesContext,
+  );
+  const planned = requiredStringList(
+    releaseNotes,
+    "planned",
+    releaseNotesContext,
+  );
+
+  return [
+    `# v${options.version} ${title}`,
+    `Rendered from \`docs/version/changelog/${options.channel}.yaml\` for the \`${options.channel}\` release channel. Human-readable changelog: \`${docPath}\`.`,
+    summary,
+    `## Channel guidance\n\n${intro}`,
+    renderSection("Expectations", expectations),
+    renderSection("Added", added),
+    renderSection("Changed", changed),
+    renderSection("Planned", planned),
+  ].join("\n\n");
+}
+
+export function composeReleaseNotes(
+  options: ComposeReleaseNotesOptions,
+): string {
+  assertChannelMatchesVersion(options.channel, options.version);
+  const channelNotes = options.channelNotes?.trim();
+  if (!channelNotes) {
+    throw new Error("channel notes must be non-empty");
+  }
+
+  const start =
+    `${CHANNEL_NOTES_START} channel=${options.channel} version=${options.version} -->`;
+  const existingBody = options.existingBody.trim();
+  const startIndex = existingBody.indexOf(CHANNEL_NOTES_START);
+  const endIndex = existingBody.indexOf(CHANNEL_NOTES_END);
+  if (startIndex === -1 && endIndex === -1) {
+    return `${start}\n${channelNotes}\n${CHANNEL_NOTES_END}${
+      existingBody ? `\n\n${existingBody}` : ""
+    }\n`;
+  }
+  if (startIndex === -1 || endIndex === -1) {
+    throw new Error("release body contains an incomplete channel-notes marker");
+  }
+  if (
+    startIndex !== existingBody.lastIndexOf(CHANNEL_NOTES_START) ||
+    endIndex !== existingBody.lastIndexOf(CHANNEL_NOTES_END) ||
+    endIndex < startIndex
+  ) {
+    throw new Error(
+      "release body contains multiple or out-of-order channel-notes markers",
+    );
+  }
+  const existingStart = existingBody.slice(
+    startIndex,
+    existingBody.indexOf("-->", startIndex) + 3,
+  );
+  if (existingStart !== start) {
+    throw new Error(
+      "release body channel-notes marker does not match the release channel or version",
+    );
+  }
+  const endAfterMarker = endIndex + CHANNEL_NOTES_END.length;
+  const replacement = `${start}\n${channelNotes}\n${CHANNEL_NOTES_END}`;
+  return `${existingBody.slice(0, startIndex)}${replacement}${
+    existingBody.slice(endAfterMarker)
+  }\n`;
+}
+
+async function main(args: string[]): Promise<void> {
+  const command = args[0];
+  const flags = parseFlags(args.slice(1));
+  const channel = requireFlag(flags, "channel") as ReleaseChannel;
+  if (!CHANNELS.includes(channel)) {
+    throw new Error(
+      `channel must be one of ${CHANNELS.join(", ")}, got ${channel}`,
+    );
+  }
+  const version = requireFlag(flags, "version");
+
+  if (command === "render") {
+    const rendered = await renderReleaseNotes({ channel, version });
+    await writeResult(rendered, flags.output);
+    return;
+  }
+  if (command === "compose") {
+    const bodyPath = requireFlag(flags, "body-file");
+    const body = await Deno.readTextFile(bodyPath);
+    const channelNotes = await renderReleaseNotes({ channel, version });
+    const composed = composeReleaseNotes({
+      channel,
+      version,
+      existingBody: body,
+      channelNotes,
+    });
+    await writeResult(composed, flags.output);
+    return;
+  }
+  throw new Error(
+    "usage: release-notes.ts <render|compose> --channel <channel> --version <version> [--body-file <path>] [--output <path>]",
+  );
+}
+
+function parseFlags(args: string[]): Record<string, string> {
+  const flags: Record<string, string> = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("--")) {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    const value = args[++index];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`flag --${key} requires a value`);
+    }
+    flags[key] = value;
+  }
+  return flags;
+}
+
+function requireFlag(flags: Record<string, string>, key: string): string {
+  const value = flags[key]?.trim();
+  if (!value) {
+    throw new Error(`missing required flag --${key}`);
+  }
+  return value;
+}
+
+function assertChannelMatchesVersion(
+  channel: ReleaseChannel,
+  version: string,
+): void {
+  const derived = channelForVersion(version);
+  if (derived !== channel) {
+    throw new Error(
+      `channel ${channel} does not match release version ${version}; expected ${derived}`,
+    );
+  }
+}
+
+function parseChannelDocument(
+  source: string,
+  sourcePath: string,
+): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = parse(source);
+  } catch (error) {
+    throw new Error(`unable to parse ${sourcePath}: ${error}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${sourcePath} must be a YAML mapping`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function requiredMapping(
+  mapping: Record<string, unknown>,
+  key: string,
+  context: string,
+): Record<string, unknown> {
+  const value = mapping[key];
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${context}.${key} must be a mapping`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requiredString(
+  mapping: Record<string, unknown>,
+  key: string,
+  context: string,
+): string {
+  const value = mapping[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${context}.${key} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function requiredStringList(
+  mapping: Record<string, unknown>,
+  key: string,
+  context: string,
+): string[] {
+  const value = mapping[key];
+  if (
+    !Array.isArray(value) || value.length === 0 ||
+    value.some((item) => typeof item !== "string" || !item.trim())
+  ) {
+    throw new Error(`${context}.${key} must be a non-empty list of strings`);
+  }
+  return value.map((item) => (item as string).trim());
+}
+
+function renderSection(title: string, items: string[]): string {
+  return `## ${title}\n\n${items.map((item) => `- ${item}`).join("\n")}`;
+}
+
+async function readFile(path: string, label: string): Promise<string> {
+  try {
+    return await Deno.readTextFile(path);
+  } catch {
+    throw new Error(`${label} was not found at ${path}`);
+  }
+}
+
+async function writeResult(
+  content: string,
+  outputPath: string | undefined,
+): Promise<void> {
+  if (outputPath) {
+    await Deno.writeTextFile(outputPath, `${content.trim()}\n`);
+    return;
+  }
+  console.log(content.trim());
+}

--- a/tools/release-notes_test.ts
+++ b/tools/release-notes_test.ts
@@ -1,0 +1,191 @@
+import { assertEquals } from "@std/assert/equals";
+import {
+  channelForVersion,
+  composeReleaseNotes,
+  renderReleaseNotes,
+} from "./release-notes.ts";
+
+Deno.test("REQ-OPS-026: release versions select the matching note channel", () => {
+  assertEquals(channelForVersion("0.1.0"), "stable");
+  assertEquals(channelForVersion("0.1.0-beta.2"), "beta");
+  assertEquals(channelForVersion("0.1.0-alpha.7"), "alpha");
+});
+
+Deno.test("REQ-OPS-026: all channel sources render versioned release notes", async () => {
+  for (
+    const [channel, version] of [
+      ["stable", "0.1.0"],
+      ["beta", "0.1.0-beta.2"],
+      ["alpha", "0.1.0-alpha.7"],
+    ] as const
+  ) {
+    const rendered = await renderReleaseNotes({ channel, version });
+    assertEquals(rendered.includes(`# v${version}`), true);
+    assertEquals(
+      rendered.includes(`docs/version/changelog/${channel}.yaml`),
+      true,
+    );
+    assertEquals(rendered.includes("## Expectations"), true);
+    assertEquals(rendered.includes("## Planned"), true);
+  }
+});
+
+Deno.test("REQ-OPS-026: invalid channel sources fail before composition", async () => {
+  const repoRoot = await Deno.makeTempDir({ prefix: "ugoite-release-notes-" });
+  const sourcePath = `${repoRoot}/docs/version/changelog/stable.yaml`;
+  const docPath = `${repoRoot}/docs/spec/versions/changelog-stable.md`;
+  await Deno.mkdir(`${repoRoot}/docs/version/changelog`, { recursive: true });
+  await Deno.mkdir(`${repoRoot}/docs/spec/versions`, { recursive: true });
+  await Deno.writeTextFile(docPath, "---\ntitle: Stable\n---\n");
+  await Deno.writeTextFile(
+    sourcePath,
+    [
+      "channel: beta",
+      "title: Stable",
+      "doc_path: docs/spec/versions/changelog-stable.md",
+      "summary: Summary",
+      "release_notes:",
+      "  intro: Intro",
+      "  expectations:",
+      "  - Expectation",
+      "  added:",
+      "  - Added",
+      "  changed:",
+      "  - Changed",
+      "  planned:",
+      "  - Planned",
+      "",
+    ].join("\n"),
+  );
+
+  await assertFails(
+    () =>
+      renderReleaseNotes({
+        channel: "stable",
+        version: "0.1.0",
+        repoRoot,
+        sourcePath,
+      }),
+    "channel must be stable",
+  );
+  await assertFails(
+    () =>
+      renderReleaseNotes({
+        channel: "beta",
+        version: "0.1.0",
+        repoRoot,
+        sourcePath,
+      }),
+    "channel beta does not match release version",
+  );
+  await Deno.writeTextFile(
+    sourcePath,
+    [
+      "channel: stable",
+      "title: Stable",
+      "doc_path: docs/spec/versions/changelog-stable.md",
+      "summary: Summary",
+      "release_notes:",
+      "  intro: Intro",
+      "  expectations:",
+      "  - Expectation",
+      "  added:",
+      "  - Added",
+      "  changed:",
+      "  - Changed",
+      "",
+    ].join("\n"),
+  );
+  await assertFails(
+    () =>
+      renderReleaseNotes({
+        channel: "stable",
+        version: "0.1.0",
+        repoRoot,
+        sourcePath,
+      }),
+    "planned must be a non-empty list",
+  );
+});
+
+Deno.test("REQ-OPS-026: marked channel notes replace once and preserve generated notes", () => {
+  const existingBody = "## Generated changes\n\n- Keep this summary";
+  const channelNotes =
+    "# v0.1.0 Stable Channel Changelog\n\n## Added\n\n- One change";
+  const first = composeReleaseNotes({
+    channel: "stable",
+    version: "0.1.0",
+    existingBody,
+    channelNotes,
+  });
+  assertEquals(first.includes(existingBody), true);
+  assertEquals((first.match(/UGOITE-CHANNEL-NOTES:v1:start/g) ?? []).length, 1);
+  assertEquals((first.match(/UGOITE-CHANNEL-NOTES:v1:end/g) ?? []).length, 1);
+
+  const rerun = composeReleaseNotes({
+    channel: "stable",
+    version: "0.1.0",
+    existingBody: first,
+    channelNotes,
+  });
+  assertEquals(rerun, first);
+
+  assertFailsSync(
+    () =>
+      composeReleaseNotes({
+        channel: "stable",
+        version: "0.1.0",
+        existingBody: "<!-- UGOITE-CHANNEL-NOTES:v1:start -->",
+        channelNotes: "# notes",
+      }),
+    "incomplete channel-notes marker",
+  );
+  assertFailsSync(
+    () =>
+      composeReleaseNotes({
+        channel: "stable",
+        version: "0.1.0",
+        existingBody:
+          "<!-- UGOITE-CHANNEL-NOTES:v1:start channel=beta version=0.1.0-beta.1 -->\nold\n<!-- UGOITE-CHANNEL-NOTES:v1:end -->",
+        channelNotes: "# notes",
+      }),
+    "does not match the release channel or version",
+  );
+});
+
+Deno.test("REQ-OPS-026: workflow updates notes after artifact quick-start verification", async () => {
+  const workflow = await Deno.readTextFile(
+    ".github/workflows/release-publish.yml",
+  );
+  const quickstartIndex = workflow.indexOf("verify-published-quickstarts:");
+  const notesJobIndex = workflow.indexOf("publish-channel-release-notes:");
+  assertEquals(notesJobIndex > quickstartIndex, true);
+  assertEquals(workflow.includes("tools/release-notes.ts compose"), true);
+  assertEquals(
+    workflow.includes('gh release edit "${RELEASE_TAG}" --notes-file'),
+    true,
+  );
+});
+
+async function assertFails(
+  operation: () => Promise<unknown>,
+  message: string,
+): Promise<void> {
+  try {
+    await operation();
+  } catch (error) {
+    assertEquals(String(error).includes(message), true);
+    return;
+  }
+  throw new Error(`expected operation to fail with ${message}`);
+}
+
+function assertFailsSync(operation: () => unknown, message: string): void {
+  try {
+    operation();
+  } catch (error) {
+    assertEquals(String(error).includes(message), true);
+    return;
+  }
+  throw new Error(`expected operation to fail with ${message}`);
+}


### PR DESCRIPTION
## Summary

- Render the repository-owned stable, beta, or alpha changelog source with the trusted release version.
- Publish one versioned channel-notes section to the GitHub Release body after artifact publication and quick-start verification, with safe rerun replacement.
- Add focused release-note coverage and align the release documentation, requirement traceability, and v0.1 trackers.

## Related Issue (required)

closes #1945

## Testing

- [x] `deno test --config tools/deno.json --lock=deno.lock --frozen -A tools/release-notes_test.ts`
- [x] `deno task --cwd docsite test --run src/spec-integrity.test.ts`
- [x] `mise run fmt:check`
- [x] `mise run validate:release`
- [x] Codex review with `gpt-5.6-luna` / `xhigh`: `PASS`
- [ ] `mise run test` (not run; focused validation only)
