### PR TITLE
ci: shorten required CI critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,6 @@ jobs:
             echo "docker_cache_to=${docker_cache_to}"
           } >>"$GITHUB_OUTPUT"
 
-      - name: Prepare artifact staging
-        run: rm -rf target/artifacts && mkdir -p target/artifacts
-
       - name: Formatting check
         id: fmt-check
         run: scripts/measure-step.sh fmt-check mise run fmt:check
@@ -143,64 +140,36 @@ jobs:
         id: check
         run: scripts/measure-step.sh check mise run check
 
-      - name: Build WASM release
-        id: build-wasm
-        run: scripts/measure-step.sh build-wasm mise run build:wasm:release
+      - name: Install Playwright browser dependencies
+        id: install-playwright
+        run: scripts/measure-step.sh install-playwright deno task e2e:install:browsers
 
-      - name: Build frontend
-        id: build-frontend
-        run: scripts/measure-step.sh build-frontend mise run build:frontend
-
-      - name: Build docsite
-        id: build-docsite
+      - name: Build release outputs
+        id: build
         env:
           DOCSITE_ORIGIN: ${{ steps.ci-config.outputs.docsite_origin }}
           DOCSITE_BASE: ${{ steps.ci-config.outputs.docsite_base }}
-        run: scripts/measure-step.sh build-docsite mise run build:docsite
-
-      - name: Build Rust release binaries
-        id: build-rust
-        run: scripts/measure-step.sh build-rust mise run build:rust:release
-
-      - name: Build runtime image
-        id: build-image
-        env:
           UGOITE_IMAGE_PREBUILT: "true"
           UGOITE_IMAGE_USE_BUILDX: "true"
           UGOITE_IMAGE_CACHE_FROM: ${{ steps.ci-config.outputs.docker_cache_from }}
           UGOITE_IMAGE_CACHE_TO: ${{ steps.ci-config.outputs.docker_cache_to }}
-        run: scripts/measure-step.sh build-image mise run build:image
+        run: scripts/measure-step.sh build mise run build
 
-      - name: Package docsite artifact
-        id: package-docsite
+      - name: Package artifacts
+        id: package
         env:
           DOCSITE_ORIGIN: ${{ steps.ci-config.outputs.docsite_origin }}
           DOCSITE_BASE: ${{ steps.ci-config.outputs.docsite_base }}
-        run: scripts/measure-step.sh package-docsite mise run package:docsite
+          UGOITE_CI_RUN_ID: ${{ github.run_id }}
+        run: scripts/measure-step.sh package mise run package
 
-      - name: Package CLI artifact
-        id: package-cli
-        run: scripts/measure-step.sh package-cli mise run package:cli
+      - name: Verify artifacts
+        id: verify
+        run: scripts/measure-step.sh verify mise run verify
 
-      - name: Package Helm artifact
-        id: package-helm
-        run: scripts/measure-step.sh package-helm mise run package:helm
-
-      - name: Rust tests
-        id: test-rust
-        run: scripts/measure-step.sh test-rust mise run test:rust
-
-      - name: Tool tests
-        id: test-tools
-        run: scripts/measure-step.sh test-tools mise run test:tools
-
-      - name: Frontend tests
-        id: test-frontend
-        run: scripts/measure-step.sh test-frontend mise run test:frontend
-
-      - name: Docsite tests
-        id: test-docsite
-        run: scripts/measure-step.sh test-docsite mise run test:docsite
+      - name: Rust, tool, frontend, and docsite tests
+        id: test
+        run: scripts/measure-step.sh test mise run test
 
       - name: Frontend coverage
         id: test-frontend-coverage
@@ -212,47 +181,19 @@ jobs:
 
       - name: Docsite navigation E2E
         id: test-docsite-navigation
+        env:
+          UGOITE_SKIP_PLAYWRIGHT_DEPS: "1"
         run: scripts/measure-step.sh test-docsite-navigation mise run test:docsite:e2e:navigation
 
