### PR TITLE
feat: expose local sample seeding task

### DIFF
--- a/docs/guide/develop/index.md
+++ b/docs/guide/develop/index.md
@@ -10,6 +10,27 @@ Development starts at the repository root and uses the same Rust server,
 frontend, docsite, and validation tasks as CI. The browser remains server-backed
 in the current release.
 
+## Seed local sample data
+
+Use the root task to create a portable sample Space for local development:
+
+```bash
+mise run seed
+```
+
+The default root is `./data`; the generated Space directory uses its immutable
+UUIDv7 and the `dev-seed` slug. It uses the `renewable-ops` scenario and
+approximately 50 entries. Pass arguments after `--` or set the `UGOITE_SEED_*`
+environment variables documented by `scripts/dev-seed.sh` when a different root,
+Space ID, scenario, entry count, or deterministic seed is needed:
+
+```bash
+mise run seed -- --space-id demo --scenario lab-qa --entry-count 10 --seed 7
+```
+
+The helper refuses to overwrite an existing target Space. Choose another Space
+ID or remove the local development data intentionally before seeding again.
+
 ## Development path
 
 1. Follow [Local development login](local-dev-auth-login.md) to start from

--- a/docs/spec/requirements/ops.yaml
+++ b/docs/spec/requirements/ops.yaml
@@ -250,15 +250,15 @@ requirements:
   linked_specifications: *id002
   id: REQ-OPS-016
   title: Local Dev Sample-Data Seeding Workflow
-  description: A root developer task should expose sample-data seeding. A helper script exists, but no root mise task is currently defined.
+  description: The root developer task `mise run seed` exposes the existing sample-data helper with configurable local root, Space ID, scenario, entry count, and seed inputs.
   related_spec:
   - testing/ci-cd.md
   - ../../guide/operate/server/operations.md
   priority: medium
-  status: planned
+  status: implemented
   verification: traced
   tests:
-  - file: crates/ugoite-iceberg/tests/test_sample_data.rs
+  - file: tools/workspace_test.ts
 - set_id: REQCAT-OPS
   source_file: requirements/ops.yaml
   scope: Operational quality, workflow, and automation requirements.

--- a/mise.toml
+++ b/mise.toml
@@ -30,6 +30,10 @@ run = [
   "deno task dev",
 ]
 