-      - name: E2E smoke
-        id: test-e2e
-        run: scripts/measure-step.sh test-e2e mise run test:e2e:smoke
-
-      - name: Form-owned Asset E2E
-        id: test-e2e-asset-owned
-        run: scripts/measure-step.sh test-e2e-asset-owned mise run test:e2e:asset-owned
-
-      - name: Package runtime image artifact
-        id: package-image
-        run: scripts/measure-step.sh package-image mise run package:image
-
-      - name: Write artifact manifest
-        id: package-manifest
+      - name: E2E smoke and Form-owned Asset
+        id: test-e2e-smoke-asset-owned
         env:
-          DOCSITE_ORIGIN: ${{ steps.ci-config.outputs.docsite_origin }}
-          DOCSITE_BASE: ${{ steps.ci-config.outputs.docsite_base }}
-          UGOITE_CI_RUN_ID: ${{ github.run_id }}
-        run: scripts/measure-step.sh package-manifest mise run package:manifest
-
-      - name: Verify docsite artifact
-        id: verify-docsite
-        run: scripts/measure-step.sh verify-docsite mise run verify:docsite
-
-      - name: Verify CLI artifact
-        id: verify-cli
-        run: scripts/measure-step.sh verify-cli mise run verify:cli
+          UGOITE_SKIP_PLAYWRIGHT_DEPS: "1"
+        run: scripts/measure-step.sh test-e2e-smoke-asset-owned mise run test:e2e:smoke-and-asset-owned
 
       - name: Validate release metadata
         id: validate-release
         run: scripts/measure-step.sh validate-release mise run validate:release
-
-      - name: Verify Helm artifact
-        id: verify-helm
-        run: scripts/measure-step.sh verify-helm mise run verify:helm
-
-      - name: Verify image artifact
-        id: verify-image
-        run: scripts/measure-step.sh verify-image mise run verify:image
 
       - name: Upload docsite artifact
         id: upload-docsite
@@ -407,28 +348,15 @@ jobs:
             echo "- fmt:check: ${{ steps.fmt-check.outputs.duration_seconds }}s"
             echo "- lint: ${{ steps.lint.outputs.duration_seconds }}s"
             echo "- check: ${{ steps.check.outputs.duration_seconds }}s"
-            echo "- build:wasm:release: ${{ steps.build-wasm.outputs.duration_seconds }}s"
-            echo "- build:frontend: ${{ steps.build-frontend.outputs.duration_seconds }}s"
-            echo "- build:docsite: ${{ steps.build-docsite.outputs.duration_seconds }}s"
-            echo "- build:rust:release: ${{ steps.build-rust.outputs.duration_seconds }}s"
-            echo "- build:image: ${{ steps.build-image.outputs.duration_seconds }}s"
-            echo "- test:rust: ${{ steps.test-rust.outputs.duration_seconds }}s"
-            echo "- test:tools: ${{ steps.test-tools.outputs.duration_seconds }}s"
-            echo "- test:frontend: ${{ steps.test-frontend.outputs.duration_seconds }}s"
-            echo "- test:docsite: ${{ steps.test-docsite.outputs.duration_seconds }}s"
+            echo "- install Playwright: ${{ steps.install-playwright.outputs.duration_seconds }}s"
+            echo "- build: ${{ steps.build.outputs.duration_seconds }}s"
+            echo "- test: ${{ steps.test.outputs.duration_seconds }}s"
             echo "- test:frontend:coverage: ${{ steps.test-frontend-coverage.outputs.duration_seconds }}s"
             echo "- test:docsite:coverage: ${{ steps.test-docsite-coverage.outputs.duration_seconds }}s"
-            echo "- test:e2e:smoke: ${{ steps.test-e2e.outputs.duration_seconds }}s"
-            echo "- test:e2e:asset-owned: ${{ steps.test-e2e-asset-owned.outputs.duration_seconds }}s"
-            echo "- package:docsite: ${{ steps.package-docsite.outputs.duration_seconds }}s"
-            echo "- package:cli: ${{ steps.package-cli.outputs.duration_seconds }}s"
-            echo "- package:helm: ${{ steps.package-helm.outputs.duration_seconds }}s"
-            echo "- package:image: ${{ steps.package-image.outputs.duration_seconds }}s"
-            echo "- package:manifest: ${{ steps.package-manifest.outputs.duration_seconds }}s"
-            echo "- verify:docsite: ${{ steps.verify-docsite.outputs.duration_seconds }}s"
-            echo "- verify:cli: ${{ steps.verify-cli.outputs.duration_seconds }}s"
-            echo "- verify:helm: ${{ steps.verify-helm.outputs.duration_seconds }}s"
-            echo "- verify:image: ${{ steps.verify-image.outputs.duration_seconds }}s"
+            echo "- docsite navigation E2E: ${{ steps.test-docsite-navigation.outputs.duration_seconds }}s"
+            echo "- E2E smoke and asset-owned: ${{ steps.test-e2e-smoke-asset-owned.outputs.duration_seconds }}s"
+            echo "- package: ${{ steps.package.outputs.duration_seconds }}s"
+            echo "- verify: ${{ steps.verify.outputs.duration_seconds }}s"
             echo "- validate:release: ${{ steps.validate-release.outputs.duration_seconds }}s"
             echo "- total workflow duration: ${total_duration_seconds}s"
             echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,11 @@ jobs:
 
       - name: Rust, tool, frontend, and docsite tests
         id: test
+        env:
+          # Keep the mise task graph parallel while leaving enough CPU for
+          # Vitest during Cargo's workspace test build.
+          MISE_JOBS: "2"
+          CARGO_BUILD_JOBS: "2"
         run: scripts/measure-step.sh test mise run test
 
       - name: Frontend coverage

--- a/deno.json
+++ b/deno.json
@@ -22,6 +22,7 @@
     "e2e:install:browsers": "deno task --cwd e2e install:browsers",
     "e2e:smoke": "bash e2e/scripts/run-e2e-parity.sh smoke",
     "e2e:asset-owned": "bash e2e/scripts/run-e2e-parity.sh asset-owned",
+    "e2e:smoke-and-asset-owned": "bash e2e/scripts/run-e2e-parity.sh smoke-and-asset-owned",
     "e2e:full": "bash e2e/scripts/run-e2e-parity.sh full",
     "e2e:static": "E2E_FRONTEND_MODE=static E2E_ENFORCE_CI_GATES=true bash e2e/scripts/run-e2e.sh smoke"
   },

--- a/e2e/deno.json
+++ b/e2e/deno.json
@@ -6,6 +6,7 @@
     "smoke": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test smoke.test.ts",
     "entries": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test entries.test.ts",
     "asset-owned": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test entries.test.ts --grep REQ-FE-1877",
+    "smoke-and-asset-owned": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test smoke.test.ts entries.test.ts --grep \"@smoke|@asset-owned\"",
     "forms": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test forms.test.ts",
     "full": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test --grep-invert @screenshot",
     "screenshot": "deno run --node-modules-dir=none -A npm:@playwright/test@^1.60.0 test ui-pages-screenshots.test.ts"

--- a/e2e/entries.test.ts
+++ b/e2e/entries.test.ts
@@ -426,7 +426,7 @@ test.describe("Entries CRUD", () => {
 		expect(entry.content).not.toContain(projectBetaId);
 	});
 