+[tasks.seed]
+description = "Seed local sample data with the development helper"
+run = "bash scripts/dev-seed.sh"
+
 [tasks.fmt]
 run = [
   "cargo fmt --all",

--- a/scripts/dev-seed.sh
+++ b/scripts/dev-seed.sh
@@ -75,8 +75,52 @@ if [[ -n "$SEED_VALUE" ]] && ! [[ "$SEED_VALUE" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-if [[ -e "$ROOT_PATH/spaces/$SPACE_ID" ]]; then
-  echo "Refusing to overwrite existing local sample space: $ROOT_PATH/spaces/$SPACE_ID" >&2
+space_path_for_slug() {
+  deno eval --quiet '
+    const [spacesRoot, expectedSlug, requireCurrentIdentity] = Deno.args;
+    const uuidV7 =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    let matchingSpace;
+
+    try {
+      for await (const entry of Deno.readDir(spacesRoot)) {
+        if (!entry.isDirectory) continue;
+        const spacePath = `${spacesRoot}/${entry.name}`;
+        try {
+          const meta = JSON.parse(
+            await Deno.readTextFile(`${spacePath}/meta.json`),
+          );
+          if (requireCurrentIdentity === "true") {
+            if (
+              meta?.slug !== expectedSlug ||
+              !uuidV7.test(entry.name) ||
+              meta?.space_uid !== entry.name
+            ) {
+              continue;
+            }
+          } else if (
+            entry.name !== expectedSlug &&
+            meta?.slug !== expectedSlug
+          ) {
+            continue;
+          }
+          matchingSpace = spacePath;
+          break;
+        } catch {
+          // Ignore incomplete or unrelated top-level directories.
+        }
+      }
+    } catch {
+      // The spaces directory does not exist yet.
+    }
+
+    if (matchingSpace) console.log(matchingSpace);
+    else Deno.exit(1);
+  ' -- "$ROOT_PATH/spaces" "$SPACE_ID" "${1:-false}"
+}
+
+if existing_space="$(space_path_for_slug)"; then
+  echo "Refusing to overwrite existing local sample space: $existing_space" >&2
   echo "Choose a different space with UGOITE_SEED_SPACE_ID or --space-id." >&2
   exit 1
 fi
@@ -102,8 +146,6 @@ command=(
   --
   space
   sample-data
-  "$ROOT_PATH"
-  "$SPACE_ID"
   --scenario
   "$SCENARIO"
   --entry-count
@@ -114,11 +156,13 @@ if [[ -n "$SEED_VALUE" ]]; then
   command+=(--seed "$SEED_VALUE")
 fi
 
+command+=(-- "$ROOT_PATH" "$SPACE_ID")
+
 "${command[@]}"
 
-if [[ ! -d "$ROOT_PATH/spaces/$SPACE_ID" ]]; then
-  echo "Seed command finished but sample space directory is missing: $ROOT_PATH/spaces/$SPACE_ID" >&2
+if ! created_space="$(space_path_for_slug true)"; then
+  echo "Seed command finished but no Space with slug '$SPACE_ID' was found below: $ROOT_PATH/spaces" >&2
   exit 1
 fi
 
-echo "Verified seeded local sample space at $ROOT_PATH/spaces/$SPACE_ID" >&2
+echo "Verified seeded local sample space at $created_space" >&2

--- a/tools/workspace_test.ts
+++ b/tools/workspace_test.ts
@@ -145,6 +145,168 @@ Deno.test("local runtime data uses one ignored repository mount", async () => {
   assertEquals(releaseCompose.includes("UGOITE_NODE_DIR"), false);
 });
 
+Deno.test("sample-data seeding is exposed through the root mise task", async () => {
+  const rootMise = await Deno.readTextFile("mise.toml");
+  const taskHeader = "[tasks.seed]";
+  const taskStart = rootMise.indexOf(taskHeader);
+  assertEquals(taskStart >= 0, true, "root seed task must exist");
+  const taskEnd = rootMise.indexOf("\n[tasks", taskStart + taskHeader.length);
+  const task = rootMise.slice(taskStart, taskEnd < 0 ? undefined : taskEnd);
+  assertEquals(
+    task.includes('run = "bash scripts/dev-seed.sh"'),
+    true,
+    "seed task must invoke the existing helper",
+  );
+});
+
+Deno.test("dev-seed forwards arguments and protects UUID-backed Spaces", async () => {
+  const root = await Deno.makeTempDir({ prefix: "ugoite-seed-forwarding-" });
+  const fakeBin = await Deno.makeTempDir({ prefix: "ugoite-seed-fake-bin-" });
+  const argsLog = `${fakeBin}/cargo-args`;
+  const fakeCargo = `${fakeBin}/cargo`;
+  const helperArgs = [
+    "--root",
+    root,
+    "--space-id",
+    "forwarded-space",
+    "--scenario",
+    "lab-qa",
+    "--entry-count",
+    "7",
+    "--seed",
+    "42",
+  ];
+  await Deno.writeTextFile(
+    fakeCargo,
+    `#!/bin/sh
+printf '%s\\n' "$@" > "$UGOITE_FAKE_CARGO_ARGS"
+space_dir="\${15}/spaces/019f0000-0000-7000-8000-000000000001"
+mkdir -p "$space_dir"
+printf '{"slug":"%s","space_uid":"019f0000-0000-7000-8000-000000000001"}' "\${16}" > "$space_dir/meta.json"
+printf '{"created":true,"id":"019f0000-0000-7000-8000-000000000001","slug":"%s","scenario":"%s","entry_count":%s}\\n' "\${16}" "$9" "\${11}"
+`,
+  );
+  await Deno.chmod(fakeCargo, 0o755);
+
+  try {
+    const env = {
+      ...Deno.env.toObject(),
+      PATH: `${fakeBin}:${Deno.env.get("PATH") ?? ""}`,
+      UGOITE_FAKE_CARGO_ARGS: argsLog,
+    };
+    const result = await new Deno.Command("bash", {
+      args: ["scripts/dev-seed.sh", ...helperArgs],
+      env,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    assertEquals(result.success, true, new TextDecoder().decode(result.stderr));
+    const summary = JSON.parse(new TextDecoder().decode(result.stdout));
+    assertEquals(summary.slug, "forwarded-space");
+    assertEquals(summary.scenario, "lab-qa");
+    assertEquals(summary.entry_count, 7);
+
+    const spaces = [];
+    for await (const entry of Deno.readDir(`${root}/spaces`)) {
+      if (entry.isDirectory) spaces.push(entry.name);
+    }
+    assertEquals(spaces, ["019f0000-0000-7000-8000-000000000001"]);
+    const meta = JSON.parse(
+      await Deno.readTextFile(`${root}/spaces/${spaces[0]}/meta.json`),
+    );
+    assertEquals(meta.slug, "forwarded-space");
+    assertEquals(meta.space_uid, spaces[0]);
+
+    const second = await new Deno.Command("bash", {
+      args: ["scripts/dev-seed.sh", ...helperArgs],
+      env,
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    assertEquals(second.success, false);
+    assertEquals(
+      new TextDecoder().decode(second.stderr).includes(
+        "Refusing to overwrite existing local sample space",
+      ),
+      true,
+    );
+    assertEquals(
+      await Deno.readTextFile(argsLog),
+      "run\n-q\n-p\nugoite-cli\n--\nspace\nsample-data\n--scenario\nlab-qa\n--entry-count\n7\n--seed\n42\n--\n" +
+        `${root}\nforwarded-space\n`,
+    );
+
+    const legacyRoot = await Deno.makeTempDir({
+      prefix: "ugoite-seed-legacy-",
+    });
+    try {
+      const legacySpace = `${legacyRoot}/spaces/legacy-space`;
+      await Deno.mkdir(legacySpace, { recursive: true });
+      await Deno.writeTextFile(
+        `${legacySpace}/meta.json`,
+        '{"slug":"legacy-space"}',
+      );
+      const legacy = await new Deno.Command("bash", {
+        args: [
+          "scripts/dev-seed.sh",
+          "--root",
+          legacyRoot,
+          "--space-id",
+          "legacy-space",
+        ],
+        env,
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      assertEquals(legacy.success, false);
+      assertEquals(
+        new TextDecoder().decode(legacy.stderr).includes(
+          "Refusing to overwrite existing local sample space",
+        ),
+        true,
+      );
+    } finally {
+      await Deno.remove(legacyRoot, { recursive: true });
+    }
+
+    const legacyDirectoryRoot = await Deno.makeTempDir({
+      prefix: "ugoite-seed-legacy-directory-",
+    });
+    try {
+      const legacySpace = `${legacyDirectoryRoot}/spaces/directory-space`;
+      await Deno.mkdir(legacySpace, { recursive: true });
+      await Deno.writeTextFile(
+        `${legacySpace}/meta.json`,
+        '{"id":"directory-space","name":"directory-space"}',
+      );
+      const legacy = await new Deno.Command("bash", {
+        args: [
+          "scripts/dev-seed.sh",
+          "--root",
+          legacyDirectoryRoot,
+          "--space-id",
+          "directory-space",
+        ],
+        env,
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      assertEquals(legacy.success, false);
+      assertEquals(
+        new TextDecoder().decode(legacy.stderr).includes(
+          "Refusing to overwrite existing local sample space",
+        ),
+        true,
+      );
+    } finally {
+      await Deno.remove(legacyDirectoryRoot, { recursive: true });
+    }
+  } finally {
+    await Deno.remove(root, { recursive: true });
+    await Deno.remove(fakeBin, { recursive: true });
+  }
+});
+
 Deno.test("CI image and E2E tasks preserve the build-once contract", async () => {
   const rootMise = await Deno.readTextFile("mise.toml");
   const workflow = await Deno.readTextFile(".github/workflows/ci.yml");


### PR DESCRIPTION
## Summary

- Expose the existing local sample-data helper through the root `mise run seed` task.
- Preserve argument forwarding and refuse duplicate current or legacy Space slugs while validating the generated UUIDv7 Space identity.
- Document the local workflow and mark REQ-OPS-016 implemented with focused contract coverage.

## Related Issue (required)

closes #1963

## Testing

- [x] `mise run fmt:check`
- [x] `mise run test:tools`
- [x] `cargo run -q -p xtask -- docs-current-stack-check`
- [x] `deno task docsite:test`
- [x] `bash -n scripts/dev-seed.sh`