-	test("REQ-FE-1877: unrelated Forms own independently named scalar and list Assets", async ({
+	test("REQ-FE-1877: unrelated Forms own independently named scalar and list Assets", { tag: "@asset-owned" }, async ({
 		page,
 		request,
 	}) => {

--- a/e2e/scripts/run-e2e-compose.sh
+++ b/e2e/scripts/run-e2e-compose.sh
@@ -3,7 +3,8 @@
 # Used by local `mise run e2e` and by GitHub Actions e2e-ci.yml.
 #
 # Usage: ./e2e/scripts/run-e2e-compose.sh [test-type]
-#   test-type: "smoke", "asset-owned", "entries", "screenshot", or "full" (default)
+#   test-type: "smoke", "asset-owned", "smoke-and-asset-owned", "entries",
+#     "screenshot", or "full" (default)
 #
 # Environment variables:
 #   E2E_BUILD_IMAGES: "true" (default) to build local images before startup;
@@ -102,47 +103,64 @@ echo "Running E2E tests (type: $TEST_TYPE)..."
 echo "=========================================="
 
 cd "$ROOT_DIR/e2e"
-mkdir -p "$(dirname "$PLAYWRIGHT_JUNIT_OUTPUT_FILE")"
-rm -f "$PLAYWRIGHT_JUNIT_OUTPUT_FILE"
+base_report_file="${PLAYWRIGHT_JUNIT_OUTPUT_FILE:-test-results/junit.xml}"
+
+validate_junit_report() {
+  local report="$1"
+  PLAYWRIGHT_JUNIT_OUTPUT_FILE="$report" deno eval '
+    const report = Deno.env.get("PLAYWRIGHT_JUNIT_OUTPUT_FILE");
+    if (!report) throw new Error("PLAYWRIGHT_JUNIT_OUTPUT_FILE is required");
+    const xml = await Deno.readTextFile(report);
+    const suites = [...xml.matchAll(/<testsuite\b[^>]*>/g)].map((match) => match[0]);
+    const attr = (text, name) => Number(text.match(new RegExp(`${name}="([^"]*)"`))?.[1] ?? 0);
+    const tests = suites.reduce((sum, suite) => sum + attr(suite, "tests"), 0);
+    const skipped = suites.reduce((sum, suite) => sum + attr(suite, "skipped"), 0);
+    if (tests === 0) throw new Error("e2e tests: zero executed tests");
+    if (skipped > 0) throw new Error(`e2e tests: skipped=${skipped} is not allowed`);
+    console.log(`e2e tests OK: tests=${tests}, skipped=${skipped}`);
+  '
+}
+
+run_e2e_task() {
+  local task="$1"
+  local report="$2"
+  export PLAYWRIGHT_JUNIT_OUTPUT_FILE="$report"
+  mkdir -p "$(dirname "$report")"
+  rm -f "$report"
+
+  cmd=(deno task "$task" --)
+  if [ -n "${E2E_TEST_TIMEOUT_MS:-}" ]; then
+    cmd+=(--timeout "$E2E_TEST_TIMEOUT_MS")
+  fi
+  "${cmd[@]}"
+  validate_junit_report "$report"
+}
+
 case "$TEST_TYPE" in
   smoke)
-    cmd=(deno task smoke --)
-    ;;
-  entries)
-    cmd=(deno task entries --)
+    run_e2e_task smoke "$base_report_file"
     ;;
   asset-owned)
-    cmd=(deno task asset-owned --)
+    run_e2e_task asset-owned "$base_report_file"
+    ;;
+  smoke-and-asset-owned)
+    run_e2e_task smoke-and-asset-owned "$base_report_file"
+    ;;
+  entries)
+    run_e2e_task entries "$base_report_file"
     ;;
   screenshot)
-    cmd=(deno task screenshot --)
+    run_e2e_task screenshot "$base_report_file"
     ;;
   full)
-    cmd=(deno task full --)
+    run_e2e_task full "$base_report_file"
     ;;
   *)
     echo "Unknown test type: $TEST_TYPE"
-    echo "Usage: ./e2e/scripts/run-e2e-compose.sh [smoke|asset-owned|entries|screenshot|full]"
+    echo "Usage: ./run-e2e-compose.sh [smoke|asset-owned|smoke-and-asset-owned|entries|screenshot|full]"
     exit 1
     ;;
 esac
-if [ -n "${E2E_TEST_TIMEOUT_MS:-}" ]; then
-  cmd+=(--timeout "$E2E_TEST_TIMEOUT_MS")
-fi
-"${cmd[@]}"
-
-deno eval '
-  const report = Deno.env.get("PLAYWRIGHT_JUNIT_OUTPUT_FILE");
-  if (!report) throw new Error("PLAYWRIGHT_JUNIT_OUTPUT_FILE is required");
-  const xml = await Deno.readTextFile(report);
-  const suites = [...xml.matchAll(/<testsuite\b[^>]*>/g)].map((match) => match[0]);
-  const attr = (text, name) => Number(text.match(new RegExp(`${name}="([^"]*)"`))?.[1] ?? 0);
-  const tests = suites.reduce((sum, suite) => sum + attr(suite, "tests"), 0);
-  const skipped = suites.reduce((sum, suite) => sum + attr(suite, "skipped"), 0);
-  if (tests === 0) throw new Error("e2e tests: zero executed tests");
-  if (skipped > 0) throw new Error(`e2e tests: skipped=${skipped} is not allowed`);
-  console.log(`e2e tests OK: tests=${tests}, skipped=${skipped}`);
-'
 
 echo ""
 echo "=========================================="

--- a/e2e/scripts/run-e2e.sh
+++ b/e2e/scripts/run-e2e.sh
@@ -3,7 +3,8 @@
 # fallback via `run-e2e-parity.sh`.
 #
 # Usage: ./e2e/scripts/run-e2e.sh [test-type]
-#   test-type: "smoke", "asset-owned", "entries", "screenshot", or "full" (runs standard tests)
+#   test-type: "smoke", "asset-owned", "smoke-and-asset-owned", "entries",
+#     "screenshot", or "full" (runs standard tests)
 #
 # Environment variables:
 #   E2E_TEST_TIMEOUT_MS: per-test timeout passed to `playwright test --timeout`
@@ -208,11 +209,7 @@ echo "Running E2E tests (type: $TEST_TYPE)..."
 echo "=========================================="
 
 cd "$ROOT_DIR/e2e"
-
-if [ "$ENFORCE_CI_GATES" = "true" ]; then
-  mkdir -p "$(dirname "$PLAYWRIGHT_JUNIT_OUTPUT_FILE")"
-  rm -f "$PLAYWRIGHT_JUNIT_OUTPUT_FILE"
-fi
+base_report_file="${PLAYWRIGHT_JUNIT_OUTPUT_FILE:-test-results/junit.xml}"
 
 TEST_TIMEOUT_ARGS=()
 if [ -n "${E2E_TEST_TIMEOUT_MS:-}" ]; then
@@ -220,42 +217,25 @@ if [ -n "${E2E_TEST_TIMEOUT_MS:-}" ]; then
 fi
 run_e2e_task() {
   local task="$1"
+  local report="$2"
+  if [ "$ENFORCE_CI_GATES" = "true" ]; then
+    export PLAYWRIGHT_JUNIT_OUTPUT_FILE="$report"
+    mkdir -p "$(dirname "$report")"
+    rm -f "$report"
+  fi
   if [ "${#TEST_TIMEOUT_ARGS[@]}" -gt 0 ]; then
     deno task "$task" -- "${TEST_TIMEOUT_ARGS[@]}"
   else
     deno task "$task"
   fi
+  if [ "$ENFORCE_CI_GATES" = "true" ]; then
+    validate_junit_report "$report"
+  fi
 }
 
-case "$TEST_TYPE" in
-  smoke)
-    run_e2e_task smoke
-    ;;
-  entries)
-    run_e2e_task entries
-    ;;
-  asset-owned)
-    if [ "${#TEST_TIMEOUT_ARGS[@]}" -gt 0 ]; then
-      deno task asset-owned -- "${TEST_TIMEOUT_ARGS[@]}"
-    else
-      deno task asset-owned
-    fi
-    ;;
-  screenshot)
-    run_e2e_task screenshot
-    ;;
-  full)
-    run_e2e_task full
-    ;;
-  *)
-    echo "Unknown test type: $TEST_TYPE"
-    echo "Usage: ./e2e/scripts/run-e2e.sh [smoke|asset-owned|entries|screenshot|full]"
-    exit 1
-    ;;
-esac
-
-if [ "$ENFORCE_CI_GATES" = "true" ]; then
-  deno eval '
+validate_junit_report() {
+  local report="$1"
+  PLAYWRIGHT_JUNIT_OUTPUT_FILE="$report" deno eval '
     const report = Deno.env.get("PLAYWRIGHT_JUNIT_OUTPUT_FILE");
     if (!report) throw new Error("PLAYWRIGHT_JUNIT_OUTPUT_FILE is required");
     const xml = await Deno.readTextFile(report);
@@ -267,7 +247,33 @@ if [ "$ENFORCE_CI_GATES" = "true" ]; then
     if (skipped > 0) throw new Error(`e2e tests: skipped=${skipped} is not allowed`);
     console.log(`e2e tests OK: tests=${tests}, skipped=${skipped}`);
   '
-fi
+}
+
+case "$TEST_TYPE" in
+  smoke)
+    run_e2e_task smoke "$base_report_file"
+    ;;
+  entries)
+    run_e2e_task entries "$base_report_file"
+    ;;
+  asset-owned)
+    run_e2e_task asset-owned "$base_report_file"
+    ;;
+  smoke-and-asset-owned)
+    run_e2e_task smoke-and-asset-owned "$base_report_file"
+    ;;
+  screenshot)
+    run_e2e_task screenshot "$base_report_file"
+    ;;
+  full)
+    run_e2e_task full "$base_report_file"
+    ;;
+  *)
+    echo "Unknown test type: $TEST_TYPE"
+    echo "Usage: ./e2e/scripts/run-e2e.sh [smoke|asset-owned|smoke-and-asset-owned|entries|screenshot|full]"
+    exit 1
+    ;;
+esac
 
 echo ""
 echo "=========================================="

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -14,7 +14,7 @@ import {
   waitForServers,
 } from "./lib/client.ts";
 
-test.describe("Smoke Tests", () => {
+test.describe("Smoke Tests", { tag: "@smoke" }, () => {
   let spaceId = "";
 
   test.beforeAll(async ({ request }) => {

--- a/mise.toml
+++ b/mise.toml
@@ -258,6 +258,9 @@ run = "docker image inspect \"${UGOITE_IMAGE_TAG:-ugoite:e2e}\" >/dev/null && E2
 [tasks."test:e2e:asset-owned"]
 run = "docker image inspect \"${UGOITE_IMAGE_TAG:-ugoite:e2e}\" >/dev/null && E2E_BUILD_IMAGES=false deno task e2e:asset-owned"
 
+[tasks."test:e2e:smoke-and-asset-owned"]
+run = "docker image inspect \"${UGOITE_IMAGE_TAG:-ugoite:e2e}\" >/dev/null && E2E_BUILD_IMAGES=false deno task e2e:smoke-and-asset-owned"
+
 [tasks.e2e]
 description = "Run CI-parity E2E tests, preferring Docker Compose and falling back to host processes"
 run = "deno task e2e:full"

--- a/mise.toml
+++ b/mise.toml
@@ -225,6 +225,9 @@ run = "deno test -A tools/*_test.ts"
 
 [tasks."test:frontend"]
 depends = ["build:wasm:debug"]
+run = { task = "test:frontend:after-wasm" }
+
+[tasks."test:frontend:after-wasm"]
 run = [
   "bash scripts/activate-ugoite-wasm.sh debug",
   "deno task frontend:test",
@@ -247,7 +250,8 @@ run = "deno task docsite:coverage"
 run = "deno task docsite:e2e:navigation"
 
 [tasks.test]
-run = [{ tasks = ["test:rust", "test:tools", "test:frontend", "test:docsite"] }]
+depends = ["build:wasm:debug"]
+run = [{ tasks = ["test:rust", "test:tools", "test:frontend:after-wasm", "test:docsite"] }]
 
 [tasks."test:e2e"]
 run = "docker image inspect \"${UGOITE_IMAGE_TAG:-ugoite:e2e}\" >/dev/null && E2E_BUILD_IMAGES=false deno task e2e:full"


### PR DESCRIPTION
## Summary

- Use the canonical `mise run build`, `test`, `package`, and `verify` task graphs in the required CI job.
- Install Playwright browser dependencies once per CI job and skip duplicate runner-level installs.
- Run smoke and REQ-FE-1877 Form-owned Asset E2E in one Compose and Playwright lifecycle.

## Related Issue (required)

closes #1955
closes #1953
closes #1954

## Testing

- [x] `bash -n e2e/scripts/run-e2e.sh e2e/scripts/run-e2e-compose.sh e2e/scripts/run-e2e-parity.sh`
- [x] `git diff --check`
- [x] `MISE_TRUSTED_CONFIG_PATHS="$PWD" mise tasks info build`, `package`, `test`, `verify`, and the combined E2E task
- [ ] `mise run test` (delegated to remote CI; full local execution was intentionally skipped)
